### PR TITLE
Nissan LEAF: Heated battery handling

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -120,10 +120,13 @@ static uint8_t LB_Failsafe_Status = 0;           //LB_STATUS = 000b = normal sta
                                                  //110b = Caution Lamp Request & Charging Mode Stop Request
                                                  //111b = Caution Lamp Request & Main Relay OFF Request
 static byte LB_Interlock =
-    1;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
-static byte LB_Full_CHARGE_flag = 0;  //LB_FCHGEND , Goes to 1 if battery is fully charged
-static byte LB_MainRelayOn_flag = 0;  //No-Permission=0, Main Relay On Permission=1
-static byte LB_Capacity_Empty = 0;    //LB_EMPTY, , Goes to 1 if battery is empty
+    true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
+static byte LB_Full_CHARGE_flag = false;  //LB_FCHGEND , Goes to 1 if battery is fully charged
+static byte LB_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
+static byte LB_Capacity_Empty = false;    //LB_EMPTY, , Goes to 1 if battery is empty
+static byte LB_HeatExist = false;         //LB_HEATEXIST, Specifies if battery pack is equipped with heating elements
+static byte LB_Heating_Stop = false;      //When transitioning from 0->1, signals a STOP heat request
+static byte LB_Heating_Start = false;     //When transitioning from 1->0, signals a START heat request
 
 // Nissan LEAF battery data from polled CAN messages
 static uint8_t battery_request_idx = 0;
@@ -385,6 +388,7 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
   print_with_units("Real SOC%: ", (LB_SOC * 0.1), "% ");
   print_with_units(", GIDS: ", LB_GIDS, " (x77Wh) ");
   print_with_units(", Battery gen: ", LEAF_Battery_Type, " ");
+  print_with_units(", Has heater: ", LB_HeatExist, " ");
   print_with_units(", Max cell voltage: ", min_max_voltage[1], "mV ");
   print_with_units(", Min cell voltage: ", min_max_voltage[0], "mV ");
   print_with_units(", Cell deviation: ", cell_deviation_mV, "mV ");
@@ -462,7 +466,8 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
         LB_StateOfHealth = LB_TEMP;  //Collect state of health from battery
       }
       break;
-    case 0x5C0:  //This method only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
+    case 0x5C0:
+      //This temperature only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
       if (LEAF_Battery_Type == AZE0_BATTERY) {
         if ((rx_frame.data.u8[0] >> 6) ==
             1) {  // Battery MAX temperature. Effectively has only 7-bit precision, as the bottom bit is always 0.
@@ -473,6 +478,11 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
           LB_HistData_Temperature_MIN = ((rx_frame.data.u8[2] / 2) - 40);
         }
       }
+
+      LB_HeatExist = (rx_frame.data.u8[4] & 0x01);
+      LB_Heating_Stop = ((rx_frame.data.u8[0] & 0x10) >> 4);
+      LB_Heating_Start = ((rx_frame.data.u8[0] & 0x20) >> 5);
+
       break;
     case 0x59E:
       //AZE0 2013-2017 or ZE1 2018-2023 battery detected


### PR DESCRIPTION
# WIP: LEAF Testers welcome!

## What
This PR adds handling for internal battery heaters on Nissan LEAF packs. 

## Why
When the LEAF battery gets cold, it does not want to accept charge. Nissan installed high voltage heating elements inside the battery on cold weather equipped vehicles, that turn on when the temperature goes below -17*C. Unfortunately, this info needs to be acknowledged by the vehicle in order to turn on. This PR adds the commands needed to ack the request to start/stop heating.

## How
We now monitor the variables sent by battery
- LB_HeatExist (Specifies if battery pack is equipped with heating elements)
- LB_Heating_Stop (When transitioning from 0->1, signals a STOP heat request)
- LB_Heating_Start (When transitioning from 1->0, signals a START heat request)
- Batt_Heater_Mail_Send_Request (Stores info when a heat request is happening)

These values are printed out to the USB serial, so that you can check if your battery has the cold weather heaters present. It will also output to USB serial when a request to start/stop heating is happening.

When the start/stop request is sent, we then modify the reply message 0x50B , normally sent by the LEAFs VehicleControlModule. We set the flag "Batt_Heater_Mail_Send_OK" to TRUE when a heating request is coming in. This *SHOULD* allow the battery to work as intended, we unfortunately have no official documentation on how this process works. So testers welcome :)
