### PR TITLE
Bugfix: Nissan LEAF, increase precision on values

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -104,8 +104,8 @@ static uint16_t LB_GIDS = 0;
 static uint16_t LB_MAX = 0;
 static uint16_t LB_Max_GIDS = 273;               //Startup in 24kWh mode
 static uint16_t LB_StateOfHealth = 99;           //State of health %
-static uint16_t LB_Total_Voltage2 = 740;          //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-static int16_t LB_Current2 = 0;                   //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
+static uint16_t LB_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
+static int16_t LB_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
 static int16_t LB_Power = 0;                     //Watts going in/out of battery
 static int16_t LB_HistData_Temperature_MAX = 6;  //-40 to 86*C
 static int16_t LB_HistData_Temperature_MIN = 5;  //-40 to 86*C
@@ -188,7 +188,8 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
 
   remaining_capacity_Wh = LB_Wh_Remaining;
 
-  LB_Power = ((LB_Total_Voltage2 * LB_Current2) / 4);  //P = U * I (Both values are 0.5 per bit so the math is non-intuitive)
+  LB_Power =
+      ((LB_Total_Voltage2 * LB_Current2) / 4);  //P = U * I (Both values are 0.5 per bit so the math is non-intuitive)
   stat_batt_power = convert2unsignedint16(LB_Power);  //add sign if needed
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
@@ -414,9 +415,9 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
       if (LB_Current2 & 0x0400) {
         // negative so extend the sign bit
         LB_Current2 |= 0xf800;
-      } //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
+      }  //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
 
-      LB_Total_Voltage2 = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6); //0.5V/bit
+      LB_Total_Voltage2 = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
 
       //Collect various data from the BMS
       LB_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -106,6 +106,7 @@ static uint16_t LB_Max_GIDS = 273;               //Startup in 24kWh mode
 static uint16_t LB_StateOfHealth = 99;           //State of health %
 static uint16_t LB_Total_Voltage = 370;          //Battery voltage (0-450V)
 static int16_t LB_Current = 0;                   //Current in A going in/out of battery
+static float LB_Current_Decimals = 0;            //Higher precision variant of the amperage value
 static int16_t LB_Power = 0;                     //Watts going in/out of battery
 static int16_t LB_HistData_Temperature_MAX = 6;  //-40 to 86*C
 static int16_t LB_HistData_Temperature_MIN = 5;  //-40 to 86*C
@@ -188,7 +189,7 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
 
   remaining_capacity_Wh = LB_Wh_Remaining;
 
-  LB_Power = LB_Total_Voltage * LB_Current;           //P = U * I
+  LB_Power = LB_Total_Voltage * LB_Current_Decimals;  //P = U * I
   stat_batt_power = convert2unsignedint16(LB_Power);  //add sign if needed
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
@@ -415,8 +416,8 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
         // negative so extend the sign bit
         LB_Current |= 0xf800;
       }
-      // Scale down the value by 0.5
-      LB_Current /= 2;
+      LB_Current_Decimals = ((float)LB_Current / 2);  //Store a precise version of the value
+      LB_Current /= 2;                                // Scale down the value by 0.5, to get whole integer value
 
       LB_Total_Voltage = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6) / 2;
 


### PR DESCRIPTION
### What
This PR improves the accuracy on both Voltage, Amperage and Power values. Thanks to Eriksson25 over on Discord for noticing! 🙌 

### Why
To get more realistic values towards inverter, and to see more realistic values in logs

### How
Instead of downsampling the values by dividing them by 2 on each CAN read, we instead do more math when it is time to use the values. Here's an example:

Ex1: Real values from battery: Voltage = 370.5V , Amperage 0.5A
- Previous implementation, 371V*1A=371W
- New implementation, 370,5V*0.5A=186W

Ex2: Real values from battery: Voltage = 400.5V , Amperage 5.5A
- Previous implementation, 401V*6A=2406W
- New implementation, 400,5V*5.5A=2203W