### PR TITLE
Bugfix: project doesn't complie if #define DEBUG_VIA_USB is not enabled

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -294,8 +294,9 @@ void update_values_kiaHyundai_64_battery() {  //This function maps all the value
   Serial.print("  |  Inverter ");
   Serial.print(inverterVoltage);
   Serial.println(" Volts");
-}
 #endif
+}
+
 
 void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
@@ -406,6 +407,7 @@ void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
+
 void send_can_kiaHyundai_64_battery() {
   unsigned long currentMillis = millis();
   //Send 100ms message

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -297,7 +297,6 @@ void update_values_kiaHyundai_64_battery() {  //This function maps all the value
 #endif
 }
 
-
 void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
     case 0x4DE:


### PR DESCRIPTION
The bracket closing **update_values_kiaHyundai_64_battery()** was inside #ifdef DEBUG_VIA_USB.
If DEBUG_VIA_USB wasn't defined, the project wouldn't compile.