### PR TITLE
Tesla: Add ERROR debug message when inverter blocks contactor closing

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -589,7 +589,10 @@ void printFaultCodesIfActive() {
   if (pyroTestInProgress == 1) {
     Serial.println("ERROR: Please wait for Pyro Connection check to finish, HV cables successfully seated!");
   }
-
+  if (inverterAllowsContactorClosing == 0) {
+    Serial.println(
+        "ERROR: Solar inverter does not allow for contactor closing. Check inverterAllowsContactorClosing parameter");
+  }
   // Check each symbol and print debug information if its value is 1
   printDebugIfActive(WatchdogReset, "ERROR: The processor has experienced a reset due to watchdog reset");
   printDebugIfActive(PowerLossReset, "ERROR: The processor has experienced a reset due to power loss");


### PR DESCRIPTION
### What
This PR adds a new fault code via USB to inform user that contactor closing is blocked

### Why
Some people were confused when using double LilyGos or Solax protocol that the contactor would not close. The `inverterAllowsContactorClosing` parameter needs to be true to allow contactor closing.

### How
A USB Serial debug message is added to the Tesla.cpp file
