### PR TITLE
Feature: Add ability to save parameters to flash

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -19,7 +19,7 @@
 #include "src/devboard/webserver/webserver.h"
 #endif
 
-Preferences preferences;  // Parameter storage
+Preferences settings;  // Store user settings
 
 // Interval settings
 int intervalUpdateValues = 4800;  // Interval at which to update inverter values / Modbus registers
@@ -105,7 +105,7 @@ bool inverterAllowsContactorClosing = true;
 void setup() {
   init_serial();
 
-  init_storage();
+  init_stored_settings();
 
 #ifdef WEBSERVER
   init_webserver();
@@ -174,35 +174,35 @@ void init_serial() {
   Serial.println("__ OK __");
 }
 
-void init_storage() {
-  preferences.begin("batterySettings", false);
+void init_stored_settings() {
+  settings.begin("batterySettings", false);
 
-#ifdef CLEAR_SAVED_SETTINGS
-  preferences.clear();  // If this clear function is executed, no parameters will be read from storage
+#ifndef LOAD_SAVED_SETTINGS_ON_BOOT
+  settings.clear();  // If this clear function is executed, no settings will be read from storage
 #endif
 
   static uint16_t temp = 0;
-  temp = preferences.getUInt("BATTERY_WH_MAX", false);
+  temp = settings.getUInt("BATTERY_WH_MAX", false);
   if (temp != 0) {
     BATTERY_WH_MAX = temp;
   }
-  temp = preferences.getUInt("MAXPERCENTAGE", false);
+  temp = settings.getUInt("MAXPERCENTAGE", false);
   if (temp != 0) {
     MAXPERCENTAGE = temp;
   }
-  temp = preferences.getUInt("MINPERCENTAGE", false);
+  temp = settings.getUInt("MINPERCENTAGE", false);
   if (temp != 0) {
     MINPERCENTAGE = temp;
   }
-  temp = preferences.getUInt("MAXCHARGEAMP", false);
+  temp = settings.getUInt("MAXCHARGEAMP", false);
   if (temp != 0) {
     MAXCHARGEAMP = temp;
   }
-  temp = preferences.getUInt("MAXDISCHARGEAMP", false);
+  temp = settings.getUInt("MAXDISCHARGEAMP", false);
   if (temp != 0) {
     MAXDISCHARGEAMP = temp;
   }
-  preferences.end();
+  settings.end();
 }
 
 void init_CAN() {
@@ -706,12 +706,12 @@ void init_serialDataLink() {
 #endif
 }
 
-void storeParameters() {
-  preferences.begin("batterySettings", false);
-  preferences.putUInt("BATTERY_WH_MAX", BATTERY_WH_MAX);
-  preferences.putUInt("MAXPERCENTAGE", MAXPERCENTAGE);
-  preferences.putUInt("MINPERCENTAGE", MINPERCENTAGE);
-  preferences.putUInt("MAXCHARGEAMP", MAXCHARGEAMP);
-  preferences.putUInt("MAXDISCHARGEAMP", MAXDISCHARGEAMP);
-  preferences.end();
+void storeSettings() {
+  settings.begin("batterySettings", false);
+  settings.putUInt("BATTERY_WH_MAX", BATTERY_WH_MAX);
+  settings.putUInt("MAXPERCENTAGE", MAXPERCENTAGE);
+  settings.putUInt("MINPERCENTAGE", MINPERCENTAGE);
+  settings.putUInt("MAXCHARGEAMP", MAXCHARGEAMP);
+  settings.putUInt("MAXDISCHARGEAMP", MAXDISCHARGEAMP);
+  settings.end();
 }

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -22,5 +22,5 @@ const char* ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 character
 const char* password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
 const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
 const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
-const char* versionNumber = "4.4.0";   // The current software version, shown on webserver
+const char* versionNumber = "4.5.0";   // The current software version, shown on webserver
 #endif

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -37,7 +37,7 @@
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
-#define LOAD_SAVED_SETTINGS_ON_BOOT //Enable this line to read settings stored via the webserver on boot
+#define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot
 
 /* Battery limits: These are set in the USER_SETTINGS.cpp file, or later on via the Webserver */
 extern volatile uint16_t BATTERY_WH_MAX;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define RENAULT_ZOE_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-//#define TEST_FAKE_BATTERY
+#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
@@ -36,7 +36,8 @@
 //#define DUAL_CAN              //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for FoxESS inverters)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
-//#define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
+#define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
+//#define CLEAR_SAVED_SETTINGS //Enable this line to clear all data that has been saved via the webserver page
 
 /* Battery limits: These are set in the USER_SETTINGS.cpp file, or later on via the Webserver */
 extern volatile uint16_t BATTERY_WH_MAX;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define RENAULT_ZOE_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-#define TEST_FAKE_BATTERY
+//#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
@@ -37,7 +37,7 @@
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
-//#define CLEAR_SAVED_SETTINGS //Enable this line to clear all data that has been saved via the webserver page
+#define LOAD_SAVED_SETTINGS_ON_BOOT //Enable this line to read settings stored via the webserver on boot
 
 /* Battery limits: These are set in the USER_SETTINGS.cpp file, or later on via the Webserver */
 extern volatile uint16_t BATTERY_WH_MAX;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,4 +1,7 @@
 #include "webserver.h"
+#include <Preferences.h>
+
+Preferences preferences3;
 
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
@@ -65,6 +68,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       BATTERY_WH_MAX = value.toInt();
+      storeParameters();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -76,6 +80,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXPERCENTAGE = value.toInt() * 10;
+      storeParameters();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -87,6 +92,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MINPERCENTAGE = value.toInt() * 10;
+      storeParameters();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -98,6 +104,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXCHARGEAMP = value.toInt() * 10;
+      storeParameters();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -109,6 +116,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXDISCHARGEAMP = value.toInt() * 10;
+      storeParameters();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -68,7 +68,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       BATTERY_WH_MAX = value.toInt();
-      storeParameters();
+      storeSettings();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -80,7 +80,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXPERCENTAGE = value.toInt() * 10;
-      storeParameters();
+      storeSettings();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -92,7 +92,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MINPERCENTAGE = value.toInt() * 10;
-      storeParameters();
+      storeSettings();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -104,7 +104,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXCHARGEAMP = value.toInt() * 10;
-      storeParameters();
+      storeSettings();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");
@@ -116,7 +116,7 @@ void init_webserver() {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
       MAXDISCHARGEAMP = value.toInt() * 10;
-      storeParameters();
+      storeSettings();
       request->send(200, "text/plain", "Updated successfully");
     } else {
       request->send(400, "text/plain", "Bad Request");

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -1,7 +1,7 @@
 #ifndef WEBSERVER_H
 #define WEBSERVER_H
 
-// Load Wi-Fi library
+#include <Preferences.h>
 #include <WiFi.h>
 #include "../../../USER_SETTINGS.h"  // Needed for WiFi ssid and password
 #include "../../lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h"
@@ -127,5 +127,8 @@ void onOTAEnd(bool success);
  */
 template <typename T>
 String formatPowerValue(String label, T value, String unit, int precision);
+
+extern void storeParameters();
+extern void restoreParameters();
 
 #endif

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -128,7 +128,7 @@ void onOTAEnd(bool success);
 template <typename T>
 String formatPowerValue(String label, T value, String unit, int precision);
 
-extern void storeParameters();
-extern void restoreParameters();
+extern void storeSettings();
+extern void restoreSettings();
 
 #endif

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -129,6 +129,5 @@ template <typename T>
 String formatPowerValue(String label, T value, String unit, int precision);
 
 extern void storeSettings();
-extern void restoreSettings();
 
 #endif


### PR DESCRIPTION
### What
This PR adds the ability to permanently store battery limit settings from the webpage. This means that even if the hardware is rebooted or updated via OTA/USB, the settings will continue to exist!

![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/fcef5c5a-94c9-4cd4-8331-fc86a5478004)


### Why
Users requested this feature

### How
The Preferences.h library is used to store data to flash memory on the ESP32.

To skip reading from flash memory, there is an option in `USER_SETTINGS.h` that you can comment out
`#define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot`
