### PR TITLE
Tesla: Fix for high voltage value

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -456,7 +456,7 @@ void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame) {
       break;
     case 0x2b4:
       low_voltage = (((rx_frame.data.u8[1] & 0x03) << 8) | rx_frame.data.u8[0]) * 0.0390625;
-      high_voltage = (((rx_frame.data.u8[2] << 6) | ((rx_frame.data.u8[1] & 0xFC) >> 2))) * 0.146484;
+      high_voltage = ((((rx_frame.data.u8[2] & 0x3F) << 6) | ((rx_frame.data.u8[1] & 0xFC) >> 2))) * 0.146484;
       output_current = (((rx_frame.data.u8[4] & 0x0F) << 8) | rx_frame.data.u8[3]) / 100;
       break;
     case 0x292:


### PR DESCRIPTION
### What
This PR attempts to fix the "High Voltage Output Pins: 1556V" that some users have been getting

### Why
Misleading information in USB output

### How
Fixed the bitshifting in the CAN reading for 0x2b4, the upper two bits in frame2 were accidentally included!