### PR TITLE
BYD CAN: Fix average temperature calculation

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -109,8 +109,9 @@ CAN_frame_t BYD_210 = {.FIR = {.B =
 static int discharge_current = 0;
 static int charge_current = 0;
 static int initialDataSent = 0;
-static int temperature_average = 0;
-
+static int16_t temperature_average = 0;
+static int16_t temp_min = 0;
+static int16_t temp_max = 0;
 static int inverter_voltage = 0;
 static int inverter_SOC = 0;
 static long inverter_timestamp = 0;
@@ -134,7 +135,9 @@ void update_values_can_byd() {  //This function maps all the values fetched from
         MAXDISCHARGEAMP;  //Cap the value to the max allowed Amp. Some inverters cannot handle large values.
   }
 
-  temperature_average = ((temperature_max + temperature_min) / 2);
+  temp_min = temperature_min;  //Convert from unsigned to signed
+  temp_max = temperature_max;
+  temperature_average = ((temp_max + temp_min) / 2);
 
   //Map values to CAN messages
   //Maxvoltage (eg 400.0V = 4000 , 16bits long)


### PR DESCRIPTION
### What
User brennar10 noticed a bug in the temperature calculation when using BYD CAN. When values go negative, there is a risk that the signed bit is lost during the calculation, causing temperature to appear incorrect

### Why
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/88c9c415-184f-4780-b8a0-7b06a265003f)

### How
The bug is fixed by converting the uint16 values to local int16 values before performing any calculations.