### PR TITLE
Nissan LEAF: Fix temperature value so its human readable

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -394,8 +394,8 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
   print_with_units(", Voltage: ", (battery_voltage * 0.1), "V ");
   print_with_units(", Max discharge power: ", max_target_discharge_power, "W ");
   print_with_units(", Max charge power: ", max_target_charge_power, "W ");
-  print_with_units(", Max temp: ", (temperature_max * 0.1), "°C ");
-  print_with_units(", Min temp: ", (temperature_min * 0.1), "°C ");
+  print_with_units(", Max temp: ", ((int16_t)temperature_max * 0.1), "°C ");
+  print_with_units(", Min temp: ", ((int16_t)temperature_min * 0.1), "°C ");
   Serial.println("");
   Serial.print("BMS Status: ");
   if (bms_status == 3) {


### PR DESCRIPTION
### What
This PR makes negative temperature values display OK on LEAF batteries

### Why
Users did not like to see 6553*C in the USB log

### How
Value is casted to int16 before showing it
