### PR TITLE
Kia/Hyundai 64kWh: Fix negative temp handling

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -186,9 +186,9 @@ void update_values_kiaHyundai_64_battery() {  //This function maps all the value
 
   stat_batt_power = convertToUnsignedInt16(powerWatt);  //Power in watts, Negative = charging batt
 
-  temperature_min = convertToUnsignedInt16(temperatureMin * 10);  //Increase decimals, 17C -> 17.0C
+  temperature_min = convertToUnsignedInt16((int8_t)temperatureMin * 10);  //Increase decimals, 17C -> 17.0C
 
-  temperature_max = convertToUnsignedInt16(temperatureMax * 10);  //Increase decimals, 18C -> 18.0C
+  temperature_max = convertToUnsignedInt16((int8_t)temperatureMax * 10);  //Increase decimals, 18C -> 18.0C
 
   cell_max_voltage = CellVoltMax_mV;
 


### PR DESCRIPTION
### What
This PR fixes negative temperature values, that would stop inverters from operating when battery gets cold

### Why
Thanks to ml265 over on the Discord server for noticing this bug. Temperatures are sent as int8, but we treat them as int16 in the code. This results in buggy values when the battery goes below freezing.

### How
Values are typecasted before they enter the formatting function