### PR TITLE
Bugfix: Add SMA CAN H findings

### DIFF
--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -2,33 +2,9 @@
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
-//TODO: change CAN sending routine once confirmed that 500ms interval is OK for this battery type
-
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis1s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis2s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis3s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis4s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis5s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis6s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis7s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis8s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis9s = 0;   // will store last time a Xs CAN Message was send
-static unsigned long previousMillis10s = 0;  // will store last time a Xs CAN Message was send
-static unsigned long previousMillis11s = 0;  // will store last time a Xs CAN Message was send
-static unsigned long previousMillis12s = 0;  // will store last time a Xs CAN Message was send
-static const int interval1s = 100;           // interval (ms) at which send CAN Messages
-static const int interval2s = 102;           // interval (ms) at which send CAN Messages
-static const int interval3s = 104;           // interval (ms) at which send CAN Messages
-static const int interval4s = 106;           // interval (ms) at which send CAN Messages
-static const int interval5s = 108;           // interval (ms) at which send CAN Messages
-static const int interval6s = 110;           // interval (ms) at which send CAN Messages
-static const int interval7s = 112;           // interval (ms) at which send CAN Messages
-static const int interval8s = 114;           // interval (ms) at which send CAN Messages
-static const int interval9s = 116;           // interval (ms) at which send CAN Messages
-static const int interval10s = 118;          // interval (ms) at which send CAN Messages
-static const int interval11s = 120;          // interval (ms) at which send CAN Messages
-static const int interval12s = 122;          // interval (ms) at which send CAN Messages
+static unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
+static const int interval100ms = 100;          // interval (ms) at which send CAN Messages
 
 //Actual content messages
 static const CAN_frame_t SMA_558 = {
@@ -176,11 +152,18 @@ void update_values_can_sma() {  //This function maps all the values fetched from
 
   //Error bits
   //SMA_158.data.u8[0] = //bit12 Fault high temperature, bit34Battery cellundervoltage, bit56 Battery cell overvoltage, bit78 batterysystemdefect
-  //TODO: add all error bits
+  //TODO: add all error bits. Sending message with all 0xAA until that.
 }
 
 void receive_can_sma(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
+    case 0x360:  //Message originating from SMA inverter - Voltage and current
+      //Frame0-1 Voltage
+      //Frame2-3 Current
+      break;
+    case 0x420:  //Message originating from SMA inverter - Timestamp
+      //Frame0-3 Timestamp
+      break;
     case 0x660:  //Message originating from SMA inverter
       break;
     case 0x5E0:  //Message originating from SMA inverter
@@ -195,65 +178,21 @@ void receive_can_sma(CAN_frame_t rx_frame) {
 void send_can_sma() {
   unsigned long currentMillis = millis();
 
-  // Send CAN Message every X ms, 1000 for testing
-  if (currentMillis - previousMillis1s >= interval1s) {
+  // Send CAN Message every 100ms
+  if (currentMillis - previousMillis100ms >= interval100ms) {
     previousMillis1s = currentMillis;
 
     ESP32Can.CANWriteFrame(&SMA_558);
-  }
-  if (currentMillis - previousMillis2s >= interval2s) {
-    previousMillis2s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_598);
-  }
-  if (currentMillis - previousMillis3s >= interval3s) {
-    previousMillis3s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_5D8);
-  }
-  if (currentMillis - previousMillis4s >= interval4s) {
-    previousMillis4s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_618_1);
-  }
-  if (currentMillis - previousMillis5s >= interval5s) {
-    previousMillis5s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_618_2);
-  }
-  if (currentMillis - previousMillis6s >= interval6s) {
-    previousMillis6s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_618_3);
-  }
-  if (currentMillis - previousMillis7s >= interval7s) {
-    previousMillis7s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_358);
-  }
-  if (currentMillis - previousMillis8s >= interval8s) {
-    previousMillis8s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_3D8);
-  }
-  if (currentMillis - previousMillis9s >= interval9s) {
-    previousMillis9s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_458);
-  }
-  if (currentMillis - previousMillis10s >= interval10s) {
-    previousMillis10s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_518);
-  }
-  if (currentMillis - previousMillis11s >= interval11s) {
-    previousMillis11s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_4D8);
-  }
-  if (currentMillis - previousMillis12s >= interval12s) {
-    previousMillis12s = currentMillis;
-
     ESP32Can.CANWriteFrame(&SMA_158);
   }
 }

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -180,7 +180,7 @@ void send_can_sma() {
 
   // Send CAN Message every 100ms
   if (currentMillis - previousMillis100ms >= interval100ms) {
-    previousMillis1s = currentMillis;
+    previousMillis100ms = currentMillis;
 
     ESP32Can.CANWriteFrame(&SMA_558);
     ESP32Can.CANWriteFrame(&SMA_598);


### PR DESCRIPTION
### What
This PR improves the SMA CAN H protocol with findings from rvr84 over on the Discord server! 

### Why
To make the "[SMA Sunny Boy Storage](https://github.com/dalathegreat/Battery-Emulator/wiki/SMA-Sunny-Boy-Storage-inverters) 2.5 / 3.7 / 5.0 / 6.0" one step closer to becoming listed as stable.

### How
- Can message sending should be 100ms , otherwise battery does not detect
- Added which messages inverter sends, and the content