### PR TITLE
Bugfix/ota improvement

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -131,6 +131,7 @@ void init_events(void) {
   events.entries[EVENT_SERIAL_RX_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_SERIAL_TX_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_SERIAL_TRANSMITTER_FAILURE].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_OTA_UPDATE_TIMEOUT].level = EVENT_LEVEL_INFO;
 
   events.entries[EVENT_DUMMY_INFO].log = true;
   events.entries[EVENT_DUMMY_DEBUG].log = true;
@@ -213,6 +214,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Error in serial function: Some ERROR level fault in transmitter, received by receiver";
     case EVENT_OTA_UPDATE:
       return "OTA update started!";
+    case EVENT_OTA_UPDATE_TIMEOUT:
+      return "OTA update timed out!";
     default:
       return "";
   }

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -39,6 +39,7 @@
   XX(EVENT_CELL_DEVIATION_HIGH)         \
   XX(EVENT_UNKNOWN_EVENT_SET)           \
   XX(EVENT_OTA_UPDATE)                  \
+  XX(EVENT_OTA_UPDATE_TIMEOUT)          \
   XX(EVENT_DUMMY_INFO)                  \
   XX(EVENT_DUMMY_DEBUG)                 \
   XX(EVENT_DUMMY_WARNING)               \

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -309,6 +309,7 @@ void wifi_monitor() {
     ESP32Can.CANInit();
     clear_event(EVENT_OTA_UPDATE);
     set_event(EVENT_OTA_UPDATE_TIMEOUT, 0);
+    ota_active = false;
   }
 }
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,6 +1,7 @@
 #include "webserver.h"
 #include <Preferences.h>
 #include "../utils/events.h"
+#include "../utils/timer.h"
 
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
@@ -20,6 +21,9 @@ enum WifiState {
 };
 
 WifiState wifi_state = INIT;
+
+MyTimer ota_timeout_timer = MyTimer(5000);
+bool ota_active = false;
 
 unsigned const long WIFI_MONITOR_INTERVAL_TIME = 15000;
 unsigned const long INIT_WIFI_CONNECT_TIMEOUT = 8000;        // Timeout for initial WiFi connect in milliseconds
@@ -298,6 +302,13 @@ void wifi_monitor() {
       Serial.println(" Channel: " + String(WiFi.channel()));
       Serial.println(" Hostname: " + String(WiFi.getHostname()));
     }
+  }
+
+  if (ota_active && ota_timeout_timer.elapsed()) {
+    // OTA timeout, try to restore can and clear the update event
+    ESP32Can.CANInit();
+    clear_event(EVENT_OTA_UPDATE);
+    set_event(EVENT_OTA_UPDATE_TIMEOUT, 0);
   }
 }
 
@@ -635,6 +646,11 @@ void onOTAStart() {
   // Log when OTA has started
   ESP32Can.CANStop();
   set_event(EVENT_OTA_UPDATE, 0);
+
+  // If already set, make a new attempt
+  clear_event(EVENT_OTA_UPDATE_TIMEOUT);
+  ota_active = true;
+  ota_timeout_timer.reset();
 }
 
 void onOTAProgress(size_t current, size_t final) {
@@ -642,6 +658,9 @@ void onOTAProgress(size_t current, size_t final) {
   if (millis() - ota_progress_millis > 1000) {
     ota_progress_millis = millis();
     Serial.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
+
+    // Reset the "watchdog"
+    ota_timeout_timer.reset();
   }
 }
 
@@ -651,7 +670,11 @@ void onOTAEnd(bool success) {
     Serial.println("OTA update finished successfully!");
   } else {
     Serial.println("There was an error during OTA update!");
+
+    // If we fail without a timeout, try to restore CAN
+    ESP32Can.CANInit();
   }
+  ota_active = false;
   clear_event(EVENT_OTA_UPDATE);
 }
 


### PR DESCRIPTION
### WHAT
Minor improvement to OTA update handling

### WHY
If an OTA update is interrupted in certain ways, the onEnd callback will not be called as it should (there are reports of it in the source repo). The emulator gets stuck in update mode, and since updates are announced to the inverter it might sit there happily while not updating the SOC since we disable CAN to make the OTA update more robust.

### HOW
A timeout was added, or more like a watchdog. If the progress callback doesn't kick the watchdog, the OTA update event is cleared and the emulator attempts to restore CAN communication. Depending on the situation, the emulator will either reset or continue without any faults.

### TESTING
Tested on the dining room table, will run live before merge if approved