### PR TITLE
SMA CAN H: Fix charge allowed message

### DIFF
--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -19,10 +19,14 @@ extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 funct
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t cell_max_voltage;  //mV,   0-4350
 extern uint16_t cell_min_voltage;  //mV,   0-4350
+extern uint8_t bms_status;
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
+
+#define READY_STATE 0x03
+#define STOP_STATE 0x02
 
 void update_values_can_sma();
 void send_can_sma();


### PR DESCRIPTION
### What
This PR fixes a bug that caused SMA Sunnyboy Storage inverters to never use the battery

### Why
The bit in the 4D8 message was not set

### How
Setting the bit to 3 allows discharge/charge. Setting it to 2 stops charging. We now set this bit depending on bms_status!