### PR TITLE
Bugfix: Remove char_dis_status variable

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -64,15 +64,14 @@ uint16_t capacity_Wh = BATTERY_WH_MAX;            //Wh,   0-60000
 uint16_t remaining_capacity_Wh = BATTERY_WH_MAX;  //Wh,   0-60000
 uint16_t max_target_discharge_power = 0;          // 0W (0W > restricts to no discharge), Updates later on from CAN
 uint16_t max_target_charge_power = 4312;          // Init to 4.3kW, Updates later on from CAN
-uint16_t temperature_max = 50;          //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
-uint16_t temperature_min = 60;          // Reads from battery later
-uint8_t bms_char_dis_status = STANDBY;  // 0 standby, 1 discharging, 2, charging
-uint8_t bms_status = ACTIVE;            // ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
-uint16_t stat_batt_power = 0;           // Power going in/out of battery
-uint16_t cell_max_voltage = 3700;       // Stores the highest cell voltage value in the system
-uint16_t cell_min_voltage = 3700;       // Stores the minimum cell voltage value in the system
-uint16_t cellvoltages[120];             // Stores all cell voltages
-uint8_t nof_cellvoltages = 0;           // Total number of cell voltages, set by each battery.
+uint16_t temperature_max = 50;     //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
+uint16_t temperature_min = 60;     // Reads from battery later
+uint8_t bms_status = ACTIVE;       // ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
+uint16_t stat_batt_power = 0;      // Power going in/out of battery
+uint16_t cell_max_voltage = 3700;  // Stores the highest cell voltage value in the system
+uint16_t cell_min_voltage = 3700;  // Stores the minimum cell voltage value in the system
+uint16_t cellvoltages[120];        // Stores all cell voltages
+uint8_t nof_cellvoltages = 0;      // Total number of cell voltages, set by each battery.
 bool LFP_Chemistry = false;
 
 // Common charger parameters

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -18,7 +18,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -118,19 +118,6 @@ void update_values_chademo_battery() {  //This function maps all the values fetc
   }
   Serial.print("BMS Status (3=OK): ");
   Serial.println(bms_status);
-  switch (bms_char_dis_status) {
-    case 0:
-      Serial.println("Battery Idle");
-      break;
-    case 1:
-      Serial.println("Battery Discharging");
-      break;
-    case 2:
-      Serial.println("Battery Charging");
-      break;
-    default:
-      break;
-  }
   Serial.print("Max discharge power: ");
   Serial.println(max_target_discharge_power);
   Serial.print("Max charge power: ");

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -19,7 +19,6 @@ extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
 extern uint8_t bms_status;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -18,7 +18,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -20,7 +20,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -392,19 +392,6 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
   } else {
     Serial.print("FAULT, ");
   }
-  switch (bms_char_dis_status) {
-    case 0:
-      Serial.print("Idle");
-      break;
-    case 1:
-      Serial.print("Discharging");
-      break;
-    case 2:
-      Serial.print("Charging");
-      break;
-    default:
-      break;
-  }
   print_with_units(", Power: ", LB_Power, "W ");
   Serial.println("");
   Serial.println("Values from battery");

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -18,7 +18,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -23,7 +23,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.h
@@ -23,7 +23,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -18,7 +18,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -37,14 +37,13 @@ void __getData() {
   max_target_discharge_power = (uint16_t)dataLinkReceive.getReceivedData(6);
   max_target_charge_power = (uint16_t)dataLinkReceive.getReceivedData(7);
   uint16_t _bms_status = (uint16_t)dataLinkReceive.getReceivedData(8);
-  bms_char_dis_status = (uint16_t)dataLinkReceive.getReceivedData(9);
-  stat_batt_power = (uint16_t)dataLinkReceive.getReceivedData(10);
-  temperature_min = (uint16_t)dataLinkReceive.getReceivedData(11);
-  temperature_max = (uint16_t)dataLinkReceive.getReceivedData(12);
-  cell_max_voltage = (uint16_t)dataLinkReceive.getReceivedData(13);
-  cell_min_voltage = (uint16_t)dataLinkReceive.getReceivedData(14);
-  LFP_Chemistry = (bool)dataLinkReceive.getReceivedData(15);
-  batteryAllowsContactorClosing = (uint16_t)dataLinkReceive.getReceivedData(16);
+  stat_batt_power = (uint16_t)dataLinkReceive.getReceivedData(9);
+  temperature_min = (uint16_t)dataLinkReceive.getReceivedData(10);
+  temperature_max = (uint16_t)dataLinkReceive.getReceivedData(11);
+  cell_max_voltage = (uint16_t)dataLinkReceive.getReceivedData(12);
+  cell_min_voltage = (uint16_t)dataLinkReceive.getReceivedData(13);
+  LFP_Chemistry = (bool)dataLinkReceive.getReceivedData(14);
+  batteryAllowsContactorClosing = (uint16_t)dataLinkReceive.getReceivedData(15);
 
   batteryFault = false;
   if (_bms_status == FAULT) {
@@ -194,8 +193,6 @@ void update_values_serial_link() {
   Serial.print(max_target_charge_power);
   Serial.print(" BMS status: ");
   Serial.print(bms_status);
-  Serial.print(" BMS status dis/cha: ");
-  Serial.print(bms_char_dis_status);
   Serial.print(" Power: ");
   Serial.print(stat_batt_power);
   Serial.print(" Temp min: ");

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
@@ -24,7 +24,6 @@ extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
 extern uint8_t bms_status;                   //Enum, 0-5
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -21,7 +21,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -19,7 +19,6 @@ extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
 extern uint8_t bms_status;                   //Enum, 0-5
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -515,12 +515,12 @@ String processor(const String& var) {
     } else {
       content += "<h4>BMS Status: FAULT </h4>";
     }
-    if (bms_char_dis_status == 2) {
-      content += "<h4>Battery charging!</h4>";
-    } else if (bms_char_dis_status == 1) {
-      content += "<h4>Battery discharging!</h4>";
-    } else {  //0 idle
+    if (battery_current == 0) {
       content += "<h4>Battery idle</h4>";
+    } else if (battery_current > 32767) {
+      content += "<h4>Battery discharging!</h4>";
+    } else {  // between 1-32767
+      content += "<h4>Battery charging!</h4>";
     }
     content += "<h4>Automatic contactor closing allowed:</h4>";
     content += "<h4>Battery: ";

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -26,7 +26,6 @@ extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
 extern uint8_t bms_status;                   //Enum, 0-5
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;    //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -13,7 +13,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -56,6 +56,8 @@ void handle_update_data_modbusp201_byd() {
 void handle_update_data_modbusp301_byd() {
   // Store the data into the array
   static uint16_t battery_data[24];
+
+  static uint8_t bms_char_dis_status = STANDBY;
   if (battery_current == 0) {
     bms_char_dis_status = STANDBY;
   } else if (battery_current > 32767) {  //Negative value = Discharging

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -16,7 +16,6 @@ extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
 extern uint8_t bms_status;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -14,7 +14,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -14,7 +14,6 @@ extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
 extern uint8_t bms_status;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
@@ -9,7 +9,7 @@
 *           Will transmit max 16 int variable - receive none
 */
 
-#define BATTERY_SEND_NUM_VARIABLES 17
+#define BATTERY_SEND_NUM_VARIABLES 16
 #define BATTERY_RECV_NUM_VARIABLES 1
 
 #ifdef BATTERY_RECV_NUM_VARIABLES
@@ -138,14 +138,13 @@ void manageSerialLinkTransmitter() {
       dataLinkTransmit.updateData(6, max_target_discharge_power);
       dataLinkTransmit.updateData(7, max_target_charge_power);
       dataLinkTransmit.updateData(8, bms_status);
-      dataLinkTransmit.updateData(9, bms_char_dis_status);
-      dataLinkTransmit.updateData(10, stat_batt_power);
-      dataLinkTransmit.updateData(11, temperature_min);
-      dataLinkTransmit.updateData(12, temperature_max);
-      dataLinkTransmit.updateData(13, cell_max_voltage);
-      dataLinkTransmit.updateData(14, cell_min_voltage);
-      dataLinkTransmit.updateData(15, (int16_t)LFP_Chemistry);
-      dataLinkTransmit.updateData(16, batteryAllowsContactorClosing);
+      dataLinkTransmit.updateData(9, stat_batt_power);
+      dataLinkTransmit.updateData(10, temperature_min);
+      dataLinkTransmit.updateData(11, temperature_max);
+      dataLinkTransmit.updateData(12, cell_max_voltage);
+      dataLinkTransmit.updateData(13, cell_min_voltage);
+      dataLinkTransmit.updateData(14, (int16_t)LFP_Chemistry);
+      dataLinkTransmit.updateData(15, batteryAllowsContactorClosing);
     }
   }
 }
@@ -170,8 +169,6 @@ void printSendingValues() {
   Serial.print(max_target_charge_power);
   Serial.print(" BMS status: ");
   Serial.print(bms_status);
-  Serial.print(" BMS status dis/cha: ");
-  Serial.print(bms_char_dis_status);
   Serial.print(" Power: ");
   Serial.print(stat_batt_power);
   Serial.print(" Temp min: ");

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
@@ -18,7 +18,6 @@ extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
 extern uint8_t bms_status;                   //Enum, 0-5
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -13,7 +13,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -14,7 +14,6 @@ extern uint16_t capacity_Wh;                 //Wh,   0-60000
 extern uint16_t remaining_capacity_Wh;       //Wh,   0-60000
 extern uint16_t max_target_discharge_power;  //W,    0-60000
 extern uint16_t max_target_charge_power;     //W,    0-60000
-extern uint8_t bms_char_dis_status;          //Enum, 0-2
 extern uint16_t stat_batt_power;             //W,    Goes thru convert2unsignedint16 function (5W = 5, -5W = 65530)
 extern uint16_t temperature_min;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)
 extern uint16_t temperature_max;   //C+1,  Goes thru convert2unsignedint16 function (15.0C = 150, -15.0C =  65385)

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -16,7 +16,6 @@ extern uint16_t capacity_Wh;
 extern uint16_t remaining_capacity_Wh;
 extern uint16_t max_target_discharge_power;
 extern uint16_t max_target_charge_power;
-extern uint8_t bms_char_dis_status;
 extern uint16_t stat_batt_power;
 extern uint16_t temperature_min;
 extern uint16_t temperature_max;


### PR DESCRIPTION
### What
The bms_char_dis_status variable was not updated on any other protocol than BYD. This caused webserver to show "Battery Idle" even when battery was in use. This PR fixes this

### Why
To make it clearer to users what battery is doing
(Note bms_char_dis_status was actually removed as global variable to increase performance)

### How
bms_char_dis_status is removed from the code. All places where we see if we charge/discharge is by checking the sign of battery_current value. This increases performance for the codebase, less global variables linked. Also the Dual LilyGo code will transmit 1 less parameter which increases performance on serial.