### PR TITLE
Battery interface streamlining

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -364,7 +364,7 @@ void inform_user_on_battery() {
 #ifdef SERIAL_LINK_RECEIVER
   Serial.println("SERIAL_DATA_LINK_RECEIVER selected");
 #endif
-#if !defined(ABSOLUTE_MAX_VOLTAGE)
+#ifndef BATTERY_SELECTED
 #error No battery selected! Choose one from the USER_SETTINGS.h file
 #endif
 }

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -360,36 +360,7 @@ void inform_user_on_inverter() {
 
 void inform_user_on_battery() {
   // Inform user what battery is used
-#ifdef BMW_I3_BATTERY
-  Serial.println("BMW i3 battery selected");
-#endif
-#ifdef CHADEMO_BATTERY
-  Serial.println("Chademo battery selected");
-#endif
-#ifdef IMIEV_CZERO_ION_BATTERY
-  Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
-#endif
-#ifdef KIA_HYUNDAI_64_BATTERY
-  Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
-#endif
-#ifdef NISSAN_LEAF_BATTERY
-  Serial.println("Nissan LEAF battery selected");
-#endif
-#ifdef RENAULT_KANGOO_BATTERY
-  Serial.println("Renault Kangoo battery selected");
-#endif
-#ifdef SANTA_FE_PHEV_BATTERY
-  Serial.println("Hyundai Santa Fe PHEV battery selected");
-#endif
-#ifdef RENAULT_ZOE_BATTERY
-  Serial.println("Renault Zoe battery selected");
-#endif
-#ifdef TESLA_MODEL_3_BATTERY
-  Serial.println("Tesla Model 3 battery selected");
-#endif
-#ifdef TEST_FAKE_BATTERY
-  Serial.println("Test mode with fake battery selected");
-#endif
+  announce_battery();
 #ifdef SERIAL_LINK_RECEIVER
   Serial.println("SERIAL_DATA_LINK_RECEIVER selected");
 #endif
@@ -406,36 +377,7 @@ void receive_can() {  // This section checks if we have a complete CAN message i
     if (rx_frame.FIR.B.FF == CAN_frame_std) {
       //printf("New standard frame");
       // Battery
-#ifdef BMW_I3_BATTERY
-      receive_can_i3_battery(rx_frame);
-#endif
-#ifdef CHADEMO_BATTERY
-      receive_can_chademo_battery(rx_frame);
-#endif
-#ifdef IMIEV_CZERO_ION_BATTERY
-      receive_can_imiev_battery(rx_frame);
-#endif
-#ifdef KIA_HYUNDAI_64_BATTERY
-      receive_can_kiaHyundai_64_battery(rx_frame);
-#endif
-#ifdef NISSAN_LEAF_BATTERY
-      receive_can_leaf_battery(rx_frame);
-#endif
-#ifdef RENAULT_KANGOO_BATTERY
-      receive_can_kangoo_battery(rx_frame);
-#endif
-#ifdef SANTA_FE_PHEV_BATTERY
-      receive_can_santafe_phev_battery(rx_frame);
-#endif
-#ifdef RENAULT_ZOE_BATTERY
-      receive_can_zoe_battery(rx_frame);
-#endif
-#ifdef TESLA_MODEL_3_BATTERY
-      receive_can_tesla_model_3_battery(rx_frame);
-#endif
-#ifdef TEST_FAKE_BATTERY
-      receive_can_test_battery(rx_frame);
-#endif
+      receive_can_battery(rx_frame);
       // Inverter
 #ifdef BYD_CAN
       receive_can_byd(rx_frame);
@@ -484,36 +426,7 @@ void send_can() {
   send_can_sofar();
 #endif
   // Battery
-#ifdef BMW_I3_BATTERY
-  send_can_i3_battery();
-#endif
-#ifdef CHADEMO_BATTERY
-  send_can_chademo_battery();
-#endif
-#ifdef IMIEV_CZERO_ION_BATTERY
-  send_can_imiev_battery();
-#endif
-#ifdef KIA_HYUNDAI_64_BATTERY
-  send_can_kiaHyundai_64_battery();
-#endif
-#ifdef NISSAN_LEAF_BATTERY
-  send_can_leaf_battery();
-#endif
-#ifdef RENAULT_KANGOO_BATTERY
-  send_can_kangoo_battery();
-#endif
-#ifdef SANTA_FE_PHEV_BATTERY
-  send_can_santafe_phev_battery();
-#endif
-#ifdef RENAULT_ZOE_BATTERY
-  send_can_zoe_battery();
-#endif
-#ifdef TESLA_MODEL_3_BATTERY
-  send_can_tesla_model_3_battery();
-#endif
-#ifdef TEST_FAKE_BATTERY
-  send_can_test_battery();
-#endif
+  send_can_battery();
 #ifdef CHEVYVOLT_CHARGER
   send_can_chevyvolt_charger();
 #endif
@@ -693,36 +606,7 @@ void handle_contactors() {
 
 void update_values() {
   // Battery
-#ifdef BMW_I3_BATTERY
-  update_values_i3_battery();  // Map the values to the correct registers
-#endif
-#ifdef CHADEMO_BATTERY
-  update_values_chademo_battery();  // Map the values to the correct registers
-#endif
-#ifdef IMIEV_CZERO_ION_BATTERY
-  update_values_imiev_battery();  // Map the values to the correct registers
-#endif
-#ifdef KIA_HYUNDAI_64_BATTERY
-  update_values_kiaHyundai_64_battery();  // Map the values to the correct registers
-#endif
-#ifdef NISSAN_LEAF_BATTERY
-  update_values_leaf_battery();  // Map the values to the correct registers
-#endif
-#ifdef RENAULT_KANGOO_BATTERY
-  update_values_kangoo_battery();  // Map the values to the correct registers
-#endif
-#ifdef SANTA_FE_PHEV_BATTERY
-  update_values_santafe_phev_battery();  // Map the values to the correct registers
-#endif
-#ifdef RENAULT_ZOE_BATTERY
-  update_values_zoe_battery();  // Map the values to the correct registers
-#endif
-#ifdef TESLA_MODEL_3_BATTERY
-  update_values_tesla_model_3_battery();  // Map the values to the correct registers
-#endif
-#ifdef TEST_FAKE_BATTERY
-  update_values_test_battery();  // Map the fake values to the correct registers
-#endif
+  update_values_battery();  // Map the fake values to the correct registers
   // Inverter
 #ifdef BYD_CAN
   update_values_can_byd();

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -27,16 +27,16 @@ volatile float CHARGER_END_A = 1.0;       // Current at which charging is consid
 #ifdef WEBSERVER
 volatile uint8_t AccessPointEnabled =
     true;  //Set to either true or false incase you want the board to enable a direct wifi access point
-const char* ssid = "comhem_F0A1A5";       // Maximum of 63 characters;
-const char* password = "3027CCA803";      // Minimum of 8 characters;
-const char* ssidAP = "Battery Emulator";  // Maximum of 63 characters;
+const char* ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
+const char* password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
+const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
 const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
 const uint8_t wifi_channel = 0;        // set to 0 for automatic channel selection
 
 // MQTT
 #ifdef MQTT
-const char* mqtt_user = "test";
-const char* mqtt_password = "test";
+const char* mqtt_user = "REDACTED";
+const char* mqtt_password = "REDACTED";
 #endif  // USE_MQTT
 
 #endif

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -27,16 +27,16 @@ volatile float CHARGER_END_A = 1.0;       // Current at which charging is consid
 #ifdef WEBSERVER
 volatile uint8_t AccessPointEnabled =
     true;  //Set to either true or false incase you want the board to enable a direct wifi access point
-const char* ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
-const char* password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
-const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
+const char* ssid = "comhem_F0A1A5";       // Maximum of 63 characters;
+const char* password = "3027CCA803";      // Minimum of 8 characters;
+const char* ssidAP = "Battery Emulator";  // Maximum of 63 characters;
 const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
 const uint8_t wifi_channel = 0;        // set to 0 for automatic channel selection
 
 // MQTT
 #ifdef MQTT
-const char* mqtt_user = "REDACTED";
-const char* mqtt_password = "REDACTED";
+const char* mqtt_user = "test";
+const char* mqtt_password = "test";
 #endif  // USE_MQTT
 
 #endif

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,11 +17,11 @@
 //#define RENAULT_ZOE_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-//#define TEST_FAKE_BATTERY
+#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-//#define BYD_MODBUS        //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
 //#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,11 +17,11 @@
 //#define RENAULT_ZOE_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
 //#define TESLA_MODEL_3_BATTERY
-#define TEST_FAKE_BATTERY
+//#define TEST_FAKE_BATTERY
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
 //#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -48,4 +48,11 @@
 #include "SERIAL-LINK-RECEIVER-FROM-BATTERY.h"  //See this file for more Serial-battery settings
 #endif
 
+#ifndef SERIAL_LINK_RECEIVER  // The serial thing does its thing
+void update_values_battery();
+void receive_can_battery(CAN_frame_t rx_frame);
+void send_can_battery();
+void announce_battery(void);
+#endif
+
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef BMW_I3_BATTERY
-#include "BMW-I3-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "BMW-I3-BATTERY.h"
 
 //TODO: before using
 // Map the final values in update_values_battery, set some to static values if not available (current, discharge max , charge max)

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1,10 +1,11 @@
+#ifdef BMW_I3_BATTERY
 #include "BMW-I3-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 //TODO: before using
-// Map the final values in update_values_i3_battery, set some to static values if not available (current, discharge max , charge max)
+// Map the final values in update_values_battery, set some to static values if not available (current, discharge max , charge max)
 // Check if I3 battery stays alive with only 10B and 512. If not, add 12F. If that doesn't help, add more from CAN log (ask Dala)
 
 /* Do not change code below unless you are sure what you are doing */
@@ -54,7 +55,7 @@ static uint16_t Battery_Status = 0;
 static uint16_t DC_link = 0;
 static int16_t Battery_Power = 0;
 
-void update_values_i3_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   //Calculate the SOC% value to send to inverter
   Calculated_SOC = (Display_SOC * 10);  //Increase decimal amount
   Calculated_SOC =
@@ -122,7 +123,7 @@ void update_values_i3_battery() {  //This function maps all the values fetched v
 #endif
 }
 
-void receive_can_i3_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   CANstillAlive = 12;
   switch (rx_frame.MsgID) {
     case 0x431:  //Battery capacity [200ms]
@@ -168,7 +169,7 @@ void receive_can_i3_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_i3_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 600ms CAN Message
   if (currentMillis - previousMillis600 >= interval600) {
@@ -190,3 +191,9 @@ void send_can_i3_battery() {
     ESP32Can.CANWriteFrame(&BMW_10B);
   }
 }
+
+void announce_battery(void) {
+  Serial.println("BMW i3 battery selected");
+}
+
+#endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -25,9 +27,5 @@ extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-void update_values_i3_battery();
-void receive_can_i3_battery(CAN_frame_t rx_frame);
-void send_can_i3_battery();
 
 #endif

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef CHADEMO_BATTERY
 #include "CHADEMO-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -89,7 +90,7 @@ uint8_t DynamicControlStatus = 0;
 uint8_t HighCurrentControlStatus = 0;
 uint8_t HighVoltageControlStatus = 0;
 
-void update_values_chademo_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
 
   SOC = ChargingRate;
 
@@ -146,7 +147,7 @@ void update_values_chademo_battery() {  //This function maps all the values fetc
 #endif
 }
 
-void receive_can_chademo_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   CANstillAlive == 12;  //We are getting CAN messages from the vehicle, inform the watchdog
 
   switch (rx_frame.MsgID) {
@@ -202,7 +203,7 @@ void receive_can_chademo_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_chademo_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= interval100) {
@@ -218,3 +219,9 @@ void send_can_chademo_battery() {
     }
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Chademo battery selected");
+}
+
+#endif

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef CHADEMO_BATTERY
-#include "CHADEMO-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "CHADEMO-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -26,9 +28,5 @@ extern uint16_t temperature_max;
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-void update_values_chademo_battery();
-void receive_can_chademo_battery(CAN_frame_t rx_frame);
-void send_can_chademo_battery();
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef IMIEV_CZERO_ION_BATTERY
-#include "IMIEV-CZERO-ION-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "IMIEV-CZERO-ION-BATTERY.h"
 
 //Code still work in progress, TODO:
 //Figure out if CAN messages need to be sent to keep the system happy?

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef IMIEV_CZERO_ION_BATTERY
 #include "IMIEV-CZERO-ION-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -40,7 +41,7 @@ static double min_volt_cel = 3.70;
 static double max_temp_cel = 20.00;
 static double min_temp_cel = 19.00;
 
-void update_values_imiev_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   SOC = (uint16_t)(BMU_SOC * 100);  //increase BMU_SOC range from 0-100 -> 100.00
 
   battery_voltage = (uint16_t)(BMU_PackVoltage * 10);  // Multiply by 10 and cast to uint16_t
@@ -161,7 +162,7 @@ void update_values_imiev_battery() {  //This function maps all the values fetche
 #endif
 }
 
-void receive_can_imiev_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   CANstillAlive =
       12;  //TODO: move this inside a known message ID to prevent CAN inverter from keeping battery alive detection going
   switch (rx_frame.MsgID) {
@@ -217,10 +218,16 @@ void receive_can_imiev_battery(CAN_frame_t rx_frame) {
   }
 }
 
-void send_can_imiev_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= interval100) {
     previousMillis100 = currentMillis;
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
+}
+
+#endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -27,9 +29,5 @@ extern uint16_t cell_max_voltage;
 extern uint16_t cell_min_voltage;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-void update_values_imiev_battery();
-void receive_can_imiev_battery(CAN_frame_t rx_frame);
-void send_can_imiev_battery();
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef KIA_HYUNDAI_64_BATTERY
-#include "KIA-HYUNDAI-64-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "KIA-HYUNDAI-64-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was send

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef KIA_HYUNDAI_64_BATTERY
 #include "KIA-HYUNDAI-64-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -146,7 +147,7 @@ CAN_frame_t KIA64_7E4_ack = {
     .MsgID = 0x7E4,
     .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
 
-void update_values_kiaHyundai_64_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   //Calculate the SOC% value to send to inverter
   soc_calculated = SOC_Display;
@@ -293,7 +294,7 @@ void update_values_kiaHyundai_64_battery() {  //This function maps all the value
 #endif
 }
 
-void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
     case 0x4DE:
       break;
@@ -523,7 +524,7 @@ void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame) {
   }
 }
 
-void send_can_kiaHyundai_64_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   //Send 100ms message
   if (currentMillis - previousMillis100 >= interval100) {
@@ -596,3 +597,9 @@ uint16_t convertToUnsignedInt16(int16_t signed_value) {
     return (uint16_t)signed_value;
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
+}
+
+#endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -31,9 +33,6 @@ extern uint8_t nof_cellvoltages;    // Total number of cell voltages, set by eac
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 
-void update_values_kiaHyundai_64_battery();
-void receive_can_kiaHyundai_64_battery(CAN_frame_t rx_frame);
-void send_can_kiaHyundai_64_battery();
 uint16_t convertToUnsignedInt16(int16_t signed_value);
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef NISSAN_LEAF_BATTERY
 #include "NISSAN-LEAF-BATTERY.h"
 #ifdef MQTT
 #include "../devboard/mqtt/mqtt.h"
@@ -165,7 +166,7 @@ void print_with_units(char* header, int value, char* units) {
   Serial.print(units);
 }
 
-void update_values_leaf_battery() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
+void update_values_battery() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
   /* Start with mapping all values */
 
   StateOfHealth = (LB_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
@@ -425,7 +426,7 @@ void update_values_leaf_battery() { /* This function maps all the values fetched
 #endif
 }
 
-void receive_can_leaf_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
@@ -689,7 +690,7 @@ void receive_can_leaf_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_leaf_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= interval100) {
@@ -923,3 +924,9 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
 void init_battery(void) {
   nof_cellvoltages = 96;
 }
+
+void announce_battery(void) {
+  Serial.println("Nissan LEAF battery selected");
+}
+
+#endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1,3 +1,4 @@
+#include "BATTERIES.h"
 #ifdef NISSAN_LEAF_BATTERY
 #include "NISSAN-LEAF-BATTERY.h"
 #ifdef MQTT

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -28,9 +30,6 @@ extern uint16_t cellvoltages[120];  //mV    0-4350 per cell
 extern uint8_t nof_cellvoltages;    // Total number of cell voltages, set by each battery.
 extern bool batteryAllowsContactorClosing;  //Bool, 1=true, 0=false
 
-void update_values_leaf_battery();
-void receive_can_leaf_battery(CAN_frame_t rx_frame);
-void send_can_leaf_battery();
 uint16_t convert2unsignedint16(int16_t signed_value);
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame_t rx_frame);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef RENAULT_KANGOO_BATTERY
 #include "RENAULT-KANGOO-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -57,7 +58,7 @@ static const int interval10 = 10;      // interval (ms) at which send CAN Messag
 static const int interval100 = 100;    // interval (ms) at which send CAN Messages
 static const int interval1000 = 1000;  // interval (ms) at which send CAN Messages
 
-void update_values_kangoo_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   StateOfHealth = (LB_SOH * 100);  //Increase range from 99% -> 99.00%
 
   //Calculate the SOC% value to send to Fronius
@@ -175,7 +176,7 @@ void update_values_kangoo_battery() {  //This function maps all the values fetch
 #endif
 }
 
-void receive_can_kangoo_battery(CAN_frame_t rx_frame)  //GKOE reworked
+void receive_can_battery(CAN_frame_t rx_frame)  //GKOE reworked
 {
 
   switch (rx_frame.MsgID) {
@@ -237,7 +238,7 @@ void receive_can_kangoo_battery(CAN_frame_t rx_frame)  //GKOE reworked
   }
 }
 
-void send_can_kangoo_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message (for 2.4s, then pause 10s)
   if ((currentMillis - previousMillis100) >= (interval100 + GVL_pause)) {
@@ -267,3 +268,9 @@ uint16_t convert2uint16(int16_t signed_value) {
     return (uint16_t)signed_value;
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Renault Kangoo battery selected");
+}
+
+#endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef RENAULT_KANGOO_BATTERY
-#include "RENAULT-KANGOO-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "RENAULT-KANGOO-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 #define LB_MAX_SOC 1000  //BMS never goes over this value. We use this info to rescale SOC% sent to Fronius

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -33,9 +35,6 @@ extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 
-void update_values_kangoo_battery();
-void receive_can_kangoo_battery(CAN_frame_t rx_frame);
-void send_can_kangoo_battery();
 uint16_t convert2uint16(int16_t signed_value);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef RENAULT_ZOE_BATTERY
 #include "RENAULT-ZOE-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -42,7 +43,7 @@ static const int interval10 = 10;      // interval (ms) at which send CAN Messag
 static const int interval100 = 100;    // interval (ms) at which send CAN Messages
 static const int interval1000 = 1000;  // interval (ms) at which send CAN Messages
 
-void update_values_zoe_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   StateOfHealth = (LB_SOH * 100);  //Increase range from 99% -> 99.00%
 
   //Calculate the SOC% value to send to Fronius
@@ -136,7 +137,7 @@ void update_values_zoe_battery() {  //This function maps all the values fetched 
 #endif
 }
 
-void receive_can_zoe_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
 
   switch (rx_frame.MsgID) {
     case 0x42E:  //HV SOC & Battery Temp & Charging Power
@@ -150,7 +151,7 @@ void receive_can_zoe_battery(CAN_frame_t rx_frame) {
   }
 }
 
-void send_can_zoe_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= interval100) {
@@ -163,3 +164,9 @@ void send_can_zoe_battery() {
     //ESP32Can.CANWriteFrame(&ZOE_423);
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Renault Zoe battery selected");
+}
+
+#endif

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef RENAULT_ZOE_BATTERY
-#include "RENAULT-ZOE-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "RENAULT-ZOE-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 #define LB_MAX_SOC 1000  //BMS never goes over this value. We use this info to rescale SOC% sent to Fronius

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -32,9 +34,5 @@ extern uint16_t cell_min_voltage;  //mV,   0-4350
 extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-void update_values_zoe_battery();
-void receive_can_zoe_battery(CAN_frame_t rx_frame);
-void send_can_zoe_battery();
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef SANTA_FE_PHEV_BATTERY
-#include "SANTA-FE-PHEV-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "SANTA-FE-PHEV-BATTERY.h"
 
 /* Credits go to maciek16c for these findings!
 https://github.com/maciek16c/hyundai-santa-fe-phev-battery

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef SANTA_FE_PHEV_BATTERY
 #include "SANTA-FE-PHEV-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -57,7 +58,7 @@ CAN_frame_t SANTAFE_523 = {.FIR = {.B =
                            .MsgID = 0x523,
                            .data = {0x60, 0x00, 0x60, 0, 0, 0, 0, 0}};
 
-void update_values_santafe_phev_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   SOC;
 
@@ -92,7 +93,7 @@ void update_values_santafe_phev_battery() {  //This function maps all the values
 #endif
 }
 
-void receive_can_santafe_phev_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   CANstillAlive = 12;
   switch (rx_frame.MsgID) {
     case 0x200:
@@ -127,7 +128,7 @@ void receive_can_santafe_phev_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_santafe_phev_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   //Send 10ms message
   if (currentMillis - previousMillis10 >= interval10) {
@@ -174,3 +175,9 @@ uint8_t CalculateCRC8(CAN_frame_t rx_frame) {
   }
   return (uint8_t)crc;
 }
+
+void announce_battery(void) {
+  Serial.println("Hyundai Santa Fe PHEV battery selected");
+}
+
+#endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4030  // 403.0V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -26,9 +28,6 @@ extern uint16_t CANerror;
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 
-void update_values_santafe_phev_battery();
-void receive_can_santafe_phev_battery(CAN_frame_t rx_frame);
-void send_can_santafe_phev_battery();
 uint8_t CalculateCRC8(CAN_frame_t rx_frame);
 
 #endif

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef TESLA_MODEL_3_BATTERY
 #include "TESLA-MODEL-3-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
@@ -163,7 +164,7 @@ static const char* hvilStatusState[] = {"NOT OK",
 
 #define REASONABLE_ENERGYAMOUNT 20  //When the BMS stops making sense on some values, they are always <20
 
-void update_values_tesla_model_3_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   //After values are mapped, we perform some safety checks, and do some serial printouts
   //Calculate the SOH% to send to inverter
   if (bat_beginning_of_life != 0) {  //div/0 safeguard
@@ -368,7 +369,7 @@ void update_values_tesla_model_3_battery() {  //This function maps all the value
 #endif
 }
 
-void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   static int mux = 0;
   static int temp = 0;
 
@@ -558,7 +559,7 @@ void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_tesla_model_3_battery() {
+void send_can_battery() {
   /*From bielec: My fist 221 message, to close the contactors is 0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96 and then, 
 to cause "hv_up_for_drive" I send an additional 221 message 0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA  so 
 two 221 messages are being continuously transmitted.   When I want to shut down, I stop the second message and only send 
@@ -683,3 +684,9 @@ void printDebugIfActive(uint8_t symbol, const char* message) {
     Serial.println(message);
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Tesla Model 3 battery selected");
+}
+
+#endif

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -1,8 +1,9 @@
+#include "BATTERIES.h"
 #ifdef TESLA_MODEL_3_BATTERY
-#include "TESLA-MODEL-3-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "TESLA-MODEL-3-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 /* Credits: Most of the code comes from Per Carlen's bms_comms_tesla_model3.py (https://gitlab.com/pelle8/batt2gen24/) */

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4030  // 403.0V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 2450    // 245.0V if battery voltage goes under this, discharging further is disabled
@@ -33,9 +35,6 @@ extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
 extern bool LFP_Chemistry;
 
-void update_values_tesla_model_3_battery();
-void receive_can_tesla_model_3_battery(CAN_frame_t rx_frame);
-void send_can_tesla_model_3_battery();
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -1,7 +1,8 @@
+#include "BATTERIES.h"
 #ifdef TEST_FAKE_BATTERY
-#include "TEST-FAKE-BATTERY.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "TEST-FAKE-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -1,3 +1,4 @@
+#ifdef TEST_FAKE_BATTERY
 #include "TEST-FAKE-BATTERY.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
@@ -16,8 +17,8 @@ void print_units(char* header, int value, char* units) {
   Serial.print(units);
 }
 
-void update_values_test_battery() { /* This function puts fake values onto the parameters sent towards the inverter */
-  SOC = 5000;                       // 50.00%
+void update_values_battery() { /* This function puts fake values onto the parameters sent towards the inverter */
+  SOC = 5000;                  // 50.00%
 
   StateOfHealth = 9900;  // 99.00%
 
@@ -63,7 +64,7 @@ void update_values_test_battery() { /* This function puts fake values onto the p
 #endif
 }
 
-void receive_can_test_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   switch (rx_frame.MsgID) {
     case 0xABC:
       break;
@@ -71,7 +72,7 @@ void receive_can_test_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void send_can_test_battery() {
+void send_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= interval100) {
@@ -79,3 +80,9 @@ void send_can_test_battery() {
     // Put fake messages here incase you want to test sending CAN
   }
 }
+
+void announce_battery(void) {
+  Serial.println("Test mode with fake battery selected");
+}
+
+#endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -5,6 +5,8 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
+#define BATTERY_SELECTED
+
 #define ABSOLUTE_MAX_VOLTAGE \
   4040  // 404.4V,if battery voltage goes over this, charging is not possible (goes into forced discharge)
 #define ABSOLUTE_MIN_VOLTAGE 3100  // 310.0V if battery voltage goes under this, discharging further is disabled
@@ -28,9 +30,5 @@ extern uint16_t cell_min_voltage;   //mV,   0-4350
 extern uint16_t cellvoltages[120];  //mV 0-5000 per cell
 extern bool batteryAllowsContactorClosing;   //Bool, 1=true, 0=false
 extern bool inverterAllowsContactorClosing;  //Bool, 1=true, 0=false
-
-void update_values_test_battery();
-void receive_can_test_battery(CAN_frame_t rx_frame);
-void send_can_test_battery();
 
 #endif


### PR DESCRIPTION
### WHAT
Common interfaces of batteries

### WHY
To enable cleanup of Software.ino with tons of #ifdefs, and for the sake of having clearly defined interfaces

### HOW
All battery files implement/define 4 functions of which 3 were previously common for all batteries with different names. The function declarations are done in BATTERIES.h. This enforces the interface definition of new batteries (somewhat). The functions currently required by the common interface are
``` 
void update_values_battery();
void receive_can_battery(CAN_frame_t rx_frame);
void send_can_battery();
void announce_battery(void);
```
The same can later be done for inverters