### PR TITLE
Feature: Add top balancing for Tesla batteries

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -202,8 +202,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //The allowed charge power behaves strangely. We instead estimate this value
   if (system_scaled_SOC_pptt == 10000) {  // When scaled SOC is 100.00%, set allowed charge power to 0
     system_max_charge_power_W = 0;
-  }
-  if (soc_vi > 990) {
+  } else if (soc_vi > 990) {
     system_max_charge_power_W = FLOAT_MAX_POWER_W;
   } else if (soc_vi > RAMPDOWN_SOC) {  // When real SOC is between RAMPDOWN_SOC-99%, ramp the value between Max<->0
     system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWN_SOC) / (1000.0 - RAMPDOWN_SOC));

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -156,9 +156,9 @@ static const char* hvilStatusState[] = {"NOT OK",
 #define MIN_CELL_VOLTAGE_NCA_NCM 2950   //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_NCA_NCM 500  //LED turns yellow on the board if mv delta exceeds this value
 
-#define MAX_CELL_VOLTAGE_LFP 3520   //Battery is put into emergency stop if one cell goes over this value
+#define MAX_CELL_VOLTAGE_LFP 3550   //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800   //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_LFP 150  //LED turns yellow on the board if mv delta exceeds this value
+#define MAX_CELL_DEVIATION_LFP 200  //LED turns yellow on the board if mv delta exceeds this value
 
 #define REASONABLE_ENERGYAMOUNT 20  //When the BMS stops making sense on some values, they are always <20
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -202,8 +202,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //The allowed charge power behaves strangely. We instead estimate this value
   if (system_scaled_SOC_pptt == 10000) {  // When scaled SOC is 100.00%, set allowed charge power to 0
     system_max_charge_power_W = 0;
-  } else if (soc_vi > RAMPDOWNSOC) {  // When real SOC is between RAMPDOWNSOC-99.99%, ramp the value between Max<->0
-    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWNSOC) / 50.0);
+  }
+  if (soc_vi > 990) {
+    system_max_charge_power_W = FLOATPOWERMAX;
+  } else if (soc_vi > RAMPDOWNSOC) {  // When real SOC is between RAMPDOWNSOC-99%, ramp the value between Max<->0
+    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWNSOC) / (1000.0 - RAMPDOWNSOC));
     //If the cellvoltages start to reach overvoltage, only allow a small amount of power in
     if (system_LFP_Chemistry) {
       if (cell_max_v > (MAX_CELL_VOLTAGE_LFP - MILLIVOLTFLOAT)) {

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -204,17 +204,17 @@ void update_values_battery() {  //This function maps all the values fetched via 
     system_max_charge_power_W = 0;
   }
   if (soc_vi > 990) {
-    system_max_charge_power_W = FLOATPOWERMAX;
-  } else if (soc_vi > RAMPDOWNSOC) {  // When real SOC is between RAMPDOWNSOC-99%, ramp the value between Max<->0
-    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWNSOC) / (1000.0 - RAMPDOWNSOC));
+    system_max_charge_power_W = FLOAT_MAX_POWER_W;
+  } else if (soc_vi > RAMPDOWN_SOC) {  // When real SOC is between RAMPDOWN_SOC-99%, ramp the value between Max<->0
+    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWN_SOC) / (1000.0 - RAMPDOWN_SOC));
     //If the cellvoltages start to reach overvoltage, only allow a small amount of power in
     if (system_LFP_Chemistry) {
-      if (cell_max_v > (MAX_CELL_VOLTAGE_LFP - MILLIVOLTFLOAT)) {
-        system_max_charge_power_W = FLOATPOWERMAX;
+      if (cell_max_v > (MAX_CELL_VOLTAGE_LFP - FLOAT_START_MV)) {
+        system_max_charge_power_W = FLOAT_MAX_POWER_W;
       }
     } else {  //NCM/A
-      if (cell_max_v > (MAX_CELL_VOLTAGE_NCA_NCM - MILLIVOLTFLOAT)) {
-        system_max_charge_power_W = FLOATPOWERMAX;
+      if (cell_max_v > (MAX_CELL_VOLTAGE_NCA_NCM - FLOAT_START_MV)) {
+        system_max_charge_power_W = FLOAT_MAX_POWER_W;
       }
     }
   } else {  // No limits, max charging power allowed

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -200,10 +200,20 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
   //The allowed charge power behaves strangely. We instead estimate this value
-  if (system_scaled_SOC_pptt == 10000) {  // When scaled SOC is 100%, set allowed charge power to 0
+  if (system_scaled_SOC_pptt == 10000) {  // When scaled SOC is 100.00%, set allowed charge power to 0
     system_max_charge_power_W = 0;
-  } else if (soc_vi > 950) {  // When real SOC is between 95-99.99%, ramp the value between Max<->0
-    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - 950) / 50.0);
+  } else if (soc_vi > RAMPDOWNSOC) {  // When real SOC is between RAMPDOWNSOC-99.99%, ramp the value between Max<->0
+    system_max_charge_power_W = MAXCHARGEPOWERALLOWED * (1 - (soc_vi - RAMPDOWNSOC) / 50.0);
+    //If the cellvoltages start to reach overvoltage, only allow a small amount of power in
+    if (system_LFP_Chemistry) {
+      if (cell_max_v > (MAX_CELL_VOLTAGE_LFP - MILLIVOLTFLOAT)) {
+        system_max_charge_power_W = FLOATPOWERMAX;
+      }
+    } else {  //NCM/A
+      if (cell_max_v > (MAX_CELL_VOLTAGE_NCA_NCM - MILLIVOLTFLOAT)) {
+        system_max_charge_power_W = FLOATPOWERMAX;
+      }
+    }
   } else {  // No limits, max charging power allowed
     system_max_charge_power_W = MAXCHARGEPOWERALLOWED;
   }

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -7,9 +7,9 @@
 
 #define BATTERY_SELECTED
 
-#define RAMPDOWNSOC 900              // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
-#define FLOATPOWERMAX 200            // W, what power to allow for top balancing battery
-#define MILLIVOLTFLOAT 20            // mV, how many mV under overvoltage to start float charging
+#define RAMPDOWN_SOC 900             // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
+#define FLOAT_MAX_POWER_W 200        // W, what power to allow for top balancing battery
+#define FLOAT_START_MV 20            // mV, how many mV under overvoltage to start float charging
 #define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
 #define MAXDISCHARGEPOWERALLOWED \
   60000  // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -7,6 +7,9 @@
 
 #define BATTERY_SELECTED
 
+#define RAMPDOWNSOC 900              // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
+#define FLOATPOWERMAX 200            // W, what power to allow for top balancing battery
+#define MILLIVOLTFLOAT 20            // mV, how many mV under overvoltage to start float charging
 #define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
 #define MAXDISCHARGEPOWERALLOWED \
   60000  // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise


### PR DESCRIPTION
### What
This PR adds top balancing feature for teslas, that reduce allowed charge power incase a cell starts to get too high

### Why
Charging with high power when nearing 100% causes some cells to go into overvoltage protection mode, and prevent the battery from balancing. 

### How
Three new parameters are added
- RAMPDOWNSOC 900 // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
- FLOATPOWERMAX 200 // W, what power to allow for top balancing battery
- MILLIVOLTFLOAT 20  // mV, how many mV under cell max voltage to start float charging

With these three parameters, the charge curve should look something more like this:
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/319beeaa-7945-4cd3-b879-5ac8eab77e51)
