### PR TITLE
Fix u32 Wh values getting corrupted

### DIFF
--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -32,8 +32,8 @@ void __getData() {
   system_SOH_pptt = (uint16_t)dataLinkReceive.getReceivedData(1);
   system_battery_voltage_dV = (uint16_t)dataLinkReceive.getReceivedData(2);
   system_battery_current_dA = (int16_t)dataLinkReceive.getReceivedData(3);
-  system_capacity_Wh = (uint32_t)dataLinkReceive.getReceivedData(4);
-  system_remaining_capacity_Wh = (uint32_t)dataLinkReceive.getReceivedData(5);
+  system_capacity_Wh = (uint32_t)(dataLinkReceive.getReceivedData(4) * 10);            //add back missing decimal
+  system_remaining_capacity_Wh = (uint32_t)(dataLinkReceive.getReceivedData(5) * 10);  //add back missing decimal
   system_max_discharge_power_W = (uint16_t)dataLinkReceive.getReceivedData(6);
   system_max_charge_power_W = (uint16_t)dataLinkReceive.getReceivedData(7);
   uint16_t _system_bms_status = (uint16_t)dataLinkReceive.getReceivedData(8);

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
@@ -133,8 +133,8 @@ void manageSerialLinkTransmitter() {
       dataLinkTransmit.updateData(1, system_SOH_pptt);
       dataLinkTransmit.updateData(2, system_battery_voltage_dV);
       dataLinkTransmit.updateData(3, system_battery_current_dA);
-      dataLinkTransmit.updateData(4, system_capacity_Wh);
-      dataLinkTransmit.updateData(5, system_remaining_capacity_Wh);
+      dataLinkTransmit.updateData(4, system_capacity_Wh / 10);            //u32, remove .0 to fit 16bit
+      dataLinkTransmit.updateData(5, system_remaining_capacity_Wh / 10);  //u32, remove .0 to fit 16bit
       dataLinkTransmit.updateData(6, system_max_discharge_power_W);
       dataLinkTransmit.updateData(7, system_max_charge_power_W);
       dataLinkTransmit.updateData(8, system_bms_status);


### PR DESCRIPTION
### What
This PR fixes large battery pack size values getting corrupted when sent to a Dual LilyGo setup

### Why
Self explanatory:
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/c5bd7a6a-5ef0-48a9-ae23-9ae9dbfd7211)

### How
Example
75123wh gets rounded down to 7512 wh at sender to fit 16bits, and rescaled to 75120 at reciever. At most 9Wh inaccuracy, we can live with that :)