### PR TITLE
Feature: Increase cellvoltagearray for 800V

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -71,10 +71,10 @@ uint16_t system_max_discharge_power_W = 0;               //Watts, 0 to 65535
 uint16_t system_max_charge_power_W = 4312;               //Watts, 0 to 65535
 uint16_t system_cell_max_voltage_mV = 3700;              //mV, 0-5000 , Stores the highest cell millivolt value
 uint16_t system_cell_min_voltage_mV = 3700;              //mV, 0-5000, Stores the minimum cell millivolt value
-uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV. Oversized to accomodate all setups
-uint8_t system_bms_status = ACTIVE;    //ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
-uint8_t system_number_of_cells = 0;    //Total number of cell voltages, set by each battery
-bool system_LFP_Chemistry = false;     //Set to true or false depending on cell chemistry
+uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages. Oversized to accomodate all setups
+uint8_t system_bms_status = ACTIVE;  //ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
+uint8_t system_number_of_cells = 0;  //Total number of cell voltages, set by each battery
+bool system_LFP_Chemistry = false;   //Set to true or false depending on cell chemistry
 
 // Common charger parameters
 volatile float charger_setpoint_HV_VDC = 0.0f;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -71,7 +71,7 @@ uint16_t system_max_discharge_power_W = 0;               //Watts, 0 to 65535
 uint16_t system_max_charge_power_W = 4312;               //Watts, 0 to 65535
 uint16_t system_cell_max_voltage_mV = 3700;              //mV, 0-5000 , Stores the highest cell millivolt value
 uint16_t system_cell_min_voltage_mV = 3700;              //mV, 0-5000, Stores the minimum cell millivolt value
-uint16_t system_cellvoltages_mV[120];  //Array with all cell voltages in mV. Oversized to accomodate all setups
+uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV. Oversized to accomodate all setups
 uint8_t system_bms_status = ACTIVE;    //ACTIVE - [0..5]<>[STANDBY,INACTIVE,DARKSTART,ACTIVE,FAULT,UPDATING]
 uint8_t system_number_of_cells = 0;    //Total number of cell voltages, set by each battery
 bool system_LFP_Chemistry = false;     //Set to true or false depending on cell chemistry

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -8,26 +8,26 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
 
 void setup_battery(void);
 

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -8,26 +8,26 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
 
 void setup_battery(void);
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -8,27 +8,27 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, 1=true, 0=false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, 1=true, 0=false
 
 void setup_battery(void);
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -11,27 +11,27 @@
 #define MAXDISCHARGEPOWERALLOWED 10000
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, 1=true, 0=false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, 1=true, 0=false
 
 void setup_battery(void);
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -27,7 +27,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -8,26 +8,26 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
 
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame_t rx_frame);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -30,7 +30,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -14,27 +14,27 @@
 #define MAX_CELL_DEVIATION_MV 500  //LED turns yellow on the board if mv delta exceeds this value
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void setup_battery(void);
 

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.h
@@ -30,7 +30,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.h
@@ -14,27 +14,27 @@
 #define MAX_CELL_DEVIATION_MV 500  //LED turns yellow on the board if mv delta exceeds this value
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, 1=true, 0=false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, 1=true, 0=false
 
 void setup_battery(void);
 

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -8,26 +8,26 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
 
 uint8_t CalculateCRC8(CAN_frame_t rx_frame);
 void setup_battery(void);

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -12,28 +12,28 @@
   60000  // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, 1=true, 0=false
-extern bool inverterAllowsContactorClosing;    //Bool, 1=true, 0=false
-extern bool system_LFP_Chemistry;              //Bool, 1=true, 0=false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, 1=true, 0=false
+extern bool inverterAllowsContactorClosing;                //Bool, 1=true, 0=false
+extern bool system_LFP_Chemistry;                          //Bool, 1=true, 0=false
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -28,7 +28,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, 1=true, 0=false

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -8,27 +8,27 @@
 #define BATTERY_SELECTED
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void setup_battery(void);
 

--- a/Software/src/devboard/config.h
+++ b/Software/src/devboard/config.h
@@ -49,4 +49,7 @@
 #define DISCHARGING 1
 #define CHARGING 2
 
+// Common definitions
+#define MAX_AMOUNT_CELLS 192
+
 #endif

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -36,6 +36,7 @@
 
 #include <Arduino.h>
 #include "../../../USER_SETTINGS.h"
+#include "../config.h"  // Needed for defines
 
 #define MQTT_MSG_BUFFER_SIZE (1024)
 

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -41,18 +41,18 @@
 
 extern const char* version_number;  // The current software version, used for mqtt
 
-extern int16_t system_temperature_min_dC;     //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;     //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;         //W, -32000 to 32000
-extern int16_t system_battery_current_dA;     //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;    //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;       //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;         //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;              //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_cell_max_voltage_mV;   //mV, 0-5000 , Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;   //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;        //Total number of cell voltages, set by each battery
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000 , Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
 
 extern const char* mqtt_user;
 extern const char* mqtt_password;

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -51,7 +51,7 @@ extern uint16_t system_real_SOC_pptt;         //SOC%, 0-100.00 (0-10000)
 extern uint16_t system_SOH_pptt;              //SOH%, 0-100.00 (0-10000)
 extern uint16_t system_cell_max_voltage_mV;   //mV, 0-5000 , Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;   //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];  //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;        //Total number of cell voltages, set by each battery
 
 extern const char* mqtt_user;

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -26,7 +26,7 @@ String cellmonitor_processor(const String& var) {
 
     // Visualize the populated cells in forward order using flexbox with conditional text color
     content += "<div class='container'>";
-    for (int i = 0; i < 192; ++i) {
+    for (int i = 0; i < MAX_AMOUNT_CELLS; ++i) {
       // Skip empty values
       if (system_cellvoltages_mV[i] == 0) {
         continue;

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -26,7 +26,7 @@ String cellmonitor_processor(const String& var) {
 
     // Visualize the populated cells in forward order using flexbox with conditional text color
     content += "<div class='container'>";
-    for (int i = 0; i < 120; ++i) {
+    for (int i = 0; i < 192; ++i) {
       // Skip empty values
       if (system_cellvoltages_mV[i] == 0) {
         continue;

--- a/Software/src/devboard/webserver/cellmonitor_html.h
+++ b/Software/src/devboard/webserver/cellmonitor_html.h
@@ -6,7 +6,7 @@
 
 extern uint16_t system_cell_max_voltage_mV;   //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;   //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];  //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV
 
 /**
  * @brief Replaces placeholder with content section in web page

--- a/Software/src/devboard/webserver/cellmonitor_html.h
+++ b/Software/src/devboard/webserver/cellmonitor_html.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <stdint.h>
+#include "../config.h"  // Needed for defines
 
 extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value

--- a/Software/src/devboard/webserver/cellmonitor_html.h
+++ b/Software/src/devboard/webserver/cellmonitor_html.h
@@ -4,9 +4,9 @@
 #include <Arduino.h>
 #include <stdint.h>
 
-extern uint16_t system_cell_max_voltage_mV;   //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;   //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];  //Array with all cell voltages in mV
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
 
 /**
  * @brief Replaces placeholder with content section in web page

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -16,29 +16,29 @@
 #include "../mqtt/mqtt.h"
 #endif
 
-extern const char* version_number;             // The current software version, shown on webserver
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000 , Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern uint8_t LEDcolor;                       //Enum, 0-10
-extern bool batteryAllowsContactorClosing;     //Bool, 1=true, 0=false
-extern bool inverterAllowsContactorClosing;    //Bool, 1=true, 0=false
+extern const char* version_number;                         // The current software version, shown on webserver
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000 , Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern uint8_t LEDcolor;                                   //Enum, 0-10
+extern bool batteryAllowsContactorClosing;                 //Bool, 1=true, 0=false
+extern bool inverterAllowsContactorClosing;                //Bool, 1=true, 0=false
 
 extern const char* ssid;
 extern const char* password;

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -33,7 +33,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000 , Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern uint8_t LEDcolor;                       //Enum, 0-10

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -22,7 +22,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -6,27 +6,27 @@
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void update_values_can_byd();
 void send_can_byd();

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -22,7 +22,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/LUNA2000-MODBUS.h
+++ b/Software/src/inverter/LUNA2000-MODBUS.h
@@ -6,27 +6,27 @@
 #define MB_RTU_NUM_VALUES 30000
 
 extern uint16_t mbPV[MB_RTU_NUM_VALUES];
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void update_modbus_registers_luna2000();
 void handle_update_data_modbus32051();

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -5,27 +5,27 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void update_values_can_pylon();
 void receive_can_pylon(CAN_frame_t rx_frame);

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -21,7 +21,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -5,27 +5,27 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 #define READY_STATE 0x03
 #define STOP_STATE 0x02

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -21,7 +21,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -5,27 +5,27 @@
 #include "../devboard/config.h"  // Needed for all defines
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 void update_values_can_sma_tripower();
 void send_can_sma_tripower();

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -21,7 +21,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -22,7 +22,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -6,27 +6,27 @@
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 // These parameters need to be mapped for the inverter
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 extern uint16_t min_voltage;
 extern uint16_t max_voltage;

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -24,7 +24,7 @@ extern uint16_t system_max_discharge_power_W;  //W,    0-65000
 extern uint16_t system_max_charge_power_W;     //W,    0-65000
 extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[120];   //Array with all cell voltages in mV
+extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
 extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
 extern uint8_t system_bms_status;              //Enum 0-5
 extern bool batteryAllowsContactorClosing;     //Bool, true/false

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -8,27 +8,27 @@
 
 extern ACAN2515 can;
 
-extern uint32_t system_capacity_Wh;            //Wh,  0-150000Wh
-extern uint32_t system_remaining_capacity_Wh;  //Wh,  0-150000Wh
-extern int16_t system_temperature_min_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_temperature_max_dC;      //C+1, -50.0 - 50.0
-extern int16_t system_active_power_W;          //W, -32000 to 32000
-extern int16_t system_battery_current_dA;      //A+1, -1000 - 1000
-extern uint16_t system_battery_voltage_dV;     //V+1,  0-500.0 (0-5000)
-extern uint16_t system_max_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_min_design_voltage_dV;  //V+1,  0-500.0 (0-5000)
-extern uint16_t system_scaled_SOC_pptt;        //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_real_SOC_pptt;          //SOC%, 0-100.00 (0-10000)
-extern uint16_t system_SOH_pptt;               //SOH%, 0-100.00 (0-10000)
-extern uint16_t system_max_discharge_power_W;  //W,    0-65000
-extern uint16_t system_max_charge_power_W;     //W,    0-65000
-extern uint16_t system_cell_max_voltage_mV;    //mV, 0-5000, Stores the highest cell millivolt value
-extern uint16_t system_cell_min_voltage_mV;    //mV, 0-5000, Stores the minimum cell millivolt value
-extern uint16_t system_cellvoltages_mV[192];   //Array with all cell voltages in mV
-extern uint8_t system_number_of_cells;         //Total number of cell voltages, set by each battery
-extern uint8_t system_bms_status;              //Enum 0-5
-extern bool batteryAllowsContactorClosing;     //Bool, true/false
-extern bool inverterAllowsContactorClosing;    //Bool, true/false
+extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
+extern uint32_t system_remaining_capacity_Wh;              //Wh,  0-150000Wh
+extern int16_t system_temperature_min_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_temperature_max_dC;                  //C+1, -50.0 - 50.0
+extern int16_t system_active_power_W;                      //W, -32000 to 32000
+extern int16_t system_battery_current_dA;                  //A+1, -1000 - 1000
+extern uint16_t system_battery_voltage_dV;                 //V+1,  0-500.0 (0-5000)
+extern uint16_t system_max_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_min_design_voltage_dV;              //V+1,  0-500.0 (0-5000)
+extern uint16_t system_scaled_SOC_pptt;                    //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_real_SOC_pptt;                      //SOC%, 0-100.00 (0-10000)
+extern uint16_t system_SOH_pptt;                           //SOH%, 0-100.00 (0-10000)
+extern uint16_t system_max_discharge_power_W;              //W,    0-65000
+extern uint16_t system_max_charge_power_W;                 //W,    0-65000
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+extern uint8_t system_number_of_cells;                     //Total number of cell voltages, set by each battery
+extern uint8_t system_bms_status;                          //Enum 0-5
+extern bool batteryAllowsContactorClosing;                 //Bool, true/false
+extern bool inverterAllowsContactorClosing;                //Bool, true/false
 
 // Timeout in milliseconds
 #define SolaxTimeout 2000


### PR DESCRIPTION
### What
This PR increases the cellvoltage array to accomodate 800V batteries

### Why
Kia EV6 800V support

### How
Array size increased