### PR TITLE
Improve visibility on scale_soc setting

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -22,8 +22,8 @@
 #include "src/devboard/webserver/webserver.h"
 #endif
 
-Preferences settings;                   // Store user settings
-const char* version_number = "5.4.dev";  // The current software version, shown on webserver
+Preferences settings;                    // Store user settings
+const char* version_number = "5.4.dev";  //The current software version, shown on webserver
 // Interval settings
 int intervalUpdateValues = 4800;  // Interval at which to update inverter values / Modbus registers
 const int interval10 = 10;        // Interval for 10ms tasks

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -15,11 +15,14 @@ String settings_processor(const String& var) {
     // Show current settings with edit buttons and input fields
     content += "<h4 style='color: white;'>Battery capacity: <span id='BATTERY_WH_MAX'>" + String(BATTERY_WH_MAX) +
                " Wh </span> <button onclick='editWh()'>Edit</button></h4>";
-    content += "<h4 style='color: white;'>Rescale SOC: <span id='USE_SCALED_SOC'>" + String(USE_SCALED_SOC) +
+    content += "<h4 style='color: white;'>Rescale SOC: <span id='USE_SCALED_SOC'>" +
+               String(USE_SCALED_SOC ? "<span>&#10003;</span>" : "<span style='color: red;'>&#10005;</span>") +
                "</span> <button onclick='editUseScaledSOC()'>Edit</button></h4>";
-    content += "<h4 style='color: white;'>SOC max percentage: " + String(MAXPERCENTAGE / 10.0, 1) +
+    content += "<h4 style='color: " + String(USE_SCALED_SOC ? "white" : "darkgrey") +
+               ";'>SOC max percentage: " + String(MAXPERCENTAGE / 10.0, 1) +
                " </span> <button onclick='editSocMax()'>Edit</button></h4>";
-    content += "<h4 style='color: white;'>SOC min percentage: " + String(MINPERCENTAGE / 10.0, 1) +
+    content += "<h4 style='color: " + String(USE_SCALED_SOC ? "white" : "darkgrey") +
+               ";'>SOC min percentage: " + String(MINPERCENTAGE / 10.0, 1) +
                " </span> <button onclick='editSocMin()'>Edit</button></h4>";
     content += "<h4 style='color: white;'>Max charge speed: " + String(MAXCHARGEAMP / 10.0, 1) +
                " A </span> <button onclick='editMaxChargeA()'>Edit</button></h4>";


### PR DESCRIPTION
### What
This PR tweaks the settings page

### Why
To improve readability of settings

### How
✕ and ✓ is now used to signal if the setting is on (instead of 0 and 1)
If the setting is off, the min/max limits are greyed out
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/8db28dbc-3e33-41f7-a469-d04194ee8db0)
