### PR TITLE
BYD CAN: Swap dis/cha limits in CAN mapping

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -156,11 +156,11 @@ void update_values_can_byd() {  //This function maps all the values fetched from
   BYD_150.data.u8[2] = (system_SOH_pptt >> 8);
   BYD_150.data.u8[3] = (system_SOH_pptt & 0x00FF);
   //Maximum charge power allowed (Unit: A+1)
-  BYD_150.data.u8[4] = (charge_current >> 8);
-  BYD_150.data.u8[5] = (charge_current & 0x00FF);
+  BYD_150.data.u8[4] = (discharge_current >> 8);
+  BYD_150.data.u8[5] = (discharge_current & 0x00FF);
   //Maximum discharge power allowed (Unit: A+1)
-  BYD_150.data.u8[6] = (discharge_current >> 8);
-  BYD_150.data.u8[7] = (discharge_current & 0x00FF);
+  BYD_150.data.u8[6] = (charge_current >> 8);
+  BYD_150.data.u8[7] = (charge_current & 0x00FF);
 
   //Voltage (ex 370.0)
   BYD_1D0.data.u8[0] = (system_battery_voltage_dV >> 8);

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -155,10 +155,10 @@ void update_values_can_byd() {  //This function maps all the values fetched from
   //StateOfHealth (100.00%)
   BYD_150.data.u8[2] = (system_SOH_pptt >> 8);
   BYD_150.data.u8[3] = (system_SOH_pptt & 0x00FF);
-  //Maximum charge power allowed (Unit: A+1)
+  //Maximum discharge power allowed (Unit: A+1)
   BYD_150.data.u8[4] = (discharge_current >> 8);
   BYD_150.data.u8[5] = (discharge_current & 0x00FF);
-  //Maximum discharge power allowed (Unit: A+1)
+  //Maximum charge power allowed (Unit: A+1)
   BYD_150.data.u8[6] = (charge_current >> 8);
   BYD_150.data.u8[7] = (charge_current & 0x00FF);
 


### PR DESCRIPTION
### What
This PR re-maps the charge/discharge allowed values in the CAN message 0x150

### Why
According to pelle_c's repository, this is how the CAN messages should be mapped

### How
For this change testers are wanted. Could someone that is using BYD-CAN test this and report back if it works as intended? 