### PR TITLE
Tesla: Rewrite LFP handling

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -249,27 +249,19 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   cell_deviation_mV = (cell_max_v - cell_min_v);
 
-  //Determine which chemistry battery pack is using (crude method, TODO: replace with real CAN identifier later)
-  if (soc_vi > 900) {  //When SOC% is over 90.0%, we can use max cell voltage to estimate what chemistry is used
-    if (cell_max_v < 3450) {
-      system_LFP_Chemistry = true;
-    }
-    if (cell_max_v > 3700) {
-      system_LFP_Chemistry = false;
-    }
-  }
-  // An even better way is to check how many cells are in the pack. NCM/A batteries have 96s, LFP has 102-106s
+  // NCM/A batteries have 96s, LFP has 102-106s
+  // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
   if (system_number_of_cells > 101) {
     system_LFP_Chemistry = true;
   }
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (system_LFP_Chemistry) {
-    system_max_design_voltage_dV = 3880;
-    system_min_design_voltage_dV = 2968;
+    system_max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
+    system_min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
   } else {  // NCM/A chemistry
-    system_max_design_voltage_dV = 4030;
-    system_min_design_voltage_dV = 3100;
+    system_max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
+    system_min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
   }
 
   //Check if SOC% is plausible
@@ -702,8 +694,14 @@ void printDebugIfActive(uint8_t symbol, const char* message) {
 void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Tesla Model 3 battery selected");
 
-  system_max_design_voltage_dV = 4030;  // 403.0V, over this, charging is not possible (goes into forced discharge)
-  system_min_design_voltage_dV = 3100;  // 310.0V under this, discharging further is disabled
+#ifdef LFP_CHEMISTRY
+  system_LFP_Chemistry = true;
+  system_max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
+  system_min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
+#else
+  system_max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
+  system_min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
+#endif
 }
 
 #endif

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -7,12 +7,18 @@
 
 #define BATTERY_SELECTED
 
+//#define LFP_CHEMISTRY // Enable this line to startup in LFP mode
+
 #define RAMPDOWN_SOC 900             // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define FLOAT_MAX_POWER_W 200        // W, what power to allow for top balancing battery
 #define FLOAT_START_MV 20            // mV, how many mV under overvoltage to start float charging
 #define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
 #define MAXDISCHARGEPOWERALLOWED \
-  60000  // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise
+  60000                             // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise
+#define MAX_PACK_VOLTAGE_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
+#define MAX_PACK_VOLTAGE_LFP 3880   // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_LFP 2968   // V+1, if pack voltage goes below this, discharge stops
 
 // These parameters need to be mapped for the inverter
 extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh


### PR DESCRIPTION
### What
This PR rewrites LFP handling of Tesla battery packs

### Why
@Newevg noticed a serious flaw in the detection of LFP / NCM-A chemistry, that led to an overvoltage scenario. Incase the emulator is restarted at close to 99% SOC, it can incorrectly assume that NCM chemistry is used for up to 3-5minutes before it figures out that it is actually LFP, but before this happens the cells have already been overvolted. 

### How
This PR does the following
- Introduce a setting in the header file, `LFP_CHEMISTRY`. If this is defined, the battery will start up in LFP mode. (Note that if LFP is used without defining it, it will still jump into LFP mode after a few minutes).
- Remove the voltage based chemistry check. This has proved to be unreliable (downright dangerous!)
- All design voltages are now proper defines in header.