### PR TITLE
Kia/Hyundai: Increase cell counter to accomodate 98S

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -202,7 +202,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
   //Map all cell voltages to the global array
-  for (int i = 0; i < 97; ++i) {
+  for (int i = 0; i < 98; ++i) {
     if (cellvoltages_mv[i] > 1000) {
       system_cellvoltages_mV[i] = cellvoltages_mv[i];
     }


### PR DESCRIPTION
### What
This PR adds back the last cell in the webserver for a 98S pack

### Why
The 90S patch previously commited broke support for 98S

### How
Increase i++ counter from 97 to 98!