### PR TITLE
Add mDNS for local device discovery.

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -19,8 +19,8 @@
 #include "src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #ifdef WEBSERVER
-#include "src/devboard/webserver/webserver.h"
 #include <ESPmDNS.h>
+#include "src/devboard/webserver/webserver.h"
 #endif
 
 Preferences settings;  // Store user settings
@@ -149,7 +149,7 @@ void setup() {
   inform_user_on_inverter();
 
   init_battery();
-  
+
   init_mDNS();
 
   // BOOT button at runtime is used as an input for various things
@@ -213,11 +213,11 @@ void loop() {
 
 // Initialise mDNS
 void init_mDNS() {
-  
+
   // Calulate the host name using the last two chars from the MAC address so each one is likely unique on a network.
   // e.g batteryemulator8C.local where the mac address is 08:F9:E0:D1:06:8C
   String mac = WiFi.macAddress();
-  String mdnsHost = "batteryemulator"+ mac.substring( mac.length() - 2 );
+  String mdnsHost = "batteryemulator" + mac.substring(mac.length() - 2);
 
   // Initialize mDNS .local resolution
   if (!MDNS.begin(mdnsHost)) {

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -20,6 +20,7 @@
 
 #ifdef WEBSERVER
 #include "src/devboard/webserver/webserver.h"
+#include <ESPmDNS.h>
 #endif
 
 Preferences settings;  // Store user settings
@@ -148,6 +149,8 @@ void setup() {
   inform_user_on_inverter();
 
   init_battery();
+  
+  init_mDNS();
 
   // BOOT button at runtime is used as an input for various things
   pinMode(0, INPUT_PULLUP);
@@ -205,6 +208,23 @@ void loop() {
     test_all_colors = false;
   } else {
     test_all_colors = true;
+  }
+}
+
+// Initialise mDNS
+void init_mDNS() {
+  
+  // Calulate the host name using the last two chars from the MAC address so each one is likely unique on a network.
+  // e.g batteryemulator8C.local where the mac address is 08:F9:E0:D1:06:8C
+  String mac = WiFi.macAddress();
+  String mdnsHost = "batteryemulator"+ mac.substring( mac.length() - 2 );
+
+  // Initialize mDNS .local resolution
+  if (!MDNS.begin(mdnsHost)) {
+    Serial.println("Error setting up MDNS responder!");
+  } else {
+    // Advertise via bonjour the service so we can auto discover these battery emulators on the local network.
+    MDNS.addService("battery_emulator", "tcp", 80);
   }
 }
 


### PR DESCRIPTION
## Description
This merge request introduces an enhancement to the Battery Emulator code by implementing mDNS (Multicast DNS) for easier device discovery on the local network therefore enhancing the overall connectivity and discoverability of the battery emulator devices.

## Changes
### 1. **mDNS resolution**

- Added `init_mDNS` function to initialize mDNS resolution using the last two characters of the device's MAC address, ensuring uniqueness on the network. This results in a more user-friendly hostname (e.g., "batteryemulator8C.local"). 

### 2. **Bonjour**
   - Add code that advertises the device as a "battery_emulator" service via Bonjour on port 80, facilitating seamless auto-discovery of these battery emulators within the local network. 

## Testing
- This project does not contain any unit tests and as such are out of the scope of this pull request.
- Manual testing has been performed using Bonjour discovery tools as well as directly accessing the .local address from a web browser.

## Dependencies
- ESPmDNS.h

## Outstanding Tasks 

- [ ] Move the hostname calculation to a global space and set the SSID when is AP mode to the it (i.e SSID = batteryemulator8C)

![image](https://github.com/dalathegreat/Battery-Emulator/assets/10802614/494e43b6-4b7e-471a-9bb0-5bc6ccb4282a)
