### PR TITLE
Create the initial support for adding API endpoints returning JSON

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -11,7 +11,6 @@
 #include "src/devboard/utils/events.h"
 #include "src/inverter/INVERTERS.h"
 #include "src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h"
-#include "src/lib/bblanchon-ArduinoJson/ArduinoJson.h"
 #include "src/lib/eModbus-eModbus/Logging.h"
 #include "src/lib/eModbus-eModbus/ModbusServerRTU.h"
 #include "src/lib/eModbus-eModbus/scripts/mbServerFCs.h"

--- a/Software/src/devboard/webserver/cellmonitor_API.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_API.cpp
@@ -1,0 +1,16 @@
+#include "cellmonitor_API.h"
+#include <Arduino.h>
+
+AsyncJsonResponse* cellmonitorAPI_GET() {
+	
+    AsyncJsonResponse * response = new AsyncJsonResponse();
+    JsonObject root = response->getRoot();
+	
+    for (uint8_t i = 0u; i < MAX_AMOUNT_CELLS; i++) {
+      if (system_cellvoltages_mV[i] == 0) {
+        continue;
+      }
+      root[String(i+1)] = system_cellvoltages_mV[i];
+    }
+	return response;
+}

--- a/Software/src/devboard/webserver/cellmonitor_API.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_API.cpp
@@ -2,15 +2,15 @@
 #include <Arduino.h>
 
 AsyncJsonResponse* cellmonitorAPI_GET() {
-	
-    AsyncJsonResponse * response = new AsyncJsonResponse();
-    JsonObject root = response->getRoot();
-	
-    for (uint8_t i = 0u; i < MAX_AMOUNT_CELLS; i++) {
-      if (system_cellvoltages_mV[i] == 0) {
-        continue;
-      }
-      root[String(i+1)] = system_cellvoltages_mV[i];
+
+  AsyncJsonResponse* response = new AsyncJsonResponse();
+  JsonObject root = response->getRoot();
+
+  for (uint8_t i = 0u; i < MAX_AMOUNT_CELLS; i++) {
+    if (system_cellvoltages_mV[i] == 0) {
+      continue;
     }
-	return response;
+    root[String(i + 1)] = system_cellvoltages_mV[i];
+  }
+  return response;
 }

--- a/Software/src/devboard/webserver/cellmonitor_API.h
+++ b/Software/src/devboard/webserver/cellmonitor_API.h
@@ -1,0 +1,22 @@
+#ifndef CELLMONITOR_A
+#define CELLMONITOR_A
+
+#include <Arduino.h>
+#include <stdint.h>
+#include "../config.h"  // Needed for defines
+#include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
+
+extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
+extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value
+extern uint16_t system_cellvoltages_mV[MAX_AMOUNT_CELLS];  //Array with all cell voltages in mV
+
+/**
+ * @brief Converts an array of cell voltages into a JSON array to be returned as part of an api endpoint response
+ *
+ * @param[in] var
+ *
+ * @return AsyncJsonResponse pointer
+ */
+AsyncJsonResponse* cellmonitorAPI_GET();
+
+#endif

--- a/Software/src/devboard/webserver/cellmonitor_API.h
+++ b/Software/src/devboard/webserver/cellmonitor_API.h
@@ -3,8 +3,8 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include "../config.h"  // Needed for defines
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
+#include "../config.h"  // Needed for defines
 
 extern uint16_t system_cell_max_voltage_mV;                //mV, 0-5000, Stores the highest cell millivolt value
 extern uint16_t system_cell_min_voltage_mV;                //mV, 0-5000, Stores the minimum cell millivolt value

--- a/Software/src/devboard/webserver/events_API.cpp
+++ b/Software/src/devboard/webserver/events_API.cpp
@@ -4,28 +4,27 @@
 
 AsyncJsonResponse* eventsAPI_GET() {
 
-    AsyncJsonResponse * response = new AsyncJsonResponse();
-    JsonObject root = response->getRoot();
+  AsyncJsonResponse* response = new AsyncJsonResponse();
+  JsonObject root = response->getRoot();
 
-    const EVENTS_STRUCT_TYPE* event_pointer;
-    for (int i = 0; i < EVENT_NOF_EVENTS; i++) {
-      event_pointer = get_event_pointer((EVENTS_ENUM_TYPE)i);
-      EVENTS_ENUM_TYPE event_handle = static_cast<EVENTS_ENUM_TYPE>(i);
+  const EVENTS_STRUCT_TYPE* event_pointer;
+  for (int i = 0; i < EVENT_NOF_EVENTS; i++) {
+    event_pointer = get_event_pointer((EVENTS_ENUM_TYPE)i);
+    EVENTS_ENUM_TYPE event_handle = static_cast<EVENTS_ENUM_TYPE>(i);
 
-      Serial.println("Event: " + String(get_event_enum_string(event_handle)) +
-                     " count: " + String(event_pointer->occurences) + " seconds: " + String(event_pointer->timestamp) +
-                     " data: " + String(event_pointer->data) +
-                     " level: " + String(get_event_level_string(event_handle)));
+    Serial.println("Event: " + String(get_event_enum_string(event_handle)) +
+                   " count: " + String(event_pointer->occurences) + " seconds: " + String(event_pointer->timestamp) +
+                   " data: " + String(event_pointer->data) + " level: " + String(get_event_level_string(event_handle)));
 
-      if (event_pointer->occurences > 0) {
-		  JsonObject nested = root.createNestedObject(String(get_event_enum_string(event_handle)));
-		  nested["Level"] = String(get_event_level_string(event_handle));
-		  nested["Last event seconds ago"] = String(event_pointer->timestamp);
-		  nested["Occurances"] = String(event_pointer->occurences);
-		  nested["Data"] = String(event_pointer->data);
-		  nested["Message"] = String(get_event_message_string(event_handle));
-		  nested["Timestamp"] =  String(millis() / 1000);
-      }
+    if (event_pointer->occurences > 0) {
+      JsonObject nested = root.createNestedObject(String(get_event_enum_string(event_handle)));
+      nested["Level"] = String(get_event_level_string(event_handle));
+      nested["Last event seconds ago"] = String(event_pointer->timestamp);
+      nested["Occurances"] = String(event_pointer->occurences);
+      nested["Data"] = String(event_pointer->data);
+      nested["Message"] = String(get_event_message_string(event_handle));
+      nested["Timestamp"] = String(millis() / 1000);
     }
-    return response;
+  }
+  return response;
 }

--- a/Software/src/devboard/webserver/events_API.cpp
+++ b/Software/src/devboard/webserver/events_API.cpp
@@ -1,0 +1,31 @@
+#include "events_API.h"
+#include <Arduino.h>
+#include "../utils/events.h"
+
+AsyncJsonResponse* eventsAPI_GET() {
+
+    AsyncJsonResponse * response = new AsyncJsonResponse();
+    JsonObject root = response->getRoot();
+
+    const EVENTS_STRUCT_TYPE* event_pointer;
+    for (int i = 0; i < EVENT_NOF_EVENTS; i++) {
+      event_pointer = get_event_pointer((EVENTS_ENUM_TYPE)i);
+      EVENTS_ENUM_TYPE event_handle = static_cast<EVENTS_ENUM_TYPE>(i);
+
+      Serial.println("Event: " + String(get_event_enum_string(event_handle)) +
+                     " count: " + String(event_pointer->occurences) + " seconds: " + String(event_pointer->timestamp) +
+                     " data: " + String(event_pointer->data) +
+                     " level: " + String(get_event_level_string(event_handle)));
+
+      if (event_pointer->occurences > 0) {
+		  JsonObject nested = root.createNestedObject(String(get_event_enum_string(event_handle)));
+		  nested["Level"] = String(get_event_level_string(event_handle));
+		  nested["Last event seconds ago"] = String(event_pointer->timestamp);
+		  nested["Occurances"] = String(event_pointer->occurences);
+		  nested["Data"] = String(event_pointer->data);
+		  nested["Message"] = String(get_event_message_string(event_handle));
+		  nested["Timestamp"] =  String(millis() / 1000);
+      }
+    }
+    return response;
+}

--- a/Software/src/devboard/webserver/events_API.h
+++ b/Software/src/devboard/webserver/events_API.h
@@ -1,0 +1,17 @@
+#ifndef EVENTS_A
+#define EVENTS_A
+
+#include <Arduino.h>
+#include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
+
+/**
+ * @brief Maps Event data to their JSON equivalent  to be returned as part of an api endpoint response
+ *
+ * @param[in] void
+ *
+ * @return AsyncJsonResponse pointer
+ */
+AsyncJ
+AsyncJsonResponse* eventsAPI_GET();
+
+#endif

--- a/Software/src/devboard/webserver/events_API.h
+++ b/Software/src/devboard/webserver/events_API.h
@@ -11,7 +11,6 @@
  *
  * @return AsyncJsonResponse pointer
  */
-AsyncJ
 AsyncJsonResponse* eventsAPI_GET();
 
 #endif

--- a/Software/src/devboard/webserver/summary_API.cpp
+++ b/Software/src/devboard/webserver/summary_API.cpp
@@ -2,94 +2,94 @@
 #include <Arduino.h>
 
 AsyncJsonResponse* summaryAPI_GET() {
-	
-    wl_status_t status = WiFi.status();
-    
-    AsyncJsonResponse * response = new AsyncJsonResponse();
-    JsonObject root = response->getRoot();
-    
-    root["Software Version"] = String(version_number);
-    root["Led Colour"] = getLEDColour();
-    
-    // WiFi Details
-    JsonObject nestedWifi = root.createNestedObject("WiFi");
-    nestedWifi["ssid"] = String(ssid);
-    nestedWifi["status"] = wirelessStatusDescription(status);
-    
-    if (status == WL_CONNECTED) {
-      nestedWifi["ip"] = WiFi.localIP().toString();
-      nestedWifi["signalStrength"] = WiFi.RSSI();
-      nestedWifi["channel"] = WiFi.channel();
-    }
-    
-    // Inverter / Battery / Charger details
-    String inverterProtocol = inverterProtocolDescription();
-    String batteryProtocol = batteryProtocolDescription();
-    String chargerProtocol = chargerProtocolDescription();
-    
-    if (inverterProtocol != "") {
-      root["inverterProtocol"] = inverterProtocol;
-    }
-    if (batteryProtocol != "") {
-      root["batteryProtocol"] = batteryProtocol;
-    }
-    if (chargerProtocol != "") {
-      root["chargerProtocol"] = chargerProtocol;
-    }
-	
-	// Battery Statistics
-	
-    float socRealFloat = static_cast<float>(system_real_SOC_pptt) / 100.0;      // Convert to float and divide by 100
-    float socScaledFloat = static_cast<float>(system_scaled_SOC_pptt) / 100.0;  // Convert to float and divide by 100
-    float sohFloat = static_cast<float>(system_SOH_pptt) / 100.0;               // Convert to float and divide by 100
-    float voltageFloat = static_cast<float>(system_battery_voltage_dV) / 10.0;  // Convert to float and divide by 10
-    float currentFloat = static_cast<float>(system_battery_current_dA) / 10.0;  // Convert to float and divide by 10
-    float powerFloat = static_cast<float>(system_active_power_W);               // Convert to float
-    float tempMaxFloat = static_cast<float>(system_temperature_max_dC) / 10.0;  // Convert to float
-    float tempMinFloat = static_cast<float>(system_temperature_min_dC) / 10.0;  // Convert to float
 
-	JsonObject nestedBatteryStats = root.createNestedObject("Battery Statistics");
-	
-    nestedBatteryStats["Real SOC"] = socRealFloat;
-    nestedBatteryStats["Scaled SOC"] = socScaledFloat;
-    nestedBatteryStats["SOH"] = sohFloat;
-    nestedBatteryStats["Voltage"] = voltageFloat;
-    nestedBatteryStats["Current"] = currentFloat;
-	
-    nestedBatteryStats["Power"] = scalePowerValue(powerFloat, "", 1);
-    nestedBatteryStats["Total capacity"] = scalePowerValue(system_capacity_Wh, "h", 0);
-    nestedBatteryStats["Remaining capacity"] = scalePowerValue(system_remaining_capacity_Wh, "h", 1);
-    nestedBatteryStats["Max charge power"] =  scalePowerValue(system_max_charge_power_W, "", 1);
-    nestedBatteryStats["Max discharge power"] = scalePowerValue(system_max_discharge_power_W, "", 1);
+  wl_status_t status = WiFi.status();
 
-    nestedBatteryStats["Cell max"] = String(system_cell_max_voltage_mV) + " mV";
-    nestedBatteryStats["Cell min"] = String(system_cell_min_voltage_mV) + " mV";
-    nestedBatteryStats["Temperature max"] = String(tempMaxFloat, 1) + " C";
-    nestedBatteryStats["Temperature min"] = String(tempMinFloat, 1) + " C";
-		
-    // BMS Status
-    if (system_bms_status == ACTIVE) {
-      nestedBatteryStats["BMS Status"] = "OK";
-    } else if (system_bms_status == UPDATING) {
-      nestedBatteryStats["BMS Status"] = "UPDATING";
-    } else {
-      nestedBatteryStats["BMS Status"] = "FAULT";
-    }
-	
-	// Battery chargins/discharging/idle state
-    if (system_battery_current_dA == 0) {
-      nestedBatteryStats["Battery State"] = "Idle";
-    } else if (system_battery_current_dA < 0) {
-      nestedBatteryStats["Battery State"] = "Discharging";
-    } else {  // > 0
-      nestedBatteryStats["Battery State"] = "Charging";
-    }
+  AsyncJsonResponse* response = new AsyncJsonResponse();
+  JsonObject root = response->getRoot();
 
-    // Automatic contactor closing allowed
-    JsonObject nestedContactorNode = nestedBatteryStats.createNestedObject("Automatic contactor closing allowed");
-    nestedContactorNode["Battery"] = batteryAllowsContactorClosing;
-    nestedContactorNode["Inverter"] = inverterAllowsContactorClosing;
-	return response;
+  root["Software Version"] = String(version_number);
+  root["Led Colour"] = getLEDColour();
+
+  // WiFi Details
+  JsonObject nestedWifi = root.createNestedObject("WiFi");
+  nestedWifi["ssid"] = String(ssid);
+  nestedWifi["status"] = wirelessStatusDescription(status);
+
+  if (status == WL_CONNECTED) {
+    nestedWifi["ip"] = WiFi.localIP().toString();
+    nestedWifi["signalStrength"] = WiFi.RSSI();
+    nestedWifi["channel"] = WiFi.channel();
+  }
+
+  // Inverter / Battery / Charger details
+  String inverterProtocol = inverterProtocolDescription();
+  String batteryProtocol = batteryProtocolDescription();
+  String chargerProtocol = chargerProtocolDescription();
+
+  if (inverterProtocol != "") {
+    root["inverterProtocol"] = inverterProtocol;
+  }
+  if (batteryProtocol != "") {
+    root["batteryProtocol"] = batteryProtocol;
+  }
+  if (chargerProtocol != "") {
+    root["chargerProtocol"] = chargerProtocol;
+  }
+
+  // Battery Statistics
+
+  float socRealFloat = static_cast<float>(system_real_SOC_pptt) / 100.0;      // Convert to float and divide by 100
+  float socScaledFloat = static_cast<float>(system_scaled_SOC_pptt) / 100.0;  // Convert to float and divide by 100
+  float sohFloat = static_cast<float>(system_SOH_pptt) / 100.0;               // Convert to float and divide by 100
+  float voltageFloat = static_cast<float>(system_battery_voltage_dV) / 10.0;  // Convert to float and divide by 10
+  float currentFloat = static_cast<float>(system_battery_current_dA) / 10.0;  // Convert to float and divide by 10
+  float powerFloat = static_cast<float>(system_active_power_W);               // Convert to float
+  float tempMaxFloat = static_cast<float>(system_temperature_max_dC) / 10.0;  // Convert to float
+  float tempMinFloat = static_cast<float>(system_temperature_min_dC) / 10.0;  // Convert to float
+
+  JsonObject nestedBatteryStats = root.createNestedObject("Battery Statistics");
+
+  nestedBatteryStats["Real SOC"] = socRealFloat;
+  nestedBatteryStats["Scaled SOC"] = socScaledFloat;
+  nestedBatteryStats["SOH"] = sohFloat;
+  nestedBatteryStats["Voltage"] = voltageFloat;
+  nestedBatteryStats["Current"] = currentFloat;
+
+  nestedBatteryStats["Power"] = scalePowerValue(powerFloat, "", 1);
+  nestedBatteryStats["Total capacity"] = scalePowerValue(system_capacity_Wh, "h", 0);
+  nestedBatteryStats["Remaining capacity"] = scalePowerValue(system_remaining_capacity_Wh, "h", 1);
+  nestedBatteryStats["Max charge power"] = scalePowerValue(system_max_charge_power_W, "", 1);
+  nestedBatteryStats["Max discharge power"] = scalePowerValue(system_max_discharge_power_W, "", 1);
+
+  nestedBatteryStats["Cell max"] = String(system_cell_max_voltage_mV) + " mV";
+  nestedBatteryStats["Cell min"] = String(system_cell_min_voltage_mV) + " mV";
+  nestedBatteryStats["Temperature max"] = String(tempMaxFloat, 1) + " C";
+  nestedBatteryStats["Temperature min"] = String(tempMinFloat, 1) + " C";
+
+  // BMS Status
+  if (system_bms_status == ACTIVE) {
+    nestedBatteryStats["BMS Status"] = "OK";
+  } else if (system_bms_status == UPDATING) {
+    nestedBatteryStats["BMS Status"] = "UPDATING";
+  } else {
+    nestedBatteryStats["BMS Status"] = "FAULT";
+  }
+
+  // Battery chargins/discharging/idle state
+  if (system_battery_current_dA == 0) {
+    nestedBatteryStats["Battery State"] = "Idle";
+  } else if (system_battery_current_dA < 0) {
+    nestedBatteryStats["Battery State"] = "Discharging";
+  } else {  // > 0
+    nestedBatteryStats["Battery State"] = "Charging";
+  }
+
+  // Automatic contactor closing allowed
+  JsonObject nestedContactorNode = nestedBatteryStats.createNestedObject("Automatic contactor closing allowed");
+  nestedContactorNode["Battery"] = batteryAllowsContactorClosing;
+  nestedContactorNode["Inverter"] = inverterAllowsContactorClosing;
+  return response;
 }
 
 String inverterProtocolDescription() {
@@ -157,21 +157,21 @@ String batteryProtocolDescription() {
 #ifdef TEST_FAKE_BATTERY
   description += "Fake battery for testing purposes";
 #endif
-  
+
   return description;
 }
 
 String chargerProtocolDescription() {
-  
+
   String description = "";
-  
+
 #ifdef CHEVYVOLT_CHARGER
   description += "Chevy Volt Gen1 Charger";
 #endif
 #ifdef NISSANLEAF_CHARGER
   description += "Nissan LEAF 2013-2024 PDM charger";
 #endif
-  
+
   return description;
 }
 
@@ -190,7 +190,7 @@ String getLEDColour() {
       return "RED";
       break;
     case TEST_ALL_COLORS:
-      return  "RGB Testing loop";
+      return "RGB Testing loop";
       break;
     default:
       break;
@@ -199,14 +199,20 @@ String getLEDColour() {
 
 String wirelessStatusDescription(wl_status_t status) {
   switch (status) {
-    case WL_NO_SHIELD: return "No WiFi Shield";
-    case WL_IDLE_STATUS: return "Idle";
-    case WL_NO_SSID_AVAIL: return "No SSID Available";
-    case WL_SCAN_COMPLETED: return "Scan Completed";
-    case WL_CONNECTED: return "Connected";
-    case WL_CONNECT_FAILED: return "Connection Failed";
-    case WL_CONNECTION_LOST: return "Connection Lost";
-    case WL_DISCONNECTED: return "Disconnected";
+    case WL_NO_SHIELD:
+      return "No WiFi Shield";
+    case WL_IDLE_STATUS:
+      return "Idle";
+    case WL_NO_SSID_AVAIL:
+      return "Scan Completed";
+    case WL_CONNECTED:
+      return "Connected";
+    case WL_CONNECT_FAILED:
+      return "Connection Failed";
+    case WL_CONNECTION_LOST:
+      return "Connection Lost";
+    case WL_DISCONNECTED:
+      return "Disconnected";
   }
 }
 

--- a/Software/src/devboard/webserver/summary_API.cpp
+++ b/Software/src/devboard/webserver/summary_API.cpp
@@ -1,0 +1,229 @@
+#include "summary_API.h"
+#include <Arduino.h>
+
+AsyncJsonResponse* summaryAPI_GET() {
+	
+    wl_status_t status = WiFi.status();
+    
+    AsyncJsonResponse * response = new AsyncJsonResponse();
+    JsonObject root = response->getRoot();
+    
+    root["Software Version"] = String(version_number);
+    root["Led Colour"] = getLEDColour();
+    
+    // WiFi Details
+    JsonObject nestedWifi = root.createNestedObject("WiFi");
+    nestedWifi["ssid"] = String(ssid);
+    nestedWifi["status"] = wirelessStatusDescription(status);
+    
+    if (status == WL_CONNECTED) {
+      nestedWifi["ip"] = WiFi.localIP().toString();
+      nestedWifi["signalStrength"] = WiFi.RSSI();
+      nestedWifi["channel"] = WiFi.channel();
+    }
+    
+    // Inverter / Battery / Charger details
+    String inverterProtocol = inverterProtocolDescription();
+    String batteryProtocol = batteryProtocolDescription();
+    String chargerProtocol = chargerProtocolDescription();
+    
+    if (inverterProtocol != "") {
+      root["inverterProtocol"] = inverterProtocol;
+    }
+    if (batteryProtocol != "") {
+      root["batteryProtocol"] = batteryProtocol;
+    }
+    if (chargerProtocol != "") {
+      root["chargerProtocol"] = chargerProtocol;
+    }
+	
+	// Battery Statistics
+	
+    float socRealFloat = static_cast<float>(system_real_SOC_pptt) / 100.0;      // Convert to float and divide by 100
+    float socScaledFloat = static_cast<float>(system_scaled_SOC_pptt) / 100.0;  // Convert to float and divide by 100
+    float sohFloat = static_cast<float>(system_SOH_pptt) / 100.0;               // Convert to float and divide by 100
+    float voltageFloat = static_cast<float>(system_battery_voltage_dV) / 10.0;  // Convert to float and divide by 10
+    float currentFloat = static_cast<float>(system_battery_current_dA) / 10.0;  // Convert to float and divide by 10
+    float powerFloat = static_cast<float>(system_active_power_W);               // Convert to float
+    float tempMaxFloat = static_cast<float>(system_temperature_max_dC) / 10.0;  // Convert to float
+    float tempMinFloat = static_cast<float>(system_temperature_min_dC) / 10.0;  // Convert to float
+
+	JsonObject nestedBatteryStats = root.createNestedObject("Battery Statistics");
+	
+    nestedBatteryStats["Real SOC"] = socRealFloat;
+    nestedBatteryStats["Scaled SOC"] = socScaledFloat;
+    nestedBatteryStats["SOH"] = sohFloat;
+    nestedBatteryStats["Voltage"] = voltageFloat;
+    nestedBatteryStats["Current"] = currentFloat;
+	
+    nestedBatteryStats["Power"] = scalePowerValue(powerFloat, "", 1);
+    nestedBatteryStats["Total capacity"] = scalePowerValue(system_capacity_Wh, "h", 0);
+    nestedBatteryStats["Remaining capacity"] = scalePowerValue(system_remaining_capacity_Wh, "h", 1);
+    nestedBatteryStats["Max charge power"] =  scalePowerValue(system_max_charge_power_W, "", 1);
+    nestedBatteryStats["Max discharge power"] = scalePowerValue(system_max_discharge_power_W, "", 1);
+
+    nestedBatteryStats["Cell max"] = String(system_cell_max_voltage_mV) + " mV";
+    nestedBatteryStats["Cell min"] = String(system_cell_min_voltage_mV) + " mV";
+    nestedBatteryStats["Temperature max"] = String(tempMaxFloat, 1) + " C";
+    nestedBatteryStats["Temperature min"] = String(tempMinFloat, 1) + " C";
+		
+    // BMS Status
+    if (system_bms_status == ACTIVE) {
+      nestedBatteryStats["BMS Status"] = "OK";
+    } else if (system_bms_status == UPDATING) {
+      nestedBatteryStats["BMS Status"] = "UPDATING";
+    } else {
+      nestedBatteryStats["BMS Status"] = "FAULT";
+    }
+	
+	// Battery chargins/discharging/idle state
+    if (system_battery_current_dA == 0) {
+      nestedBatteryStats["Battery State"] = "Idle";
+    } else if (system_battery_current_dA < 0) {
+      nestedBatteryStats["Battery State"] = "Discharging";
+    } else {  // > 0
+      nestedBatteryStats["Battery State"] = "Charging";
+    }
+
+    // Automatic contactor closing allowed
+    JsonObject nestedContactorNode = nestedBatteryStats.createNestedObject("Automatic contactor closing allowed");
+    nestedContactorNode["Battery"] = batteryAllowsContactorClosing;
+    nestedContactorNode["Inverter"] = inverterAllowsContactorClosing;
+	return response;
+}
+
+String inverterProtocolDescription() {
+
+  String description = "";
+
+#ifdef BYD_CAN
+  description += "BYD Battery-Box Premium HVS over CAN Bus";
+#endif
+#ifdef BYD_MODBUS
+  description += "BYD 11kWh HVM battery over Modbus RTU";
+#endif
+#ifdef LUNA2000_MODBUS
+  description += "Luna2000 battery over Modbus RTU";
+#endif
+#ifdef PYLON_CAN
+  description += "Pylontech battery over CAN bus";
+#endif
+#ifdef SERIAL_LINK_TRANSMITTER
+  description += "Serial link to another LilyGo board";
+#endif
+#ifdef SMA_CAN
+  description += "BYD Battery-Box H 8.9kWh, 7 mod over CAN bus";
+#endif
+#ifdef SOFAR_CAN
+  description += "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame) over CAN bus";
+#endif
+#ifdef SOLAX_CAN
+  description += "SolaX Triple Power LFP over CAN bus";
+#endif
+
+  return description;
+}
+
+String batteryProtocolDescription() {
+  String description = "";
+
+#ifdef BMW_I3_BATTERY
+  description += "BMW i3";
+#endif
+#ifdef CHADEMO_BATTERY
+  description += "Chademo V2X mode";
+#endif
+#ifdef IMIEV_CZERO_ION_BATTERY
+  description += "I-Miev / C-Zero / Ion Triplet";
+#endif
+#ifdef KIA_HYUNDAI_64_BATTERY
+  description += "Kia/Hyundai 64kWh";
+#endif
+#ifdef NISSAN_LEAF_BATTERY
+  description += "Nissan LEAF";
+#endif
+#ifdef RENAULT_KANGOO_BATTERY
+  description += "Renault Kangoo";
+#endif
+#ifdef RENAULT_ZOE_BATTERY
+  description += "Renault Zoe";
+#endif
+#ifdef SERIAL_LINK_RECEIVER
+  description += "Serial link to another LilyGo board";
+#endif
+#ifdef TESLA_MODEL_3_BATTERY
+  description += "Tesla Model S/3/X/Y";
+#endif
+#ifdef TEST_FAKE_BATTERY
+  description += "Fake battery for testing purposes";
+#endif
+  
+  return description;
+}
+
+String chargerProtocolDescription() {
+  
+  String description = "";
+  
+#ifdef CHEVYVOLT_CHARGER
+  description += "Chevy Volt Gen1 Charger";
+#endif
+#ifdef NISSANLEAF_CHARGER
+  description += "Nissan LEAF 2013-2024 PDM charger";
+#endif
+  
+  return description;
+}
+
+String getLEDColour() {
+  switch (LEDcolor) {
+    case GREEN:
+      return "GREEN";
+      break;
+    case YELLOW:
+      return "YELLOW";
+      break;
+    case BLUE:
+      return "BLUE";
+      break;
+    case RED:
+      return "RED";
+      break;
+    case TEST_ALL_COLORS:
+      return  "RGB Testing loop";
+      break;
+    default:
+      break;
+  }
+}
+
+String wirelessStatusDescription(wl_status_t status) {
+  switch (status) {
+    case WL_NO_SHIELD: return "No WiFi Shield";
+    case WL_IDLE_STATUS: return "Idle";
+    case WL_NO_SSID_AVAIL: return "No SSID Available";
+    case WL_SCAN_COMPLETED: return "Scan Completed";
+    case WL_CONNECTED: return "Connected";
+    case WL_CONNECT_FAILED: return "Connection Failed";
+    case WL_CONNECTION_LOST: return "Connection Lost";
+    case WL_DISCONNECTED: return "Disconnected";
+  }
+}
+
+template <typename S>
+String scalePowerValue(S value, String unit, int precision) {
+
+  String result = "";
+  if (std::is_same<S, float>::value || std::is_same<S, uint16_t>::value || std::is_same<S, uint32_t>::value) {
+    float convertedValue = static_cast<float>(value);
+
+    if (convertedValue >= 1000.0 || convertedValue <= -1000.0) {
+      result += String(convertedValue / 1000.0, precision) + " kW";
+    } else {
+      result += String(convertedValue, 0) + " W";
+    }
+  }
+
+  result += unit;
+  return result;
+}

--- a/Software/src/devboard/webserver/summary_API.h
+++ b/Software/src/devboard/webserver/summary_API.h
@@ -1,21 +1,10 @@
-#ifndef WEBSERVER_H
-#define WEBSERVER_H
+#ifndef SUMMARY_A
+#define SUMMARY_A
 
-#include <Preferences.h>
-#include <WiFi.h>
-#include "../../../USER_SETTINGS.h"  // Needed for WiFi ssid and password
-#include "../../lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h"
-#ifdef MQTT
-#include "../../lib/knolleary-pubsubclient/PubSubClient.h"
-#endif
-#include "../../lib/me-no-dev-AsyncTCP/src/AsyncTCP.h"
-#include "../../lib/me-no-dev-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
+#include <Arduino.h>
+#include <stdint.h>
+#include "../config.h"  // Needed for defines
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
-#include "../../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
-#include "../config.h"  // Needed for LED defines
-#ifdef MQTT
-#include "../mqtt/mqtt.h"
-#endif
 
 extern const char* version_number;                         // The current software version, shown on webserver
 extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh
@@ -59,116 +48,66 @@ extern float charger_stat_LVvol;
 extern uint16_t OBC_Charge_Power;
 
 /**
- * @brief Initialization function for the webserver.
+ * @brief Pepares and returns an AsyncJsonResponse configured with the summary json data
  *
  * @param[in] void
  *
- * @return void
+ * @return AsyncJsonResponse
  */
-void init_webserver();
+AsyncJsonResponse* summaryAPI_GET();
 
 /**
- * @brief Monitoring loop for WiFi. Will attempt to reconnect to access point if the connection goes down.
- *
- * @param[in] void
- * 
- * @return void
- */
-void wifi_monitor();
-
-/**
- * @brief Initialization function that creates a WiFi Access Point.
- *
- * @param[in] void
- * 
- * @return void
- */
-void init_WiFi_AP();
-
-/**
- * @brief Initialization function that connects to an existing network.
- *
- * @param[in] ssid WiFi network name
- * @param[in] password WiFi network password
- * 
- * @return void
- */
-void init_WiFi_STA(const char* ssid, const char* password, const uint8_t channel);
-
-/**
- * @brief Initialization function for ElegantOTA.
- *
- * @param[in] void
- * 
- * @return void
- */
-void init_ElegantOTA();
-
-/**
- * @brief Replaces placeholder with content section in web page
- *
- * @param[in] var
- *
- * @return String
- */
-String processor(const String& var);
-
-/**
- * @brief Initialization function that sets up the API endpoints for the webserver
+ * @brief Returns a description of the user defined battery protocol
  *
  * @param[in] void
  *
- * @return void
+ * @return String: Protocol Description
  */
-void init_rest_API();
+String batteryProtocolDescription();
 
 /**
-* @brief Provides an implementation of a 404 Not found route when no API endpoint is found.
-*
-* @param[in] void
-*
-* @return void
-*/	
-void notFound(AsyncWebServerRequest *request);
-
-/**
- * @brief Executes on OTA start 
+ * @brief Returns a description of the user defined charger protocol
  *
  * @param[in] void
  *
- * @return void
+ * @return String: Protocol Description
  */
-void onOTAStart();
+String chargerProtocolDescription();
 
 /**
- * @brief Executes on OTA progress 
- * 
- * @param[in] current Current bytes
- * @param[in] final Final bytes
- *
- * @return void
- */
-void onOTAProgress(size_t current, size_t final);
-
-/**
- * @brief Executes on OTA end 
+ * @brief Returns a description of the user defined inverter protocol
  *
  * @param[in] void
- * 
- * @return bool success: success = true, failed = false
+ *
+ * @return String: Protocol Description
  */
-void onOTAEnd(bool success);
+String inverterProtocolDescription();
 
 /**
- * @brief Formats power values 
+ * @brief Returns the current LED colour (which itself is based on the current state of the system)
  *
- * @param[in] float or uint16_t 
- * 
+ * @param[in] void
+ *
+ * @return String: Colour
+ */
+String getLEDColour();
+
+/**
+ * @brief Returns a description of the current state of the wireless connection
+ *
+ * @param[in] void
+ *
+ * @return String; WiFi connection description
+ */
+String wirelessStatusDescription(wl_status_t status);
+
+/**
+ * @brief Scales power values
+ *
+ * @param[in] float or uint16_t
+ *
  * @return string: values
  */
-template <typename T>
-String formatPowerValue(String label, T value, String unit, int precision);
-
-extern void storeSettings();
-
+template <typename S>
+String scalePowerValue(S value, String unit, int precision);
 #endif

--- a/Software/src/devboard/webserver/summary_API.h
+++ b/Software/src/devboard/webserver/summary_API.h
@@ -3,8 +3,8 @@
 
 #include <Arduino.h>
 #include <stdint.h>
-#include "../config.h"  // Needed for defines
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
+#include "../config.h"  // Needed for defines
 
 extern const char* version_number;                         // The current software version, shown on webserver
 extern uint32_t system_capacity_Wh;                        //Wh,  0-150000Wh

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -16,8 +16,8 @@ unsigned long ota_progress_millis = 0;
 
 // Include API Endpoint implementations
 #include "cellmonitor_API.h"
-#include "summary_API.h"
 #include "events_API.h"
+#include "summary_API.h"
 
 enum WifiState {
   INIT,          //before connecting first time
@@ -55,7 +55,7 @@ void init_webserver() {
 
   // initialise the API
   init_rest_API();
-  
+
   // Route for root / web page
   server.on("/", HTTP_GET,
             [](AsyncWebServerRequest* request) { request->send_P(200, "text/html", index_html, processor); });
@@ -266,39 +266,38 @@ void init_webserver() {
 
 void init_rest_API() {
   // Get the device summary data
-  server.on("/api/v1/summary", HTTP_GET, [](AsyncWebServerRequest * request) {
-    AsyncJsonResponse * response = summaryAPI_GET();
-    response->setLength();
-    request->send(response);
-  });
-  
-  // Get the cell monitor data for the battery
-  server.on("/api/v1/cellMonitor", HTTP_GET, [](AsyncWebServerRequest * request) {
-    AsyncJsonResponse * response = cellmonitorAPI_GET();
+  server.on("/api/v1/summary", HTTP_GET, [](AsyncWebServerRequest* request) {
+    AsyncJsonResponse* response = summaryAPI_GET();
     response->setLength();
     request->send(response);
   });
 
   // Get the cell monitor data for the battery
-  server.on("/api/v1/events", HTTP_GET, [](AsyncWebServerRequest * request) {
-    AsyncJsonResponse * response = eventsAPI_GET();
+  server.on("/api/v1/cellMonitor", HTTP_GET, [](AsyncWebServerRequest* request) {
+    AsyncJsonResponse* response = cellmonitorAPI_GET();
     response->setLength();
     request->send(response);
   });
-  
+
+  // Get the cell monitor data for the battery
+  server.on("/api/v1/events", HTTP_GET, [](AsyncWebServerRequest* request) {
+    AsyncJsonResponse* response = eventsAPI_GET();
+    response->setLength();
+    request->send(response);
+  });
+
   // Get a list of localNetworks
-  server.on("/api/v1/localNetworks", HTTP_GET, [](AsyncWebServerRequest * request) {
-    
-    AsyncJsonResponse * response = new AsyncJsonResponse();
+  server.on("/api/v1/localNetworks", HTTP_GET, [](AsyncWebServerRequest* request) {
+    AsyncJsonResponse* response = new AsyncJsonResponse();
     JsonObject root = response->getRoot();
-    
+
     int n = WiFi.scanComplete();
-    
-    if(n == -2) {
+
+    if (n == -2) {
       WiFi.scanNetworks(true);
-    } else if(n) {
+    } else if (n) {
       JsonArray networks = root.createNestedArray("networks");
-      
+
       for (int i = 0; i < n; ++i) {
         JsonObject network = networks.createNestedObject();
         network["rssi"] = String(WiFi.RSSI(i));
@@ -307,10 +306,10 @@ void init_rest_API() {
         network["channel"] = WiFi.channel(i);
         network["encryption"] = WiFi.encryptionType(i);
       }
-      
+
       WiFi.scanDelete();
-      
-      if(WiFi.scanComplete() == -2){
+
+      if (WiFi.scanComplete() == -2) {
         WiFi.scanNetworks(true);
       }
     }
@@ -687,9 +686,9 @@ String processor(const String& var) {
     content += "function goToSettingsPage() { window.location.href = '/settings'; }";
     content += "function goToEventsPage() { window.location.href = '/events'; }";
     content +=
-    "function promptToReboot() { if (window.confirm('Are you sure you want to reboot the emulator? NOTE: If "
-    "emulator is handling contactors, they will open during reboot!')) { "
-    "rebootServer(); } }";
+        "function promptToReboot() { if (window.confirm('Are you sure you want to reboot the emulator? NOTE: If "
+        "emulator is handling contactors, they will open during reboot!')) { "
+        "rebootServer(); } }";
     content += "function rebootServer() {";
     content += "  var xhr = new XMLHttpRequest();";
     content += "  xhr.open('GET', '/reboot', true);";
@@ -761,6 +760,6 @@ String formatPowerValue(String label, T value, String unit, int precision) {
   return result;
 }
 
-void notFound(AsyncWebServerRequest *request) {
+void notFound(AsyncWebServerRequest* request) {
   request->send(404, "application/json", "{\"message\":\"Not found\"}");
 }

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -9,8 +9,8 @@
 #include "../../lib/knolleary-pubsubclient/PubSubClient.h"
 #endif
 #include "../../lib/me-no-dev-AsyncTCP/src/AsyncTCP.h"
-#include "../../lib/me-no-dev-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
 #include "../../lib/me-no-dev-ESPAsyncWebServer/src/AsyncJson.h"
+#include "../../lib/me-no-dev-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
 #include "../../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "../config.h"  // Needed for LED defines
 #ifdef MQTT
@@ -128,8 +128,8 @@ void init_rest_API();
 * @param[in] void
 *
 * @return void
-*/	
-void notFound(AsyncWebServerRequest *request);
+*/
+void notFound(AsyncWebServerRequest* request);
 
 /**
  * @brief Executes on OTA start 


### PR DESCRIPTION
## For Discussion!
This merge request I have put up for discussion. There are several to do items I will add to the end of this merge request.

## Description
This merge request introduces several enhancements and additions to the existing codebase. The changes include the implementation of API endpoints for retrieving information related to cell monitoring, events, and system summary. Utility functions and descriptions for various protocols and system states have been included.

Documentation and payload examples and sample code to consume the endpoints are NOT included in this pull request

## Changes
### 1. **Summary API**
   - Added a new API endpoint `/api/v1/summary` to retrieve system summary information.
   - Implemented the `summaryAPI_GET()` function to handle the summary API request.
   - Included utility functions for describing battery, charger, and inverter protocols, as well as scaling power values.
  
### 2. **Cell Monitor API**
   - Added a new API endpoint `/api/v1/cellMonitor` to retrieve cell voltage data.
   - Implemented the `cellmonitorAPI_GET()` function to handle the cell monitor API request.

### 3. **Events API**
   - Added a new API endpoint `/api/v1/events` to retrieve events and their details.
   - Implemented the `eventsAPI_GET()` function to handle the events API request.
   - Included utility functions for mapping event data to JSON and describing event protocols.

### 4. **Utility Functions**
   - Added utility functions for describing various protocols (`inverterProtocolDescription()`, `batteryProtocolDescription()`, `chargerProtocolDescription()`).
   - Included functions for obtaining LED color, wireless status, and scaling power values.

### 5. **Webserver Endpoints**
   - Integrated the new API endpoints into the webserver initialization (`init_rest_API()`).
   - Added a 404 Not Found route (`notFound()`) for handling undefined API endpoints.

## Testing
- This project does not contain any unit tests and as such are out of the scope of this pull request.
- Manual testing has been performed to ensure proper functionality of the introduced features and example iOS app code produced as a form of end-to-end testing

## Dependencies
- No new dependencies have been introduced.

## Notes
- Please review the changes and provide feedback.
- Ensure that the new API endpoints are functioning as expected.
- Check the utility functions for correctness and consistency.
- I have no recent experience writing C++ code and have limited understanding of the pitfalls (such as memory leaks) or using String class. No memory management code has been written by myself or considered. Pleas provide any feedback on this as deemed necessary. 

## Related Issues
The mDNS and Bonjour implementation I have included in a previous merge request helps with the auto discovery of these devices on the network which will help with applications or services who will be consuming the api.

## Outstanding Tasks 

- [ ]  Implement POST/PUT api's to allow changing of device settings.
- [ ] Add API Token support and ability to set that token on initial setup via the API.
- [ ] Add example payloads and document the endpoints.
- [ ] Submit an example iOS project demonstrating the use of the API.

## Examples

```
GET: http://batteryemulator8c.local/api/v1/summary

Response:
{
	"Software Version": "5.5.dev",
	"Led Colour": "RED",
	"WiFi": {
		"ssid": "My WiFi Access Point",
		"status": "Connected",
		"ip": "192.168.1.xxx",
		"signalStrength": -53,
		"channel": 1
	},
	"Battery Statistics": {
		"Real SOC": 50,
		"Scaled SOC": 50,
		"SOH": 99,
		"Voltage": 370,
		"Current": 0,
		"Power": " 0 W",
		"Total capacity": "30 kWh",
		"Remaining capacity": "15.0 kWh",
		"Max charge power": "5.0 kW",
		"Max discharge power": "5.0 kW",
		"Cell max": "3596 mV",
		"Cell min": "3500 mV",
		"Temperature max": "6.0 C",
		"Temperature min": "5.0 C",
		"BMS Status": "FAULT",
		"Battery State": "Idle",
		"Automatic contactor closing allowed": {
			"Battery": false,
			"Inverter": true
		}
	}
}
```
```
GET: http://batteryemulator8c.local/api/v1/events

Response:
{
    "CAN_TX_FAILURE": {
        "Level": "ERROR",
        "Last event seconds ago": "293",
        "Occurances": "1",
        "Data": "0",
        "Message": "ERROR: CAN messages failed to transmit, or no one on the bus to ACK the message!",
        "Timestamp": "294"
    }
}
```
```
GET: http://batteryemulator8c.local/api/v1/cellMonitor

Response:
{
    "1": 3500,
    "2": 3501,
    "3": 3502,
    "4": 3503,
    "5": 3504,
    "6": 3505,
    "7": 3506,
    "8": 3507,
    "9": 3508,
    "10": 3509,
    "11": 3510,
    "12": 3511,
    "13": 3512,
    "14": 3513,
    "15": 3514,
    "16": 3515,
    "17": 3516,
    "18": 3517,
    "19": 3518,
    "20": 3519,
    "21": 3520,
    "22": 3521,
    "23": 3522,
    "24": 3523,
    "25": 3524,
    "26": 3525,
    "27": 3526,
    "28": 3527,
    "29": 3528,
    "30": 3529,
    "31": 3530,
    "32": 3531,
    "33": 3532,
    "34": 3533,
    "35": 3534,
    "36": 3535,
    "37": 3536,
    "38": 3537,
    "39": 3538,
    "40": 3539,
    "41": 3540,
    "42": 3541,
    "43": 3542,
    "44": 3543,
    "45": 3544,
    "46": 3545,
    "47": 3546,
    "48": 3547,
    "49": 3548,
    "50": 3549,
    "51": 3550,
    "52": 3551,
    "53": 3552,
    "54": 3553,
    "55": 3554,
    "56": 3555,
    "57": 3556,
    "58": 3557,
    "59": 3558,
    "60": 3559,
    "61": 3560,
    "62": 3561,
    "63": 3562,
    "64": 3563,
    "65": 3564,
    "66": 3565,
    "67": 3566,
    "68": 3567,
    "69": 3568,
    "70": 3569,
    "71": 3570,
    "72": 3571,
    "73": 3572,
    "74": 3573,
    "75": 3574,
    "76": 3575,
    "77": 3576,
    "78": 3577,
    "79": 3578,
    "80": 3579,
    "81": 3580,
    "82": 3581,
    "83": 3582,
    "84": 3583,
    "85": 3584,
    "86": 3585,
    "87": 3586,
    "88": 3587,
    "89": 3588,
    "90": 3589,
    "91": 3590,
    "92": 3591,
    "93": 3592,
    "94": 3593,
    "95": 3594,
    "96": 3595,
    "97": 3596
}
```