### PR TITLE
Triplet battery: Revise safety limits

### DIFF
--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -233,8 +233,8 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
 
-  system_max_design_voltage_dV = 4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)
-  system_min_design_voltage_dV = 3100;  // 310.0V under this, discharging further is disabled
+  system_max_design_voltage_dV = 3600;  // 360.0V, over this, charging is not possible (goes into forced discharge)
+  system_min_design_voltage_dV = 3160;  // 316.0V under this, discharging further is disabled
 }
 
 #endif


### PR DESCRIPTION
### What
This PR changes the max allowed voltages for triplet batteries

### Why
Noticed by Ruudi S on Discord server, the values allow overcharging of the 88S battery in a worst case scenario

### How
We now limit to 360V max (4.1V/cell on 88s) , and 316V min (3.6V/cell on 88s)