### PR TITLE
Enable autoupdate of the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@
 
 exclude: '^Software/src/lib/'  # don't run hooks on external libraries
 
+# This continuous integration section is optional, and enables autoupdating the pre-commit configuration, ensuring that
+# the hook versions are kept up to date.
+ci:
+  autoupdate_schedule: monthly
+
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v17.0.4


### PR DESCRIPTION
## What
This pull request enables autoupdate of the pre-commit configuration file, ensuring that the hook versions are kept up to date. The autoupdate is run on a monthly basis.

## How
It does this by means of pre-commit.ci. More information about this CI is found on [pre-commit.ci](https://pre-commit.ci). Dependabot is currently not supporting to autoupdate the pre-commit-config.yaml file, as described in [this GitHub Issue](https://github.com/dependabot/dependabot-core/issues/1524). As pre-commit.ci does offer the autoupdate functionality, pre-commit.ci is used rather than Dependabot.

## Why
Automatically updating the dependencies of the pre-commit file on a regular basis will ensure pre-commit uses the latest releases of dependencies, which may include new functionalities or bug fixes for issues.