### PR TITLE
Bugfix: BMW i3 values

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -376,7 +376,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   system_battery_voltage_dV = battery_volts;  //Unit V+1 (5000 = 500.0V)
 
-  system_battery_current_dA = battery_current * 10;
+  system_battery_current_dA = battery_current;
 
   system_capacity_Wh = BATTERY_WH_MAX;
 
@@ -445,8 +445,8 @@ void receive_can_battery(CAN_frame_t rx_frame) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery_awake = true;
       CANstillAlive = 12;  //This message is only sent if 30C (Wakeup pin on battery) is energized with 12V
-      battery_current = ((rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]) / 10) - 819;  //Amps
-      battery_volts = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);                 //500.0 V
+      battery_current = (rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]) - 8192;  //deciAmps (-819.2 to 819.0A)
+      battery_volts = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);           //500.0 V
       battery_HVBatt_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8 | rx_frame.data.u8[4]);
       battery_request_open_contactors = (rx_frame.data.u8[5] & 0xC0) >> 6;
       battery_request_open_contactors_instantly = (rx_frame.data.u8[6] & 0x03);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -479,7 +479,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       break;
     case 0x2BD:  //BMS [100ms] Status diagnosis high voltage - 1
       battery_awake = true;
-      if (calculateCRC(rx_frame, 3, 0x15) != rx_frame.data.u8[0]) {
+      if (calculateCRC(rx_frame, rx_frame.FIR.B.DLC, 0x15) != rx_frame.data.u8[0]) {
         //If calculated CRC does not match transmitted CRC, increase CANerror counter
         CANerror++;
         break;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -394,7 +394,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
     system_max_discharge_power_W = (battery_max_discharge_amperage * system_battery_voltage_dV);
   }
 
-  battery_power = (system_battery_current_dA * (system_battery_voltage_dV / 10));
+  battery_power = (system_battery_current_dA * (system_battery_voltage_dV / 100));
 
   system_active_power_W = battery_power;
 

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -376,7 +376,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   system_battery_voltage_dV = battery_volts;  //Unit V+1 (5000 = 500.0V)
 
-  system_battery_current_dA = battery_current;
+  system_battery_current_dA = battery_current * 10;
 
   system_capacity_Wh = BATTERY_WH_MAX;
 

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -382,9 +382,17 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   system_remaining_capacity_Wh = (battery_energy_content_maximum_kWh * 1000);  // Convert kWh to Wh
 
-  system_max_charge_power_W = (battery_max_charge_amperage * system_battery_voltage_dV);
+  if ((battery_max_charge_amperage * system_battery_voltage_dV) > 65000) {
+    system_max_charge_power_W = 65000;
+  } else {
+    system_max_charge_power_W = (battery_max_charge_amperage * system_battery_voltage_dV);
+  }
 
-  system_max_discharge_power_W = (battery_max_discharge_amperage * system_battery_voltage_dV);
+  if ((battery_max_discharge_amperage * system_battery_voltage_dV) > 65000) {
+    system_max_discharge_power_W = 65000;
+  } else {
+    system_max_discharge_power_W = (battery_max_discharge_amperage * system_battery_voltage_dV);
+  }
 
   battery_power = (system_battery_current_dA * (system_battery_voltage_dV / 10));
 


### PR DESCRIPTION
### What
A few values is scaled wrong / glitches on i3 batteries
- Current value
- Power value
- Max allowed charge/discharge overflows
- CRC check is broken on 2BD message

![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/653c5e0f-3f39-436d-b7e1-0e418f5a399b)

### Why
Mistakes were made in the first implementation

### How
Iterative fixes