### PR TITLE
Bugfix: Further CPU load reductions

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -16,7 +16,6 @@ static unsigned long previousMillis5000 = 0;   // will store last time a 5000ms 
 static unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
 static uint8_t CANstillAlive = 12;             // counter for checking if CAN is still alive
 static uint16_t CANerror = 0;                  // counter on how many CAN errors encountered
-#define MAX_CAN_FAILURES 500                   // Amount of malformed CAN messages to allow before raising a warning
 #define ALIVE_MAX_VALUE 14                     // BMW CAN messages contain alive counter, goes from 0...14
 
 static const uint16_t WUPonDuration = 477;   // in milliseconds how long WUP should be ON after poweron

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -647,43 +647,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
 }
 void send_can_battery() {
   unsigned long currentMillis = millis();
-  // Send 100ms CAN Message
-  if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    previousMillis100 = currentMillis;
 
-    //When battery requests heating pack status change, ack this
-    if (Batt_Heater_Mail_Send_Request) {
-      LEAF_50B.data.u8[6] = 0x20;  //Batt_Heater_Mail_Send_OK
-    } else {
-      LEAF_50B.data.u8[6] = 0x00;  //Batt_Heater_Mail_Send_NG
-    }
-
-    // VCM message, containing info if battery should sleep or stay awake
-    ESP32Can.CANWriteFrame(&LEAF_50B);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
-
-    LEAF_50C.data.u8[3] = mprun100;
-    switch (mprun100) {
-      case 0:
-        LEAF_50C.data.u8[4] = 0x5D;
-        LEAF_50C.data.u8[5] = 0xC8;
-        break;
-      case 1:
-        LEAF_50C.data.u8[4] = 0xB2;
-        LEAF_50C.data.u8[5] = 0x31;
-        break;
-      case 2:
-        LEAF_50C.data.u8[4] = 0x5D;
-        LEAF_50C.data.u8[5] = 0x63;
-        break;
-      case 3:
-        LEAF_50C.data.u8[4] = 0xB2;
-        LEAF_50C.data.u8[5] = 0x9A;
-        break;
-    }
-    ESP32Can.CANWriteFrame(&LEAF_50C);
-
-    mprun100 = (mprun100 + 1) % 4;  // mprun100 cycles between 0-1-2-3-0-1...
-  }
   //Send 10ms message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
     // Check if sending of CAN messages has been delayed too much.
@@ -810,6 +774,45 @@ void send_can_battery() {
 
     mprun10 = (mprun10 + 1) % 4;  // mprun10 cycles between 0-1-2-3-0-1...
   }
+
+  // Send 100ms CAN Message
+  if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
+    previousMillis100 = currentMillis;
+
+    //When battery requests heating pack status change, ack this
+    if (Batt_Heater_Mail_Send_Request) {
+      LEAF_50B.data.u8[6] = 0x20;  //Batt_Heater_Mail_Send_OK
+    } else {
+      LEAF_50B.data.u8[6] = 0x00;  //Batt_Heater_Mail_Send_NG
+    }
+
+    // VCM message, containing info if battery should sleep or stay awake
+    ESP32Can.CANWriteFrame(&LEAF_50B);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
+
+    LEAF_50C.data.u8[3] = mprun100;
+    switch (mprun100) {
+      case 0:
+        LEAF_50C.data.u8[4] = 0x5D;
+        LEAF_50C.data.u8[5] = 0xC8;
+        break;
+      case 1:
+        LEAF_50C.data.u8[4] = 0xB2;
+        LEAF_50C.data.u8[5] = 0x31;
+        break;
+      case 2:
+        LEAF_50C.data.u8[4] = 0x5D;
+        LEAF_50C.data.u8[5] = 0x63;
+        break;
+      case 3:
+        LEAF_50C.data.u8[4] = 0xB2;
+        LEAF_50C.data.u8[5] = 0x9A;
+        break;
+    }
+    ESP32Can.CANWriteFrame(&LEAF_50C);
+
+    mprun100 = (mprun100 + 1) % 4;  // mprun100 cycles between 0-1-2-3-0-1...
+  }
+
   //Send 10s CAN messages
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
     previousMillis10s = currentMillis;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -662,24 +662,21 @@ void send_can_battery() {
     // VCM message, containing info if battery should sleep or stay awake
     ESP32Can.CANWriteFrame(&LEAF_50B);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 
+    LEAF_50C.data.u8[3] = mprun100;
     switch (mprun100) {
       case 0:
-        LEAF_50C.data.u8[3] = 0x00;
         LEAF_50C.data.u8[4] = 0x5D;
         LEAF_50C.data.u8[5] = 0xC8;
         break;
       case 1:
-        LEAF_50C.data.u8[3] = 0x01;
         LEAF_50C.data.u8[4] = 0xB2;
         LEAF_50C.data.u8[5] = 0x31;
         break;
       case 2:
-        LEAF_50C.data.u8[3] = 0x02;
         LEAF_50C.data.u8[4] = 0x5D;
         LEAF_50C.data.u8[5] = 0x63;
         break;
       case 3:
-        LEAF_50C.data.u8[3] = 0x03;
         LEAF_50C.data.u8[4] = 0xB2;
         LEAF_50C.data.u8[5] = 0x9A;
         break;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -13,7 +13,6 @@ static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN 
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
 static uint16_t CANerror = 0;                //counter on how many CAN errors encountered
-#define MAX_CAN_FAILURES 5000                //Amount of malformed CAN messages to allow before raising a warning
 static uint8_t CANstillAlive = 12;           //counter for checking if CAN is still alive
 static uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
 static uint8_t mprun10 = 0;                  //counter 0-3

--- a/Software/src/devboard/config.h
+++ b/Software/src/devboard/config.h
@@ -55,6 +55,7 @@
 
 // Common definitions
 #define MAX_AMOUNT_CELLS 192
+#define MAX_CAN_FAILURES 500  // Amount of malformed CAN messages to allow before raising a warning
 
 #define INTERVAL_10_MS 10
 #define INTERVAL_20_MS 20

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -32,7 +32,7 @@ String cellmonitor_processor(const String& var) {
 
     // Close the block
     content += "</div>";
-    content += "<button onclick='goToMainPage()'>Back to main page</button>";
+    content += "<button onclick='home()'>Back to main page</button>";
     content += "<script>";
     // Populate cell data
     content += "const data = [";
@@ -52,7 +52,7 @@ String cellmonitor_processor(const String& var) {
     content += "const valueDisplay = document.getElementById('valueDisplay');";
     content += "const cellContainer = document.getElementById('cellContainer');";
 
-    content += "function goToMainPage() { window.location.href = '/'; }";
+    content += "function home() { window.location.href = '/'; }";
 
     // Arduino-style map() function
     content +=

--- a/Software/src/devboard/webserver/events_html.cpp
+++ b/Software/src/devboard/webserver/events_html.cpp
@@ -9,7 +9,7 @@ const char EVENTS_HTML_END[] = R"=====(
 </div></div>
 <button onclick='home()'>Back to main page</button>
 <style>.event:nth-child(even){background-color:#455a64}.event:nth-child(odd){background-color:#394b52}</style>
-<script>function showEvent(){document.querySelector(".event-log");var i=(new Date).getTime()/1e3;document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".last-event-sec-ago"),t=e.querySelector(".timestamp");if(n&&t){var o=parseInt(n.innerText,10),a=parseFloat(t.innerText),r=new Date(1e3*(i-a+o)).toLocaleString();n.innerText=r}})}function home(){window.location.href="/"}window.onload=function(){showEvent()}</script>
+<script>function showEvent(){document.querySelector(".event-log");var i=(new Date).getTime()/1e3;document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".sec-ago"),t=e.querySelector(".timestamp");if(n&&t){var o=parseInt(n.innerText,10),a=parseFloat(t.innerText),r=new Date(1e3*(i-a+o)).toLocaleString();n.innerText=r}})}function home(){window.location.href="/"}window.onload=function(){showEvent()}</script>
 )=====";
 
 String events_processor(const String& var) {
@@ -32,7 +32,7 @@ String events_processor(const String& var) {
         content.concat("<div class='event'>");
         content.concat("<div>" + String(get_event_enum_string(event_handle)) + "</div>");
         content.concat("<div>" + String(get_event_level_string(event_handle)) + "</div>");
-        content.concat("<div class='last-event-sec-ago'>" + String(event_pointer->timestamp) + "</div>");
+        content.concat("<div class='sec-ago'>" + String(event_pointer->timestamp) + "</div>");
         content.concat("<div>" + String(event_pointer->occurences) + "</div>");
         content.concat("<div>" + String(event_pointer->data) + "</div>");
         content.concat("<div>" + String(get_event_message_string(event_handle)) + "</div>");
@@ -55,7 +55,7 @@ function showEvent() {
     // Loop through the events and update the "Last Event" column
     var events = document.querySelectorAll('.event');
     events.forEach(function(event) {
-        var secondsAgoElement = event.querySelector('.last-event-sec-ago');
+        var secondsAgoElement = event.querySelector('.sec-ago');
         var timestampElement = event.querySelector('.timestamp');
         if (secondsAgoElement && timestampElement) {
             var secondsAgo = parseInt(secondsAgoElement.innerText, 10);

--- a/Software/src/devboard/webserver/events_html.cpp
+++ b/Software/src/devboard/webserver/events_html.cpp
@@ -7,9 +7,9 @@ const char EVENTS_HTML_START[] = R"=====(
 )=====";
 const char EVENTS_HTML_END[] = R"=====(
 </div></div>
-<button onclick='goToMainPage()'>Back to main page</button>
+<button onclick='home()'>Back to main page</button>
 <style>.event:nth-child(even){background-color:#455a64}.event:nth-child(odd){background-color:#394b52}</style>
-<script>function displayEventLog(){document.querySelector(".event-log");var i=(new Date).getTime()/1e3;document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".last-event-seconds-ago"),t=e.querySelector(".timestamp");if(n&&t){var o=parseInt(n.innerText,10),a=parseFloat(t.innerText),r=new Date(1e3*(i-a+o)).toLocaleString();n.innerText=r}})}function goToMainPage(){window.location.href="/"}window.onload=function(){displayEventLog()}</script>
+<script>function showEvent(){document.querySelector(".event-log");var i=(new Date).getTime()/1e3;document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".last-event-sec-ago"),t=e.querySelector(".timestamp");if(n&&t){var o=parseInt(n.innerText,10),a=parseFloat(t.innerText),r=new Date(1e3*(i-a+o)).toLocaleString();n.innerText=r}})}function home(){window.location.href="/"}window.onload=function(){showEvent()}</script>
 )=====";
 
 String events_processor(const String& var) {
@@ -32,7 +32,7 @@ String events_processor(const String& var) {
         content.concat("<div class='event'>");
         content.concat("<div>" + String(get_event_enum_string(event_handle)) + "</div>");
         content.concat("<div>" + String(get_event_level_string(event_handle)) + "</div>");
-        content.concat("<div class='last-event-seconds-ago'>" + String(event_pointer->timestamp) + "</div>");
+        content.concat("<div class='last-event-sec-ago'>" + String(event_pointer->timestamp) + "</div>");
         content.concat("<div>" + String(event_pointer->occurences) + "</div>");
         content.concat("<div>" + String(event_pointer->data) + "</div>");
         content.concat("<div>" + String(get_event_message_string(event_handle)) + "</div>");
@@ -48,14 +48,14 @@ String events_processor(const String& var) {
 
 /* Script for displaying event log before it gets minified
 <script>
-function displayEventLog() {
+function showEvent() {
     var eventLogElement = document.querySelector('.event-log');
     // Get the current time on the client side
     var currentTime = new Date().getTime() / 1000; // Convert milliseconds to seconds
     // Loop through the events and update the "Last Event" column
     var events = document.querySelectorAll('.event');
     events.forEach(function(event) {
-        var secondsAgoElement = event.querySelector('.last-event-seconds-ago');
+        var secondsAgoElement = event.querySelector('.last-event-sec-ago');
         var timestampElement = event.querySelector('.timestamp');
         if (secondsAgoElement && timestampElement) {
             var secondsAgo = parseInt(secondsAgoElement.innerText, 10);
@@ -70,12 +70,12 @@ function displayEventLog() {
     });
 }
 
-// Call the displayEventLog function when the page is loaded
+// Call the showEvent function when the page is loaded
 window.onload = function() {
-    displayEventLog();
+    showEvent();
 };
 
-function goToMainPage() {
+function home() {
     window.location.href = '/';
 }
 </script>

--- a/Software/src/devboard/webserver/index_html.cpp
+++ b/Software/src/devboard/webserver/index_html.cpp
@@ -1,8 +1,8 @@
 const char index_html[] = R"rawliteral(
-<!DOCTYPE HTML><html><head><title>Battery Emulator</title><meta name="viewport" content="width=device-width"><style>html{font-family:Arial;display:inline-block;text-align:center}h2{font-size:3rem}body{max-width:800px;margin:0 auto}</style></head><body><h2>Battery Emulator</h2>%ABC%</body></html>
+<!doctypehtml><title>Battery Emulator</title><meta content="width=device-width"name=viewport><style>html{font-family:Arial;display:inline-block;text-align:center}h2{font-size:3rem}body{max-width:800px;margin:0 auto}</style><h2>Battery Emulator</h2>%ABC%
 )rawliteral";
 
-/* The above code is minified to increase performance. Here is the full HTML function:
+/* The above code is minified (https://kangax.github.io/html-minifier/) to increase performance. Here is the full HTML function:
 <!DOCTYPE HTML><html>
 <head>
   <title>Battery Emulator</title>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -598,25 +598,25 @@ String processor(const String& var) {
     content += "</div>";
 #endif
 
-    content += "<button onclick='goToUpdatePage()'>Perform OTA update</button>";
+    content += "<button onclick='OTA()'>Perform OTA update</button>";
     content += " ";
-    content += "<button onclick='goToSettingsPage()'>Change Settings</button>";
+    content += "<button onclick='Settings()'>Change Settings</button>";
     content += " ";
-    content += "<button onclick='goToCellmonitorPage()'>Cellmonitor</button>";
+    content += "<button onclick='Cellmon()'>Cellmonitor</button>";
     content += " ";
-    content += "<button onclick='goToEventsPage()'>Events</button>";
+    content += "<button onclick='Events()'>Events</button>";
     content += " ";
-    content += "<button onclick='promptToReboot()'>Reboot Emulator</button>";
+    content += "<button onclick='askReboot()'>Reboot Emulator</button>";
     content += "<script>";
-    content += "function goToUpdatePage() { window.location.href = '/update'; }";
-    content += "function goToCellmonitorPage() { window.location.href = '/cellmonitor'; }";
-    content += "function goToSettingsPage() { window.location.href = '/settings'; }";
-    content += "function goToEventsPage() { window.location.href = '/events'; }";
+    content += "function OTA() { window.location.href = '/update'; }";
+    content += "function Cellmon() { window.location.href = '/cellmonitor'; }";
+    content += "function Settings() { window.location.href = '/settings'; }";
+    content += "function Events() { window.location.href = '/events'; }";
     content +=
-        "function promptToReboot() { if (window.confirm('Are you sure you want to reboot the emulator? NOTE: If "
+        "function askReboot() { if (window.confirm('Are you sure you want to reboot the emulator? NOTE: If "
         "emulator is handling contactors, they will open during reboot!')) { "
-        "rebootServer(); } }";
-    content += "function rebootServer() {";
+        "reboot(); } }";
+    content += "function reboot() {";
     content += "  var xhr = new XMLHttpRequest();";
     content += "  xhr.open('GET', '/reboot', true);";
     content += "  xhr.send();";
@@ -625,7 +625,7 @@ String processor(const String& var) {
 
     //Script for refreshing page
     content += "<script>";
-    content += "setTimeout(function(){ location.reload(true); }, 10000);";
+    content += "setTimeout(function(){ location.reload(true); }, 15000);";
     content += "</script>";
 
     return content;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -475,7 +475,7 @@ String processor(const String& var) {
         break;
       case BLUE:
       case TEST_ALL_COLORS:
-        content += "#2B35AF;"; // Blue in test mode
+        content += "#2B35AF;";  // Blue in test mode
         break;
       case RED:
         content += "#A70107;";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -465,26 +465,28 @@ String processor(const String& var) {
     content += "</div>";
 
     // Start a new block with a specific background color. Color changes depending on BMS status
+    content += "<div style='background-color: ";
     switch (LEDcolor) {
       case GREEN:
-        content += "<div style='background-color: #2D3F2F; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+        content += "#2D3F2F;";
         break;
       case YELLOW:
-        content += "<div style='background-color: #F5CC00; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+        content += "#F5CC00;";
         break;
       case BLUE:
-        content += "<div style='background-color: #2B35AF; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+      case TEST_ALL_COLORS:
+        content += "#2B35AF;"; // Blue in test mode
         break;
       case RED:
-        content += "<div style='background-color: #A70107; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+        content += "#A70107;";
         break;
-      case TEST_ALL_COLORS:  //Blue in test mode
-        content += "<div style='background-color: #2B35AF; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
-        break;
-      default:  //Some new color, make background green
-        content += "<div style='background-color: #2D3F2F; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+      default:  // Some new color, make background green
+        content += "#2D3F2F;";
         break;
     }
+
+    // Add the common style properties
+    content += "padding: 10px; margin-bottom: 10px; border-radius: 50px;'>";
 
     // Display battery statistics within this block
     float socRealFloat = static_cast<float>(system_real_SOC_pptt) / 100.0;      // Convert to float and divide by 100

--- a/Software/src/lib/me-no-dev-AsyncTCP/src/AsyncTCP.h
+++ b/Software/src/lib/me-no-dev-AsyncTCP/src/AsyncTCP.h
@@ -32,7 +32,7 @@ extern "C" {
 
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
-#define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
+#define CONFIG_ASYNC_TCP_RUNNING_CORE 0 //any available core
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
 #endif
 


### PR DESCRIPTION
### What
This PR focuses on reducing CPU load further, to reduce the amount of CAN_OVERRUN events

### Why
Keeping the CAN messages in time is essential for good control over batteries. Delayed messages could cause issues in form of contactors opening under load

### How
- Webserver filesize further reduced, reducing load when accessing pages
- Webserver set to refresh mainpage every 15 seconds instead of 10 seconds
- Nissan LEAF: 10ms messages now sent before 100ms are queued
- AsyncTCP moved to Core 0 to reduce load on Core 1
- Scheduler delay reduced from 2ms to 1ms
- LED code made less resource intensive. 
   - digitalRead moved into LED block, which makes it run less often.
   - Amount of if statements reduced