### PR TITLE
Bugfix: Missing include for Volvo

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -1,9 +1,9 @@
 #include "BATTERIES.h"
 #ifdef VOLVO_SPA_BATTERY
-#include "VOLVO-SPA-BATTERY.h"
 #include "../devboard/utils/events.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+#include "VOLVO-SPA-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -1,3 +1,4 @@
+#include "BATTERIES.h"
 #ifdef VOLVO_SPA_BATTERY
 #include "VOLVO-SPA-BATTERY.h"
 #include "../devboard/utils/events.h"


### PR DESCRIPTION
### What
The Volvo file on main doesn’t include BATTERIES.h , this causes compilation error

### Why
The github Actions use command line compiler flags for the battery define, so VOLVO_SPA_BATTERY is #defined when compiling the volvo .cpp file. Compiling locally, the definition comes from BATTERIES.h, that in turn includes USER_SETTINGS.h

### How
Added include line to fix issue!