### PR TITLE
Feat/platformio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@
 # Ignore .exe (unit tests)
 *.exe
 **/.DS_Store
+
+#ignore platformio
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json
+.pio

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,20 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = ./Software
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+monitor_speed = 115200
+framework = arduino
+build_flags = -I include
+lib_deps = 


### PR DESCRIPTION
What
Adds option to start developing on platformio. Platformio is an IDE that allows to develop arduino code on different code editors. For example VSCode.

Why
Arduino IDE is not very user friendly when it comes down to multy folder development. And VSCode is popular code editor.

How
Open VSCode and install Platformio extension. Once done you can verify code, upload it to your microcontroller and use the serial monitor from buttons below.
![image](https://github.com/dalathegreat/Battery-Emulator/assets/22599331/5190e543-2a44-4448-b81b-39561eec1980)
