### PR TITLE
Feature: Add CAN logging to TEST-BATTERY

### DIFF
--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -62,13 +62,18 @@ void update_values_battery() {  /* This function puts fake values onto the param
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
-    case 0xABC:
-      break;
-    default:
-      break;
+void receive_can_battery(CAN_frame_t rx_frame) {  // All CAN messages recieved will be logged via serial
+  Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
+  Serial.print("  ");
+  Serial.print(rx_frame.MsgID, HEX);
+  Serial.print("  ");
+  Serial.print(rx_frame.FIR.B.DLC);
+  Serial.print("  ");
+  for (int i = 0; i < rx_frame.FIR.B.DLC; ++i) {
+    Serial.print(rx_frame.data.u8[i], HEX);
+    Serial.print(" ");
   }
+  Serial.println("");
 }
 void send_can_battery() {
   unsigned long currentMillis = millis();


### PR DESCRIPTION
### What
This PR adds CAN logging via USB serial.

### Why
Very useful feature for those working with new and unknown hardware, and don't have access to expensive CAN logging equipment. Now you can just use the inexpensive LilyGo board, and sniff CAN buses. 

### How
The CAN-logging is added to the `TEST_FAKE_BATTERY` feature. When you are using this test mode, all the received CAN messages will get timestamp, ID, DLC, and data fields printed out via the Arduino IDE. This can then be exported to a .txt file for later analysis. Example format:

```
7556  54A  8  10 0 70 2 0 0 0 2B 
7558  54B  8  1 8 80 12 4 0 0 0 
7560  54C  8  61 66 0 0 0 0 57 0 
7561  1D4  8  F7 7 0 0 7 46 0 7B 
7573  11A  8  1 40 0 AA C0 0 0 3 
7574  1F2  8  10 64 0 0 0 1E 0 C 
7575  50B  6  0 0 2 C0 0 60 
7576  54F  8  21 1 0 0 7 0 8C 20 
7577  1DB  8  FF C0 B9 EA 0 0 3 D8 
7589  1DA  8  BA 64 18 0 0 1 3 C1 
7590  1DC  8  6E F 8F FD C E4 E0 D1 
7591  380  8  2 4 10 21 0 0 0 8D 
7592  5BF  8  0 0 0 0 28 0 0 1A 
7593  1D4  8  F7 7 0 0 47 46 0 BC 
```

