### PR TITLE
Add platformio serial logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .clang_complete
 .gcc-flags.json
 .pio
+logs

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ src_dir = ./Software
 platform = espressif32
 board = esp32dev
 monitor_speed = 115200
+monitor_filters = default, time, log2file
 framework = arduino
 build_flags = -I include
 lib_deps = 


### PR DESCRIPTION
What
When using platformio serial monitor it automatically creates log file with serial data in logs folder.

Why
Copying serial monitor data is tricky. This makes it a lot easier to debug even if there is lots of data in serial monitor. And also sending serial data to others for debugging is easier with this.

How
In VSCode using platformio serial monitor it automatically saves serial monitor output to log file in logs folder.