### PR TITLE
Bugfix: Remove Volvo battery writing to bms_status

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -324,14 +324,12 @@ void receive_can_battery(CAN_frame_t rx_frame) {
           }
 
           if (min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            system_bms_status = FAULT;
             set_event(EVENT_CELL_OVER_VOLTAGE, 0);
 #ifdef DEBUG_VIA_USB
             Serial.println("CELL OVERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!");
 #endif
           }
           if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            system_bms_status = FAULT;
             set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
 #ifdef DEBUG_VIA_USB
             Serial.println("CELL UNDERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!");


### PR DESCRIPTION
### What
This PR removes a few lines where Volvo batteries were writing `system_bms_status = FAULT;`

### Why
This is redundant, event is already called which sets the status. Writing to same variable from multiple places can cause issues.

### How
Events are responsible for setting the system_bms_status 