### PR TITLE
USB debug removal and improvements

### DIFF
--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -8,7 +8,6 @@
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static uint8_t CANstillAlive = 12;           //counter for checking if CAN is still alive
-static uint8_t errorCode = 0;                //stores if we have an error code active from battery control logic
 
 CAN_frame_t CHADEMO_108 = {.FIR = {.B =
                                        {
@@ -104,7 +103,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   /* Check if the Vehicle is still sending CAN messages. If we go 60s without messages we raise an error*/
   if (!CANstillAlive) {
-    errorCode = 7;
     set_event(EVENT_CAN_RX_FAILURE, 0);
   } else {
     CANstillAlive--;
@@ -112,24 +110,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
 #ifdef DEBUG_VIA_USB
-  if (errorCode > 0) {
-    Serial.print("ERROR CODE ACTIVE IN SYSTEM. NUMBER: ");
-    Serial.println(errorCode);
-  }
-  Serial.print("BMS Status (3=OK): ");
-  Serial.println(system_bms_status);
-  Serial.print("Max discharge power: ");
-  Serial.println(system_max_discharge_power_W);
-  Serial.print("Max charge power: ");
-  Serial.println(system_max_charge_power_W);
-  Serial.print("SOH%: ");
-  Serial.println(system_SOH_pptt);
-  Serial.print("SOC% to Inverter: ");
-  Serial.println(system_scaled_SOC_pptt);
-  Serial.print("Temperature Min: ");
-  Serial.println(system_temperature_min_dC);
-  Serial.print("Temperature Max: ");
-  Serial.println(system_temperature_max_dC);
+  Serial.print("SOC 0x100: ");
+  Serial.println(ConstantOfChargingRateIndication);
 #endif
 }
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -122,7 +122,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
 #ifdef DEBUG_VIA_USB
-
   Serial.println("Battery Values");
   Serial.print("BMU SOC: ");
   Serial.print(BMU_SOC);
@@ -140,29 +139,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   Serial.print(max_temp_cel);
   Serial.print(" Cell min temp: ");
   Serial.println(min_temp_cel);
-
-  Serial.println("Values sent to inverter");
-  Serial.print("SOC% (0-100.00): ");
-  Serial.print(system_scaled_SOC_pptt);
-  Serial.print(" Voltage (0-400.0): ");
-  Serial.print(system_battery_voltage_dV);
-  Serial.print(" Capacity WH full (0-60000): ");
-  Serial.print(system_capacity_Wh);
-  Serial.print(" Capacity WH remain (0-60000): ");
-  Serial.print(system_remaining_capacity_Wh);
-  Serial.print(" Max charge power W (0-10000): ");
-  Serial.print(system_max_charge_power_W);
-  Serial.print(" Max discharge power W (0-10000): ");
-  Serial.print(system_max_discharge_power_W);
-  Serial.print(" Temp max ");
-  Serial.print(system_temperature_max_dC);
-  Serial.print(" Temp min ");
-  Serial.print(system_temperature_min_dC);
-  Serial.print(" Cell mV max ");
-  Serial.print(system_cell_max_voltage_mV);
-  Serial.print(" Cell mV min ");
-  Serial.print(system_cell_min_voltage_mV);
-
 #endif
 }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -263,9 +263,6 @@ void update_values_battery() { /* This function maps all the values fetched via 
   }
 
   if (LB_Relay_Cut_Request) {  //LB_FAIL, BMS requesting shutdown and contactors to be opened
-#ifdef DEBUG_VIA_USB
-    Serial.println("Battery requesting immediate shutdown and contactors to be opened!");
-#endif
     //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
     system_max_discharge_power_W = 0;
     system_max_charge_power_W = 0;
@@ -287,10 +284,7 @@ void update_values_battery() { /* This function maps all the values fetched via 
         //Normal stop request. For stationary storage we don't disconnect contactors, so we ignore this.
         break;
       case (4):
-//Caution Lamp Request
-#ifdef DEBUG_VIA_USB
-        Serial.println("ERROR: Battery raised caution indicator. Inspect battery status!");
-#endif
+        //Caution Lamp Request //TODO: Should we create info event for this?
         break;
       case (5):
         //Caution Lamp Request & Normal Stop Request
@@ -349,23 +343,6 @@ void update_values_battery() { /* This function maps all the values fetched via 
 
 /*Finally print out values to serial if configured to do so*/
 #ifdef DEBUG_VIA_USB
-  Serial.println("Values going to inverter");
-  print_with_units("SOH%: ", (system_SOH_pptt * 0.01), "% ");
-  print_with_units(", SOC% scaled: ", (system_scaled_SOC_pptt * 0.01), "% ");
-  print_with_units(", Voltage: ", (system_battery_voltage_dV * 0.1), "V ");
-  print_with_units(", Max discharge power: ", system_max_discharge_power_W, "W ");
-  print_with_units(", Max charge power: ", system_max_charge_power_W, "W ");
-  print_with_units(", Max temp: ", (system_temperature_max_dC * 0.1), "°C ");
-  print_with_units(", Min temp: ", (system_temperature_min_dC * 0.1), "°C ");
-  Serial.println("");
-  Serial.print("BMS Status: ");
-  if (system_bms_status == 3) {
-    Serial.print("Active, ");
-  } else {
-    Serial.print("FAULT, ");
-  }
-  print_with_units(", Power: ", LB_Power, "W ");
-  Serial.println("");
   Serial.println("Values from battery");
   print_with_units("Real SOC%: ", (LB_SOC * 0.1), "% ");
   print_with_units(", GIDS: ", LB_GIDS, " (x77Wh) ");
@@ -374,10 +351,10 @@ void update_values_battery() { /* This function maps all the values fetched via 
   print_with_units(", Max cell voltage: ", min_max_voltage[1], "mV ");
   print_with_units(", Min cell voltage: ", min_max_voltage[0], "mV ");
   print_with_units(", Cell deviation: ", cell_deviation_mV, "mV ");
-  if (LB_Heating_Stop) {
+  if (LB_Heating_Stop) {  //TODO: Should we create info event for this?
     Serial.println("Battery requesting heating pads to stop. The battery is now warm enough.");
   }
-  if (LB_Heating_Start) {
+  if (LB_Heating_Start) {  //TODO: Should we create info event for this?
     Serial.println("COLD BATTERY! Battery requesting heating pads to activate");
   }
 

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -318,22 +318,13 @@ void receive_can_battery(CAN_frame_t rx_frame) {
 
           if (cell_deviation_mV > MAX_CELL_DEVIATION) {
             set_event(EVENT_CELL_DEVIATION_HIGH, 0);
-#ifdef DEBUG_VIA_USB
-            Serial.println("HIGH CELL DEVIATION!!! Inspect battery!");
-#endif
           }
 
           if (min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
             set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-#ifdef DEBUG_VIA_USB
-            Serial.println("CELL OVERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!");
-#endif
           }
           if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
             set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-#ifdef DEBUG_VIA_USB
-            Serial.println("CELL UNDERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!");
-#endif
           }
           ESP32Can.CANWriteFrame(&VOLVO_SOH_Req);  //Send SOH read request
         }


### PR DESCRIPTION
### What
This PR cleans up some unnecessary USB debug handling

### Why
Reduces complexity

### How
* Volvo SPA: Removed USB printouts for cellvoltage errors (Events are better and already in place)
* Nissan LEAF: Removed USB printouts for inverter values (Can be viewed in Webserver instead, and data is 100% known working)
* Triplets: Removed USB printouts for inverter values (Can be viewed in Webserver instead)
* Chademo: Removed obsolete errorCode, and inverter values (Can be viewed in Webserver instead)