### PR TITLE
Add INTERVAL_500_MS_DELAYED to types.h for KIA-E-GMP-BATTERY.cpp

### DIFF
--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -26,6 +26,7 @@ enum led_color { GREEN, YELLOW, RED, BLUE, RGB };
 #define INTERVAL_20_MS_DELAYED 30
 #define INTERVAL_30_MS_DELAYED 40
 #define INTERVAL_100_MS_DELAYED 120
+#define INTERVAL_500_MS_DELAYED 550
 
 #define MAX_CAN_FAILURES 500  // Amount of malformed CAN messages to allow before raising a warning
 


### PR DESCRIPTION
What
This PR fixes KIA-E-GMP-BATTERY.cpp build.

Why
Refactor missed INTERVAL_500_MS_DELAYED definition.