### PR TITLE
Kia/Hyundai 64: Add allowed charge limits from CAN

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -26,8 +26,8 @@ static uint8_t CellVmaxNo = 0;
 static uint16_t CellVoltMin_mV = 3700;
 static uint8_t CellVminNo = 0;
 static uint16_t cell_deviation_mV = 0;
-static int16_t allowedDischargePower = 0;
-static int16_t allowedChargePower = 0;
+static uint16_t allowedDischargePower = 0;
+static uint16_t allowedChargePower = 0;
 static uint16_t batteryVoltage = 0;
 static int16_t batteryAmps = 0;
 static int16_t temperatureMax = 0;
@@ -158,18 +158,16 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
 
-  //datalayer.battery.status.max_charge_power_W = (uint16_t)allowedChargePower * 10;  //From kW*100 to Watts
-  //The allowed charge power is not available. We estimate this value
   if (datalayer.battery.status.reported_soc == 10000) {  // When scaled SOC is 100%, set allowed charge power to 0
     datalayer.battery.status.max_charge_power_W = 0;
-  } else {  // No limits, max charging power allowed
-    datalayer.battery.status.max_charge_power_W = MAXCHARGEPOWERALLOWED;
+  } else {  // Limit according to CAN value
+    datalayer.battery.status.max_charge_power_W = allowedChargePower;
   }
-  //datalayer.battery.status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
+
   if (datalayer.battery.status.reported_soc < 100) {  // When scaled SOC is <1%, set allowed charge power to 0
     datalayer.battery.status.max_discharge_power_W = 0;
-  } else {  // No limits, max charging power allowed
-    datalayer.battery.status.max_discharge_power_W = MAXDISCHARGEPOWERALLOWED;
+  } else {  // Limit according to CAN value
+    datalayer.battery.status.max_discharge_power_W = allowedDischargePower;
   }
 
   //Power in watts, Negative = charging batt
@@ -257,9 +255,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
   Serial.print((int16_t)datalayer.battery.status.active_power_W);
   Serial.println(" Watts");
   Serial.print("Allowed Charge ");
-  Serial.print((uint16_t)allowedChargePower * 10);
+  Serial.print((uint16_t)allowedChargePower);
   Serial.print(" W  |  Allowed Discharge ");
-  Serial.print((uint16_t)allowedDischargePower * 10);
+  Serial.print((uint16_t)allowedDischargePower);
   Serial.println(" W");
   Serial.print("MaxCellVolt ");
   Serial.print(CellVoltMax_mV);
@@ -309,6 +307,8 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       SOC_Display = rx_frame.data.u8[0] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x594:
+      allowedChargePower = ((rx_frame.data.u8[0] << 8) + rx_frame.data.u8[1]);
+      allowedDischargePower = ((rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3]);
       SOC_BMS = rx_frame.data.u8[5] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x595:
@@ -365,8 +365,6 @@ void receive_can_battery(CAN_frame_t rx_frame) {
           break;
         case 0x21:  //First frame in PID group
           if (poll_data_pid == 1) {
-            allowedChargePower = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[4]);
-            allowedDischargePower = ((rx_frame.data.u8[5] << 8) + rx_frame.data.u8[6]);
             batteryRelay = rx_frame.data.u8[7];
           } else if (poll_data_pid == 2) {
             cellvoltages_mv[0] = (rx_frame.data.u8[2] * 20);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -161,13 +161,13 @@ void update_values_battery() {  //This function maps all the values fetched via 
   if (datalayer.battery.status.reported_soc == 10000) {  // When scaled SOC is 100%, set allowed charge power to 0
     datalayer.battery.status.max_charge_power_W = 0;
   } else {  // Limit according to CAN value
-    datalayer.battery.status.max_charge_power_W = allowedChargePower;
+    datalayer.battery.status.max_charge_power_W = allowedChargePower * 10;
   }
 
   if (datalayer.battery.status.reported_soc < 100) {  // When scaled SOC is <1%, set allowed charge power to 0
     datalayer.battery.status.max_discharge_power_W = 0;
   } else {  // Limit according to CAN value
-    datalayer.battery.status.max_discharge_power_W = allowedDischargePower;
+    datalayer.battery.status.max_discharge_power_W = allowedDischargePower * 10;
   }
 
   //Power in watts, Negative = charging batt
@@ -307,8 +307,8 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       SOC_Display = rx_frame.data.u8[0] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x594:
-      allowedChargePower = ((rx_frame.data.u8[0] << 8) + rx_frame.data.u8[1]);
-      allowedDischargePower = ((rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3]);
+      allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
+      allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
       SOC_BMS = rx_frame.data.u8[5] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x595:

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -255,9 +255,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
   Serial.print((int16_t)datalayer.battery.status.active_power_W);
   Serial.println(" Watts");
   Serial.print("Allowed Charge ");
-  Serial.print((uint16_t)allowedChargePower);
+  Serial.print((uint16_t)allowedChargePower * 10);
   Serial.print(" W  |  Allowed Discharge ");
-  Serial.print((uint16_t)allowedDischargePower);
+  Serial.print((uint16_t)allowedDischargePower * 10);
   Serial.println(" W");
   Serial.print("MaxCellVolt ");
   Serial.print(CellVoltMax_mV);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -6,9 +6,6 @@
 
 #define BATTERY_SELECTED
 
-#define MAXCHARGEPOWERALLOWED 10000
-#define MAXDISCHARGEPOWERALLOWED 10000
-
 void setup_battery(void);
 
 #endif


### PR DESCRIPTION
### What
This PR makes the Kia/Hyundai battery respect the BMS max allowed charge/discharge values

### How
By the reverse engineering performed by projectgus and tiny_man over on the Discord, we now know that the value to use is in CAN message 0x594

### Why
Safer battery operation