### PR TITLE
Bugfix: Decrease time before CAN retransmission

### DIFF
--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
@@ -21,7 +21,7 @@ int ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame) {
       clear_event(EVENT_CAN_TX_FAILURE);
     }
   } else {
-    if ((millis() - start_time) >= 2000) {
+    if ((millis() - start_time) >= 20) {
       tx_ok = true;
     }
   }


### PR DESCRIPTION
### What
This PR makes the board attempt to retransmit messages quicker incase the bus failed. This makes it so that double LilyGo / double CAN is no longer needed for Goodwe/GE inverters, everything can co-exist on one CAN bus! 🥳 

### Why
Some inverters like to swap between 250kbps and 500kbps to poll what battery is connected. Doing this with battery/inverter/emulator on same CAN channel might cause contactors to open on battery side.

### How
The hold off delay was lowered from 2000ms -> 20ms. ⚠️ This might cause unforseen consequences, incase we actually have an issue it should be better to hold off the retransmission for longer periods of time, to let the other CAN devices recover more gracefully. 