### PR TITLE
Bugfix: Make faulted LED solid red again 🔴 

### DIFF
--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -70,7 +70,7 @@ void LED::exe(void) {
           break;
         case EVENT_LEVEL_ERROR:
           color = led_color::RED;
-          pixels.setPixelColor(0, COLOR_RED(brightness));  // Red LED full brightness
+          pixels.setPixelColor(0, COLOR_RED(150));  // Red LED full brightness
           break;
         default:
           break;

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -70,7 +70,7 @@ void LED::exe(void) {
           break;
         case EVENT_LEVEL_ERROR:
           color = led_color::RED;
-          pixels.setPixelColor(0, COLOR_RED(150));  // Red LED full brightness
+          pixels.setPixelColor(0, COLOR_RED(LED_MAX_BRIGHTNESS));  // Red LED full brightness
           break;
         default:
           break;


### PR DESCRIPTION
### What
This PR makes the LED on the board stay on with solid red color incase we enter faulted state

### Why
Having the fault state solid red without any animations helps the user figure out that something is wrong. It is also better for colorblind users that may mistake the green from red.

### How
The rewrite for the LED handling introduced in software 5.7.1 added new animations. The fault state accidentally got animated, it should be static.