### PR TITLE
Feature: Add contactor opening if faulted for too long (Kia64)

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -42,6 +42,7 @@ static uint8_t BMS_ign = 0;
 static uint8_t batteryRelay = 0;
 static uint8_t waterleakageSensor = 164;
 static uint8_t counter_200 = 0;
+static uint8_t counter_200_open = 0;
 static int8_t temperature_water_inlet = 0;
 static int8_t heatertemp = 0;
 static int8_t powerRelayTemperature = 0;
@@ -611,7 +612,15 @@ void send_can_battery() {
     }
 
     if (datalayer.system.status.battery_allows_contactor_closing == false) {
-      KIA_HYUNDAI_200.data.u8[5] &= ~(1 << 5);  // Bit45 holds contactor closing value
+      KIA_HYUNDAI_200.data.u8[0] = 0x09;
+      KIA_HYUNDAI_200.data.u8[1] = 0x00;
+      KIA_HYUNDAI_200.data.u8[2] = 0x9D;
+      KIA_HYUNDAI_200.data.u8[3] = 0x00;
+      KIA_HYUNDAI_200.data.u8[4] = 0x00;
+      KIA_HYUNDAI_200.data.u8[5] = (counter_200_open << 6);
+      KIA_HYUNDAI_200.data.u8[6] = 0xD0;
+      KIA_HYUNDAI_200.data.u8[7] = 0x00;
+      counter_200_open = (counter_200_open + 1) % 4;  // counter_200_open cycles between 0-1-2-3-0-1...
     }
 
     ESP32Can.CANWriteFrame(&KIA_HYUNDAI_200);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -610,9 +610,11 @@ void send_can_battery() {
         break;
     }
 
-    if (datalayer.system.status.battery_allows_contactor_closing == true) {
-      ESP32Can.CANWriteFrame(&KIA_HYUNDAI_200);
+    if (datalayer.system.status.battery_allows_contactor_closing == false) {
+      KIA_HYUNDAI_200.data.u8[5] &= ~(1 << 5);  // Bit45 holds contactor closing value
     }
+
+    ESP32Can.CANWriteFrame(&KIA_HYUNDAI_200);
 
     ESP32Can.CANWriteFrame(&KIA_HYUNDAI_523);
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -142,6 +142,7 @@ void init_events(void) {
   events.entries[EVENT_BATTERY_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_BATTERY_OPENS_CONTACTORS].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_LOW_SOH].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_HVIL_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_INTERNAL_OPEN_FAULT].level = EVENT_LEVEL_ERROR;
@@ -224,6 +225,9 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Info: COLD BATTERY! Battery requesting heating pads to activate!";
     case EVENT_BATTERY_WARMED_UP:
       return "Info: Battery requesting heating pads to stop. The battery is now warm enough.";
+    case EVENT_BATTERY_OPENS_CONTACTORS:
+      return "Info: Battery spent too much time in FAULT state. Opening contactors! See the other fault code for "
+             "reason.";
     case EVENT_LOW_SOH:
       return "ERROR: State of health critically low. Battery internal resistance too high to continue. Recycle "
              "battery.";

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0002  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0003  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -44,6 +44,7 @@
   XX(EVENT_BATTERY_CHG_DISCHG_STOP_REQ) \
   XX(EVENT_BATTERY_REQUESTS_HEAT)       \
   XX(EVENT_BATTERY_WARMED_UP)           \
+  XX(EVENT_BATTERY_OPENS_CONTACTORS)    \
   XX(EVENT_LOW_SOH)                     \
   XX(EVENT_HVIL_FAILURE)                \
   XX(EVENT_INTERNAL_OPEN_FAULT)         \

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -9,6 +9,7 @@
 
 #include "devboard/hal/hal.h"
 #include "devboard/utils/time_meas.h"
+#include "devboard/utils/timer.h"
 #include "devboard/utils/types.h"
 
 #include "battery/BATTERIES.h"


### PR DESCRIPTION
### What
This PR adds automatic contactor opening incase battery goes into faulted state for over 1 minute. This implementation is only for Hyundai/Kia 64 batteries to start with.

### Why
To improve safety

### How
A timer is used to gauge how much time has been spent in FAULT mode. If it goes over 60 seconds, the 0x200 message is no longer sent towards the battery, causing contactors to open.

![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/e76d2533-9c99-48d2-a97b-558c3df7b18d)
