### PR TITLE
Feature: Add more events for BMW i3 to aid troubleshooting

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -459,6 +459,18 @@ void update_values_battery() {  //This function maps all the values fetched via 
     set_event(EVENT_CAN_RX_WARNING, 0);
   }
 
+  // Perform other safety checks
+  if (battery_status_error_locking == 2) {  // HVIL seated?
+    set_event(EVENT_HVIL_FAILURE, 0);
+  } else {
+    clear_event(EVENT_HVIL_FAILURE);
+  }
+  if (battery_status_precharge_locked == 2) {  // Capacitor seated?
+    set_event(EVENT_PRECHARGE_FAILURE, 0);
+  } else {
+    clear_event(EVENT_PRECHARGE_FAILURE);
+  }
+
 #ifdef DEBUG_VIA_USB
   Serial.println(" ");
   Serial.print("Values sent to inverter: ");

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -229,8 +229,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "ERROR: State of health critically low. Battery internal resistance too high to continue. Recycle "
              "battery.";
     case EVENT_HVIL_FAILURE:
-      return "ERROR: Battery interlock loop broken. Check that high voltage connectors are seated. Battery will be "
-             "disabled!";
+      return "ERROR: Battery interlock loop broken. Check that high voltage / low voltage connectors are seated. "
+             "Battery will be disabled!";
     case EVENT_PRECHARGE_FAILURE:
       return "Info: Battery failed to precharge. Check that capacitor is seated on high voltage output.";
     case EVENT_INTERNAL_OPEN_FAULT:

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -144,6 +144,7 @@ void init_events(void) {
   events.entries[EVENT_BATTERY_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_LOW_SOH].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_HVIL_FAILURE].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_PRECHARGE_FAILURE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_INTERNAL_OPEN_FAULT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_INVERTER_OPEN_CONTACTOR].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CELL_UNDER_VOLTAGE].level = EVENT_LEVEL_ERROR;
@@ -230,6 +231,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_HVIL_FAILURE:
       return "ERROR: Battery interlock loop broken. Check that high voltage connectors are seated. Battery will be "
              "disabled!";
+    case EVENT_PRECHARGE_FAILURE:
+      return "Info: Battery failed to precharge. Check that capacitor is seated on high voltage output.";
     case EVENT_INTERNAL_OPEN_FAULT:
       return "ERROR: High voltage cable removed while battery running. Opening contactors!";
     case EVENT_INVERTER_OPEN_CONTACTOR:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0002  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0003  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -46,6 +46,7 @@
   XX(EVENT_BATTERY_WARMED_UP)           \
   XX(EVENT_LOW_SOH)                     \
   XX(EVENT_HVIL_FAILURE)                \
+  XX(EVENT_PRECHARGE_FAILURE)           \
   XX(EVENT_INTERNAL_OPEN_FAULT)         \
   XX(EVENT_INVERTER_OPEN_CONTACTOR)     \
   XX(EVENT_CELL_UNDER_VOLTAGE)          \


### PR DESCRIPTION
### What
This PR adds two more events to the i3 battery code

### Why
To assist installation troubleshooting

### How
We now alert the user via the webui via events, one for high voltage interlock not seated, and another one for capacitor missing on HV side.