### PR TITLE
Improvement/build serial link rx

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -46,8 +46,8 @@ jobs:
           - SERIAL_LINK_RECEIVER
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
-#         - BYD_CAN
-          - BYD_MODBUS
+          - BYD_CAN
+#         - BYD_MODBUS
 #         - LUNA2000_MODBUS
 #         - PYLON_CAN
 #         - SMA_CAN

--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -43,6 +43,7 @@ jobs:
           - TESLA_MODEL_3_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
+          - SERIAL_LINK_RECEIVER
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
 #         - BYD_CAN

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -46,7 +46,6 @@ jobs:
           - TESLA_MODEL_3_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
-          - SERIAL_INK_RECEIVER
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - BYD_CAN

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -46,6 +46,7 @@ jobs:
           - TESLA_MODEL_3_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
+          - SERIAL_INK_RECEIVER
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - BYD_CAN


### PR DESCRIPTION
### WHAT
Add build of SERIAL_LINK_RECEIVER at commit or PR

### WHY
Currently, we don't build SERIAL_LINK_RECEIVER and this causes a risk of undetected regressions

### HOW
Add SERIAL_LINK_RECEIVER to workflows. Change the target "inverter" to BYD_CAN since BYD_MODBUS and SERIAL_LINK_RECEIVER are incompatible. Compile All Combinations cannot be updated as it will attempt to build the incompatible configuration.