### PR TITLE
Feature: Add Event when automatic contactor opening happens

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -91,7 +91,7 @@ MyTimer loop_task_timer_10s(INTERVAL_10_S);
 enum State { DISCONNECTED, PRECHARGE, NEGATIVE, POSITIVE, PRECHARGE_OFF, COMPLETED, SHUTDOWN_REQUESTED };
 State contactorStatus = DISCONNECTED;
 
-#define MAX_ALLOWED_FAULT_TICKS 500
+#define MAX_ALLOWED_FAULT_TICKS 1000
 #define PRECHARGE_TIME_MS 160
 #define NEGATIVE_CONTACTOR_TIME_MS 1000
 #define POSITIVE_CONTACTOR_TIME_MS 2000
@@ -630,6 +630,7 @@ void handle_contactors() {
     digitalWrite(PRECHARGE_PIN, LOW);
     digitalWrite(NEGATIVE_CONTACTOR_PIN, LOW);
     digitalWrite(POSITIVE_CONTACTOR_PIN, LOW);
+    set_event(EVENT_ERROR_OPEN_CONTACTOR, 0);
     return;  // A fault scenario latches the contactor control. It is not possible to recover without a powercycle (and investigation why fault occured)
   }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -147,6 +147,7 @@ void init_events(void) {
   events.entries[EVENT_PRECHARGE_FAILURE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_INTERNAL_OPEN_FAULT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_INVERTER_OPEN_CONTACTOR].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_ERROR_OPEN_CONTACTOR].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CELL_UNDER_VOLTAGE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CELL_OVER_VOLTAGE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CELL_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
@@ -237,6 +238,9 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "ERROR: High voltage cable removed while battery running. Opening contactors!";
     case EVENT_INVERTER_OPEN_CONTACTOR:
       return "Info: Inverter side opened contactors. Normal operation.";
+    case EVENT_ERROR_OPEN_CONTACTOR:
+      return "Info: Too much time spent in error state. Opening contactors, not safe to continue charging. "
+             "Check other error code for reason!";
     case EVENT_CELL_UNDER_VOLTAGE:
       return "ERROR: CELL UNDERVOLTAGE!!! Stopping battery charging and discharging. Inspect battery!";
     case EVENT_CELL_OVER_VOLTAGE:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0003  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0004  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -49,6 +49,7 @@
   XX(EVENT_PRECHARGE_FAILURE)           \
   XX(EVENT_INTERNAL_OPEN_FAULT)         \
   XX(EVENT_INVERTER_OPEN_CONTACTOR)     \
+  XX(EVENT_ERROR_OPEN_CONTACTOR)        \
   XX(EVENT_CELL_UNDER_VOLTAGE)          \
   XX(EVENT_CELL_OVER_VOLTAGE)           \
   XX(EVENT_CELL_DEVIATION_HIGH)         \


### PR DESCRIPTION
### What
This PR adds an event for when automatic contactor control (via GPIO) decides to open contactors

### Why
For easier troubleshooting

### How
- An event is added "Info: Too much time spent in error state. Opening contactors, not safe to continue charging. Check other error code for reason!"
- We also increase ticks from 500->1000, to avoid making the control too rapid.