### PR TITLE
Improvement/event uptimestamp

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -226,7 +226,7 @@ void core_loop(void* task_time_us) {
     if (millis() - previousMillisUpdateVal >= intervalUpdateValues)  // Every 5s normally
     {
       previousMillisUpdateVal = millis();
-      update_SOC();               // Check if real or calculated SOC% value should be sent
+      update_SOC();     // Check if real or calculated SOC% value should be sent
       update_values();  // Update values heading towards inverter. Prepare for sending on CAN, or write directly to Modbus.
       if (DUMMY_EVENT_ENABLED) {
         set_event(EVENT_DUMMY_ERROR, (uint8_t)millis());

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -226,7 +226,6 @@ void core_loop(void* task_time_us) {
     if (millis() - previousMillisUpdateVal >= intervalUpdateValues)  // Every 5s normally
     {
       previousMillisUpdateVal = millis();
-      uptime::calculateUptime();  // millis() overflows every 50 days, so update occasionally to adjust
       update_SOC();               // Check if real or calculated SOC% value should be sent
       update_values();  // Update values heading towards inverter. Prepare for sending on CAN, or write directly to Modbus.
       if (DUMMY_EVENT_ENABLED) {

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -5,8 +5,8 @@
 #endif
 
 #include "../../../USER_SETTINGS.h"
-#include "timer.h"
 #include "../../lib/Uptime_Library/src/uptime.h"
+#include "timer.h"
 
 #define EE_NOF_EVENT_ENTRIES 30
 #define EE_EVENT_ENTRY_SIZE sizeof(EVENT_LOG_ENTRY_TYPE)

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -6,6 +6,7 @@
 
 #include "../../../USER_SETTINGS.h"
 #include "timer.h"
+#include "../../lib/Uptime_Library/src/uptime.h"
 
 #define EE_NOF_EVENT_ENTRIES 30
 #define EE_EVENT_ENTRY_SIZE sizeof(EVENT_LOG_ENTRY_TYPE)
@@ -165,7 +166,7 @@ void init_events(void) {
 
   events.entries[EVENT_EEPROM_WRITE].log = false;  // Don't log the logger...
 
-  events.second_timer.set_interval(1000);
+  events.second_timer.set_interval(600);
   // Write to EEPROM every X minutes (if an event has been set)
   events.ee_timer.set_interval(EE_WRITE_PERIOD_MINUTES * 60 * 1000);
   events.update_timer.set_interval(2000);
@@ -352,8 +353,10 @@ static void update_event_level(void) {
 }
 
 static void update_event_time(void) {
+  // This should run roughly 2 times per second
   if (events.second_timer.elapsed() == true) {
-    events.time_seconds++;
+    uptime::calculateUptime();  // millis() overflows every 50 days, so update occasionally to adjust
+    events.time_seconds = uptime::getSeconds();
   }
 }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -8,6 +8,11 @@
 #include "../../lib/Uptime_Library/src/uptime.h"
 #include "timer.h"
 
+// Time conversion macros
+#define DAYS_TO_SECS 86400  // 24 * 60 * 60
+#define HOURS_TO_SECS 3600  // 60 * 60
+#define MINUTES_TO_SECS 60
+
 #define EE_NOF_EVENT_ENTRIES 30
 #define EE_EVENT_ENTRY_SIZE sizeof(EVENT_LOG_ENTRY_TYPE)
 #define EE_WRITE_PERIOD_MINUTES 10
@@ -45,7 +50,7 @@ typedef struct {
 
 typedef struct {
   EVENTS_STRUCT_TYPE entries[EVENT_NOF_EVENTS];
-  uint32_t time_seconds;
+  unsigned long time_seconds;
   MyTimer second_timer;
   MyTimer ee_timer;
   MyTimer update_timer;
@@ -356,8 +361,15 @@ static void update_event_time(void) {
   // This should run roughly 2 times per second
   if (events.second_timer.elapsed() == true) {
     uptime::calculateUptime();  // millis() overflows every 50 days, so update occasionally to adjust
-    events.time_seconds = uptime::getSeconds();
+    events.time_seconds = uptime::getDays() * DAYS_TO_SECS;
+    events.time_seconds += uptime::getHours() * HOURS_TO_SECS;
+    events.time_seconds += uptime::getMinutes() * MINUTES_TO_SECS;
+    events.time_seconds += uptime::getSeconds();
   }
+}
+
+unsigned long get_current_event_time_secs(void) {
+  return events.time_seconds;
 }
 
 static void log_event(EVENTS_ENUM_TYPE event, uint8_t data) {

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -98,6 +98,7 @@ const char* get_event_enum_string(EVENTS_ENUM_TYPE event);
 const char* get_event_message_string(EVENTS_ENUM_TYPE event);
 const char* get_event_level_string(EVENTS_ENUM_TYPE event);
 const char* get_event_type(EVENTS_ENUM_TYPE event);
+unsigned long get_current_event_time_secs(void);
 
 EVENTS_LEVEL_TYPE get_event_level(void);
 

--- a/Software/src/devboard/webserver/events_html.cpp
+++ b/Software/src/devboard/webserver/events_html.cpp
@@ -9,7 +9,7 @@ const char EVENTS_HTML_END[] = R"=====(
 </div></div>
 <button onclick='home()'>Back to main page</button>
 <style>.event:nth-child(even){background-color:#455a64}.event:nth-child(odd){background-color:#394b52}</style>
-<script>function showEvent(){document.querySelector(".event-log");var i=(new Date).getTime()/1e3;document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".sec-ago"),t=e.querySelector(".timestamp");if(n&&t){var o=parseInt(n.innerText,10),a=parseFloat(t.innerText),r=new Date(1e3*(i-a+o)).toLocaleString();n.innerText=r}})}function home(){window.location.href="/"}window.onload=function(){showEvent()}</script>
+<script>function showEvent(){document.querySelectorAll(".event").forEach(function(e){var n=e.querySelector(".sec-ago");n&&(n.innerText=new Date(new Date().getTime()-1e3*parseInt(n.innerText,10)).toLocaleString())})}function home(){window.location.href="/"}window.onload=function(){showEvent()}</script>
 )=====";
 
 String events_processor(const String& var) {
@@ -19,6 +19,9 @@ String events_processor(const String& var) {
     // Page format
     content.concat(FPSTR(EVENTS_HTML_START));
     const EVENTS_STRUCT_TYPE* event_pointer;
+
+    unsigned long timestamp_now = get_current_event_time_secs();
+
     for (int i = 0; i < EVENT_NOF_EVENTS; i++) {
       event_pointer = get_event_pointer((EVENTS_ENUM_TYPE)i);
       EVENTS_ENUM_TYPE event_handle = static_cast<EVENTS_ENUM_TYPE>(i);
@@ -32,11 +35,10 @@ String events_processor(const String& var) {
         content.concat("<div class='event'>");
         content.concat("<div>" + String(get_event_enum_string(event_handle)) + "</div>");
         content.concat("<div>" + String(get_event_level_string(event_handle)) + "</div>");
-        content.concat("<div class='sec-ago'>" + String(event_pointer->timestamp) + "</div>");
+        content.concat("<div class='sec-ago'>" + String(timestamp_now - event_pointer->timestamp) + "</div>");
         content.concat("<div>" + String(event_pointer->occurences) + "</div>");
         content.concat("<div>" + String(event_pointer->data) + "</div>");
         content.concat("<div>" + String(get_event_message_string(event_handle)) + "</div>");
-        content.concat("<div class='timestamp' style='display:none;'>" + String(millis() / 1000) + "</div>");
         content.concat("</div>");  // End of event row
       }
     }


### PR DESCRIPTION
### WHAT
Event timestamp update

### WHY
@smaresca added a proper library for tracking uptime. Previously, the event timestamp was relative time since last second, basically a 1s timer that incremented a counter. This introduces lots of inaccuracy, and since uptime is precisely what we need for the timestamp, uptime is what we should use

### HOW
uptime::calculateUptime() is moved from the core task and a 5 second period to the loop() task and a 600 ms period to increase uptime updates while keeping that load in the lowest priority task. It gets plenty of run time so there's no risk of errors. In events.cpp:update_event_time() we now use the uptime library to update the event timestamp.

In addition, events_html.cpp is updated with a leaner javascript function.

### TESTING
The update is tested live and is showing no-to-little jitter, and no drift over time