### PR TITLE
Improvement: Make amp value based on actual voltage

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -118,7 +118,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //Calculate values
   charge_current =
       ((datalayer.battery.status.max_charge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   charge_current = (charge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (charge_current > datalayer.battery.info.max_charge_amp_dA) {
@@ -129,7 +129,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 
   discharge_current =
       ((datalayer.battery.status.max_discharge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   discharge_current = (discharge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (discharge_current > datalayer.battery.info.max_discharge_amp_dA) {

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -107,7 +107,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //Calculate values
   charge_current =
       ((datalayer.battery.status.max_charge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   charge_current = (charge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (charge_current > datalayer.battery.info.max_charge_amp_dA) {
@@ -118,7 +118,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 
   discharge_current =
       ((datalayer.battery.status.max_discharge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   discharge_current = (discharge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (discharge_current > datalayer.battery.info.max_discharge_amp_dA) {

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -165,7 +165,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //Calculate values
   charge_current =
       ((datalayer.battery.status.max_charge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   charge_current = (charge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (charge_current > datalayer.battery.info.max_charge_amp_dA) {
@@ -176,7 +176,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 
   discharge_current =
       ((datalayer.battery.status.max_discharge_power_W * 10) /
-       datalayer.battery.info.max_design_voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
+       datalayer.battery.status.voltage_dV);  //Charge power in W , max volt in V+1decimal (P=UI, solve for I)
   //The above calculation results in (30 000*10)/3700=81A
   discharge_current = (discharge_current * 10);  //Value needs a decimal before getting sent to inverter (81.0A)
   if (discharge_current > datalayer.battery.info.max_discharge_amp_dA) {


### PR DESCRIPTION
### What
This makes the calculated max charge/discharge value sent on CAN be based on actual battery voltage (instead of theoretical pack max voltage)

### Why
To make values make more sense. @Newevg noticed that the values sent towards inverter were too small, and loosing out on a few kW of power

### How
In all calculations, `datalayer.battery.info.max_design_voltage_dV` is replaced with `datalayer.battery.status.voltage_dV`