### PR TITLE
Fix serial-link

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -131,7 +131,7 @@ void setup() {
 
   init_contactors();
 
-  init_modbus();
+  init_rs485();
 
   init_serialDataLink();
 
@@ -415,8 +415,7 @@ void init_contactors() {
 #endif
 }
 
-void init_modbus() {
-#ifdef MODBUS_INVERTER_SELECTED
+void init_rs485() {
   // Set up Modbus RTU Server
   pinMode(RS485_EN_PIN, OUTPUT);
   digitalWrite(RS485_EN_PIN, HIGH);
@@ -425,6 +424,7 @@ void init_modbus() {
   pinMode(PIN_5V_EN, OUTPUT);
   digitalWrite(PIN_5V_EN, HIGH);
 
+#ifdef MODBUS_INVERTER_SELECTED
 #ifdef BYD_MODBUS
   // Init Static data to the RTU Modbus
   handle_static_data_modbus_byd();


### PR DESCRIPTION
### WHAT
Serial-link fixer upper

### WHY
Serial-link is handy!

### HOW
RS485_EN_PIN, RS485_SE_PIN and PIN_5V_EN are needed for using Serial2 via the RS485 pins. Their configuration had been excluded from serial-link builds when the function was made exclusive for modbus

### TESTING
Tested ok on the kitchen table, tested live in a user setup.