### PR TITLE
Pylon CAN: Add more battery mappings

### DIFF
--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -197,10 +197,10 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4211.data.u8[3] = (datalayer.battery.status.current_dA & 0x00FF);
 
   // BMS Temperature (We dont have BMS temp, send max cell voltage instead)
-  PYLON_4210.data.u8[4] = (datalayer.battery.status.temperature_max_dC >> 8);
-  PYLON_4210.data.u8[5] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
-  PYLON_4211.data.u8[4] = (datalayer.battery.status.temperature_max_dC >> 8);
-  PYLON_4211.data.u8[5] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
+  PYLON_4210.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
+  PYLON_4210.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
+  PYLON_4211.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
+  PYLON_4211.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
 
   //SOC (100.00%)
   PYLON_4210.data.u8[6] = (datalayer.battery.status.reported_soc / 100);  //Remove decimals

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -174,13 +174,6 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //There are more mappings that could be added, but this should be enough to use as a starting point
   // Note we map both 0 and 1 messages
 
-  //Amount of cells
-  PYLON_7320.data.u8[0] = datalayer.battery.info.number_of_cells;
-  //Modules in series (not really how EV packs work, but let's map it to a reasonable Pylon value)
-  PYLON_7320.data.u8[2] = (datalayer.battery.info.number_of_cells / 15);
-  //Capacity in AH
-  PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
-
   //Charge / Discharge allowed
   PYLON_4280.data.u8[0] = 0;
   PYLON_4280.data.u8[1] = 0;
@@ -282,6 +275,13 @@ void send_can_inverter() {
 }
 
 void send_setup_info() {  //Ensemble information
+  //Amount of cells
+  PYLON_7320.data.u8[0] = datalayer.battery.info.number_of_cells;
+  //Modules in series (not really how EV packs work, but let's map it to a reasonable Pylon value)
+  PYLON_7320.data.u8[2] = (datalayer.battery.info.number_of_cells / 15);
+  //Capacity in AH
+  PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
+
 #ifdef SEND_0
   ESP32Can.CANWriteFrame(&PYLON_7310);
   ESP32Can.CANWriteFrame(&PYLON_7320);

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -174,6 +174,13 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //There are more mappings that could be added, but this should be enough to use as a starting point
   // Note we map both 0 and 1 messages
 
+  //Amount of cells
+  PYLON_7320.data.u8[0] = datalayer.battery.info.number_of_cells;
+  //Modules in series (not really how EV packs work, but let's map it to a reasonable Pylon value)
+  PYLON_7320.data.u8[2] = (datalayer.battery.info.number_of_cells / 15);
+  //Capacity in AH
+  PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
+
   //Charge / Discharge allowed
   PYLON_4280.data.u8[0] = 0;
   PYLON_4280.data.u8[1] = 0;
@@ -229,6 +236,18 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4221.data.u8[2] = (datalayer.battery.info.max_design_voltage_dV >> 8);
   PYLON_4221.data.u8[3] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
 #endif
+
+  //Max/Min cell voltage
+  PYLON_4230.data.u8[0] = (datalayer.battery.status.cell_max_voltage_mV >> 8);
+  PYLON_4230.data.u8[1] = (datalayer.battery.status.cell_max_voltage_mV & 0x00FF);
+  PYLON_4230.data.u8[2] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
+  PYLON_4230.data.u8[3] = (datalayer.battery.status.cell_min_voltage_mV & 0x00FF);
+
+  //Max/Min temperature battery
+  PYLON_4240.data.u8[0] = (datalayer.battery.status.temperature_max_dC >> 8);
+  PYLON_4240.data.u8[1] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
+  PYLON_4240.data.u8[2] = (datalayer.battery.status.temperature_min_dC >> 8);
+  PYLON_4240.data.u8[3] = (datalayer.battery.status.temperature_min_dC & 0x00FF);
 
   //In case we run into any errors/faults, we can set charge / discharge forbidden
   if (datalayer.battery.status.bms_status == FAULT) {

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -7,8 +7,8 @@
 
 #define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
 //#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_VOLTAGE  //If defined, the min/max voltage frames will be inverted, \
-                        //useful for some inverters like Sofar that report the voltages incorrect otherwise
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes
+                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
 
 /* Do not change code below unless you are sure what you are doing */
 //Actual content messages
@@ -197,10 +197,17 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4211.data.u8[3] = (datalayer.battery.status.current_dA & 0x00FF);
 
   // BMS Temperature (We dont have BMS temp, send max cell voltage instead)
+#ifdef INVERT_LOW_HIGH_BYTES  //Useful for Sofar inverters
+  PYLON_4210.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
+  PYLON_4210.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
+  PYLON_4211.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
+  PYLON_4211.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
+#else
   PYLON_4210.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
   PYLON_4210.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
   PYLON_4211.data.u8[4] = ((datalayer.battery.status.temperature_max_dC + 1000) >> 8);
   PYLON_4211.data.u8[5] = ((datalayer.battery.status.temperature_max_dC + 1000) & 0x00FF);
+#endif
 
   //SOC (100.00%)
   PYLON_4210.data.u8[6] = (datalayer.battery.status.reported_soc / 100);  //Remove decimals
@@ -210,7 +217,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4210.data.u8[7] = (datalayer.battery.status.soh_pptt / 100);
   PYLON_4211.data.u8[7] = (datalayer.battery.status.soh_pptt / 100);
 
-#ifdef INVERT_VOLTAGE  //Useful for Sofar inverters \
+#ifdef INVERT_LOW_HIGH_BYTES  //Useful for Sofar inverters \
                        //Maxvoltage (eg 400.0V = 4000 , 16bits long) Discharge Cutoff Voltage
   PYLON_4220.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
   PYLON_4220.data.u8[1] = (datalayer.battery.info.max_design_voltage_dV >> 8);

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -286,7 +286,9 @@ void send_setup_info() {  //Ensemble information
   //Modules in series (not really how EV packs work, but let's map it to a reasonable Pylon value)
   PYLON_7320.data.u8[2] = (datalayer.battery.info.number_of_cells / 15);
   //Capacity in AH
-  PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
+  if(datalayer.battery.status.voltage_dV > 10){ //div0 safeguard
+    PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
+  }
 
 #ifdef SEND_0
   ESP32Can.CANWriteFrame(&PYLON_7310);

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -7,7 +7,7 @@
 
 #define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
 //#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
                                //useful for some inverters like Sofar that report the voltages incorrect otherwise
 
 /* Do not change code below unless you are sure what you are doing */

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -236,11 +236,17 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4230.data.u8[2] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
   PYLON_4230.data.u8[3] = (datalayer.battery.status.cell_min_voltage_mV & 0x00FF);
 
-  //Max/Min temperature battery
+  //Max/Min temperature per cell
   PYLON_4240.data.u8[0] = (datalayer.battery.status.temperature_max_dC >> 8);
   PYLON_4240.data.u8[1] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
   PYLON_4240.data.u8[2] = (datalayer.battery.status.temperature_min_dC >> 8);
   PYLON_4240.data.u8[3] = (datalayer.battery.status.temperature_min_dC & 0x00FF);
+
+  //Max/Min temperature per module
+  PYLON_4270.data.u8[0] = (datalayer.battery.status.temperature_max_dC >> 8);
+  PYLON_4270.data.u8[1] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
+  PYLON_4270.data.u8[2] = (datalayer.battery.status.temperature_min_dC >> 8);
+  PYLON_4270.data.u8[3] = (datalayer.battery.status.temperature_min_dC & 0x00FF);
 
   //In case we run into any errors/faults, we can set charge / discharge forbidden
   if (datalayer.battery.status.bms_status == FAULT) {

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -196,6 +196,12 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4211.data.u8[2] = (datalayer.battery.status.current_dA >> 8);
   PYLON_4211.data.u8[3] = (datalayer.battery.status.current_dA & 0x00FF);
 
+  // BMS Temperature (We dont have BMS temp, send max cell voltage instead)
+  PYLON_4210.data.u8[4] = (datalayer.battery.status.temperature_max_dC >> 8);
+  PYLON_4210.data.u8[5] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
+  PYLON_4211.data.u8[4] = (datalayer.battery.status.temperature_max_dC >> 8);
+  PYLON_4211.data.u8[5] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
+
   //SOC (100.00%)
   PYLON_4210.data.u8[6] = (datalayer.battery.status.reported_soc / 100);  //Remove decimals
   PYLON_4211.data.u8[6] = (datalayer.battery.status.reported_soc / 100);  //Remove decimals
@@ -286,7 +292,7 @@ void send_setup_info() {  //Ensemble information
   //Modules in series (not really how EV packs work, but let's map it to a reasonable Pylon value)
   PYLON_7320.data.u8[2] = (datalayer.battery.info.number_of_cells / 15);
   //Capacity in AH
-  if(datalayer.battery.status.voltage_dV > 10){ //div0 safeguard
+  if (datalayer.battery.status.voltage_dV > 10) {  //div0 safeguard
     PYLON_7320.data.u8[6] = (datalayer.battery.info.total_capacity_Wh / (datalayer.battery.status.voltage_dV / 10));
   }
 


### PR DESCRIPTION
### What
This PR adds more mappings to the CAN inverter protocol Pylon

### Why
User Pazdzierz on the Discord noticed that the following were hardcoded from early development.

### How
We now map:
- Cellvoltage max
- Cellvoltage min
- Celltemperature max
- Celltemperature min
- Number of cells
- Number of modules (fake but ok)
- Battery capacity in AH