### PR TITLE
Bugfix: Correct scaling on kWh for Solax

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -192,8 +192,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1873.data.u8[3] = (datalayer.battery.status.current_dA >> 8);
   SOLAX_1873.data.u8[4] = (uint8_t)(datalayer.battery.status.reported_soc / 100);  //SOC (100.00%)
   //SOLAX_1873.data.u8[5] = //Seems like this is not required? Or shall we put SOC decimals here?
-  SOLAX_1873.data.u8[6] = (uint8_t)(capped_remaining_capacity_Wh / 100);
-  SOLAX_1873.data.u8[7] = ((capped_remaining_capacity_Wh / 100) >> 8);
+  SOLAX_1873.data.u8[6] = (uint8_t)(capped_remaining_capacity_Wh / 10);
+  SOLAX_1873.data.u8[7] = ((capped_remaining_capacity_Wh / 10) >> 8);
 
   //BMS_CellData
   SOLAX_1874.data.u8[0] = (int8_t)datalayer.battery.status.temperature_max_dC;


### PR DESCRIPTION
### What
This PR fixes kWh remaning on Solax 

### Why
Decimal point was wrong;
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/01b1edfa-018d-4a51-8937-ec2d3ec24b80)

### How
Instead of dividing value with 100, divide with 10