### PR TITLE
Improvement: Send cellmV when cell events are raised

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -455,7 +455,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   // Start checking safeties. First up, cellvoltages!
   if (battery_cell_deviation_mV > MAX_CELL_DEVIATION_MV) {
-    set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+    set_event(EVENT_CELL_DEVIATION_HIGH, battery_cell_deviation_mV);
   } else {
     clear_event(EVENT_CELL_DEVIATION_HIGH);
   }
@@ -463,28 +463,28 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
     datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
     if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_60AH) {
-      set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+      set_event(EVENT_CELL_OVER_VOLTAGE, (datalayer.battery.status.cell_max_voltage_mV / 20));
     }
     if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_60AH) {
-      set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+      set_event(EVENT_CELL_UNDER_VOLTAGE, (datalayer.battery.status.cell_min_voltage_mV / 20));
     }
   } else if (detectedBattery == BATTERY_94AH) {
     datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_94AH;
     datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_94AH;
     if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_94AH) {
-      set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+      set_event(EVENT_CELL_OVER_VOLTAGE, (datalayer.battery.status.cell_max_voltage_mV / 20));
     }
     if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_94AH) {
-      set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+      set_event(EVENT_CELL_UNDER_VOLTAGE, (datalayer.battery.status.cell_min_voltage_mV / 20));
     }
   } else {  // BATTERY_120AH
     datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_120AH;
     datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_120AH;
     if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_120AH) {
-      set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+      set_event(EVENT_CELL_OVER_VOLTAGE, (datalayer.battery.status.cell_max_voltage_mV / 20));
     }
     if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_120AH) {
-      set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+      set_event(EVENT_CELL_UNDER_VOLTAGE, (datalayer.battery.status.cell_min_voltage_mV / 20));
     }
   }
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -116,13 +116,13 @@ void update_values_battery() {  //This function maps all the values fetched via 
   cell_deviation_mV = (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);
 
   if (CellVoltMax_mV >= MAX_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+    set_event(EVENT_CELL_OVER_VOLTAGE, (CellVoltMax_mV / 20));
   }
   if (CellVoltMin_mV <= MIN_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+    set_event(EVENT_CELL_UNDER_VOLTAGE, (CellVoltMin_mV / 20));
   }
   if (cell_deviation_mV > MAX_CELL_DEVIATION) {
-    set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+    set_event(EVENT_CELL_DEVIATION_HIGH, cell_deviation_mV);
   } else {
     clear_event(EVENT_CELL_DEVIATION_HIGH);
   }

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -219,13 +219,13 @@ void update_values_battery() {  //This function maps all the values fetched via 
   cell_deviation_mV = (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);
 
   if (CellVoltMax_mV >= MAX_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+    set_event(EVENT_CELL_OVER_VOLTAGE, (CellVoltMax_mV / 20));
   }
   if (CellVoltMin_mV <= MIN_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+    set_event(EVENT_CELL_UNDER_VOLTAGE, (CellVoltMin_mV / 20));
   }
   if (cell_deviation_mV > MAX_CELL_DEVIATION) {
-    set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+    set_event(EVENT_CELL_DEVIATION_HIGH, cell_deviation_mV);
   } else {
     clear_event(EVENT_CELL_DEVIATION_HIGH);
   }

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -527,14 +527,14 @@ void receive_can_battery(CAN_frame_t rx_frame) {
           datalayer.battery.status.cell_min_voltage_mV = min_max_voltage[0];
 
           if (cell_deviation_mV > MAX_CELL_DEVIATION) {
-            set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+            set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
           }
 
           if (min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+            set_event(EVENT_CELL_OVER_VOLTAGE, (min_max_voltage[1] / 20));
           }
           if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+            set_event(EVENT_CELL_UNDER_VOLTAGE, (min_max_voltage[0] / 20));
           }
           break;
         }

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
@@ -76,13 +76,13 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
   if (LB_Cell_Max_Voltage >= ABSOLUTE_CELL_MAX_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+    set_event(EVENT_CELL_OVER_VOLTAGE, (LB_Cell_Max_Voltage / 20));
   }
   if (LB_Cell_Min_Voltage <= ABSOLUTE_CELL_MIN_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+    set_event(EVENT_CELL_UNDER_VOLTAGE, (LB_Cell_Min_Voltage / 20));
   }
   if (cell_deviation_mV > MAX_CELL_DEVIATION_MV) {
-    set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+    set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
   } else {
     clear_event(EVENT_CELL_DEVIATION_HIGH);
   }

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -317,14 +317,14 @@ void receive_can_battery(CAN_frame_t rx_frame) {
           cell_deviation_mV = (min_max_voltage[1] - min_max_voltage[0]);
 
           if (cell_deviation_mV > MAX_CELL_DEVIATION) {
-            set_event(EVENT_CELL_DEVIATION_HIGH, 0);
+            set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
           }
 
           if (min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+            set_event(EVENT_CELL_OVER_VOLTAGE, (min_max_voltage[1] / 20));
           }
           if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+            set_event(EVENT_CELL_UNDER_VOLTAGE, (min_max_voltage[0] / 20));
           }
           ESP32Can.CANWriteFrame(&VOLVO_SOH_Req);  //Send SOH read request
         }


### PR DESCRIPTION
### What
This PR makes the cell over/under/deviation events easier to troubleshoot. Added to all battery types that were missing this.

### Why
Now when for instance a cell overvoltage event is raised, it is hard to know what the value of the cell was when it occured.

### How
Since the event can only get an u8 parsed (0-255), we shrink the cellvoltage by 20, and when reviewing the events you can simply add *20 to the value. (4250mV sent as 4250/20 = 212)