### PR TITLE
Bugfix/bmw i3 messages

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -451,8 +451,10 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.temperature_max_dC = battery_temperature_max * 10;  // Add a decimal
 
-  datalayer.battery.status.cell_min_voltage_mV = datalayer.battery.status.cell_voltages_mV[0];
-  datalayer.battery.status.cell_max_voltage_mV = datalayer.battery.status.cell_voltages_mV[2];
+  if (datalayer.battery.status.cell_voltages_mV[0] > 0) {
+    datalayer.battery.status.cell_min_voltage_mV = datalayer.battery.status.cell_voltages_mV[0];
+    datalayer.battery.status.cell_max_voltage_mV = datalayer.battery.status.cell_voltages_mV[2];
+  }
 
   battery_cell_deviation_mV =
       (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -465,7 +465,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
     // Start checking safeties. First up, cellvoltages!
     if (battery_cell_deviation_mV > MAX_CELL_DEVIATION_MV) {
       uint8_t report_value = 0;
-      if (battery_cell_deviation_mV <= 20*254) {
+      if (battery_cell_deviation_mV <= 20 * 254) {
         report_value = battery_cell_deviation_mV / 20;
       } else {
         report_value = 255;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -895,14 +895,14 @@ void send_can_battery() {
       BMW_3E5.data.u8[0] = 0xFD;  // First 3E5 message byte0 we send is unique, once we sent initial value send this
     }
   } else {
-      previousMillis20 = currentMillis;
-      previousMillis100 = currentMillis;
-      previousMillis200 = currentMillis;
-      previousMillis500 = currentMillis;
-      previousMillis640 = currentMillis;
-      previousMillis1000 = currentMillis;
-      previousMillis5000 = currentMillis;
-      previousMillis10000 = currentMillis;
+    previousMillis20 = currentMillis;
+    previousMillis100 = currentMillis;
+    previousMillis200 = currentMillis;
+    previousMillis500 = currentMillis;
+    previousMillis640 = currentMillis;
+    previousMillis1000 = currentMillis;
+    previousMillis5000 = currentMillis;
+    previousMillis10000 = currentMillis;
   }
 }
 

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -452,7 +452,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.temperature_max_dC = battery_temperature_max * 10;  // Add a decimal
 
   datalayer.battery.status.cell_min_voltage_mV = datalayer.battery.status.cell_voltages_mV[0];
-  datalayer.battery.status.cell_max_voltage_mV = datalayer.battery.status.cell_voltages_mV[1];
+  datalayer.battery.status.cell_max_voltage_mV = datalayer.battery.status.cell_voltages_mV[2];
 
   battery_cell_deviation_mV =
       (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -517,7 +517,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   } else {
     clear_event(EVENT_PRECHARGE_FAILURE);
   }
-  
 
 #ifdef DEBUG_VIA_USB
   Serial.println(" ");


### PR DESCRIPTION
**What**
Fixed fetching extra data and wait until data available before setting low voltage event. Use max cell voltage instead of average voltage. Reduced risk of making unneeded events. 

**Why**
Make using BMW i3 batteries more robust.

**How**
Send different defined 0x6F1 messages and parse them as the type requested. Made logic regarding raising events more robust.