### PR TITLE
Feature: Add initial support for Stark hardware

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -342,9 +342,11 @@ void init_stored_settings() {
 }
 
 void init_CAN() {
-  // CAN pins
+// CAN pins
+#ifdef CAN_SE_PIN
   pinMode(CAN_SE_PIN, OUTPUT);
   digitalWrite(CAN_SE_PIN, LOW);
+#endif
   CAN_cfg.speed = CAN_SPEED_500KBPS;
   CAN_cfg.tx_pin_id = GPIO_NUM_27;
   CAN_cfg.rx_pin_id = GPIO_NUM_26;
@@ -419,16 +421,27 @@ void init_contactors() {
   pinMode(PRECHARGE_PIN, OUTPUT);
   digitalWrite(PRECHARGE_PIN, LOW);
 #endif
+// Init BMS contactor
+#ifdef HW_STARK  // TODO: Rewrite this so LilyGo can aslo handle this BMS contactor
+  pinMode(BMS_POWER, OUTPUT);
+  digitalWrite(BMS_POWER, HIGH);
+#endif
 }
 
 void init_rs485() {
-  // Set up Modbus RTU Server
+// Set up Modbus RTU Server
+#ifdef RS485_EN_PIN
   pinMode(RS485_EN_PIN, OUTPUT);
   digitalWrite(RS485_EN_PIN, HIGH);
+#endif
+#ifdef RS485_SE_PIN
   pinMode(RS485_SE_PIN, OUTPUT);
   digitalWrite(RS485_SE_PIN, HIGH);
+#endif
+#ifdef PIN_5V_EN
   pinMode(PIN_5V_EN, OUTPUT);
   digitalWrite(PIN_5V_EN, HIGH);
+#endif
 
 #ifdef MODBUS_INVERTER_SELECTED
 #ifdef BYD_MODBUS

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -32,6 +32,10 @@
 //#define SOFAR_CAN        //Enable this line to emulate a "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame)" over CAN bus
 //#define SOLAX_CAN        //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
 
+/* Select hardware used for Battery-Emulator */
+#define HW_LILYGO
+//#define HW_STARK
+
 /* Other options */
 //#define DEBUG_VIA_USB  //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
 //#define DEBUG_CANFD_DATA    //Enable this line to have the USB port output CAN-FD data while program runs (WARNING, raises CPU load, do not use for production)

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -3,11 +3,10 @@
 
 #include "../../../USER_SETTINGS.h"
 
-/* Select HW - DONT TOUCH */
-#define HW_LILYGO
-
 #if defined(HW_LILYGO)
 #include "hw_lilygo.h"
+#elif defined(HW_STARK)
+#include "hw_stark.h"
 #elif defined(HW_SJB_V1)
 #include "hw_sjb_v1.h"
 #endif

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -1,0 +1,66 @@
+#ifndef __HW_STARK06_H__
+#define __HW_STARK06_H__
+
+// Board boot-up time
+#define BOOTUP_TIME 1000  // Time in ms it takes before system is considered fully started up
+
+// Core assignment
+#define CORE_FUNCTION_CORE 1
+#define MODBUS_CORE 0
+#define WIFI_CORE 0
+
+// RS485
+// #define PIN_5V_EN 16 	// No function, GPIO 16 used instead as MCP_SCK
+// #define RS485_EN_PIN 17  // RE, No function, GPIO 17 is instead available as extra GPIO via pin header
+#define RS485_TX_PIN 22
+#define RS485_RX_PIN 21
+// #define RS485_SE_PIN 19  // No function, GPIO 19 is instead available as extra GPIO via pin header
+
+// CAN settings. CAN_2 is not defined as it can be either MCP2515 or MCP2517, defined by the user settings
+#define CAN_1_TYPE ESP32CAN
+
+// CAN1 PIN mappings, do not change these unless you are adding on extra hardware to the PCB
+#define CAN_TX_PIN GPIO_NUM_27
+#define CAN_RX_PIN GPIO_NUM_26
+// #define CAN_SE_PIN 23 // (No function, GPIO 23 used instead as MCP_SCK)
+
+// CAN2 defines below
+
+// DUAL_CAN defines
+//#define MCP2515_SCK 12   // SCK input of MCP2515
+//#define MCP2515_MOSI 5   // SDI input of MCP2515
+//#define MCP2515_MISO 34  // SDO output of MCP2515 | Pin 34 is input only, without pullup/down resistors
+//#define MCP2515_CS 18    // CS input of MCP2515
+//#define MCP2515_INT 35   // INT output of MCP2515 |  | Pin 35 is input only, without pullup/down resistors
+
+// CAN_FD defines
+#define MCP2517_SCK 16  // SCK input of MCP2517 (Changed from 12 to 16 since 12 can be used for JTAG TDI)
+#define MCP2517_SDI 5   // SDI input of MCP2517
+#define MCP2517_SDO 34  // SDO output of MCP2517
+#define MCP2517_CS 18   // CS input of MCP2517
+#define MCP2517_INT 35  // INT output of MCP2517
+
+// Contactor handling
+#define POSITIVE_CONTACTOR_PIN 32
+#define NEGATIVE_CONTACTOR_PIN 33
+#define PRECHARGE_PIN 25
+#define BMS_POWER 23  // Also connected to MCP_SCK
+
+// SD card
+//#define SD_MISO_PIN 2
+//#define SD_MOSI_PIN 15
+//#define SD_SCLK_PIN 14
+//#define SD_CS_PIN 13
+
+// LED
+#define LED_PIN 4
+#define LED_MAX_BRIGHTNESS 40
+
+/* ----- Error checks below, don't change (can't be moved to separate file) ----- */
+#ifndef HW_CONFIGURED
+#define HW_CONFIGURED
+#else
+#error Multiple HW defined! Please select a single HW
+#endif
+
+#endif


### PR DESCRIPTION
### What
This PR adds support for the Stark hardware board, developed by @StarkJohan 🙌 

### Why
This board is considered more of a heavy-duty / prosumer board compared to the LilyGo alternative. The Stark board has built in support for 2x CAN channels, one of them being CAN-FD. It also has built in relays for actuating contactor closing, more advanced LED visualization of each output, DIP switches for CAN terminaton, and more. Once the board reaches maturity, we'll do a more in-depth explanation of it!

### How
In the USER_SETTINGS.h file, you can now choose which hardware you are using ( LilyGo / Stark )