### PR TITLE
Fix canfd startup. Now when INT pin is connected then everything shou…

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -377,6 +377,7 @@ void init_CAN() {
                               DataBitRateFactor::x4);      // Arbitration bit rate: 500 kbit/s, data bit rate: 2 Mbit/s
   settings.mRequestedMode = ACAN2517FDSettings::NormalFD;  // ListenOnly / Normal20B / NormalFD
   const uint32_t errorCode = canfd.begin(settings, [] { canfd.isr(); });
+  canfd.poll();
   if (errorCode == 0) {
 #ifdef DEBUG_VIA_USB
     Serial.print("Bit Rate prescaler: ");


### PR DESCRIPTION
…ld work as intended and no need to fiddle with disconnecting INT pin

What
This PR fixes canfd startup with INT pin connected.

Why
For some reason canfd did not start with INT pin connected and it required disconnecting INT and then reconnecting for it to work.

How
After many trial and error and debugging the ACAN2517FD library it turns out that the fix was to call canfd.poll() after starting. Dont know why but it works for me.