### PR TITLE
Prevent MQTT to publish cell voltage values before they are populated

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -75,7 +75,8 @@ static void publish_cell_voltages(void) {
     doc.clear();  // clear after sending autoconfig
   } else {
     // If cell voltages haven't been populated...
-    if (datalayer.battery.info.number_of_cells == 0u || datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]==0u) {
+    if (datalayer.battery.info.number_of_cells == 0u ||
+        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]==0u) {
       return;
     }
 
@@ -160,7 +161,8 @@ static void publish_common_info(void) {
     doc["battery_current"] = ((float)((int16_t)datalayer.battery.status.current_dA)) / 10.0;
     doc["battery_voltage"] = ((float)datalayer.battery.status.voltage_dV) / 10.0;
     // publish only if cell voltages have been populated...
-    if (datalayer.battery.info.number_of_cells != 0u && datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]!=0u) {
+    if (datalayer.battery.info.number_of_cells != 0u &&
+        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]!=0u) {
       doc["cell_max_voltage"] = ((float)datalayer.battery.status.cell_max_voltage_mV) / 1000.0;
       doc["cell_min_voltage"] = ((float)datalayer.battery.status.cell_min_voltage_mV) / 1000.0;
     }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -75,7 +75,7 @@ static void publish_cell_voltages(void) {
     doc.clear();  // clear after sending autoconfig
   } else {
     // If cell voltages haven't been populated...
-    if (datalayer.battery.info.number_of_cells == 0u) {
+    if (datalayer.battery.info.number_of_cells == 0u || datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]==0u) {
       return;
     }
 
@@ -158,10 +158,12 @@ static void publish_common_info(void) {
     doc["temperature_max"] = ((float)((int16_t)datalayer.battery.status.temperature_max_dC)) / 10.0;
     doc["stat_batt_power"] = ((float)((int32_t)datalayer.battery.status.active_power_W));
     doc["battery_current"] = ((float)((int16_t)datalayer.battery.status.current_dA)) / 10.0;
-    doc["cell_max_voltage"] = ((float)datalayer.battery.status.cell_max_voltage_mV) / 1000.0;
-    doc["cell_min_voltage"] = ((float)datalayer.battery.status.cell_min_voltage_mV) / 1000.0;
     doc["battery_voltage"] = ((float)datalayer.battery.status.voltage_dV) / 10.0;
-
+    // publish only if cell voltages have been populated...
+    if (datalayer.battery.info.number_of_cells != 0u && datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]!=0u) {
+      doc["cell_max_voltage"] = ((float)datalayer.battery.status.cell_max_voltage_mV) / 1000.0;
+      doc["cell_min_voltage"] = ((float)datalayer.battery.status.cell_min_voltage_mV) / 1000.0;
+    }
     serializeJson(doc, mqtt_msg);
     if (!mqtt_publish(state_topic.c_str(), mqtt_msg, false)) {
 #ifdef DEBUG_VIA_USB

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -76,7 +76,7 @@ static void publish_cell_voltages(void) {
   } else {
     // If cell voltages haven't been populated...
     if (datalayer.battery.info.number_of_cells == 0u ||
-        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]==0u) {
+        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells - 1] == 0u) {
       return;
     }
 
@@ -162,7 +162,7 @@ static void publish_common_info(void) {
     doc["battery_voltage"] = ((float)datalayer.battery.status.voltage_dV) / 10.0;
     // publish only if cell voltages have been populated...
     if (datalayer.battery.info.number_of_cells != 0u &&
-        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells-1]!=0u) {
+        datalayer.battery.status.cell_voltages_mV[datalayer.battery.info.number_of_cells - 1] != 0u) {
       doc["cell_max_voltage"] = ((float)datalayer.battery.status.cell_max_voltage_mV) / 1000.0;
       doc["cell_min_voltage"] = ((float)datalayer.battery.status.cell_min_voltage_mV) / 1000.0;
     }


### PR DESCRIPTION
In addition to checking the value of the variable number_of_cells, we also test the value of the last cell, as the value of the cells can be filled some time after initializing the number of cells. This test was also added before publishing the values cell_max_voltage and cell_min_voltage since they are ​​calculated from the cell data.