### PR TITLE
Feature: ESP32 Arduino Core v3.0.0 compatibility

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -336,9 +336,9 @@ void update_values_battery() { /* This function maps all the values fetched via 
 }
 
 void receive_can_battery(CAN_frame_t rx_frame) {
-  can_bus_alive = true;
   switch (rx_frame.MsgID) {
     case 0x1DB:
+      can_bus_alive = true;
       if (is_message_corrupt(rx_frame)) {
         datalayer.battery.status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -50,7 +50,7 @@ void handle_static_data_modbus_byd() {
 }
 
 void handle_update_data_modbusp201_byd() {
-  mbPV[202] = std::min(datalayer.battery.info.total_capacity_Wh, 60000u);  //Cap capacity to 60kWh if needed
+  mbPV[202] = std::min(datalayer.battery.info.total_capacity_Wh, static_cast<uint32_t>(60000u));  //Cap to 60kWh
   mbPV[205] = (datalayer.battery.info.max_design_voltage_dV);  // Max Voltage, if higher Gen24 forces discharge
   mbPV[206] = (datalayer.battery.info.min_design_voltage_dV);  // Min Voltage, if lower Gen24 disables battery
 }
@@ -83,10 +83,10 @@ void handle_update_data_modbusp301_byd() {
   mbPV[300] = datalayer.battery.status.bms_status;
   mbPV[302] = 128 + bms_char_dis_status;
   mbPV[303] = datalayer.battery.status.reported_soc;
-  mbPV[304] = std::min(datalayer.battery.info.total_capacity_Wh, 60000u);        //Cap capacity to 60kWh if needed
-  mbPV[305] = std::min(datalayer.battery.status.remaining_capacity_Wh, 60000u);  //Cap capacity to 60kWh if needed
-  mbPV[306] = std::min(max_discharge_W, 30000u);                                 //Cap to 30000 if exceeding
-  mbPV[307] = std::min(max_charge_W, 30000u);                                    //Cap to 30000 if exceeding
+  mbPV[304] = std::min(datalayer.battery.info.total_capacity_Wh, static_cast<uint32_t>(60000u));        //Cap to 60kWh
+  mbPV[305] = std::min(datalayer.battery.status.remaining_capacity_Wh, static_cast<uint32_t>(60000u));  //Cap to 60kWh
+  mbPV[306] = std::min(max_discharge_W, static_cast<uint32_t>(30000u));  //Cap to 30000 if exceeding
+  mbPV[307] = std::min(max_charge_W, static_cast<uint32_t>(30000u));     //Cap to 30000 if exceeding
   mbPV[310] = datalayer.battery.status.voltage_dV;
   mbPV[312] = datalayer.battery.status.temperature_min_dC;
   mbPV[313] = datalayer.battery.status.temperature_max_dC;

--- a/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/AsyncEventSource.cpp
+++ b/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/AsyncEventSource.cpp
@@ -185,7 +185,7 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     return;
   }
   if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+      //ets_printf("ERROR: Too many messages queued\n");
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);

--- a/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/AsyncWebSocket.cpp
+++ b/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/AsyncWebSocket.cpp
@@ -548,7 +548,7 @@ void AsyncWebSocketClient::_queueMessage(AsyncWebSocketMessage *dataMessage){
     return;
   }
   if(_messageQueue.length() >= WS_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+      //ets_printf("ERROR: Too many messages queued\n");
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);
@@ -829,7 +829,7 @@ void AsyncWebSocketClient::binary(AsyncWebSocketMessageBuffer * buffer)
 
 IPAddress AsyncWebSocketClient::remoteIP() {
     if(!_client) {
-        return IPAddress(0U);
+        return IPAddress(static_cast<uint32_t>(0U));
     }
     return _client->remoteIP();
 }
@@ -1259,9 +1259,9 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   (String&)key += WS_STR_UUID;
   mbedtls_sha1_context ctx;
   mbedtls_sha1_init(&ctx);
-  mbedtls_sha1_starts_ret(&ctx);
-  mbedtls_sha1_update_ret(&ctx, (const unsigned char*)key.c_str(), key.length());
-  mbedtls_sha1_finish_ret(&ctx, hash);
+  mbedtls_sha1_starts(&ctx);
+  mbedtls_sha1_update(&ctx, (const unsigned char*)key.c_str(), key.length());
+  mbedtls_sha1_finish(&ctx, hash);
   mbedtls_sha1_free(&ctx);
 #endif
   base64_encodestate _state;

--- a/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/WebAuthentication.cpp
+++ b/Software/src/lib/me-no-dev-ESPAsyncWebServer/src/WebAuthentication.cpp
@@ -71,9 +71,9 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   memset(_buf, 0x00, 16);
 #ifdef ESP32
   mbedtls_md5_init(&_ctx);
-  mbedtls_md5_starts_ret(&_ctx);
-  mbedtls_md5_update_ret(&_ctx, data, len);
-  mbedtls_md5_finish_ret(&_ctx, _buf);
+  mbedtls_md5_starts(&_ctx);
+  mbedtls_md5_update(&_ctx, data, len);
+  mbedtls_md5_finish(&_ctx, _buf);
 #else
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -34,7 +34,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
-#include "esp_intr.h"
+#include "esp_intr_alloc.h" // Renamed when migrating ESP32 2.x -> 3.x
 #include "soc/dport_reg.h"
 #include <math.h>
 
@@ -42,6 +42,10 @@
 
 #include "can_regdef.h"
 #include "CAN_config.h"
+
+#define TWAI_TX_IDX 123 // TODO: Are these OK? 
+// not sure what file is needed now, maybe "soc/gpio_sig_map.h" but using hard coded values for now
+#define TWAI_RX_IDX 94  // TODO: Are these OK? 
 
 // CAN Filter - no acceptance filter
 static CAN_filter_t __filter = { Dual_Mode, 0, 0, 0, 0, 0Xff, 0Xff, 0Xff, 0Xff };
@@ -177,12 +181,12 @@ int CAN_init() {
 	// configure TX pin
 	gpio_set_level(CAN_cfg.tx_pin_id, 1);
 	gpio_set_direction(CAN_cfg.tx_pin_id, GPIO_MODE_OUTPUT);
-	gpio_matrix_out(CAN_cfg.tx_pin_id, CAN_TX_IDX, 0, 0);
+	gpio_matrix_out(CAN_cfg.tx_pin_id, TWAI_TX_IDX, 0, 0);
 	gpio_pad_select_gpio(CAN_cfg.tx_pin_id);
 
 	// configure RX pin
 	gpio_set_direction(CAN_cfg.rx_pin_id, GPIO_MODE_INPUT);
-	gpio_matrix_in(CAN_cfg.rx_pin_id, CAN_RX_IDX, 0);
+	gpio_matrix_in(CAN_cfg.rx_pin_id, TWAI_RX_IDX, 0);
 	gpio_pad_select_gpio(CAN_cfg.rx_pin_id);
 
 	// set to PELICAN mode


### PR DESCRIPTION
### What
This PR fixes the issues encountered when upgrading from from Espressif versions 2.X.X (based on ESP-IDF 4.4) to version 3.0.0 (based on ESP-IDF 5.1) of the Arduino ESP32 core

This PR also fixes a minor bug in the LEAF code, that could cause contactors to never turn on

### Why
All Arduino builds will be migrated to 3.0.0, the automatic build system we have in place already uses 3.0.0 , so we need to update the code

### How
IMPORTANT! Users will need to update their version of ESP32 to 3.0.0, it can be done here in the Arduino IDE:
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/2c1eee53-aa30-40ff-bd74-a0af423119be)
