### PR TITLE
Bugfix: Kia/Hundai, Make 12V default value reasonable

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -25,7 +25,7 @@ static uint16_t batteryVoltage = 0;
 static uint16_t inverterVoltageFrameHigh = 0;
 static uint16_t inverterVoltage = 0;
 static uint16_t cellvoltages_mv[98];
-static int16_t leadAcidBatteryVoltage = 0;
+static int16_t leadAcidBatteryVoltage = 120;
 static int16_t batteryAmps = 0;
 static int16_t temperatureMax = 0;
 static int16_t temperatureMin = 0;


### PR DESCRIPTION
### What
This PR fixes the amber warning light seen on startup, when using Kia/Hyundai batteries

### Why
If the 12V value has not updated via CAN, the safety would check the incorrect default value (0V), and report it as too low

### How
Default value is now 12.0 V instead of 0V