### PR TITLE
Microfeature: Add hardware printout to Webui

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -374,6 +374,13 @@ String processor(const String& var) {
 
     // Show version number
     content += "<h4>Software: " + String(version_number) + "</h4>";
+// Show hardware used:
+#ifdef HW_LILYGO
+    content += "<h4>Hardware: LilyGo T-CAN485</h4>";
+#endif
+#ifdef HW_STARK
+    content += "<h4>Hardware: Stark CMR Module</h4>";
+#endif
     content += "<h4>Uptime: " + uptime_formatter::getUptime() + "</h4>";
 #ifdef FUNCTION_TIME_MEASUREMENT
     // Load information
@@ -395,9 +402,8 @@ String processor(const String& var) {
     content += "<h4>SSID: " + String(ssid) + "</h4>";
     if (status == WL_CONNECTED) {
       content += "<h4>IP: " + WiFi.localIP().toString() + "</h4>";
-      // Get and display the signal strength (RSSI)
-      content += "<h4>Signal Strength: " + String(WiFi.RSSI()) + " dBm</h4>";
-      content += "<h4>Channel: " + String(WiFi.channel()) + "</h4>";
+      // Get and display the signal strength (RSSI) and channel
+      content += "<h4>Signal strength: " + String(WiFi.RSSI()) + " dBm, at channel " + String(WiFi.channel()) + "</h4>";
     } else {
       content += "<h4>Wifi state: " + getConnectResultString(status) + "</h4>";
     }


### PR DESCRIPTION
### What
This PR adds a microfeature to the WebUI, it now shows what hardware the code has been compiled for!
![bild](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/f946a0b3-ee9c-4f26-b033-31cf1b7b069b)

### Why
To spot configuration mistakes more easily, and to easier be able to spot what HW has been used from people sending screenshots.

### How
Added ifdef printing to webserver.cpp