### PR TITLE
Bugfix: Add clearing of overrun event

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -687,6 +687,8 @@ void send_can_battery() {
       // Check if sending of CAN messages has been delayed too much.
       if ((currentMillis - previousMillis20 >= INTERVAL_20_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
         set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis20));
+      } else {
+        clear_event(EVENT_CAN_OVERRUN);
       }
       previousMillis20 = currentMillis;
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -264,6 +264,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis50 >= INTERVAL_50_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis50));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis50 = currentMillis;
 

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -689,6 +689,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis100 = currentMillis;
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -188,6 +188,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis100 = currentMillis;
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -377,6 +377,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis500ms >= INTERVAL_500_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis500ms));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis500ms = currentMillis;
     //  Section added to close contractor

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -525,6 +525,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis10 = currentMillis;
 

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -125,6 +125,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis10 = currentMillis;
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -559,6 +559,8 @@ void send_can_battery() {
       // Check if sending of CAN messages has been delayed too much.
       if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
         set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
+      } else {
+        clear_event(EVENT_CAN_OVERRUN);
       }
       previousMillis10 = currentMillis;
 

--- a/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-BATTERY.cpp
@@ -125,6 +125,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis100 = currentMillis;
     //ESP32Can.CANWriteFrame(&ZOE_423);

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -123,6 +123,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis10 = currentMillis;
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -568,6 +568,8 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis30 >= INTERVAL_30_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis30));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis30 = currentMillis;
 

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -331,6 +331,8 @@ void send_can_battery() {
     // Check if sending of CAN messages has been delayed too much.
     if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
+    } else {
+      clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis100 = currentMillis;
 


### PR DESCRIPTION
### What
This PR adds possibility to clear any "CAN OVERRUN" event, when the messages are no longer delayed.

### Why
To allow for better visualization of CPU load issues. Now we just get 1 single event, no way to know if it was a one time occurance, or a massive problem that happens several times per day

### How
Added clear_event() to all sections that use this event