### PR TITLE
CPU load improvement: Apply less filtering on CAN signals

### DIFF
--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -228,7 +228,7 @@ int CAN_init() {
 	 * 1 -> triple; the bus is sampled three times; recommended for low/medium speed buses     (class A and B) where
 	 * filtering spikes on the bus line is beneficial 0 -> single; the bus is sampled once; recommended for high speed
 	 * buses (SAE class C)*/
-	MODULE_CAN->BTR1.B.SAM = 0x1;
+	MODULE_CAN->BTR1.B.SAM = 0x0;
 
 	// enable all interrupts
 	MODULE_CAN->IER.U = 0xef; //ESP32 V3 0XEF     ESP32 NOT V3 0XFF


### PR DESCRIPTION
### What
This PR attempts to reduce CPU load, by filtering the CAN signals less

### Why
The code occasionally spikes in CPU load, this should help!

### How
Instead of triple checking that the CAN signals are going high/low, we instead directly set the values to high/low once they are sampled. This reduces CPU load in two ways;
- Less Processing: Sampling once requires fewer computations and less time compared to sampling three times.
- Reduced Interrupt Load: With fewer samples, there are fewer interrupts generated for processing the CAN messages.

:warning: After making this change, we need to monitor CAN communication performance to ensure that it has the desired effect of reducing CPU load, and does not introduce any new CAN issues