### PR TITLE
Move WIFI out from the core task

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -184,7 +184,7 @@ void mqtt_loop(void* task_time_us) {
     END_TIME_MEASUREMENT_MAX(mqtt, datalayer.system.status.mqtt_task_10s_max_us);
 
 #ifdef FUNCTION_TIME_MEASUREMENT
-    if (mqtt_task_timer_10s.elapsed()) {
+    if (connectivity_task_timer_10s.elapsed()) {
       datalayer.system.status.mqtt_task_10s_max_us = 0;
       datalayer.system.status.wifi_task_10s_max_us = 0;
     }

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -86,8 +86,8 @@ float charger_stat_LVvol = 0;
 int64_t core_task_time_us;
 MyTimer core_task_timer_10s(INTERVAL_10_S);
 
-int64_t mqtt_task_time_us;
-MyTimer mqtt_task_timer_10s(INTERVAL_10_S);
+int64_t connectivity_task_time_us;
+MyTimer connectivity_task_timer_10s(INTERVAL_10_S);
 
 MyTimer loop_task_timer_10s(INTERVAL_10_S);
 
@@ -116,7 +116,7 @@ unsigned long timeSpentInFaultedMode = 0;
 #endif
 
 TaskHandle_t main_loop_task;
-TaskHandle_t mqtt_loop_task;
+TaskHandle_t connectivity_loop_task;
 
 // Initialization
 void setup() {
@@ -128,8 +128,8 @@ void setup() {
   init_webserver();
   init_mDNS();
 #ifdef MQTT
-  xTaskCreatePinnedToCore((TaskFunction_t)&mqtt_loop, "mqtt_loop", 4096, &mqtt_task_time_us, TASK_CONNECTIVITY_PRIO,
-                          &mqtt_loop_task, WIFI_CORE);
+  xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, &connectivity_task_time_us,
+                          TASK_CONNECTIVITY_PRIO, &connectivity_loop_task, WIFI_CORE);
 #endif
 #endif
 
@@ -176,6 +176,9 @@ void mqtt_loop(void* task_time_us) {
   init_mqtt();
 
   while (true) {
+    START_TIME_MEASUREMENT(wifi);
+    wifi_monitor();
+    END_TIME_MEASUREMENT_MAX(wifi, datalayer.system.status.wifi_task_10s_max_us);
     START_TIME_MEASUREMENT(mqtt);
     mqtt_loop();
     END_TIME_MEASUREMENT_MAX(mqtt, datalayer.system.status.mqtt_task_10s_max_us);
@@ -183,6 +186,7 @@ void mqtt_loop(void* task_time_us) {
 #ifdef FUNCTION_TIME_MEASUREMENT
     if (mqtt_task_timer_10s.elapsed()) {
       datalayer.system.status.mqtt_task_10s_max_us = 0;
+      datalayer.system.status.wifi_task_10s_max_us = 0;
     }
 #endif
     delay(1);
@@ -211,10 +215,9 @@ void core_loop(void* task_time_us) {
 #endif
     END_TIME_MEASUREMENT_MAX(comm, datalayer.system.status.time_comm_us);
 #ifdef WEBSERVER
-    START_TIME_MEASUREMENT(wifi_ota);
-    wifi_monitor();
+    START_TIME_MEASUREMENT(ota);
     ElegantOTA.loop();
-    END_TIME_MEASUREMENT_MAX(wifi_ota, datalayer.system.status.time_wifi_us);
+    END_TIME_MEASUREMENT_MAX(ota, datalayer.system.status.time_ota_us);
 #endif
 
     START_TIME_MEASUREMENT(time_10ms);
@@ -262,13 +265,13 @@ void core_loop(void* task_time_us) {
       datalayer.system.status.time_snap_10ms_us = datalayer.system.status.time_10ms_us;
       datalayer.system.status.time_snap_5s_us = datalayer.system.status.time_5s_us;
       datalayer.system.status.time_snap_cantx_us = datalayer.system.status.time_cantx_us;
-      datalayer.system.status.time_snap_wifi_us = datalayer.system.status.time_wifi_us;
+      datalayer.system.status.time_snap_ota_us = datalayer.system.status.time_ota_us;
     }
 
     datalayer.system.status.core_task_max_us =
         MAX(datalayer.system.status.core_task_10s_max_us, datalayer.system.status.core_task_max_us);
     if (core_task_timer_10s.elapsed()) {
-      datalayer.system.status.time_wifi_us = 0;
+      datalayer.system.status.time_ota_us = 0;
       datalayer.system.status.time_comm_us = 0;
       datalayer.system.status.time_10ms_us = 0;
       datalayer.system.status.time_5s_us = 0;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -171,7 +171,7 @@ void loop() {
 }
 
 #ifdef MQTT
-void mqtt_loop(void* task_time_us) {
+void connectivity_loop(void* task_time_us) {
   // Init MQTT
   init_mqtt();
 

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -125,8 +125,6 @@ void setup() {
   init_stored_settings();
 
 #ifdef WEBSERVER
-  init_webserver();
-  init_mDNS();
 #ifdef MQTT
   xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, &connectivity_task_time_us,
                           TASK_CONNECTIVITY_PRIO, &connectivity_loop_task, WIFI_CORE);
@@ -170,9 +168,12 @@ void loop() {
 #endif
 }
 
+#ifdef WEBSERVER
 #ifdef MQTT
 void connectivity_loop(void* task_time_us) {
-  // Init MQTT
+  // Init
+  init_webserver();
+  init_mDNS();
   init_mqtt();
 
   while (true) {
@@ -192,6 +193,7 @@ void connectivity_loop(void* task_time_us) {
     delay(1);
   }
 }
+#endif
 #endif
 
 void core_loop(void* task_time_us) {

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -113,13 +113,15 @@ typedef struct {
   int64_t core_task_max_us = 0;
   /** Core task measurement variable, reset each 10 seconds */
   int64_t core_task_10s_max_us = 0;
-  /** MQTT task measurement variable, reset each 10 seconds */
+  /** MQTT sub-task measurement variable, reset each 10 seconds */
   int64_t mqtt_task_10s_max_us = 0;
+  /** Wifi sub-task measurement variable, reset each 10 seconds */
+  int64_t wifi_task_10s_max_us = 0;
   /** loop() task measurement variable, reset each 10 seconds */
   int64_t loop_task_10s_max_us = 0;
 
-  /** OTA/Wifi handling function measurement variable */
-  int64_t time_wifi_us = 0;
+  /** OTA handling function measurement variable */
+  int64_t time_ota_us = 0;
   /** CAN RX or serial link function measurement variable */
   int64_t time_comm_us = 0;
   /** 10 ms function measurement variable */
@@ -130,9 +132,9 @@ typedef struct {
   int64_t time_cantx_us = 0;
 
   /** Function measurement snapshot variable.
-   * This will show the performance of OTA/Wifi handling when the total time reached a new worst case
+   * This will show the performance of OTA handling when the total time reached a new worst case
    */
-  int64_t time_snap_wifi_us = 0;
+  int64_t time_snap_ota_us = 0;
   /** Function measurement snapshot variable.
    * This will show the performance of CAN RX or serial link when the total time reached a new worst case
    */

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -386,7 +386,12 @@ String processor(const String& var) {
     // Load information
     content += "<h4>Core task max load: " + String(datalayer.system.status.core_task_max_us) + " us</h4>";
     content += "<h4>Core task max load last 10 s: " + String(datalayer.system.status.core_task_10s_max_us) + " us</h4>";
-    content += "<h4>MQTT task max load last 10 s: " + String(datalayer.system.status.mqtt_task_10s_max_us) + " us</h4>";
+    content +=
+        "<h4>MQTT function (MQTT task) max load last 10 s: " + String(datalayer.system.status.mqtt_task_10s_max_us) +
+        " us</h4>";
+    content +=
+        "<h4>WIFI function (MQTT task) max load last 10 s: " + String(datalayer.system.status.wifi_task_10s_max_us) +
+        " us</h4>";
     content +=
         "<h4>loop() task max load last 10 s: " + String(datalayer.system.status.loop_task_10s_max_us) + " us</h4>";
     content += "<h4>Max load @ worst case execution of core task:</h4>";
@@ -394,7 +399,7 @@ String processor(const String& var) {
     content += "<h4>5s function timing: " + String(datalayer.system.status.time_snap_5s_us) + " us</h4>";
     content += "<h4>CAN/serial RX function timing: " + String(datalayer.system.status.time_snap_comm_us) + " us</h4>";
     content += "<h4>CAN TX function timing: " + String(datalayer.system.status.time_snap_cantx_us) + " us</h4>";
-    content += "<h4>Wifi and OTA function timing: " + String(datalayer.system.status.time_snap_wifi_us) + " us</h4>";
+    content += "<h4>OTA function timing: " + String(datalayer.system.status.time_snap_ota_us) + " us</h4>";
 #endif
 
     wl_status_t status = WiFi.status();


### PR DESCRIPTION
### WHAT
A relocation of wifi_monitor() to a separate task dedicated to various connectivity

### WHY
The WIFI functionality sometimes takes a looong time to finish handling reconnections and other shenanigans, which we don't want to affect core functions

### HOW
Move wifi_monitor() to the mqtt task, rename everything properly enough, test

### TESTING
Tested on my personal FroLeaf setup. WIFI load now doesn't affect the core task