### PR TITLE
Bugfix: Rescale voltage for Atto3

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -75,7 +75,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.real_soc = BMS_SOC * 100;
 
-  datalayer.battery.status.voltage_dV = BMS_voltage * 100;
+  datalayer.battery.status.voltage_dV = BMS_voltage * 10;
 
   datalayer.battery.status.current_dA = BMS_current;  //TODO: Signed right way?
 


### PR DESCRIPTION
### What
This PR fixes the voltage scaling on BYD Atto3

### Why
Voltages were scaled 10x too large, blocking charge/discharge
![image](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/864e7aed-bee7-4fe0-84d4-8372a96ea4d3)
