### PR TITLE
Bring Wifi back

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -125,10 +125,8 @@ void setup() {
   init_stored_settings();
 
 #ifdef WEBSERVER
-#ifdef MQTT
   xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, &connectivity_task_time_us,
                           TASK_CONNECTIVITY_PRIO, &connectivity_loop_task, WIFI_CORE);
-#endif
 #endif
 
   init_events();

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -169,20 +169,23 @@ void loop() {
 }
 
 #ifdef WEBSERVER
-#ifdef MQTT
 void connectivity_loop(void* task_time_us) {
   // Init
   init_webserver();
   init_mDNS();
+#ifdef MQTT
   init_mqtt();
+#endif
 
   while (true) {
     START_TIME_MEASUREMENT(wifi);
     wifi_monitor();
     END_TIME_MEASUREMENT_MAX(wifi, datalayer.system.status.wifi_task_10s_max_us);
+#ifdef MQTT
     START_TIME_MEASUREMENT(mqtt);
     mqtt_loop();
     END_TIME_MEASUREMENT_MAX(mqtt, datalayer.system.status.mqtt_task_10s_max_us);
+#endif
 
 #ifdef FUNCTION_TIME_MEASUREMENT
     if (connectivity_task_timer_10s.elapsed()) {
@@ -193,7 +196,6 @@ void connectivity_loop(void* task_time_us) {
     delay(1);
   }
 }
-#endif
 #endif
 
 void core_loop(void* task_time_us) {


### PR DESCRIPTION
### WHAT
A bugfix for lost Wifi if not using MQTT

### WHY
People love their Wifi

### HOW
When Wifi handling was moved out of the core loop, it ended up under a `#ifdef MQTT`section, causing Wifi to be inactive unless you use MQTT. Since the dev uses MQTT, he didn't notice this (shaame). Now the #ifdefs should be split properly.