### PR TITLE
Improvement: Improve performance on LED driver

### DIFF
--- a/Software/src/lib/adafruit-Adafruit_NeoPixel/esp.c
+++ b/Software/src/lib/adafruit-Adafruit_NeoPixel/esp.c
@@ -158,13 +158,6 @@ void espShow(uint8_t pin, uint8_t* pixels, uint32_t numBytes, boolean is800KHz) 
 
   // Write and wait to finish
   rmt_write_sample(0, pixels, (size_t)numBytes, false);
-  // rmt_wait_tx_done(config.channel, pdMS_TO_TICKS(100));
-
-  // Free channel again
-  // rmt_driver_uninstall(config.channel);
-  // rmt_reserved_channels[channel] = false;
-
-  // gpio_set_direction(pin, GPIO_MODE_OUTPUT);
 }
 
 #endif


### PR DESCRIPTION
### What
This PR reduces CPU load, by optmizing the LED driver

### Why
To improve CPU overhead on the Battery-Emulator, less time spent on LED modes, more time spent on actual battery-inverter synergy

### How
Stolen from @Cabooman 's CAN buffer branch 🕴️ 🙊 