### PR TITLE
Feature: Add SSID/PWD writing from webserver!

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -320,9 +320,6 @@ void init_stored_settings() {
   settings.clear();  // If this clear function is executed, no settings will be read from storage
 #endif
 
-  Serial.println("SSID before: ");
-  Serial.println(String(ssid.c_str()));
-
   char tempSSIDstring[63];  // Allocate buffer with sufficient size
   size_t lengthSSID = settings.getString("SSID", tempSSIDstring, sizeof(tempSSIDstring));
   if (lengthSSID > 0) {  // Successfully read the string from memory. Set it to SSID!

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -320,6 +320,22 @@ void init_stored_settings() {
   settings.clear();  // If this clear function is executed, no settings will be read from storage
 #endif
 
+  Serial.println("SSID before: ");
+  Serial.println(String(ssid.c_str()));
+
+  char tempSSIDstring[63];  // Allocate buffer with sufficient size
+  size_t lengthSSID = settings.getString("SSID", tempSSIDstring, sizeof(tempSSIDstring));
+  if (lengthSSID > 0) {  // Successfully read the string from memory. Set it to SSID!
+    ssid = tempSSIDstring;
+  } else {  // Reading from settings failed. Do nothing with SSID. Raise event?
+  }
+  char tempPasswordString[63];  // Allocate buffer with sufficient size
+  size_t lengthPassword = settings.getString("PASSWORD", tempPasswordString, sizeof(tempPasswordString));
+  if (lengthPassword > 7) {  // Successfully read the string from memory. Set it to password!
+    password = tempPasswordString;
+  } else {  // Reading from settings failed. Do nothing with SSID. Raise event?
+  }
+
   static uint32_t temp = 0;
   temp = settings.getUInt("BATTERY_WH_MAX", false);
   if (temp != 0) {
@@ -733,6 +749,8 @@ void init_serialDataLink() {
 
 void storeSettings() {
   settings.begin("batterySettings", false);
+  settings.putString("SSID", String(ssid.c_str()));
+  settings.putString("PASSWORD", String(password.c_str()));
   settings.putUInt("BATTERY_WH_MAX", datalayer.battery.info.total_capacity_Wh);
   settings.putUInt("MAXPERCENTAGE",
                    datalayer.battery.settings.max_percentage / 10);  // Divide by 10 for backwards compatibility
@@ -741,7 +759,6 @@ void storeSettings() {
   settings.putUInt("MAXCHARGEAMP", datalayer.battery.info.max_charge_amp_dA);
   settings.putUInt("MAXDISCHARGEAMP", datalayer.battery.info.max_discharge_amp_dA);
   settings.putBool("USE_SCALED_SOC", datalayer.battery.settings.soc_scaling_active);
-
   settings.end();
 }
 

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -1,5 +1,5 @@
 #include "USER_SETTINGS.h"
-
+#include <string>
 /* This file contains all the battery settings and limits */
 /* They can be defined here, or later on in the WebUI */
 
@@ -14,8 +14,8 @@ volatile float CHARGER_END_A = 1.0;       // Current at which charging is consid
 #ifdef WEBSERVER
 volatile uint8_t AccessPointEnabled =
     true;  //Set to either true or false incase you want the board to enable a direct wifi access point
-const char* ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
-const char* password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
+std::string ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
+std::string password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
 const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
 const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
 const uint8_t wifi_channel = 0;        // set to 0 for automatic channel selection

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -52,7 +52,7 @@
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
-//#define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot (overrides any battery settings set in USER_SETTINGS.cpp)
+#define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot (overrides Wifi/battery settings set below)
 //#define FUNCTION_TIME_MEASUREMENT  // Enable this to record execution times and present them in the web UI (WARNING, raises CPU load, do not use for production)
 
 /* MQTT options */

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1,6 +1,7 @@
 #include "settings_html.h"
 #include <Arduino.h>
 #include "../../datalayer/datalayer.h"
+#include "webserver.h"
 
 String settings_processor(const String& var) {
   if (var == "X") {
@@ -12,6 +13,18 @@ String settings_processor(const String& var) {
 
     // Start a new block with a specific background color
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+
+    content += "<h4 style='color: white;'>SSID: <span id='SSID'>" + String(ssid.c_str()) +
+               " </span> <button onclick='editSSID()'>Edit</button></h4>";
+    content +=
+        "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
+        "onclick='editPassword()'>Edit</button></h4>";
+
+    // Close the block
+    content += "</div>";
+
+    // Start a new block with a specific background color
+    content += "<div style='background-color: #2D3F2F; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
     // Show current settings with edit buttons and input fields
     content += "<h4 style='color: white;'>Battery capacity: <span id='BATTERY_WH_MAX'>" +
@@ -86,6 +99,26 @@ String settings_processor(const String& var) {
     content += "}";
     content += "function editError() {";
     content += "    alert('Invalid input');";
+    content += "}";
+    content += "function editSSID() {";
+    content += "var value = prompt('Enter new SSID:');";
+    content += "if (value !== null) {";
+    content += "    var xhr = new XMLHttpRequest();";
+    content += "    xhr.onload = editComplete;";
+    content += "    xhr.onerror = editError;";
+    content += "    xhr.open('GET', '/updateSSID?value=' + encodeURIComponent(value), true);";
+    content += "    xhr.send();";
+    content += "}";
+    content += "}";
+    content += "function editPassword() {";
+    content += "var value = prompt('Enter new password:');";
+    content += "if (value !== null) {";
+    content += "    var xhr = new XMLHttpRequest();";
+    content += "    xhr.onload = editComplete;";
+    content += "    xhr.onerror = editError;";
+    content += "    xhr.open('GET', '/updatePassword?value=' + encodeURIComponent(value), true);";
+    content += "    xhr.send();";
+    content += "}";
     content += "}";
     content += "function editWh() {";
     content += "var value = prompt('How much energy the battery can store. Enter new Wh value (1-120000):');";

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -90,228 +90,99 @@ String settings_processor(const String& var) {
     content += "</div>";
 #endif
 
-    content += "<script>";
-    content += "function editComplete() {";
-    content += "  if (this.status == 200) {";
-    content += "    window.location.reload();";
-    content += "  }";
-    content += "}";
-    content += "function editError() {";
-    content += "    alert('Invalid input');";
-    content += "}";
-    content += "function editSSID() {";
-    content += "var value = prompt('Enter new SSID:');";
-    content += "if (value !== null) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateSSID?value=' + encodeURIComponent(value), true);";
-    content += "    xhr.send();";
-    content += "}";
-    content += "}";
-    content += "function editPassword() {";
-    content += "var value = prompt('Enter new password:');";
-    content += "if (value !== null) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updatePassword?value=' + encodeURIComponent(value), true);";
-    content += "    xhr.send();";
-    content += "}";
-    content += "}";
-    content += "function editWh() {";
-    content += "var value = prompt('How much energy the battery can store. Enter new Wh value (1-120000):');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 1 && value <= 120000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateBatterySize?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 1 and 120000.');";
-    content += "  }";
-    content += "}";
-    content += "}";
-    content += "function editUseScaledSOC() {";
-    content += "var value = prompt('Should SOC% be scaled? (0 = No, 1 = Yes):');";
-    content += "if (value !== null) {";
-    content += "  if (value == 0 || value == 1) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateUseScaledSOC?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 1.');";
-    content += "  }";
-    content += "}";
-    content += "}";
-    content += "function editSocMax() {";
+    content += "<script>";  // Note, this section is minified to improve performance
+    content += "function editComplete(){if(this.status==200){window.location.reload();}}";
+    content += "function editError(){alert('Invalid input');}";
     content +=
-        "var value = prompt('Inverter will see fully charged (100pct)SOC when this value is reached. Enter new maximum "
-        "SOC value that battery will charge to (50.0-100.0):');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 50 && value <= 100) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateSocMax?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 50.0 and 100.0');";
-    content += "  }";
-    content += "}";
-    content += "}";
-    content += "function editSocMin() {";
+        "function editSSID(){var value=prompt('Enter new SSID:');if(value!==null){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateSSID?value='+encodeURIComponent(value),true);xhr.send();}}";
     content +=
-        "var value = prompt('Inverter will see completely discharged (0pct)SOC when this value is reached. Enter new "
-        "minimum SOC value that battery will discharge to (0-50.0):');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 50) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateSocMin?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 50.0');";
-    content += "  }";
-    content += "}";
-    content += "}";
-    content += "function editMaxChargeA() {";
+        "function editPassword(){var value=prompt('Enter new password:');if(value!==null){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updatePassword?value='+encodeURIComponent(value),true);xhr.send();}}";
     content +=
-        "var value = prompt('BYD CAN specific setting, some inverters needs to be artificially limited. Enter new "
-        "maximum charge current in A (0-1000.0):');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 1000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateMaxChargeA?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 1000.0');";
-    content += "  }";
-    content += "}";
-    content += "}";
-    content += "function editMaxDischargeA() {";
+        "function editWh(){var value=prompt('How much energy the battery can store. Enter new Wh value "
+        "(1-120000):');if(value!==null){if(value>=1&&value<=120000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateBatterySize?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 1 "
+        "and 120000.');}}}";
     content +=
-        "var value = prompt('BYD CAN specific setting, some inverters needs to be artificially limited. Enter new "
-        "maximum discharge current in A (0-1000.0):');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 1000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateMaxDischargeA?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 1000.0');";
-    content += "  }";
-    content += "}";
-    content += "}";
+        "function editUseScaledSOC(){var value=prompt('Should SOC% be scaled? (0 = No, 1 = "
+        "Yes):');if(value!==null){if(value==0||value==1){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateUseScaledSOC?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
+        "and 1.');}}}";
+    content +=
+        "function editSocMax(){var value=prompt('Inverter will see fully charged (100pct)SOC when this value is "
+        "reached. Enter new maximum SOC value that battery will charge to "
+        "(50.0-100.0):');if(value!==null){if(value>=50&&value<=100){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateSocMax?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 50.0 and "
+        "100.0');}}}";
+    content +=
+        "function editSocMin(){var value=prompt('Inverter will see completely discharged (0pct)SOC when this value is "
+        "reached. Enter new minimum SOC value that battery will discharge to "
+        "(0-50.0):');if(value!==null){if(value>=0&&value<=50){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateSocMin?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 and "
+        "50.0');}}}";
+    content +=
+        "function editMaxChargeA(){var value=prompt('Some inverters needs to be artificially limited. Enter new "
+        "maximum charge current in A (0-1000.0):');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateMaxChargeA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
+        "and 1000.0');}}}";
+    content +=
+        "function editMaxDischargeA(){var value=prompt('Some inverters needs to be artificially limited. Enter new "
+        "maximum discharge current in A (0-1000.0):');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateMaxDischargeA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
+        "and 1000.0');}}}";
+    content += "</script>";
 
 #ifdef TEST_FAKE_BATTERY
-    content += "function editFakeBatteryVoltage() {";
-    content += "  var value = prompt('Enter new fake battery voltage');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 5000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateFakeBatteryVoltage?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 1000');";
-    content += "  }";
-    content += "}";
-    content += "}";
+    content +=
+        "function editFakeBatteryVoltage(){var value=prompt('Enter new fake battery "
+        "voltage');if(value!==null){if(value>=0&&value<=5000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateFakeBatteryVoltage?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+        "between 0 and 1000');}}}";
 #endif
 
 #if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
-    content += "function editChargerHVDCEnabled() {";
-    content += "  var value = prompt('Enable or disable HV DC output. Enter 1 for enabled, 0 for disabled');";
-    content += "  if (value !== null) {";
-    content += "    if (value == 0 || value == 1) {";
-    content += "      var xhr = new XMLHttpRequest();";
-    content += "      xhr.onload = editComplete;";
-    content += "      xhr.onerror = editError;";
-    content += "      xhr.open('GET', '/updateChargerHvEnabled?value=' + value, true);";
-    content += "      xhr.send();";
-    content += "    }";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter 1 or 0');";
-    content += "  }";
-    content += "}";
-
-    content += "function editChargerAux12vEnabled() {";
     content +=
-        "var value = prompt('Enable or disable low voltage 12v auxiliary DC output. Enter 1 for enabled, 0 for "
-        "disabled');";
-    content += "if (value !== null) {";
-    content += "  if (value == 0 || value == 1) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateChargerAux12vEnabled?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter 1 or 0');";
-    content += "  }";
-    content += "}";
-    content += "}";
-
-    content += "function editChargerSetpointVDC() {";
+        "function editChargerHVDCEnabled(){var value=prompt('Enable or disable HV DC output. Enter 1 for enabled, 0 "
+        "for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateChargerHvEnabled?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}";
     content +=
-        "var value = prompt('Set charging voltage. Input will be validated against inverter and/or charger "
-        "configuration parameters, but use sensible values like 200 to 420.');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 1000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateChargeSetpointV?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 1000');";
-    content += "  }";
-    content += "}";
-    content += "}";
-
-    content += "function editChargerSetpointIDC() {";
+        "function editChargerAux12vEnabled(){var value=prompt('Enable or disable low voltage 12v auxiliary DC output. "
+        "Enter 1 for enabled, 0 for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateChargerAux12vEnabled?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter 1 or "
+        "0');}}}";
     content +=
-        "var value = prompt('Set charging amperage. Input will be validated against inverter and/or charger "
-        "configuration parameters, but use sensible values like 6 to 48.');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 1000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateChargeSetpointA?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 100');";
-    content += "  }";
-    content += "}";
-    content += "}";
-
-    content += "function editChargerSetpointEndI() {";
+        "function editChargerSetpointVDC(){var value=prompt('Set charging voltage. Input will be validated against "
+        "inverter and/or charger configuration parameters, but use sensible values like 200 to "
+        "420.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateChargeSetpointV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between "
+        "0 and 1000');}}}";
     content +=
-        "var value = prompt('Set amperage that terminates charge as being sufficiently complete. Input will be "
-        "validated against inverter and/or charger configuration parameters, but use sensible values like 1-5.');";
-    content += "if (value !== null) {";
-    content += "  if (value >= 0 && value <= 1000) {";
-    content += "    var xhr = new XMLHttpRequest();";
-    content += "    xhr.onload = editComplete;";
-    content += "    xhr.onerror = editError;";
-    content += "    xhr.open('GET', '/updateChargeEndA?value=' + value, true);";
-    content += "    xhr.send();";
-    content += "  } else {";
-    content += "    alert('Invalid value. Please enter a value between 0 and 100');";
-    content += "  }";
-    content += "}";
-    content += "}";
+        "function editChargerSetpointIDC(){var value=prompt('Set charging amperage. Input will be validated against "
+        "inverter and/or charger configuration parameters, but use sensible values like 6 to "
+        "48.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateChargeSetpointA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between "
+        "0 and 100');}}}";
+    content +=
+        "function editChargerSetpointEndI(){var value=prompt('Set amperage that terminates charge as being "
+        "sufficiently complete. Input will be validated against inverter and/or charger configuration parameters, but "
+        "use sensible values like 1-5.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+        "updateChargeEndA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
+        "and 100');}}}";
 #endif
     content += "</script>";
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1,7 +1,6 @@
 #include "settings_html.h"
 #include <Arduino.h>
 #include "../../datalayer/datalayer.h"
-#include "webserver.h"
 
 String settings_processor(const String& var) {
   if (var == "X") {

--- a/Software/src/devboard/webserver/settings_html.h
+++ b/Software/src/devboard/webserver/settings_html.h
@@ -2,6 +2,10 @@
 #define SETTINGS_H
 
 #include <Arduino.h>
+#include <string>
+
+extern std::string ssid;
+extern std::string password;
 
 #include "../../../USER_SETTINGS.h"  // Needed for WiFi ssid and password
 

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -18,8 +18,9 @@
 
 extern const char* version_number;  // The current software version, shown on webserver
 
-extern const char* ssid;
-extern const char* password;
+#include <string>
+extern std::string ssid;
+extern std::string password;
 extern const uint8_t wifi_channel;
 extern const char* ssidAP;
 extern const char* passwordAP;


### PR DESCRIPTION
### What
This PR adds Wifi SSID/Password settings to the Webserver, so user can edit them there. Once entered, they get stored to permanent storage and loaded on boot. This PR also enables the LOAD_SAVED_SETTINGS_ON_BOOT by default.

![image](https://github.com/dalathegreat/Battery-Emulator/assets/26695010/6a8e8011-9662-4f8f-b9a7-db51304f4d8f)

### Why
This allows the user to update the board over the air with a software that is compiled without specific WiFi SSID and password. Flashing the binary that is compiled without specific WiFi SSID and password would still allow the board to connect to the WiFi network it was previously connected to. This helps the user to quickly update to the latest version of the software, without having to manually update the WiFi SSID and password in the source code.

### How
This allows the user to flash code without specific WiFi SSID and password to the board, connect to the WiFi access point of the board, and then add the WiFi SSID and password of the network they want the board to connect to.  Ofcourse also setting the password via the .cpp file as before works!

