### PR TITLE
Feature: BMW i3 cellvoltages + small fixes

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -335,6 +335,7 @@ static uint32_t BMW_328_counter = 0;
 static bool battery_awake = false;
 static bool battery2_awake = false;
 static bool battery_info_available = false;
+static bool battery2_info_available = false;
 
 static uint32_t battery_serial_number = 0;
 static uint32_t battery_available_power_shortterm_charge = 0;
@@ -952,21 +953,22 @@ void receive_can_battery2(CAN_frame_t rx_frame) {
         }
 
         switch (cmdState) {
-          case CELL_VOLTAGE:
+          case CELL_VOLTAGE_MINMAX:
             if (next_data >= 4) {
-              datalayer.battery2.status.cell_voltages_mV[0] = (message_data[0] << 8 | message_data[1]);
-              datalayer.battery2.status.cell_voltages_mV[2] = (message_data[2] << 8 | message_data[3]);
+              datalayer.battery2.status.cell_min_voltage_mV = (message_data[0] << 8 | message_data[1]);
+              datalayer.battery2.status.cell_max_voltage_mV = (message_data[2] << 8 | message_data[3]);
             }
             break;
           case CELL_VOLTAGE_AVG:
-            if (next_data >= 30) {
-              datalayer.battery2.status.cell_voltages_mV[1] = (message_data[10] << 8 | message_data[11]) / 10;
+            if (next_data >= 30) {  //AVG not used
+              //datalayer.battery2.status.cell_voltages_mV[1] = (message_data[10] << 8 | message_data[11]) / 10;
               battery2_capacity_cah = (message_data[4] << 8 | message_data[5]);
             }
             break;
           case SOH:
             if (next_data >= 4) {
               battery2_soh = message_data[3];
+              battery2_info_available = true;
             }
             break;
           case SOC:

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1158,7 +1158,7 @@ void send_can_battery() {
           if (current_cell_polled > 96) {
             datalayer.battery.info.number_of_cells = 97;
             cmdState = CELL_VOLTAGE_CELLNO_LAST;
-          } else { 
+          } else {
             cmdState = CELL_VOLTAGE_CELLNO;
 
             BMW_6F4_CELL_VOLTAGE_CELLNO.data.u8[6] = current_cell_polled;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -434,13 +434,15 @@ void update_values_battery() {  //This function maps all the values fetched via 
     return;
   }
 
-  datalayer.battery.status.real_soc = (battery_HVBatt_SOC * 10);
+  datalayer.battery.status.real_soc = (battery_display_SOC * 50);
 
   datalayer.battery.status.voltage_dV = battery_volts;  //Unit V+1 (5000 = 500.0V)
 
   datalayer.battery.status.current_dA = battery_current;
 
-  datalayer.battery.status.remaining_capacity_Wh = (battery_energy_content_maximum_kWh * 1000);  // Convert kWh to Wh
+  datalayer.battery.info.total_capacity_Wh = (battery_energy_content_maximum_kWh * 1000);  // Convert kWh to Wh
+
+  datalayer.battery.status.remaining_capacity_Wh = battery_predicted_energy_charge_condition;
 
   datalayer.battery.status.soh_pptt = battery_soh * 100;
 
@@ -620,9 +622,9 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       battery_prediction_duration_charging_minutes = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);
       battery_prediction_time_end_of_charging_minutes = rx_frame.data.u8[4];
       battery_energy_content_maximum_kWh = (((rx_frame.data.u8[6] & 0x0F) << 8 | rx_frame.data.u8[5])) / 50;
-      if (battery_energy_content_maximum_kWh > 37) {
+      if (battery_energy_content_maximum_kWh > 33) {
         detectedBattery = BATTERY_120AH;
-      } else if (battery_energy_content_maximum_kWh > 25) {
+      } else if (battery_energy_content_maximum_kWh > 20) {
         detectedBattery = BATTERY_94AH;
       } else {
         detectedBattery = BATTERY_60AH;
@@ -633,7 +635,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       battery_target_voltage_in_CV_mode = ((rx_frame.data.u8[1] << 4 | rx_frame.data.u8[0] >> 4)) / 10;
       battery_request_charging_condition_minimum = (rx_frame.data.u8[2] / 2);
       battery_request_charging_condition_maximum = (rx_frame.data.u8[3] / 2);
-      battery_display_SOC = (rx_frame.data.u8[4] / 2);
+      battery_display_SOC = rx_frame.data.u8[4];
       break;
     case 0x507:  //BMS [640ms] Network Management - 2 - This message is sent on the bus for sleep coordination purposes
       break;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -559,8 +559,8 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       battery_status_cold_shutoff_valve = (rx_frame.data.u8[3] & 0x0F);
       battery_temperature_HV = (rx_frame.data.u8[4] - 50);
       battery_temperature_heat_exchanger = (rx_frame.data.u8[5] - 50);
-      battery_temperature_max = (rx_frame.data.u8[6] - 50);
-      battery_temperature_min = (rx_frame.data.u8[7] - 50);
+      battery_temperature_min = (rx_frame.data.u8[6] - 50);
+      battery_temperature_max = (rx_frame.data.u8[7] - 50);
       break;
     case 0x239:                                                                                      //BMS [200ms]
       battery_predicted_energy_charge_condition = (rx_frame.data.u8[2] << 8 | rx_frame.data.u8[1]);  //Wh

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -170,8 +170,16 @@ CAN_frame BMW_6F1_CELL_VOLTAGE_AVG = {.FD = false,
                                       .ID = 0x6F1,
                                       .data = {0x07, 0x03, 0x22, 0xDF, 0xA0}};
 CAN_frame BMW_6F1_CONTINUE = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x6F1, .data = {0x07, 0x30, 0x00, 0x02}};
-CAN_frame BMW_6F4_CELL_VOLTAGE_CELLNO = {.FD = false, .ext_ID = false, .DLC = 7, .ID = 0x6F4, .data = {0x07, 0x05, 0x31, 0x01, 0xAD, 0x6E, 0x01}};
-CAN_frame BMW_6F4_CELL_CONTINUE = {.FD = false, .ext_ID = false, .DLC = 6, .ID = 0x6F4, .data = {0x07, 0x04, 0x31, 0x03, 0xAD, 0x6E}};
+CAN_frame BMW_6F4_CELL_VOLTAGE_CELLNO = {.FD = false,
+                                         .ext_ID = false,
+                                         .DLC = 7,
+                                         .ID = 0x6F4,
+                                         .data = {0x07, 0x05, 0x31, 0x01, 0xAD, 0x6E, 0x01}};
+CAN_frame BMW_6F4_CELL_CONTINUE = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 6,
+                                   .ID = 0x6F4,
+                                   .data = {0x07, 0x04, 0x31, 0x03, 0xAD, 0x6E}};
 
 //The above CAN messages need to be sent towards the battery to keep it alive
 
@@ -466,9 +474,12 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
 #ifdef DEBUG_VIA_USB
   Serial.println(" ");
-  Serial.print("Values sent to inverter: ");
-  Serial.print("Real SOC%: ");
-  Serial.print(datalayer.battery.status.real_soc * 0.01);
+  Serial.print("Battery display SOC%: ");
+  Serial.print(battery_display_SOC * 50);
+  Serial.print("Battery display SOC%: ");
+  Serial.print(battery_HVBatt_SOC * 10);
+  Serial.print("Battery polled SOC%: ");
+  Serial.print(battery_soc);
   Serial.print(" Battery voltage: ");
   Serial.print(datalayer.battery.status.voltage_dV * 0.1);
   Serial.print(" Battery current: ");
@@ -1033,9 +1044,9 @@ void send_can_battery() {
             cmdState = CELL_VOLTAGE_CELLNO;
 
             BMW_6F4_CELL_VOLTAGE_CELLNO.data.u8[6] = current_cell_polled;
-            ESP32Can.CANWriteFrame(&BMW_6F4_CELL_VOLTAGE_CELLNO);
+            transmit_can(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery);
 #ifdef DOUBLE_BATTERY
-            CAN_WriteFrame(&BMW_6F4_CELL_VOLTAGE_CELLNO);
+            transmit_can(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery_double);
 #endif
           }
           break;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -7,19 +7,19 @@
 #define BATTERY_SELECTED
 
 #define WUP_PIN 25
-#define MAX_CELL_VOLTAGE_60AH 4110   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_60AH 2700   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_94AH 4140   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_94AH 2700   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_120AH 4190  // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_120AH 2790  // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 250    // LED turns yellow on the board if mv delta exceeds this value
-#define MAX_PACK_VOLTAGE_60AH 3950   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_60AH 2590   // Discharge stops if pack voltage exceeds this value
+#define MAX_CELL_VOLTAGE_60AH 4104   // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_60AH 3000   // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_94AH 4177   // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_94AH 3000   // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_120AH 4210  // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_120AH 3000  // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_DEVIATION_MV 150    // LED turns yellow on the board if mv delta exceeds this value
+#define MAX_PACK_VOLTAGE_60AH 3920   // Charge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_60AH 3300   // Discharge stops if pack voltage exceeds this value
 #define MAX_PACK_VOLTAGE_94AH 3980   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_94AH 2590   // Discharge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_94AH 3300   // Discharge stops if pack voltage exceeds this value
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_120AH 3300  // Discharge stops if pack voltage exceeds this value
 void setup_battery(void);
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -6,19 +6,19 @@
 #define BATTERY_SELECTED
 
 #define WUP_PIN 25
-#define MAX_CELL_VOLTAGE_60AH 4104   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_60AH 3000   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_94AH 4177   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_94AH 3000   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_120AH 4210  // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_120AH 3000  // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 150    // LED turns yellow on the board if mv delta exceeds this value
-#define MAX_PACK_VOLTAGE_60AH 3920   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_60AH 3300   // Discharge stops if pack voltage exceeds this value
+#define MAX_CELL_VOLTAGE_60AH 4110   // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_60AH 2700   // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_94AH 4140   // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_94AH 2700   // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_120AH 4190  // Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_120AH 2790  // Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_DEVIATION_MV 250    // LED turns yellow on the board if mv delta exceeds this value
+#define MAX_PACK_VOLTAGE_60AH 3950   // Charge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_60AH 2590   // Discharge stops if pack voltage exceeds this value
 #define MAX_PACK_VOLTAGE_94AH 3980   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_94AH 3300   // Discharge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_94AH 2590   // Discharge stops if pack voltage exceeds this value
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_120AH 3300  // Discharge stops if pack voltage exceeds this value
+#define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);
 


### PR DESCRIPTION
### What
This PR adds cellvoltage monitoring for the BMW i3. It also fixes some minor issues that Havrla noticed while testing the code, like using wrong SOC% value and wrong capacity value.

### Why
Safer operation of the battery. SOC% is now using the display value, since the raw value can sometimes get "stuck" during recalibration. kWh remaining is also rewritten.

### How
Reverse engineering how the cellvalue reading worked, in cooperation with Havrla :raised_hands: 