### PR TITLE
BYD Atto 3: Add stuck SOC% value detection

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -106,7 +106,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.voltage_dV = BMS_voltage * 10;
 
   if (BMS_state == UNLOCKED) {  // This value can be frozen if battery is crashed
-    datalayer.battery.status.real_soc = BMS_SOC_polled * 10;
+    datalayer.battery.status.real_soc = BMS_SOC_periodic * 10;
   } else {  // Incase we have a locked BMS, estimate SOC based on voltage
     datalayer.battery.status.real_soc = estimateSOC(datalayer.battery.status.voltage_dV);
   }
@@ -164,9 +164,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
           BMS_state = LOCKED;
         }
       } else {
-        counter_SOC_stuck = 0;         // reset the counter
-        counter_SOC_moves++;           // Increment counter, we have movement on SOC%!
-        if (counter_SOC_moves > 10) {  // SOC seems to have moved 3 times, we can switch to using it!
+        counter_SOC_stuck = 0;        // reset the counter
+        counter_SOC_moves++;          // Increment counter, we have movement on SOC%!
+        if (counter_SOC_moves > 3) {  // SOC seems to have moved 3 times, we can switch to using it!
           BMS_state = UNLOCKED;
         }
       }

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -157,7 +157,6 @@ void init_events(void) {
   events.entries[EVENT_BATTERY_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_ISOLATION].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_LOCKED].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_LOW_SOH].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_VOLTAGE_DIFFERENCE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_SOH_DIFFERENCE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_SOH_LOW].level = EVENT_LEVEL_ERROR;

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -155,6 +155,7 @@ void init_events(void) {
   events.entries[EVENT_BATTERY_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_ISOLATION].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_LOCKED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_LOW_SOH].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_HVIL_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_PRECHARGE_FAILURE].level = EVENT_LEVEL_INFO;
@@ -270,6 +271,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Warning: Battery under minimum design voltage. Charge battery to prevent damage!";
     case EVENT_BATTERY_ISOLATION:
       return "Warning: Battery reports isolation error. High voltage might be leaking to ground. Check battery!";
+    case EVENT_BATTERY_LOCKED:
+      return "Info: Battery BMS is locked or SRS crash active. All features might not be available.";
     case EVENT_LOW_SOH:
       return "ERROR: State of health critically low. Battery internal resistance too high to continue. Recycle "
              "battery.";

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0011  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0012  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0008  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0009  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -49,6 +49,7 @@
   XX(EVENT_BATTERY_OVERVOLTAGE)         \
   XX(EVENT_BATTERY_UNDERVOLTAGE)        \
   XX(EVENT_BATTERY_ISOLATION)           \
+  XX(EVENT_BATTERY_LOCKED)              \
   XX(EVENT_BATTERY_REQUESTS_HEAT)       \
   XX(EVENT_BATTERY_WARMED_UP)           \
   XX(EVENT_LOW_SOH)                     \


### PR DESCRIPTION
### What
This PR adds improvements to SOC% reading for BYD Atto 3 batteries
- Reading of SOC% via periodically transmitted CAN message
- Detection of stuck SOC%
   - Event for info incase stuck SOC% is noticed

### Why
Previously we have been using voltage based SOC% estimate for the BYD Atto 3 all the time. This has been necessary, since the BMS goes into a semi-locked state if the vehicle is crashed too hard. However, if you use a pristine battery, estimated SOC% is not super accurate, and it would be better to use the real SOC% value sent by the BMS

### How
We start out with normal estimated SOC%, but now read the periodically transmitted SOC%. Incase the read value stays stuck at the same value for 1 hour after startup, we consider the value unusable. If the value moves around 3 times, we consider it usable, and ditch the estimation.

:warning: Incorrect switching from estimate to a locked value could result in damage to the battery. This algorithm needs testing on both locked and unlocked packs before we can merge it. BYD Atto 3 testers wanted!