### PR TITLE
BMW i3: Add error about pin usage

### DIFF
--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -75,4 +75,10 @@
 #endif
 #endif
 
+#ifdef BMW_I3_BATTERY
+#ifdef CONTACTOR_CONTROL
+#error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
### What
This PR adds a compilation error. 

### Why
Some users accidentally enabled contactor control on i3 batteries. This caused WUP pin 25 to never go high. Contactor control is not required on i3, and will collide with GPIO pin 25 usage

### How
#error added in HAL