### PR TITLE
Refactor: CAN abstraction layer

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -535,7 +535,9 @@ void receive_can_native() {  // This section checks if we have a complete CAN me
   if (xQueueReceive(CAN_cfg.rx_queue, &rx_frame, 0) == pdTRUE) {
 
     if (can_config.battery == CAN_NATIVE) {
+#ifndef SERIAL_LINK_RECEIVER
       receive_can_battery(rx_frame);
+#endif  // SERIAL_LINK_RECEIVER
     }
     if (can_config.inverter == CAN_NATIVE) {
 #ifdef CAN_INVERTER_SELECTED
@@ -901,7 +903,7 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
       //Struct with ACAN2515 library format, needed to use the MCP2515 library for CAN2
       CANMessage MCP2515Frame;
       MCP2515Frame.id = tx_frame->MsgID;
-      //MCP2515Frame.ext = false; //TODO: Howto handle this?
+      MCP2515Frame.ext = tx_frame->FIR.B.FF;
       MCP2515Frame.len = tx_frame->FIR.B.DLC;
       for (uint8_t i = 0; i < MCP2515Frame.len; i++) {
         MCP2515Frame.data[i] = tx_frame->data.u8[i];

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -574,41 +574,22 @@ void send_can() {
 }
 
 #ifdef DUAL_CAN
-void receive_can_addonMCP2515() {  // This section checks if we have a complete CAN message incoming on native CAN port
-  // Depending on which battery/inverter is selected, we forward this to their respective CAN handlers
-  CAN_frame_t
-      rx_frame_can_addonMCP2515;  // Struct with ESP32Can library format, compatible with the rest of the program
-  CANMessage MCP2515Frame;        // Struct with ACAN2515 library format, needed to use thw MCP2515 library
+void receive_can_addonMCP2515() {  // This section checks if we have a complete CAN message incoming on add-on CAN port
+  CAN_frame rx_frame;              // Struct with our CAN format
+  CANMessage MCP2515Frame;         // Struct with ACAN2515 library format, needed to use the MCP2515 library
 
   if (can.available()) {
     can.receive(MCP2515Frame);
 
-    rx_frame_can_addonMCP2515.MsgID = MCP2515Frame.id;
-    rx_frame_can_addonMCP2515.FIR.B.FF = MCP2515Frame.ext ? CAN_frame_ext : CAN_frame_std;
-    rx_frame_can_addonMCP2515.FIR.B.RTR = MCP2515Frame.rtr ? CAN_RTR : CAN_no_RTR;
-    rx_frame_can_addonMCP2515.FIR.B.DLC = MCP2515Frame.len;
+    rx_frame.ID = MCP2515Frame.id;
+    rx_frame.ext_ID = MCP2515Frame.ext ? CAN_frame_ext : CAN_frame_std;
+    rx_frame.DLC = MCP2515Frame.len;
     for (uint8_t i = 0; i < MCP2515Frame.len && i < 8; i++) {
-      rx_frame_can_addonMCP2515.data.u8[i] = MCP2515Frame.data[i];
+      rx_frame.data.u8[i] = MCP2515Frame.data[i];
     }
 
-    if (can_config.battery == CAN_ADDON_MCP2515) {
-      receive_can_battery(rx_frame_can_addonMCP2515);
-    }
-    if (can_config.inverter == CAN_ADDON_MCP2515) {
-#ifdef CAN_INVERTER_SELECTED
-      receive_can_inverter(rx_frame_can_addonMCP2515);
-#endif  // CAN_INVERTER_SELECTED
-    }
-    if (can_config.battery_double == CAN_ADDON_MCP2515) {
-#ifdef DOUBLE_BATTERY
-      receive_can_battery2(rx_frame_can_addonMCP2515);
-#endif  // DOUBLE_BATTERY
-    }
-    if (can_config.charger == CAN_ADDON_MCP2515) {
-#ifdef CHARGER_SELECTED
-      receive_can_charger(rx_frame_can_addonMCP2515);
-#endif  // CHARGER_SELECTED
-    }
+    //message incoming, pass it on to the handler
+    receive_can(&rx_frame, CAN_ADDON_MCP2515);
   }
 }
 #endif  // DUAL_CAN

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -897,7 +897,9 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
         MCP2515Frame.data[i] = tx_frame->data.u8[i];
       }
       can.tryToSend(MCP2515Frame);
-#endif
+#else   // Interface not compiled, and settings try to use it
+      set_event(EVENT_INTERFACE_MISSING, interface);
+#endif  //DUAL_CAN
     } break;
     case CAN_ADDON_FD_MCP2518:
 #ifdef CAN_FD
@@ -909,7 +911,9 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
         MCP2518Frame.data[i] = tx_frame->data.u8[i];
       }
       canfd.tryToSend(MCP2518Frame);
-#endif
+#else   // Interface not compiled, and settings try to use it
+      set_event(EVENT_INTERFACE_MISSING, interface);
+#endif  //CAN_FD
       break;
     default:
       // Invalid interface sent with function call. TODO: Raise event that coders messed up

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -913,7 +913,7 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
       set_event(EVENT_INTERFACE_MISSING, interface);
 #endif  //DUAL_CAN
     } break;
-    case CAN_ADDON_FD_MCP2518:
+    case CAN_ADDON_FD_MCP2518: {
 #ifdef CAN_FD
       CANFDMessage MCP2518Frame;
       MCP2518Frame.id = tx_frame->MsgID;
@@ -926,7 +926,7 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
 #else   // Interface not compiled, and settings try to use it
       set_event(EVENT_INTERFACE_MISSING, interface);
 #endif  //CAN_FD
-      break;
+    } break;
     default:
       // Invalid interface sent with function call. TODO: Raise event that coders messed up
       break;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -888,6 +888,7 @@ void transmit_can(CAN_frame* tx_frame, int interface) {
       frame.MsgID = tx_frame->ID;
       frame.FIR.B.FF = tx_frame->ext_ID ? CAN_frame_ext : CAN_frame_std;
       frame.FIR.B.DLC = tx_frame->DLC;
+      frame.FIR.B.RTR = CAN_no_RTR;
       for (uint8_t i = 0; i < tx_frame->DLC; i++) {
         frame.data.u8[i] = tx_frame->data.u8[i];
       }
@@ -903,6 +904,7 @@ void transmit_can(CAN_frame* tx_frame, int interface) {
       MCP2515Frame.id = tx_frame->ID;
       MCP2515Frame.ext = tx_frame->ext_ID ? CAN_frame_ext : CAN_frame_std;
       MCP2515Frame.len = tx_frame->DLC;
+      MCP2515Frame.rtr = false;
       for (uint8_t i = 0; i < MCP2515Frame.len; i++) {
         MCP2515Frame.data[i] = tx_frame->data.u8[i];
       }
@@ -917,6 +919,7 @@ void transmit_can(CAN_frame* tx_frame, int interface) {
       MCP2518Frame.id = tx_frame->ID;
       MCP2518Frame.ext = tx_frame->ext_ID ? CAN_frame_ext : CAN_frame_std;
       MCP2518Frame.len = tx_frame->DLC;
+      MCP2518Frame.rtr = false;
       for (uint8_t i = 0; i < MCP2518Frame.len; i++) {
         MCP2518Frame.data[i] = tx_frame->data.u8[i];
       }

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -394,8 +394,12 @@ void init_CAN() {
 #endif
   SPI.begin(MCP2517_SCK, MCP2517_SDO, MCP2517_SDI);
   ACAN2517FDSettings settings(ACAN2517FDSettings::OSC_40MHz, 500 * 1000,
-                              DataBitRateFactor::x4);      // Arbitration bit rate: 500 kbit/s, data bit rate: 2 Mbit/s
+                              DataBitRateFactor::x4);  // Arbitration bit rate: 500 kbit/s, data bit rate: 2 Mbit/s
+#ifdef USE_CANFD_INTERFACE_AS_CLASSIC_CAN
+  settings.mRequestedMode = ACAN2517FDSettings::Normal20B;  // ListenOnly / Normal20B / NormalFD
+#else
   settings.mRequestedMode = ACAN2517FDSettings::NormalFD;  // ListenOnly / Normal20B / NormalFD
+#endif
   const uint32_t errorCode = canfd.begin(settings, [] { canfd.isr(); });
   canfd.poll();
   if (errorCode == 0) {

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -917,7 +917,7 @@ void transmit_can(CAN_frame_t* tx_frame, int interface) {
 #ifdef CAN_FD
       CANFDMessage MCP2518Frame;
       MCP2518Frame.id = tx_frame->MsgID;
-      //MCP2518Frame.ext = false; //TODO: Howto handle this?
+      MCP2518Frame.ext = tx_frame->FIR.B.FF;
       MCP2518Frame.len = tx_frame->FIR.B.DLC;
       for (uint8_t i = 0; i < MCP2518Frame.len; i++) {
         MCP2518Frame.data[i] = tx_frame->data.u8[i];

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -3,8 +3,7 @@
 #include "src/devboard/hal/hal.h"
 /* This file contains all the battery settings and limits */
 /* They can be defined here, or later on in the WebUI */
-
-/* Select which CAN interface each component is connected to */
+/* Most important is to select which CAN interface each component is connected to */
 /* 
 CAN_NATIVE = Native CAN port on the LilyGo & Stark hardware
 CANFD_NATIVE = Native CANFD port on the Stark CMR hardware
@@ -13,12 +12,11 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_NATIVE,  // Which CAN is your battery connected to?
-    .inverter = CAN_NATIVE  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
-                    .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
-    .charger = CAN_NATIVE;                                // (OPTIONAL) Which CAN is your charger connected to?
-}
-;
+    .battery = CAN_NATIVE,   // Which CAN is your battery connected to?
+    .inverter = CAN_NATIVE,  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
+    .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
+    .charger = CAN_NATIVE                 // (OPTIONAL) Which CAN is your charger connected to?
+};
 
 #ifdef WEBSERVER
 volatile uint8_t AccessPointEnabled = true;           //Set to either true/false to enable direct wifi access point

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -1,13 +1,36 @@
 #include "USER_SETTINGS.h"
 #include <string>
+#include "src/devboard/hal/hal.h"
 /* This file contains all the battery settings and limits */
 /* They can be defined here, or later on in the WebUI */
 
-/*  */
-extern volatile uint8_t CAN_BATTERY;
-extern volatile uint8_t CAN_BATTERY_DOUBLE;
-extern volatile uint8_t CAN_INVERTER;
+/* Select which CAN interface each component is connected to */
+/* 
+CAN_NATIVE = Native CAN port on the LilyGo & Stark hardware
+CANFD_NATIVE = Native CANFD port on the Stark CMR hardware
+CAN_ADDON_MCP2515 = Add-on CAN MCP2515 connected to GPIO pins
+CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
+*/
 
+volatile CAN_Configuration can_config = {
+    .battery = CAN_NATIVE,                // Which CAN is your battery connected to?
+    .battery_double = CAN_ADDON_MCP2515,  // Which CAN is your optional second battery connected to?
+    .inverter = CAN_NATIVE                // Which CAN is your inverter connected to? (Not needed for RS485 inverters)
+};
+
+#ifdef WEBSERVER
+volatile uint8_t AccessPointEnabled = true;           //Set to either true/false to enable direct wifi access point
+std::string ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
+std::string password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
+const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
+const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
+const uint8_t wifi_channel = 0;        // Set to 0 for automatic channel selection
+// MQTT
+#ifdef MQTT
+const char* mqtt_user = "REDACTED";
+const char* mqtt_password = "REDACTED";
+#endif  // USE_MQTT
+#endif  // WEBSERVER
 
 /* Charger settings (Optional, when using generator charging) */
 volatile float CHARGER_SET_HV = 384;      // Reasonably appropriate 4.0v per cell charging of a 96s pack
@@ -16,19 +39,3 @@ volatile float CHARGER_MIN_HV = 200;      // Min permissible output (VDC) of cha
 volatile float CHARGER_MAX_POWER = 3300;  // Max power capable of charger, as a ceiling for validating config
 volatile float CHARGER_MAX_A = 11.5;      // Max current output (amps) of charger
 volatile float CHARGER_END_A = 1.0;       // Current at which charging is considered complete
-
-#ifdef WEBSERVER
-volatile uint8_t AccessPointEnabled = true;  //Set to either true/false to enable direct wifi access point
-std::string ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
-std::string password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
-const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;
-const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
-const uint8_t wifi_channel = 0;        // set to 0 for automatic channel selection
-
-// MQTT
-#ifdef MQTT
-const char* mqtt_user = "REDACTED";
-const char* mqtt_password = "REDACTED";
-#endif  // USE_MQTT
-
-#endif

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -13,10 +13,12 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_NATIVE,                // Which CAN is your battery connected to?
-    .battery_double = CAN_ADDON_MCP2515,  // Which CAN is your optional second battery connected to?
-    .inverter = CAN_NATIVE                // Which CAN is your inverter connected to? (Not needed for RS485 inverters)
-};
+    .battery = CAN_NATIVE,  // Which CAN is your battery connected to?
+    .inverter = CAN_NATIVE  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
+                    .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
+    .charger = CAN_NATIVE;                                // (OPTIONAL) Which CAN is your charger connected to?
+}
+;
 
 #ifdef WEBSERVER
 volatile uint8_t AccessPointEnabled = true;           //Set to either true/false to enable direct wifi access point

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -12,7 +12,7 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_ADDON_FD_MCP2518,   // Which CAN is your battery connected to?
+    .battery = CAN_NATIVE,   // Which CAN is your battery connected to?
     .inverter = CAN_NATIVE,  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
     .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
     .charger = CAN_NATIVE                 // (OPTIONAL) Which CAN is your charger connected to?

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -3,6 +3,12 @@
 /* This file contains all the battery settings and limits */
 /* They can be defined here, or later on in the WebUI */
 
+/*  */
+extern volatile uint8_t CAN_BATTERY;
+extern volatile uint8_t CAN_BATTERY_DOUBLE;
+extern volatile uint8_t CAN_INVERTER;
+
+
 /* Charger settings (Optional, when using generator charging) */
 volatile float CHARGER_SET_HV = 384;      // Reasonably appropriate 4.0v per cell charging of a 96s pack
 volatile float CHARGER_MAX_HV = 420;      // Max permissible output (VDC) of charger
@@ -12,8 +18,7 @@ volatile float CHARGER_MAX_A = 11.5;      // Max current output (amps) of charge
 volatile float CHARGER_END_A = 1.0;       // Current at which charging is considered complete
 
 #ifdef WEBSERVER
-volatile uint8_t AccessPointEnabled =
-    true;  //Set to either true/false incase you want to enable direct wifi access point
+volatile uint8_t AccessPointEnabled = true;  //Set to either true/false to enable direct wifi access point
 std::string ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters;
 std::string password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters;
 const char* ssidAP = "Battery Emulator";              // Maximum of 63 characters;

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -12,7 +12,7 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_NATIVE,   // Which CAN is your battery connected to?
+    .battery = CAN_ADDON_FD_MCP2518,   // Which CAN is your battery connected to?
     .inverter = CAN_NATIVE,  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
     .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
     .charger = CAN_NATIVE                 // (OPTIONAL) Which CAN is your charger connected to?

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -12,7 +12,7 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_ADDON_FD_MCP2518,  // Which CAN is your battery connected to?
+    .battery = CAN_NATIVE,   // Which CAN is your battery connected to?
     .inverter = CAN_NATIVE,  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
     .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
     .charger = CAN_NATIVE                 // (OPTIONAL) Which CAN is your charger connected to?

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -12,7 +12,7 @@ CAN_ADDON_FD_MCP2518 = Add-on CAN-FD MCP2518 connected to GPIO pins
 */
 
 volatile CAN_Configuration can_config = {
-    .battery = CAN_ADDON_FD_MCP2518,   // Which CAN is your battery connected to?
+    .battery = CAN_ADDON_FD_MCP2518,  // Which CAN is your battery connected to?
     .inverter = CAN_NATIVE,  // Which CAN is your inverter connected to? (No need to configure incase you use RS485)
     .battery_double = CAN_ADDON_MCP2515,  // (OPTIONAL) Which CAN is your second battery connected to?
     .charger = CAN_NATIVE                 // (OPTIONAL) Which CAN is your charger connected to?

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -14,7 +14,7 @@
 //#define IMIEV_CZERO_ION_BATTERY
 //#define JAGUAR_IPACE_BATTERY
 //#define KIA_HYUNDAI_64_BATTERY
-//#define KIA_E_GMP_BATTERY
+#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
 //#define NISSAN_LEAF_BATTERY
@@ -49,7 +49,7 @@
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
-//#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
+#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
-//#define NISSAN_LEAF_BATTERY
+#define NISSAN_LEAF_BATTERY
 //#define PYLON_BATTERY
 //#define RENAULT_KANGOO_BATTERY
 //#define RENAULT_ZOE_GEN1_BATTERY
@@ -49,7 +49,7 @@
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
-//#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
+#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -30,7 +30,7 @@
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-//#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
 //#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus
@@ -48,7 +48,7 @@
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
-//#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
+#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
 //#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
@@ -87,8 +87,8 @@
 typedef enum { CAN_NATIVE = 0, CANFD_NATIVE = 1, CAN_ADDON_MCP2515 = 2, CAN_ADDON_FD_MCP2518 = 3 } CAN_Interface;
 typedef struct {
   CAN_Interface battery;
-  CAN_Interface battery_double;
   CAN_Interface inverter;
+  CAN_Interface battery_double;
   CAN_Interface charger;
 } CAN_Configuration;
 extern volatile CAN_Configuration can_config;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -29,7 +29,7 @@
 //#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires DUAL_CAN setup)
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
-#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+//#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
 //#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
@@ -84,11 +84,12 @@
 
 /* Do not change any code below this line unless you are sure what you are doing */
 /* Only change battery specific settings in "USER_SETTINGS.h" */
-typedef enum { CAN_NATIVE = 0, CAN_ADDON_MCP2515 = 1, CAN_ADDON_FD_MCP2518 = 2 } CAN_Interface;
+typedef enum { CAN_NATIVE = 0, CANFD_NATIVE = 1, CAN_ADDON_MCP2515 = 2, CAN_ADDON_FD_MCP2518 = 3 } CAN_Interface;
 typedef struct {
   CAN_Interface battery;
   CAN_Interface battery_double;
   CAN_Interface inverter;
+  CAN_Interface charger;
 } CAN_Configuration;
 extern volatile CAN_Configuration can_config;
 extern volatile uint8_t AccessPointEnabled;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -65,7 +65,7 @@
 #define DUMMY_EVENT_ENABLED false  //Enable this line to have a dummy event that gets logged to test the interface
 
 /* Select charger used (Optional) */
-#define CHEVYVOLT_CHARGER  //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.
+//#define CHEVYVOLT_CHARGER  //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.
 //#define NISSANLEAF_CHARGER //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
 
 /* Battery settings */

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -43,7 +43,7 @@
 //#define HW_STARK
 
 /* Other options */
-#define DEBUG_VIA_USB  //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
+//#define DEBUG_VIA_USB  //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
 //#define DEBUG_CANFD_DATA    //Enable this line to have the USB port output CAN-FD data while program runs (WARNING, raises CPU load, do not use for production)
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
-#define NISSAN_LEAF_BATTERY
+//#define NISSAN_LEAF_BATTERY
 //#define PYLON_BATTERY
 //#define RENAULT_KANGOO_BATTERY
 //#define RENAULT_ZOE_GEN1_BATTERY
@@ -30,7 +30,7 @@
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
 //#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
 //#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus
@@ -48,7 +48,7 @@
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
-#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
+//#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
 //#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
@@ -65,7 +65,7 @@
 #define DUMMY_EVENT_ENABLED false  //Enable this line to have a dummy event that gets logged to test the interface
 
 /* Select charger used (Optional) */
-//#define CHEVYVOLT_CHARGER //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.
+#define CHEVYVOLT_CHARGER  //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.
 //#define NISSANLEAF_CHARGER //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
 
 /* Battery settings */

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
-#define NISSAN_LEAF_BATTERY
+//#define NISSAN_LEAF_BATTERY
 //#define PYLON_BATTERY
 //#define RENAULT_KANGOO_BATTERY
 //#define RENAULT_ZOE_GEN1_BATTERY
@@ -49,7 +49,8 @@
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
-#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
+//#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
+//#define USE_CANFD_INTERFACE_AS_CLASSIC_CAN // Enable this line if you intend to use the CANFD add-on chip as normal CAN
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -14,7 +14,7 @@
 //#define IMIEV_CZERO_ION_BATTERY
 //#define JAGUAR_IPACE_BATTERY
 //#define KIA_HYUNDAI_64_BATTERY
-#define KIA_E_GMP_BATTERY
+//#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
 //#define NISSAN_LEAF_BATTERY
@@ -43,13 +43,13 @@
 //#define HW_STARK
 
 /* Other options */
-//#define DEBUG_VIA_USB  //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
+#define DEBUG_VIA_USB  //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
 //#define DEBUG_CANFD_DATA    //Enable this line to have the USB port output CAN-FD data while program runs (WARNING, raises CPU load, do not use for production)
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 controller (Needed for some inverters / double battery)
-#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
+//#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2517FD controller (Needed for some batteries)
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -66,7 +66,7 @@
 
 /* Select charger used (Optional) */
 //#define CHEVYVOLT_CHARGER  //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.
-//#define NISSANLEAF_CHARGER //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
+//#define NISSANLEAF_CHARGER  //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
 
 /* Battery settings */
 // Predefined total energy capacity of the battery in Watt-hours

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -17,7 +17,7 @@
 //#define KIA_E_GMP_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MG_5_BATTERY
-//#define NISSAN_LEAF_BATTERY
+#define NISSAN_LEAF_BATTERY
 //#define PYLON_BATTERY
 //#define RENAULT_KANGOO_BATTERY
 //#define RENAULT_ZOE_GEN1_BATTERY
@@ -29,7 +29,7 @@
 //#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires DUAL_CAN setup)
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
-//#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
 //#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define LUNA2000_MODBUS  //Enable this line to emulate a "Luna2000 battery" over Modbus RTU
 //#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
@@ -69,7 +69,6 @@
 //#define NISSANLEAF_CHARGER //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
 
 /* Battery settings */
-
 // Predefined total energy capacity of the battery in Watt-hours
 #define BATTERY_WH_MAX 30000
 // Increases battery life. If true will rescale SOC between the configured min/max-percentage
@@ -83,10 +82,17 @@
 // 300 = 30.0A , BYD CAN specific setting, Max discharge in Amp (Some inverters needs to be limited)
 #define BATTERY_MAX_DISCHARGE_AMP 300
 
+/* Do not change any code below this line unless you are sure what you are doing */
+/* Only change battery specific settings in "USER_SETTINGS.h" */
+typedef enum { CAN_NATIVE = 0, CAN_ADDON_MCP2515 = 1, CAN_ADDON_FD_MCP2518 = 2 } CAN_Interface;
+typedef struct {
+  CAN_Interface battery;
+  CAN_Interface battery_double;
+  CAN_Interface inverter;
+} CAN_Configuration;
+extern volatile CAN_Configuration can_config;
 extern volatile uint8_t AccessPointEnabled;
 extern const uint8_t wifi_channel;
-
-/* Charger limits (Optional): Set in the USER_SETTINGS.cpp or later in the webserver */
 extern volatile float charger_setpoint_HV_VDC;
 extern volatile float charger_setpoint_HV_IDC;
 extern volatile float charger_setpoint_HV_IDC_END;
@@ -99,4 +105,4 @@ extern volatile float CHARGER_END_A;
 extern bool charger_HV_enabled;
 extern bool charger_aux12V_enabled;
 
-#endif
+#endif  // __USER_SETTINGS_H__

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -1,7 +1,7 @@
 #ifndef BATTERIES_H
 #define BATTERIES_H
-
 #include "../../USER_SETTINGS.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"  // This include is annoying, consider defining a frame type in types.h
 
 #ifdef BMW_I3_BATTERY
 #include "BMW-I3-BATTERY.h"
@@ -79,12 +79,7 @@
 #include "SERIAL-LINK-RECEIVER-FROM-BATTERY.h"
 #endif
 
-#ifdef SERIAL_LINK_RECEIVER  // The serial thing does its thing
-void receive_can_battery();
-#else
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"  // This include is annoying, consider defining a frame type in types.h
 void receive_can_battery(CAN_frame_t rx_frame);
-#endif
 #ifdef CAN_FD
 void receive_canfd_battery(CANFDMessage frame);
 #endif

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -1,7 +1,6 @@
 #ifndef BATTERIES_H
 #define BATTERIES_H
 #include "../../USER_SETTINGS.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"  // This include is annoying, consider defining a frame type in types.h
 
 #ifdef BMW_I3_BATTERY
 #include "BMW-I3-BATTERY.h"
@@ -79,7 +78,7 @@
 #include "SERIAL-LINK-RECEIVER-FROM-BATTERY.h"
 #endif
 
-void receive_can_battery(CAN_frame_t rx_frame);
+void receive_can_battery(CAN_frame rx_frame);
 #ifdef CAN_FD
 void receive_canfd_battery(CANFDMessage frame);
 #endif
@@ -90,7 +89,7 @@ void setup_battery(void);
 
 #ifdef DOUBLE_BATTERY
 void update_values_battery2();
-void receive_can_battery2(CAN_frame_t rx_frame);
+void receive_can_battery2(CAN_frame rx_frame);
 #endif
 
 #endif

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -79,9 +79,6 @@
 #endif
 
 void receive_can_battery(CAN_frame rx_frame);
-#ifdef CAN_FD
-void receive_canfd_battery(CANFDMessage frame);
-#endif
 
 void update_values_battery();
 void send_can_battery();

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -79,7 +79,6 @@
 #endif
 
 void receive_can_battery(CAN_frame rx_frame);
-
 void update_values_battery();
 void send_can_battery();
 void setup_battery(void);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -482,7 +482,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery_awake = true;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -44,264 +44,130 @@ const unsigned char crc8_table[256] =
 0AA 105 13D 0BB 0AD 0A5 150 100 1A1 10E 153 197 429 1AA 12F 59A 2E3 2BE 211 2b3 3FD 2E8 2B7 108 29D 29C 29B 2C0 330
 3E9 32F 19E 326 55E 515 509 50A 51A 2F5 3A4 432 3C9 
 */
-
-CAN_frame_t BMW_10B = {.FIR = {.B =
-                                   {
-                                       .DLC = 3,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x10B,
-                       .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command
-CAN_frame_t BMW_12F = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x12F,
-                       .data = {0xE6, 0x24, 0x86, 0x1A, 0xF1, 0x31, 0x30, 0x00}};  //0x12F Wakeup VCU
-CAN_frame_t BMW_13E = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x13E,
-                       .data = {0xFF, 0x31, 0xFA, 0xFA, 0xFA, 0xFA, 0x0C, 0x00}};
-CAN_frame_t BMW_192 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x192,
-                       .data = {0xFF, 0xFF, 0xA3, 0x8F, 0x93, 0xFF, 0xFF, 0xFF}};
-CAN_frame_t BMW_19B = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x19B,
-                       .data = {0x20, 0x40, 0x40, 0x55, 0xFD, 0xFF, 0xFF, 0xFF}};
-CAN_frame_t BMW_1D0 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x1D0,
-                       .data = {0x4D, 0xF0, 0xAE, 0xF8, 0xFF, 0xFF, 0xFF, 0xFF}};
-CAN_frame_t BMW_2CA = {.FIR = {.B =
-                                   {
-                                       .DLC = 2,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x2CA,
-                       .data = {0x57, 0x57}};
-CAN_frame_t BMW_2E2 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x2E2,
-                       .data = {0x4F, 0xDB, 0x7F, 0xB9, 0x07, 0x51, 0xff, 0x00}};
-CAN_frame_t BMW_30B = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x30B,
-                       .data = {0xe1, 0xf0, 0xff, 0xff, 0xf1, 0xff, 0xff, 0xff}};
-CAN_frame_t BMW_328 = {.FIR = {.B =
-                                   {
-                                       .DLC = 6,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x328,
-                       .data = {0xB0, 0xE4, 0x87, 0x0E, 0x30, 0x22}};
-CAN_frame_t BMW_37B = {.FIR = {.B =
-                                   {
-                                       .DLC = 6,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x37B,
-                       .data = {0x40, 0x00, 0x00, 0xFF, 0xFF, 0x00}};
-CAN_frame_t BMW_380 = {.FIR = {.B =
-                                   {
-                                       .DLC = 7,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x380,
-                       .data = {0x56, 0x5A, 0x37, 0x39, 0x34, 0x34, 0x34}};
-CAN_frame_t BMW_3A0 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3A0,
-                       .data = {0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC}};
-CAN_frame_t BMW_3A7 = {.FIR = {.B =
-                                   {
-                                       .DLC = 7,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3A7,
-                       .data = {0x05, 0xF5, 0x0A, 0x00, 0x4F, 0x11, 0xF0}};
-CAN_frame_t BMW_3C5 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3C5,
-                       .data = {0x30, 0x05, 0x47, 0x70, 0x2c, 0xce, 0xc3, 0x34}};
-CAN_frame_t BMW_3CA = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3CA,
-                       .data = {0x87, 0x80, 0x30, 0x0C, 0x0C, 0x81, 0xFF, 0xFF}};
-CAN_frame_t BMW_3D0 = {.FIR = {.B =
-                                   {
-                                       .DLC = 2,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3D0,
-                       .data = {0xFD, 0xFF}};
-CAN_frame_t BMW_3E4 = {.FIR = {.B =
-                                   {
-                                       .DLC = 6,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3E4,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF}};
-CAN_frame_t BMW_3E5 = {.FIR = {.B =
-                                   {
-                                       .DLC = 3,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3E5,
-                       .data = {0xFC, 0xFF, 0xFF}};
-CAN_frame_t BMW_3E8 = {.FIR = {.B =
-                                   {
-                                       .DLC = 2,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3E8,
-                       .data = {0xF0, 0xFF}};  //1000ms OBD reset
-CAN_frame_t BMW_3EC = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3EC,
-                       .data = {0xF5, 0x10, 0x00, 0x00, 0x80, 0x25, 0x0F, 0xFC}};
-CAN_frame_t BMW_3F9 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3F9,
-                       .data = {0xA7, 0x2A, 0x00, 0xE2, 0xA6, 0x30, 0xC3, 0xFF}};
-CAN_frame_t BMW_3FB = {.FIR = {.B =
-                                   {
-                                       .DLC = 6,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3FB,
-                       .data = {0xFF, 0xFF, 0xFF, 0xFF, 0x5F, 0x00}};
-CAN_frame_t BMW_3FC = {.FIR = {.B =
-                                   {
-                                       .DLC = 3,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3FC,
-                       .data = {0xC0, 0xF9, 0x0F}};
-CAN_frame_t BMW_418 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x418,
-                       .data = {0xFF, 0x7C, 0xFF, 0x00, 0xC0, 0x3F, 0xFF, 0xFF}};
-CAN_frame_t BMW_41D = {.FIR = {.B =
-                                   {
-                                       .DLC = 4,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x41D,
-                       .data = {0xFF, 0xF7, 0x7F, 0xFF}};
-CAN_frame_t BMW_433 = {.FIR = {.B =
-                                   {
-                                       .DLC = 4,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x433,
-                       .data = {0xFF, 0x00, 0x0F, 0xFF}};  // HV specification
-CAN_frame_t BMW_512 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x512,                                             // Required to keep BMS active
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12}};  // 0x512 Network management
-CAN_frame_t BMW_592_0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x592,
-                         .data = {0x86, 0x10, 0x07, 0x21, 0x6e, 0x35, 0x5e, 0x86}};
-CAN_frame_t BMW_592_1 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x592,
-                         .data = {0x86, 0x21, 0xb4, 0xdd, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t BMW_5F8 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x5F8,
-                       .data = {0x64, 0x01, 0x00, 0x0B, 0x92, 0x03, 0x00, 0x05}};
-
-CAN_frame_t BMW_6F1_CELL = {.FIR = {.B =
-                                        {
-                                            .DLC = 5,
-                                            .FF = CAN_frame_std,
-                                        }},
-                            .MsgID = 0x6F1,
-                            .data = {0x07, 0x03, 0x22, 0xDD, 0xBF}};
-
-CAN_frame_t BMW_6F1_SOH = {.FIR = {.B =
-                                       {
-                                           .DLC = 5,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x6F1,
-                           .data = {0x07, 0x03, 0x22, 0x63, 0x35}};
-
-CAN_frame_t BMW_6F1_SOC = {.FIR = {.B =
-                                       {
-                                           .DLC = 5,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x6F1,
-                           .data = {0x07, 0x03, 0x22, 0xDD, 0xBC}};
-
-CAN_frame_t BMW_6F1_CELL_VOLTAGE_AVG = {.FIR = {.B =
-                                                    {
-                                                        .DLC = 5,
-                                                        .FF = CAN_frame_std,
-                                                    }},
-                                        .MsgID = 0x6F1,
-                                        .data = {0x07, 0x03, 0x22, 0xDF, 0xA0}};
-
-CAN_frame_t BMW_6F1_CONTINUE = {.FIR = {.B =
-                                            {
-                                                .DLC = 4,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x6F1,
-                                .data = {0x07, 0x30, 0x00, 0x02}};
+CAN_frame BMW_10B = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 3,
+                     .ID = 0x10B,
+                     .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command
+CAN_frame BMW_12F = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x12F,
+                     .data = {0xE6, 0x24, 0x86, 0x1A, 0xF1, 0x31, 0x30, 0x00}};  //0x12F Wakeup VCU
+CAN_frame BMW_13E = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x13E,
+                     .data = {0xFF, 0x31, 0xFA, 0xFA, 0xFA, 0xFA, 0x0C, 0x00}};
+CAN_frame BMW_192 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x192,
+                     .data = {0xFF, 0xFF, 0xA3, 0x8F, 0x93, 0xFF, 0xFF, 0xFF}};
+CAN_frame BMW_19B = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x19B,
+                     .data = {0x20, 0x40, 0x40, 0x55, 0xFD, 0xFF, 0xFF, 0xFF}};
+CAN_frame BMW_1D0 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x1D0,
+                     .data = {0x4D, 0xF0, 0xAE, 0xF8, 0xFF, 0xFF, 0xFF, 0xFF}};
+CAN_frame BMW_2CA = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x2CA, .data = {0x57, 0x57}};
+CAN_frame BMW_2E2 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x2E2,
+                     .data = {0x4F, 0xDB, 0x7F, 0xB9, 0x07, 0x51, 0xff, 0x00}};
+CAN_frame BMW_30B = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x30B,
+                     .data = {0xe1, 0xf0, 0xff, 0xff, 0xf1, 0xff, 0xff, 0xff}};
+CAN_frame BMW_328 = {.FD = false, .ext_ID = false, .DLC = 6, .ID = 0x328, .data = {0xB0, 0xE4, 0x87, 0x0E, 0x30, 0x22}};
+CAN_frame BMW_37B = {.FD = false, .ext_ID = false, .DLC = 6, .ID = 0x37B, .data = {0x40, 0x00, 0x00, 0xFF, 0xFF, 0x00}};
+CAN_frame BMW_380 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 7,
+                     .ID = 0x380,
+                     .data = {0x56, 0x5A, 0x37, 0x39, 0x34, 0x34, 0x34}};
+CAN_frame BMW_3A0 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3A0,
+                     .data = {0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC}};
+CAN_frame BMW_3A7 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 7,
+                     .ID = 0x3A7,
+                     .data = {0x05, 0xF5, 0x0A, 0x00, 0x4F, 0x11, 0xF0}};
+CAN_frame BMW_3C5 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3C5,
+                     .data = {0x30, 0x05, 0x47, 0x70, 0x2c, 0xce, 0xc3, 0x34}};
+CAN_frame BMW_3CA = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3CA,
+                     .data = {0x87, 0x80, 0x30, 0x0C, 0x0C, 0x81, 0xFF, 0xFF}};
+CAN_frame BMW_3D0 = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x3D0, .data = {0xFD, 0xFF}};
+CAN_frame BMW_3E4 = {.FD = false, .ext_ID = false, .DLC = 6, .ID = 0x3E4, .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF}};
+CAN_frame BMW_3E5 = {.FD = false, .ext_ID = false, .DLC = 3, .ID = 0x3E5, .data = {0xFC, 0xFF, 0xFF}};
+CAN_frame BMW_3E8 = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x3E8, .data = {0xF0, 0xFF}};  //1000ms OBD reset
+CAN_frame BMW_3EC = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3EC,
+                     .data = {0xF5, 0x10, 0x00, 0x00, 0x80, 0x25, 0x0F, 0xFC}};
+CAN_frame BMW_3F9 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3F9,
+                     .data = {0xA7, 0x2A, 0x00, 0xE2, 0xA6, 0x30, 0xC3, 0xFF}};
+CAN_frame BMW_3FB = {.FD = false, .ext_ID = false, .DLC = 6, .ID = 0x3FB, .data = {0xFF, 0xFF, 0xFF, 0xFF, 0x5F, 0x00}};
+CAN_frame BMW_3FC = {.FD = false, .ext_ID = false, .DLC = 3, .ID = 0x3FC, .data = {0xC0, 0xF9, 0x0F}};
+CAN_frame BMW_418 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x418,
+                     .data = {0xFF, 0x7C, 0xFF, 0x00, 0xC0, 0x3F, 0xFF, 0xFF}};
+CAN_frame BMW_41D = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x41D, .data = {0xFF, 0xF7, 0x7F, 0xFF}};
+CAN_frame BMW_433 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 4,
+                     .ID = 0x433,
+                     .data = {0xFF, 0x00, 0x0F, 0xFF}};  // HV specification
+CAN_frame BMW_512 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x512,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12}};  // 0x512 Network management
+CAN_frame BMW_592_0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x592,
+                       .data = {0x86, 0x10, 0x07, 0x21, 0x6e, 0x35, 0x5e, 0x86}};
+CAN_frame BMW_592_1 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x592,
+                       .data = {0x86, 0x21, 0xb4, 0xdd, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame BMW_5F8 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x5F8,
+                     .data = {0x64, 0x01, 0x00, 0x0B, 0x92, 0x03, 0x00, 0x05}};
+CAN_frame BMW_6F1_CELL = {.FD = false, .ext_ID = false, .DLC = 5, .ID = 0x6F1, .data = {0x07, 0x03, 0x22, 0xDD, 0xBF}};
+CAN_frame BMW_6F1_SOH = {.FD = false, .ext_ID = false, .DLC = 5, .ID = 0x6F1, .data = {0x07, 0x03, 0x22, 0x63, 0x35}};
+CAN_frame BMW_6F1_SOC = {.FD = false, .ext_ID = false, .DLC = 5, .ID = 0x6F1, .data = {0x07, 0x03, 0x22, 0xDD, 0xBC}};
+CAN_frame BMW_6F1_CELL_VOLTAGE_AVG = {.FD = false,
+                                      .ext_ID = false,
+                                      .DLC = 5,
+                                      .ID = 0x6F1,
+                                      .data = {0x07, 0x03, 0x22, 0xDF, 0xA0}};
+CAN_frame BMW_6F1_CONTINUE = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x6F1, .data = {0x07, 0x30, 0x00, 0x02}};
 //The above CAN messages need to be sent towards the battery to keep it alive
 
 static uint8_t startup_counter_contactor = 0;
@@ -460,7 +326,8 @@ static uint8_t battery2_soh = 99;
 static uint8_t message_data[50];
 static uint8_t next_data = 0;
 
-static uint8_t calculateCRC(CAN_frame_t rx_frame, uint8_t length, uint8_t initial_value) {
+template <typename T>  // Works on both our own CAN implementation, and on miwagner format
+static uint8_t calculateCRC(T rx_frame, uint8_t length, uint8_t initial_value) {
   uint8_t crc = initial_value;
   for (uint8_t j = 1; j < length; j++) {  //start at 1, since 0 is the CRC
     crc = crc8_table[(crc ^ static_cast<uint8_t>(rx_frame.data.u8[j])) % 256];

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -482,7 +482,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery_awake = true;
@@ -645,7 +645,7 @@ receive_can_battery(CAN_frame_t rx_frame) {
       break;
   }
 }
-void receive_can_battery2(CAN_frame_t rx_frame) {
+void receive_can_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery2_awake = true;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -2,7 +2,6 @@
 #define BMW_I3_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -3,9 +3,6 @@
 #include <Arduino.h>
 #include "../include.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
-#include "../lib/pierremolinaro-acan2515/ACAN2515.h"
-
-extern ACAN2515 can;
 
 #define BATTERY_SELECTED
 
@@ -24,5 +21,6 @@ extern ACAN2515 can;
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
 #define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -21,6 +21,6 @@
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
 #define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -44,29 +44,21 @@ static uint16_t BMS_highest_cell_voltage_mV = 3300;
 #define POLL_FOR_BATTERY_CELL_MV_MIN 0x2B
 #define UNKNOWN_POLL_1 0xFC
 
-CAN_frame_t ATTO_3_12D = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_std,
-                                      }},
-                          .MsgID = 0x12D,
-                          .data = {0xA0, 0x28, 0x02, 0xA0, 0x0C, 0x71, 0xCF, 0x49}};
-CAN_frame_t ATTO_3_411 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_std,
-                                      }},
-                          .MsgID = 0x411,
-                          .data = {0x98, 0x3A, 0x88, 0x13, 0x9D, 0x00, 0xFF, 0x8C}};
-
-CAN_frame_t ATTO_3_7E7_POLL = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x7E7,
-    .data = {0x03, 0x22, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 00 05 (POLL_FOR_BATTERY_SOC)
+CAN_frame ATTO_3_12D = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x12D,
+                        .data = {0xA0, 0x28, 0x02, 0xA0, 0x0C, 0x71, 0xCF, 0x49}};
+CAN_frame ATTO_3_411 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x411,
+                        .data = {0x98, 0x3A, 0x88, 0x13, 0x9D, 0x00, 0xFF, 0x8C}};
+CAN_frame ATTO_3_7E7_POLL = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E7,  //Poll PID 03 22 00 05 (POLL_FOR_BATTERY_SOC)
+                             .data = {0x03, 0x22, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00}};
 
 // Define the data points for %SOC depending on pack voltage
 const uint8_t numPoints = 14;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -130,7 +130,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {  //Log values taken with 422V from battery
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -130,10 +130,10 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {  //Log values taken with 422V from battery
-    case 0x244:              //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
+  switch (rx_frame.ID) {  //Log values taken with 422V from battery
+    case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;
     case 0x245:  //01,00,02,19,3A,25,90,F4 Seems to have a mux in frame0
                  //02,00,90,01,79,79,90,EA // Point of interest, went from 7E,75 to 7B,7C when discharging

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef BYD_ATTO_3_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "BYD-ATTO-3-BATTERY.h"
 
 /* TODO: 
@@ -232,7 +230,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
 
       //This message transmits every 5?seconds. Seems like suitable place to poll for a PID
-      ESP32Can.CANWriteFrame(&ATTO_3_7E7_POLL);
+      transmit_can(&ATTO_3_7E7_POLL, can_config.battery);
 
       switch (ATTO_3_7E7_POLL.data.u8[3]) {
         case POLL_FOR_BATTERY_SOC:
@@ -341,7 +339,7 @@ void send_can_battery() {
     ATTO_3_12D.data.u8[6] = (0x0F | (frame6_counter << 4));
     ATTO_3_12D.data.u8[7] = (0x09 | (frame7_counter << 4));
 
-    ESP32Can.CANWriteFrame(&ATTO_3_12D);
+    transmit_can(&ATTO_3_12D, can_config.battery);
   }
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -354,7 +352,7 @@ void send_can_battery() {
       ATTO_3_411.data.u8[7] = 0xF5;
     }
 
-    ESP32Can.CANWriteFrame(&ATTO_3_411);
+    transmit_can(&ATTO_3_411, can_config.battery);
   }
 }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -2,7 +2,6 @@
 #define ATTO_3_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 150

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -367,7 +367,7 @@ inline void process_vehicle_vendor_ID(CAN_frame_t rx_frame) {
       ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2]);  //Actually more bytes, but not needed for our purpose
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
 #ifdef CH_CAN_DEBUG
   Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   Serial.print("  ");

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -702,8 +702,8 @@ void send_can_battery() {
      * that is the limiting factor. Therefore, we
      * can generally send as is without tweaks here.
      */
-    ESP32Can.CANWriteFrame(&CHADEMO_108);
-    ESP32Can.CANWriteFrame(&CHADEMO_109);
+    transmit_can(&CHADEMO_108, can_config.battery);
+    transmit_can(&CHADEMO_109, can_config.battery);
 
     /* TODO for dynamic control: can send x118 with byte 6 bit 0 set to 0 for 1s (before flipping back to 1) as a way of giving vehicle a chance to update 101.1 and 101.2
      * 	within 6 seconds of x118 toggle.
@@ -712,9 +712,9 @@ void send_can_battery() {
      */
 
     if (EVSE_mode == CHADEMO_DISCHARGE || EVSE_mode == CHADEMO_BIDIRECTIONAL) {
-      ESP32Can.CANWriteFrame(&CHADEMO_208);
+      transmit_can(&CHADEMO_208, can_config.battery);
       if (x201_received) {
-        ESP32Can.CANWriteFrame(&CHADEMO_209);
+        transmit_can(&CHADEMO_209, can_config.battery);
         x209_sent = true;
       }
     }
@@ -726,7 +726,7 @@ void send_can_battery() {
       //FIXME REMOVE
       Serial.println("REMOVE: proto 2.0");
 #endif
-      ESP32Can.CANWriteFrame(&CHADEMO_118);
+      transmit_can(&CHADEMO_118, can_config.battery);
     }
   }
 }

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -367,15 +367,15 @@ inline void process_vehicle_vendor_ID(CAN_frame_t rx_frame) {
       ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2]);  //Actually more bytes, but not needed for our purpose
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
 #ifdef CH_CAN_DEBUG
   Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   Serial.print("  ");
-  Serial.print(rx_frame.MsgID, HEX);
+  Serial.print(rx_frame.ID, HEX);
   Serial.print("  ");
-  Serial.print(rx_frame.FIR.B.DLC);
+  Serial.print(rx_frame.DLC);
   Serial.print("  ");
-  for (int i = 0; i < rx_frame.FIR.B.DLC; ++i) {
+  for (int i = 0; i < rx_frame.DLC; ++i) {
     Serial.print(rx_frame.data.u8[i], HEX);
     Serial.print(" ");
   }
@@ -384,7 +384,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
 
   // CHADEMO coexists with a CAN-based shunt. Only process CHADEMO-specific IDs
   // 202 is unknown
-  if (!((rx_frame.MsgID >= 0x100 && rx_frame.MsgID <= 0x202) || rx_frame.MsgID == 0x700)) {
+  if (!((rx_frame.ID >= 0x100 && rx_frame.ID <= 0x202) || rx_frame.ID == 0x700)) {
     return;
   }
 
@@ -397,7 +397,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive =
       CAN_STILL_ALIVE;  //We are getting CAN messages from the vehicle, inform the watchdog
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x100:
       process_vehicle_charging_minimums(rx_frame);
       break;

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -75,49 +75,39 @@ struct x109_EVSE_Status x109_evse_state;
 struct x118_EVSE_Dynamic_Control x118_evse_dyn;
 struct x208_EVSE_Discharge_Capability x208_evse_dischg_cap;
 
-CAN_frame_t CHADEMO_108 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x108,
-                           .data = {0x01, 0xF4, 0x01, 0x0F, 0xB3, 0x01, 0x00, 0x00}};
-CAN_frame_t CHADEMO_109 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x109,
-                           .data = {0x02, 0x00, 0x00, 0x00, 0x01, 0x20, 0xFF, 0xFF}};
+CAN_frame CHADEMO_108 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x108,
+                         .data = {0x01, 0xF4, 0x01, 0x0F, 0xB3, 0x01, 0x00, 0x00}};
+CAN_frame CHADEMO_109 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x109,
+                         .data = {0x02, 0x00, 0x00, 0x00, 0x01, 0x20, 0xFF, 0xFF}};
 //For chademo v2.0 only
-CAN_frame_t CHADEMO_118 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x118,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame CHADEMO_118 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x118,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
 // OLD value from skeleton implementation, indicates dynamic control is possible.
 // Hardcode above as being incompatible for simplicity in current incarnation.
 // .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
 
 //    0x200 : From vehicle-side. A V2X-ready vehicle will send this message to broadcast its “Maximum discharger current”. (It is a similar logic to the limits set in 0x100 or 0x102 during a DC charging session)
 //    0x208 : From EVSE-side. A V2X EVSE will use this to send the “present discharger current” during the session, and the “available input current”. (uses similar logic to 0x108 and 0x109 during a DC charging session)
-CAN_frame_t CHADEMO_208 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x208,
-                           .data = {0xFF, 0xF4, 0x01, 0xF0, 0x00, 0x00, 0xFA, 0x00}};
-
-CAN_frame_t CHADEMO_209 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x209,
-                           .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame CHADEMO_208 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x208,
+                         .data = {0xFF, 0xF4, 0x01, 0xF0, 0x00, 0x00, 0xFA, 0x00}};
+CAN_frame CHADEMO_209 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x209,
+                         .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 //This function maps all the values fetched via CAN to the correct parameters used for the inverter
 void update_values_battery() {
@@ -469,7 +459,7 @@ void evse_init() {
 }
 
 /* updates for x108 */
-void update_evse_capabilities(CAN_frame_t& f) {
+void update_evse_capabilities(CAN_frame& f) {
 
   /* TODO use charger defines/runtime config?
    * for now..leave as a future tweak.
@@ -507,7 +497,7 @@ void update_evse_capabilities(CAN_frame_t& f) {
 }
 
 /* updates for x109 */
-void update_evse_status(CAN_frame_t& f) {
+void update_evse_status(CAN_frame& f) {
 
   x109_evse_state.s.status.EVSE_status = 1;
   x109_evse_state.s.status.EVSE_error = 0;
@@ -598,7 +588,7 @@ void update_evse_status(CAN_frame_t& f) {
  * NOTE: x209 is emitted in CAN logs when x201 isn't even present
  * 	it may not be understood by leaf (or ignored unless >= a certain protocol version or v2h sequence number
  */
-void update_evse_discharge_estimate(CAN_frame_t& f) {
+void update_evse_discharge_estimate(CAN_frame& f) {
 
   //x209_evse_dischg_est.remaining_discharge_time_1m = x201_discharge_estimate.ApproxDischargeCompletionTime;
 
@@ -616,7 +606,7 @@ void update_evse_discharge_estimate(CAN_frame_t& f) {
 }
 
 /* x208 EVSE, peer to 0x200 Vehicle */
-void update_evse_discharge_capabilities(CAN_frame_t& f) {
+void update_evse_discharge_capabilities(CAN_frame& f) {
   //present discharge current is a measured value
   x208_evse_dischg_cap.present_discharge_current = 0xFF - get_measured_current();
 

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -149,21 +149,21 @@ void update_values_battery() {
 //see IEEE Table A.26—Charge control termination command pattern on pg58
 //for stop conditions
 
-inline void process_vehicle_charging_minimums(CAN_frame_t rx_frame) {
+inline void process_vehicle_charging_minimums(CAN_frame rx_frame) {
   x100_chg_lim.MinimumChargeCurrent = rx_frame.data.u8[0];
   x100_chg_lim.MinimumBatteryVoltage = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
   x100_chg_lim.MaximumBatteryVoltage = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
   x100_chg_lim.ConstantOfChargingRateIndication = rx_frame.data.u8[6];
 }
 
-inline void process_vehicle_charging_maximums(CAN_frame_t rx_frame) {
+inline void process_vehicle_charging_maximums(CAN_frame rx_frame) {
   x101_chg_est.MaxChargingTime10sBit = rx_frame.data.u8[1];
   x101_chg_est.MaxChargingTime1minBit = rx_frame.data.u8[2];
   x101_chg_est.EstimatedChargingTime = rx_frame.data.u8[3];
   x101_chg_est.RatedBatteryCapacity = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
 }
 
-inline void process_vehicle_charging_session(CAN_frame_t rx_frame) {
+inline void process_vehicle_charging_session(CAN_frame rx_frame) {
 
   uint16_t newTargetBatteryVoltage = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2]);
   uint16_t priorChargingCurrentRequest = x102_chg_session.ChargingCurrentRequest;
@@ -305,7 +305,7 @@ inline void process_vehicle_charging_session(CAN_frame_t rx_frame) {
 }
 
 /* x200 Vehicle, peer to x208 EVSE */
-inline void process_vehicle_charging_limits(CAN_frame_t rx_frame) {
+inline void process_vehicle_charging_limits(CAN_frame rx_frame) {
 
   x200_discharge_limits.MaximumDischargeCurrent = rx_frame.data.u8[0];
   x200_discharge_limits.MinimumDischargeVoltage = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
@@ -334,7 +334,7 @@ inline void process_vehicle_charging_limits(CAN_frame_t rx_frame) {
 /* Vehicle 0x201, peer to EVSE 0x209 
  * HOWEVER, 201 isn't even emitted in any of the v2x canlogs available
  */
-inline void process_vehicle_discharge_estimate(CAN_frame_t rx_frame) {
+inline void process_vehicle_discharge_estimate(CAN_frame rx_frame) {
   unsigned long currentMillis = millis();
 
   x201_discharge_estimate.V2HchargeDischargeSequenceNum = rx_frame.data.u8[0];
@@ -352,7 +352,7 @@ inline void process_vehicle_discharge_estimate(CAN_frame_t rx_frame) {
 #endif
 }
 
-inline void process_vehicle_dynamic_control(CAN_frame_t rx_frame) {
+inline void process_vehicle_dynamic_control(CAN_frame rx_frame) {
   //SM Dynamic Control = Charging station can increase of decrease "available output current" during charging.
   //If you set 0x110 byte 0, bit 0 to 1 you say you can do dynamic control.
   //Charging station communicates this in 0x118 byte 0, bit 0
@@ -361,7 +361,7 @@ inline void process_vehicle_dynamic_control(CAN_frame_t rx_frame) {
   x110_vehicle_dyn.u.status.DynamicControlStatus = bitRead(rx_frame.data.u8[0], 0);
 }
 
-inline void process_vehicle_vendor_ID(CAN_frame_t rx_frame) {
+inline void process_vehicle_vendor_ID(CAN_frame rx_frame) {
   x700_vendor_id.AutomakerCode = rx_frame.data.u8[0];
   x700_vendor_id.OptionalContent =
       ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2]);  //Actually more bytes, but not needed for our purpose

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -15,5 +15,6 @@
 #define ISA_SHUNT
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -2,7 +2,6 @@
 #define CHADEMO_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -15,6 +15,6 @@
 #define ISA_SHUNT
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -74,15 +74,15 @@ uint16_t get_measured_current() {
 }
 
 //This is our CAN interrupt service routine to catch inbound frames
-inline void ISA_handleFrame(CAN_frame_t* frame) {
+inline void ISA_handleFrame(CAN_frame* frame) {
 
-  if (frame->MsgID < 0x521 || frame->MsgID > 0x528) {
+  if (frame->ID < 0x521 || frame->ID > 0x528) {
     return;
   }
 
   framecount++;
 
-  switch (frame->MsgID) {
+  switch (frame->ID) {
     case 0x511:
       break;
 
@@ -123,7 +123,7 @@ inline void ISA_handleFrame(CAN_frame_t* frame) {
 }
 
 //handle frame for Amperes
-inline void ISA_handle521(CAN_frame_t* frame) {
+inline void ISA_handle521(CAN_frame* frame) {
   long current = 0;
   current =
       (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
@@ -133,7 +133,7 @@ inline void ISA_handle521(CAN_frame_t* frame) {
 }
 
 //handle frame for Voltage
-inline void ISA_handle522(CAN_frame_t* frame) {
+inline void ISA_handle522(CAN_frame* frame) {
   long volt =
       (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
 
@@ -156,7 +156,7 @@ inline void ISA_handle522(CAN_frame_t* frame) {
 }
 
 //handle frame for Voltage 2
-inline void ISA_handle523(CAN_frame_t* frame) {
+inline void ISA_handle523(CAN_frame* frame) {
   long volt =
       (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
 
@@ -175,7 +175,7 @@ inline void ISA_handle523(CAN_frame_t* frame) {
 }
 
 //handle frame for Voltage3
-inline void ISA_handle524(CAN_frame_t* frame) {
+inline void ISA_handle524(CAN_frame* frame) {
   long volt =
       (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
 
@@ -192,7 +192,7 @@ inline void ISA_handle524(CAN_frame_t* frame) {
 }
 
 //handle frame for Temperature
-inline void ISA_handle525(CAN_frame_t* frame) {
+inline void ISA_handle525(CAN_frame* frame) {
   long temp = 0;
   temp = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
 
@@ -200,14 +200,14 @@ inline void ISA_handle525(CAN_frame_t* frame) {
 }
 
 //handle frame for Kilowatts
-inline void ISA_handle526(CAN_frame_t* frame) {
+inline void ISA_handle526(CAN_frame* frame) {
   watt = 0;
   watt = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
   KW = watt / 1000.0f;
 }
 
 //handle frame for Ampere-Hours
-inline void ISA_handle527(CAN_frame_t* frame) {
+inline void ISA_handle527(CAN_frame* frame) {
   As = 0;
   As = (frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]);
 
@@ -216,7 +216,7 @@ inline void ISA_handle527(CAN_frame_t* frame) {
 }
 
 //handle frame for kiloWatt-hours
-inline void ISA_handle528(CAN_frame_t* frame) {
+inline void ISA_handle528(CAN_frame* frame) {
   wh = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
   KWH += (wh - lastWh) / 1000.0f;
   lastWh = wh;

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -59,16 +59,11 @@ long lastWh;
  * Please note that all delay/sleep operations are solely in this section of code,
  * not used during normal operation. Such delays are currently commented out.
  */
-CAN_frame_t outframe = {.FIR = {.B =
-                                    {
-                                        .DLC = 8,
-                                        .unknown_2 = 0,
-                                        .RTR = CAN_no_RTR,
-                                        .FF = CAN_frame_std,
-                                    }},
-
-                        .MsgID = 0x411,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame outframe = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 8,
+                      .ID = 0x411,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 uint16_t get_measured_voltage() {
   return (uint16_t)Voltage;

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -244,7 +244,7 @@ void ISA_initialize() {
         outframe.data.u8[6]=0x00;
         outframe.data.u8[7]=0x00;
 
-        ESP32Can.CANWriteFrame(&outframe);
+        transmit_can((&outframe, can_config.battery);
 
         delay(500);
 
@@ -268,7 +268,7 @@ void ISA_STOP() {
     outframe.data.u8[5]=0x00;
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 
 }
 
@@ -281,7 +281,7 @@ void ISA_sendSTORE() {
     outframe.data.u8[5]=0x00;
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 }
 
 void ISA_START() {
@@ -293,7 +293,7 @@ void ISA_START() {
     outframe.data.u8[5]=0x00;
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 }
 
 void ISA_RESTART() {
@@ -306,7 +306,7 @@ void ISA_RESTART() {
     outframe.data.u8[5]=0x00;
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 }
 
 void ISA_deFAULT() {
@@ -319,7 +319,7 @@ void ISA_deFAULT() {
     outframe.data.u8[5]=0x00;
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 }
 
 void ISA_initCurrent() {
@@ -337,7 +337,7 @@ void ISA_initCurrent() {
     outframe.data.u8[6]=0x00;
     outframe.data.u8[7]=0x00;
 
-    ESP32Can.CANWriteFrame(&outframe);
+    transmit_can((&outframe, can_config.battery);
 
     delay(500);
 

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -1,6 +1,8 @@
 #ifndef CHADEMO_SHUNTS_H
 #define CHADEMO_SHUNTS_H
 
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+
 uint16_t get_measured_voltage();
 uint16_t get_measured_current();
 inline void ISA_handler(CAN_frame_t* frame);
@@ -12,5 +14,7 @@ inline void ISA_handle525(CAN_frame_t* frame);
 inline void ISA_handle526(CAN_frame_t* frame);
 inline void ISA_handle527(CAN_frame_t* frame);
 inline void ISA_handle528(CAN_frame_t* frame);
+
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -15,6 +15,6 @@ inline void ISA_handle526(CAN_frame_t* frame);
 inline void ISA_handle527(CAN_frame_t* frame);
 inline void ISA_handle528(CAN_frame_t* frame);
 
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -5,15 +5,15 @@
 
 uint16_t get_measured_voltage();
 uint16_t get_measured_current();
-inline void ISA_handler(CAN_frame_t* frame);
-inline void ISA_handle521(CAN_frame_t* frame);
-inline void ISA_handle522(CAN_frame_t* frame);
-inline void ISA_handle523(CAN_frame_t* frame);
-inline void ISA_handle524(CAN_frame_t* frame);
-inline void ISA_handle525(CAN_frame_t* frame);
-inline void ISA_handle526(CAN_frame_t* frame);
-inline void ISA_handle527(CAN_frame_t* frame);
-inline void ISA_handle528(CAN_frame_t* frame);
+inline void ISA_handler(CAN_frame* frame);
+inline void ISA_handle521(CAN_frame* frame);
+inline void ISA_handle522(CAN_frame* frame);
+inline void ISA_handle523(CAN_frame* frame);
+inline void ISA_handle524(CAN_frame* frame);
+inline void ISA_handle525(CAN_frame* frame);
+inline void ISA_handle526(CAN_frame* frame);
+inline void ISA_handle527(CAN_frame* frame);
+inline void ISA_handle528(CAN_frame* frame);
 
 void transmit_can(CAN_frame* tx_frame, int interface);
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -165,7 +165,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       BMU_Detected = 1;
       //Pid index 0-3
-      pid_index = (rx_frame.MsgID) - 1761;
+      pid_index = (rx_frame.ID) - 1761;
       //cmu index 1-12: ignore high order nibble which appears to sometimes contain other status bits
       cmu_id = (rx_frame.data.u8[0] & 0x0f);
       //

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -133,8 +133,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+receive_can_battery(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x374:  //BMU message, 10ms - SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       temp_value = ((rx_frame.data.u8[1] - 10) / 2);

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -133,7 +133,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x374:  //BMU message, 10ms - SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef IMIEV_CZERO_ION_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "IMIEV-CZERO-ION-BATTERY.h"
 
 //Code still work in progress, TODO:

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -2,7 +2,6 @@
 #define IMIEV_CZERO_ION_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 500

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -2,7 +2,6 @@
 #ifdef JAGUAR_IPACE_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "JAGUAR-IPACE-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -257,7 +256,7 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    //ESP32Can.CANWriteFrame(&ipace_keep_alive);
+    //transmit_can(&ipace_keep_alive);
   }
 
   // Send 500ms CAN Message
@@ -281,7 +280,7 @@ void send_can_battery() {
                            }},
                .MsgID = 0x7e4,
                .data = {0x03, 0x19, 0x02, 0x8f, 0x00, 0x00, 0x00, 0x00}};
-        err = ESP32Can.CANWriteFrame(&msg);
+        err = transmit_can(&msg, can_config.battery);
         if (err == 0)
           state++;
 
@@ -297,7 +296,7 @@ void send_can_battery() {
                            }},
                .MsgID = 0x7e4,
                .data = {0x06, 0x19, 0x04, 0xc0, 0x64, 0x88, 0xff, 0x00}};
-        err = ESP32Can.CANWriteFrame(&msg);
+        err = transmit_can(&msg, can_config.battery);
         if (err == 0)
           state++;
         break;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -225,7 +225,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 
   // Discard non-interesting can messages so they do not get logged via serial
-  if (rx_frame.MsgID < 0x500) {
+  if (rx_frame.ID < 0x500) {
     return;
   }
 

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -280,9 +280,8 @@ void send_can_battery() {
                            }},
                .MsgID = 0x7e4,
                .data = {0x03, 0x19, 0x02, 0x8f, 0x00, 0x00, 0x00, 0x00}};
-        err = transmit_can(&msg, can_config.battery);
-        if (err == 0)
-          state++;
+        transmit_can(&msg, can_config.battery);
+        state++;
 
         break;
       case 1:
@@ -296,9 +295,8 @@ void send_can_battery() {
                            }},
                .MsgID = 0x7e4,
                .data = {0x06, 0x19, 0x04, 0xc0, 0x64, 0x88, 0xff, 0x00}};
-        err = transmit_can(&msg, can_config.battery);
-        if (err == 0)
-          state++;
+        transmit_can(&msg, can_config.battery);
+        state++;
         break;
       case 2:
         /* reset */

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -120,7 +120,7 @@ void update_values_battery() {
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.MsgID == 0 && rx_frame.FIR.B.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
@@ -129,7 +129,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
     return;
   }
 
-  switch (rx_frame.MsgID) {  // These messages are periodically transmitted by the battery
+  switch (rx_frame.ID) {  // These messages are periodically transmitted by the battery
     case 0x080:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       HVBatteryContactorStatus = ((rx_frame.data.u8[0] & 0x80) >> 7);

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -120,7 +120,7 @@ void update_values_battery() {
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.MsgID == 0 && rx_frame.FIR.B.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -42,21 +42,16 @@ static bool HVILBattIsolationError = false;
 static bool HVIsolationTestStatus = false;
 
 /* TODO: Actually use a proper keepalive message */
-CAN_frame_t ipace_keep_alive = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x063,
-                                .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-CAN_frame_t ipace_7e4 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x7e4,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame ipace_keep_alive = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x063,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame ipace_7e4 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x7e4,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 void print_units(char* header, int value, char* units) {
   Serial.print(header);
@@ -263,7 +258,7 @@ void send_can_battery() {
   if (currentMillis - previousMillis500 >= INTERVAL_500_MS) {
     previousMillis500 = currentMillis;
 
-    CAN_frame_t msg;
+    CAN_frame msg;
     int err;
 
     switch (state) {
@@ -273,12 +268,10 @@ void send_can_battery() {
         // response:     7EC 07 59 02 8F F0 01 00 28
         // response:     7EC 03 59 02 8F 00 00 00 00
         //               7EC  8  3 7F 19 11 0 0 0 0
-        msg = {.FIR = {.B =
-                           {
-                               .DLC = 8,
-                               .FF = CAN_frame_std,
-                           }},
-               .MsgID = 0x7e4,
+        msg = {.FD = false,
+               .ext_ID = false,
+               .DLC = 8,
+               .ID = 0x7e4,
                .data = {0x03, 0x19, 0x02, 0x8f, 0x00, 0x00, 0x00, 0x00}};
         transmit_can(&msg, can_config.battery);
         state++;
@@ -287,13 +280,10 @@ void send_can_battery() {
       case 1:
         // car response: 7EC 11 fa 59 04 c0 64 88 28
         // response:
-
-        msg = {.FIR = {.B =
-                           {
-                               .DLC = 8,
-                               .FF = CAN_frame_std,
-                           }},
-               .MsgID = 0x7e4,
+        msg = {.FD = false,
+               .ext_ID = false,
+               .DLC = 8,
+               .ID = 0x7e4,
                .data = {0x06, 0x19, 0x04, 0xc0, 0x64, 0x88, 0xff, 0x00}};
         transmit_can(&msg, can_config.battery);
         state++;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -123,7 +123,7 @@ void update_values_battery() {
 void receive_can_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
-  if (rx_frame.MsgID == 0 && rx_frame.FIR.B.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
+  if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
       rx_frame.data.u8[2] == 0 && rx_frame.data.u8[3] == 0 && rx_frame.data.u8[4] == 0 && rx_frame.data.u8[5] == 0 &&
       rx_frame.data.u8[6] == 0x80 && rx_frame.data.u8[7] == 0) {
     return;
@@ -232,11 +232,11 @@ void receive_can_battery(CAN_frame rx_frame) {
   // All CAN messages recieved will be logged via serial
   Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   Serial.print("  ");
-  Serial.print(rx_frame.MsgID, HEX);
+  Serial.print(rx_frame.ID, HEX);
   Serial.print("  ");
-  Serial.print(rx_frame.FIR.B.DLC);
+  Serial.print(rx_frame.DLC);
   Serial.print("  ");
-  for (int i = 0; i < rx_frame.FIR.B.DLC; ++i) {
+  for (int i = 0; i < rx_frame.DLC; ++i) {
     Serial.print(rx_frame.data.u8[i], HEX);
     Serial.print(" ");
   }

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -1,7 +1,6 @@
 #ifndef JAGUAR_IPACE_BATTERY_H
 #define JAGUAR_IPACE_BATTERY_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999  // TODO is this ok ?

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -7,6 +7,6 @@
 #define MAX_CELL_DEVIATION_MV 9999  // TODO is this ok ?
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -1,10 +1,12 @@
 #ifndef JAGUAR_IPACE_BATTERY_H
 #define JAGUAR_IPACE_BATTERY_H
 #include "../include.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999  // TODO is this ok ?
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -361,7 +361,7 @@ void receive_canfd_battery(CANFDMessage frame) {
   }
 }
 
-void receive_can_battery(CAN_frame_t frame) {}  // Not used on CAN-FD battery, just included to compile
+void receive_can_battery(CAN_frame frame) {}  // Not used on CAN-FD battery, just included to compile
 
 void send_can_battery() {
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -43,20 +43,16 @@ static int8_t temperature_water_inlet = 0;
 static int8_t powerRelayTemperature = 0;
 static int8_t heatertemp = 0;
 
-CAN_frame_t EGMP_7E4 = {.FIR = {.B =
-                                    {
-                                        .DLC = 8,
-                                        .FF = CAN_frame_std,  // Converted to CAN-FD when sent
-                                    }},
-                        .MsgID = 0x7E4,
-                        .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
-CAN_frame_t EGMP_7E4_ack = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,  // Converted to CAN-FD when sent
-                }},
-    .MsgID = 0x7E4,
+CAN_frame EGMP_7E4 = {.FD = true,
+                      .ext_ID = false,
+                      .DLC = 8,
+                      .ID = 0x7E4,
+                      .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
+CAN_frame EGMP_7E4_ack = {
+    .FD = true,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x7E4,
     .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
 
 void set_cell_voltages(CANFDMessage frame, int start, int length, int startCell) {

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -43,8 +43,21 @@ static int8_t temperature_water_inlet = 0;
 static int8_t powerRelayTemperature = 0;
 static int8_t heatertemp = 0;
 
-CANFDMessage EGMP_7E4;
-CANFDMessage EGMP_7E4_ack;
+CAN_frame_t EGMP_7E4 = {.FIR = {.B =
+                                    {
+                                        .DLC = 8,
+                                        .FF = CAN_frame_std,  // Converted to CAN-FD when sent
+                                    }},
+                        .MsgID = 0x7E4,
+                        .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
+CAN_frame_t EGMP_7E4_ack = {
+    .FIR = {.B =
+                {
+                    .DLC = 8,
+                    .FF = CAN_frame_std,  // Converted to CAN-FD when sent
+                }},
+    .MsgID = 0x7E4,
+    .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
 
 void set_cell_voltages(CANFDMessage frame, int start, int length, int startCell) {
   for (size_t i = 0; i < length; i++) {
@@ -173,18 +186,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void send_canfd_frame(CANFDMessage frame) {
-#ifdef DEBUG_VIA_USB
-  const bool ok = canfd.tryToSend(frame);
-  if (ok) {
-  } else {
-    Serial.println("Send canfd failure.");
-  }
-#else
-  canfd.tryToSend(frame);
-#endif
-}
-
 void receive_canfd_battery(CANFDMessage frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (frame.id) {
@@ -195,7 +196,7 @@ void receive_canfd_battery(CANFDMessage frame) {
           // Serial.println ("Send ack");
           poll_data_pid = frame.data[4];
           // if (frame.data[4] == poll_data_pid) {
-          send_canfd_frame(EGMP_7E4_ack);  //Send ack to BMS if the same frame is sent as polled
+          transmit_can(&EGMP_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           // }
           break;
         case 0x21:  //First frame in PID group
@@ -388,8 +389,8 @@ void send_can_battery() {
       datalayer.system.status.battery_allows_contactor_closing = false;
     }
     //  Section end
-    EGMP_7E4.data[3] = KIA_7E4_COUNTER;
-    send_canfd_frame(EGMP_7E4);
+    EGMP_7E4.data.u8[3] = KIA_7E4_COUNTER;
+    transmit_can(&EGMP_7E4, can_config.battery);
 
     KIA_7E4_COUNTER++;
     if (KIA_7E4_COUNTER > 0x0D) {  // gets up to 0x010C before repeating
@@ -409,18 +410,6 @@ void setup_battery(void) {  // Performs one time setup at startup
       8064;  // TODO: define when battery is known, charging is not possible (goes into forced discharge)
   datalayer.battery.info.min_design_voltage_dV =
       4320;  // TODO: define when battery is known. discharging further is disabled
-
-  EGMP_7E4.id = 0x7E4;
-  EGMP_7E4.ext = false;
-  EGMP_7E4.len = 8;
-  uint8_t dataEGMP_7E4[8] = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00};  //Poll PID 03 22 01 01
-  memcpy(EGMP_7E4.data, dataEGMP_7E4, sizeof(dataEGMP_7E4));
-
-  EGMP_7E4_ack.id = 0x7E4;
-  EGMP_7E4_ack.ext = false;
-  EGMP_7E4_ack.len = 8;
-  uint8_t dataEGMP_7E4_ack[8] = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};  //Ack frame, correct PID is returned
-  memcpy(EGMP_7E4_ack.data, dataEGMP_7E4_ack, sizeof(dataEGMP_7E4_ack));
 }
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef KIA_E_GMP_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "../lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h"
 #include "KIA-E-GMP-BATTERY.h"
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -13,5 +13,6 @@ extern ACAN2517FD canfd;
 #define MAXDISCHARGEPOWERALLOWED 10000
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -13,6 +13,6 @@ extern ACAN2517FD canfd;
 #define MAXDISCHARGEPOWERALLOWED 10000
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -2,7 +2,6 @@
 #define KIA_E_GMP_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "../lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h"
 
 extern ACAN2517FD canfd;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef KIA_HYUNDAI_64_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "KIA-HYUNDAI-64-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -313,17 +311,17 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       }
       poll_data_pid++;
       if (poll_data_pid == 1) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id1);
+        transmit_can(&KIA64_7E4_id1, can_config.battery);
       } else if (poll_data_pid == 2) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id2);
+        transmit_can(&KIA64_7E4_id2, can_config.battery);
       } else if (poll_data_pid == 3) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id3);
+        transmit_can(&KIA64_7E4_id3, can_config.battery);
       } else if (poll_data_pid == 4) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id4);
+        transmit_can(&KIA64_7E4_id4, can_config.battery);
       } else if (poll_data_pid == 5) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id5);
+        transmit_can(&KIA64_7E4_id5, can_config.battery);
       } else if (poll_data_pid == 6) {
-        ESP32Can.CANWriteFrame(&KIA64_7E4_id6);
+        transmit_can(&KIA64_7E4_id6, can_config.battery);
       } else if (poll_data_pid == 7) {
       } else if (poll_data_pid == 8) {
       } else if (poll_data_pid == 9) {
@@ -334,7 +332,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
-            ESP32Can.CANWriteFrame(&KIA64_7E4_ack);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can(&KIA64_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -516,9 +514,9 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    ESP32Can.CANWriteFrame(&KIA64_553);
-    ESP32Can.CANWriteFrame(&KIA64_57F);
-    ESP32Can.CANWriteFrame(&KIA64_2A1);
+    transmit_can(&KIA64_553, can_config.battery);
+    transmit_can(&KIA64_57F, can_config.battery);
+    transmit_can(&KIA64_2A1, can_config.battery);
   }
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
@@ -570,11 +568,11 @@ void send_can_battery() {
         break;
     }
 
-    ESP32Can.CANWriteFrame(&KIA_HYUNDAI_200);
+    transmit_can(&KIA_HYUNDAI_200, can_config.battery);
 
-    ESP32Can.CANWriteFrame(&KIA_HYUNDAI_523);
+    transmit_can(&KIA_HYUNDAI_523, can_config.battery);
 
-    ESP32Can.CANWriteFrame(&KIA_HYUNDAI_524);
+    transmit_can(&KIA_HYUNDAI_524, can_config.battery);
   }
 }
 
@@ -583,9 +581,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV =
-      4040;  // 404.0V, over this, charging is not possible (goes into forced discharge)
-  datalayer.battery.info.min_design_voltage_dV = 3100;  // 310.0V under this, discharging further is disabled
+  datalayer.battery.info.max_design_voltage_dV = 4040;  // 404.0V
+  datalayer.battery.info.min_design_voltage_dV = 3100;  // 310.0V
 }
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -233,8 +233,8 @@ void update_number_of_cells() {
   }
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+receive_can_battery(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x4DE:
       startedUp = true;
       break;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -40,104 +40,74 @@ static int8_t heatertemp = 0;
 static int8_t powerRelayTemperature = 0;
 static bool startedUp = false;
 
-CAN_frame_t KIA_HYUNDAI_200 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x200,
-                               //.data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x50, 0xD0, 0x00}}; //Initial value
-                               .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};  //Mid log value
-CAN_frame_t KIA_HYUNDAI_523 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x523,
-                               //.data = {0x00, 0x38, 0x28, 0x28, 0x28, 0x28, 0x00, 0x01}}; //Initial value
-                               .data = {0x08, 0x38, 0x36, 0x36, 0x33, 0x34, 0x00, 0x01}};  //Mid log value
-CAN_frame_t KIA_HYUNDAI_524 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x524,
-                               .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Initial value
-
+CAN_frame KIA_HYUNDAI_200 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x200,
+                             .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};  //Mid log value
+CAN_frame KIA_HYUNDAI_523 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x523,
+                             .data = {0x08, 0x38, 0x36, 0x36, 0x33, 0x34, 0x00, 0x01}};  //Mid log value
+CAN_frame KIA_HYUNDAI_524 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x524,
+                             .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Initial value
 //553 Needed frame 200ms
-CAN_frame_t KIA64_553 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x553,
-                         .data = {0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00}};
+CAN_frame KIA64_553 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x553,
+                       .data = {0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00}};
 //57F Needed frame 100ms
-CAN_frame_t KIA64_57F = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x57F,
-                         .data = {0x80, 0x0A, 0x72, 0x00, 0x00, 0x00, 0x00, 0x72}};
+CAN_frame KIA64_57F = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x57F,
+                       .data = {0x80, 0x0A, 0x72, 0x00, 0x00, 0x00, 0x00, 0x72}};
 //Needed frame 100ms
-CAN_frame_t KIA64_2A1 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x2A1,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-CAN_frame_t KIA64_7E4_id1 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
-CAN_frame_t KIA64_7E4_id2 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 02
-CAN_frame_t KIA64_7E4_id3 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 03
-CAN_frame_t KIA64_7E4_id4 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 04
-CAN_frame_t KIA64_7E4_id5 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 05
-CAN_frame_t KIA64_7E4_id6 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x7E4,
-                             .data = {0x03, 0x22, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 06
-CAN_frame_t KIA64_7E4_ack = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x7E4,
+CAN_frame KIA64_2A1 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x2A1,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA64_7E4_id1 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
+CAN_frame KIA64_7E4_id2 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 02
+CAN_frame KIA64_7E4_id3 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 03
+CAN_frame KIA64_7E4_id4 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 04
+CAN_frame KIA64_7E4_id5 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 05
+CAN_frame KIA64_7E4_id6 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x7E4,
+                           .data = {0x03, 0x22, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 06
+CAN_frame KIA64_7E4_ack = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x7E4,
     .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -233,7 +233,7 @@ void update_number_of_cells() {
   }
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4DE:
       startedUp = true;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -9,6 +9,6 @@
 
 void setup_battery(void);
 void update_number_of_cells();
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -2,7 +2,6 @@
 #define KIA_HYUNDAI_64_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 150

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -9,5 +9,6 @@
 
 void setup_battery(void);
 void update_number_of_cells();
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -90,7 +90,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x5F1:

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef KIA_HYUNDAI_HYBRID_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "KIA-HYUNDAI-HYBRID-BATTERY.h"
 
 /* TODO: 
@@ -124,7 +122,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[3] == poll_data_pid) {
-            ESP32Can.CANWriteFrame(&KIA_7E4_ack);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can(&KIA_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:                      //First frame in PID group
@@ -259,15 +257,15 @@ void send_can_battery() {
     }
     poll_data_pid++;
     if (poll_data_pid == 1) {
-      ESP32Can.CANWriteFrame(&KIA_7E4_id1);
+      transmit_can(&KIA_7E4_id1, can_config.battery);
     } else if (poll_data_pid == 2) {
-      ESP32Can.CANWriteFrame(&KIA_7E4_id2);
+      transmit_can(&KIA_7E4_id2, can_config.battery);
     } else if (poll_data_pid == 3) {
-      ESP32Can.CANWriteFrame(&KIA_7E4_id3);
+      transmit_can(&KIA_7E4_id3, can_config.battery);
     } else if (poll_data_pid == 4) {
 
     } else if (poll_data_pid == 5) {
-      ESP32Can.CANWriteFrame(&KIA_7E4_id5);
+      transmit_can(&KIA_7E4_id5, can_config.battery);
     }
   }
 }

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -27,41 +27,31 @@ static uint16_t cellvoltages_mv[98];
 static uint16_t min_cell_voltage_mv = 3700;
 static uint16_t max_cell_voltage_mv = 3700;
 
-CAN_frame_t KIA_7E4_id1 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x7E4,
-                           .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t KIA_7E4_id2 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x7E4,
-                           .data = {0x02, 0x21, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t KIA_7E4_id3 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x7E4,
-                           .data = {0x02, 0x21, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t KIA_7E4_id5 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x7E4,
-                           .data = {0x02, 0x21, 0x05, 0x04, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t KIA_7E4_ack = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
-                           .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA_7E4_id1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x7E4,
+                         .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA_7E4_id2 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x7E4,
+                         .data = {0x02, 0x21, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA_7E4_id3 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x7E4,
+                         .data = {0x02, 0x21, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA_7E4_id5 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x7E4,
+                         .data = {0x02, 0x21, 0x05, 0x04, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KIA_7E4_ack = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
+                         .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -90,9 +90,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x5F1:
       break;
     case 0x51E:

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 100
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -2,7 +2,6 @@
 #define KIA_HYUNDAI_HYBRID_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 100

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 100
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -50,7 +50,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x171:  //Following messages were detected on a MG5 battery BMS

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -17,13 +17,11 @@ static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN
 
 static int BMS_SOC = 0;
 
-CAN_frame_t MG_5_100 = {.FIR = {.B =
-                                    {
-                                        .DLC = 8,
-                                        .FF = CAN_frame_std,
-                                    }},
-                        .MsgID = 0x100,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
+CAN_frame MG_5_100 = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 8,
+                      .ID = 0x100,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef MG_5_BATTERY_H
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "MG-5-BATTERY.h"
 
 /* TODO: 
@@ -130,13 +128,13 @@ void send_can_battery() {
     }
     previousMillis10 = currentMillis;
 
-    ESP32Can.CANWriteFrame(&MG_5_100);
+    transmit_can(&MG_5_100, can_config.battery);
   }
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    //ESP32Can.CANWriteFrame(&MG_5_100);
+    //transmit_can(&MG_5_100, can_config.battery);
   }
 }
 

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -50,9 +50,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x171:  //Following messages were detected on a MG5 battery BMS
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
       break;

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -2,7 +2,6 @@
 #define MG_5_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 150

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -15,50 +15,39 @@ static uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
 static uint8_t mprun10 = 0;                  //counter 0-3
 static uint8_t mprun100 = 0;                 //counter 0-3
 
-CAN_frame_t LEAF_1F2 = {.FIR = {.B =
-                                    {
-                                        .DLC = 8,
-                                        .FF = CAN_frame_std,
-                                    }},
-                        .MsgID = 0x1F2,
-                        .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
-CAN_frame_t LEAF_50B = {.FIR = {.B =
-                                    {
-                                        .DLC = 7,
-                                        .FF = CAN_frame_std,
-                                    }},
-                        .MsgID = 0x50B,
-                        .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
-CAN_frame_t LEAF_50C = {.FIR = {.B =
-                                    {
-                                        .DLC = 6,
-                                        .FF = CAN_frame_std,
-                                    }},
-                        .MsgID = 0x50C,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t LEAF_1D4 = {.FIR = {.B =
-                                    {
-                                        .DLC = 8,
-                                        .FF = CAN_frame_std,
-                                    }},
-                        .MsgID = 0x1D4,
-                        .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
-//These CAN messages need to be sent towards the battery to keep it alive
+// These CAN messages need to be sent towards the battery to keep it alive
+CAN_frame LEAF_1F2 = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 8,
+                      .ID = 0x1F2,
+                      .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
+CAN_frame LEAF_50B = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 7,
+                      .ID = 0x50B,
+                      .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
+CAN_frame LEAF_50C = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 6,
+                      .ID = 0x50C,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame LEAF_1D4 = {.FD = false,
+                      .ext_ID = false,
+                      .DLC = 8,
+                      .ID = 0x1D4,
+                      .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
+// Active polling messages
+CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x79B,
+                                .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
+CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
+                                    .ext_ID = false,
+                                    .DLC = 8,
+                                    .ID = 0x79B,
+                                    .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 
-CAN_frame_t LEAF_GROUP_REQUEST = {.FIR = {.B =
-                                              {
-                                                  .DLC = 8,
-                                                  .FF = CAN_frame_std,
-                                              }},
-                                  .MsgID = 0x79B,
-                                  .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
-CAN_frame_t LEAF_NEXT_LINE_REQUEST = {.FIR = {.B =
-                                                  {
-                                                      .DLC = 8,
-                                                      .FF = CAN_frame_std,
-                                                  }},
-                                      .MsgID = 0x79B,
-                                      .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 // The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
 // groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second
 // replies with all the battery’s cells voltages in millivolt, the third and the fifth one are still unknown, the

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -6,8 +6,6 @@
 #endif
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -468,8 +468,8 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
     }
   }
 }
-void receive_can_battery2(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+void receive_can_battery2(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
         datalayer.battery2.status.CAN_error_counter++;
@@ -720,8 +720,8 @@ void receive_can_battery2(CAN_frame_t rx_frame) {
 }
 #endif  // DOUBLE_BATTERY
 
-void receive_can_battery(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+void receive_can_battery(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
         datalayer.battery.status.CAN_error_counter++;
@@ -1176,7 +1176,7 @@ void send_can_battery() {
   }
 }
 
-bool is_message_corrupt(CAN_frame_t rx_frame) {
+bool is_message_corrupt(CAN_frame rx_frame) {
   uint8_t crc = 0;
   for (uint8_t j = 0; j < 7; j++) {
     crc = crctable[(crc ^ static_cast<uint8_t>(rx_frame.data.u8[j])) % 256];

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -3,7 +3,6 @@
 
 #include "../include.h"
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
-#include "../lib/pierremolinaro-acan2515/ACAN2515.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 500

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -2,11 +2,8 @@
 #define NISSAN_LEAF_BATTERY_H
 
 #include "../include.h"
-
 #include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "../lib/pierremolinaro-acan2515/ACAN2515.h"
-
-extern ACAN2515 can;
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 500
@@ -14,5 +11,6 @@ extern ACAN2515 can;
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame_t rx_frame);
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -2,13 +2,12 @@
 #define NISSAN_LEAF_BATTERY_H
 
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 500
 
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
-bool is_message_corrupt(CAN_frame_t rx_frame);
+bool is_message_corrupt(CAN_frame rx_frame);
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -10,6 +10,6 @@
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame_t rx_frame);
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef PYLON_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "PYLON-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -173,10 +171,10 @@ void send_can_battery() {
 
     previousMillis1000 = currentMillis;
 
-    ESP32Can.CANWriteFrame(&PYLON_3010);  // Heartbeat
-    ESP32Can.CANWriteFrame(&PYLON_4200);  // Ensemble OR System equipment info, depends on frame0
-    ESP32Can.CANWriteFrame(&PYLON_8200);  // Control device quit sleep status
-    ESP32Can.CANWriteFrame(&PYLON_8210);  // Charge command
+    transmit_can(&PYLON_3010, can_config.battery);  // Heartbeat
+    transmit_can(&PYLON_4200, can_config.battery);  // Ensemble OR System equipment info, depends on frame0
+    transmit_can(&PYLON_8200, can_config.battery);  // Control device quit sleep status
+    transmit_can(&PYLON_8210, can_config.battery);  // Charge command
 
     if (ensemble_info_ack) {
       PYLON_4200.data.u8[0] = 0x00;  //Request system equipment info

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -8,34 +8,26 @@
 static unsigned long previousMillis1000 = 0;  // will store last time a 1s CAN Message was sent
 
 //Actual content messages
-CAN_frame_t PYLON_3010 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x3010,
-                          .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_8200 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x8200,
-                          .data = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_8210 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x8210,
-                          .data = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_4200 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4200,
-                          .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_3010 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x3010,
+                        .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_8200 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x8200,
+                        .data = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_8210 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x8210,
+                        .data = {0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4200 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4200,
+                        .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static int16_t celltemperature_max_dC = 0;
 static int16_t celltemperature_min_dC = 0;

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -80,7 +80,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = discharge_cutoff_voltage;
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x7310:

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -80,9 +80,9 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = discharge_cutoff_voltage;
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x7310:
     case 0x7311:
       ensemble_info_ack = true;

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -2,7 +2,6 @@
 #define PYLON_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -147,7 +147,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x155:  //BMS1

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -147,9 +147,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x155:  //BMS1
       datalayer.battery.status.CAN_battery_still_alive =
           CAN_STILL_ALIVE;  //Indicate that we are still getting CAN messages from the BMS

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef RENAULT_KANGOO_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "RENAULT-KANGOO-BATTERY.h"
 
 /* TODO:
@@ -233,7 +231,7 @@ void send_can_battery() {
   // Send 100ms CAN Message (for 2.4s, then pause 10s)
   if ((currentMillis - previousMillis100) >= (INTERVAL_100_MS + GVL_pause)) {
     previousMillis100 = currentMillis;
-    ESP32Can.CANWriteFrame(&KANGOO_423);
+    transmit_can(&KANGOO_423, can_config.battery);
     GVI_Pollcounter++;
     GVL_pause = 0;
     if (GVI_Pollcounter >= 24) {
@@ -245,9 +243,9 @@ void send_can_battery() {
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
     previousMillis1000 = currentMillis;
     if (GVB_79B_Continue)
-      ESP32Can.CANWriteFrame(&KANGOO_79B_Continue);
+      transmit_can(&KANGOO_79B_Continue, can_config.battery);
   } else {
-    ESP32Can.CANWriteFrame(&KANGOO_79B);
+    transmit_can(&KANGOO_79B, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -46,31 +46,25 @@ static uint8_t LB_MaxInput_kW = 0;
 static uint8_t LB_MaxOutput_kW = 0;
 static bool GVB_79B_Continue = false;
 
-CAN_frame_t KANGOO_423 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_std,
-                                      }},
-                          .MsgID = 0x423,
-                          .data = {0x0B, 0x1D, 0x00, 0x02, 0xB2, 0x20, 0xB2, 0xD9}};  // Charging
+CAN_frame KANGOO_423 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x423,
+                        .data = {0x0B, 0x1D, 0x00, 0x02, 0xB2, 0x20, 0xB2, 0xD9}};  // Charging
 // Driving: 0x07  0x1D  0x00  0x02  0x5D  0x80  0x5D  0xD8
 // Charging: 0x0B   0x1D  0x00  0x02  0xB2  0x20  0xB2  0xD9
 // Fastcharging: 0x07   0x1E  0x00  0x01  0x5D  0x20  0xB2  0xC7
 // Old hardcoded message: .data = {0x33, 0x00, 0xFF, 0xFF, 0x00, 0xE0, 0x00, 0x00}};
-CAN_frame_t KANGOO_79B = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_std,
-                                      }},
-                          .MsgID = 0x79B,
-                          .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0xE0, 0x00, 0x00}};
-CAN_frame_t KANGOO_79B_Continue = {.FIR = {.B =
-                                               {
-                                                   .DLC = 8,
-                                                   .FF = CAN_frame_std,
-                                               }},
-                                   .MsgID = 0x79B,
-                                   .data = {0x030, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame KANGOO_79B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x79B,
+                        .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0xE0, 0x00, 0x00}};
+CAN_frame KANGOO_79B_Continue = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x79B,
+                                 .data = {0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static unsigned long previousMillis10 = 0;    // will store last time a 10ms CAN Message was sent
 static unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -12,5 +12,6 @@
 #define MAX_CHARGE_POWER_W 5000         // Battery can be charged with this amount of power
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -12,6 +12,6 @@
 #define MAX_CHARGE_POWER_W 5000         // Battery can be charged with this amount of power
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -2,7 +2,6 @@
 #define RENAULT_KANGOO_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -73,7 +73,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x427:

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef RENAULT_ZOE_GEN1_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "RENAULT-ZOE-GEN1-BATTERY.h"
 
 /* Information in this file is based of the OVMS V3 vehicle_renaultzoe.cpp component 
@@ -114,7 +112,7 @@ void send_can_battery() {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
     }
     previousMillis100 = currentMillis;
-    ESP32Can.CANWriteFrame(&ZOE_423);
+    transmit_can(&ZOE_423, can_config.battery);
 
     if ((counter_423 / 5) % 2 == 0) {  // Alternate every 5 messages between these two
       ZOE_423.data.u8[4] = 0xB2;
@@ -128,7 +126,7 @@ void send_can_battery() {
   // 5000ms CAN handling
   if (currentMillis - previousMillis5000 >= INTERVAL_5_S) {
     previousMillis5000 = currentMillis;
-    ESP32Can.CANWriteFrame(&ZOE_POLL_79B);
+    transmit_can(&ZOE_POLL_79B, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -19,20 +19,16 @@ static uint16_t LB_Cell_Max_Voltage = 3700;
 static uint16_t LB_Cell_Min_Voltage = 3700;
 static uint16_t LB_Battery_Voltage = 3700;
 
-CAN_frame_t ZOE_423 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x423,
-                       .data = {0x07, 0x1d, 0x00, 0x02, 0x5d, 0x80, 0x5d, 0xc8}};
-CAN_frame_t ZOE_POLL_79B = {.FIR = {.B =
-                                        {
-                                            .DLC = 8,
-                                            .FF = CAN_frame_std,
-                                        }},
-                            .MsgID = 0x79B,  //0x41 = cell bat module 1-62 , 0x42 = cell bat module 63-96
-                            .data = {0x02, 0x21, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame ZOE_423 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x423,
+                     .data = {0x07, 0x1d, 0x00, 0x02, 0x5d, 0x80, 0x5d, 0xc8}};
+CAN_frame ZOE_POLL_79B = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x79B,  //0x41 = cell bat module 1-62 , 0x42 = cell bat module 63-96
+                          .data = {0x02, 0x21, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent
 static unsigned long previousMillis5000 = 0;  // will store last time a 1000ms CAN Message was sent

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -73,9 +73,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x427:
       LB_Charge_Power_W = rx_frame.data.u8[5] * 300;
       LB_kWh_Remaining = (((((rx_frame.data.u8[6] << 8) | (rx_frame.data.u8[7])) >> 6) & 0x3ff) * 0.1);

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -1,7 +1,6 @@
 #ifndef RENAULT_ZOE_GEN1_BATTERY_H
 #define RENAULT_ZOE_GEN1_BATTERY_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -10,6 +10,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -10,5 +10,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -19,20 +19,16 @@ static uint16_t LB_Cell_Max_Voltage = 3700;
 static uint16_t LB_Cell_Min_Voltage = 3700;
 static uint16_t LB_Battery_Voltage = 3700;
 
-CAN_frame_t ZOE_373 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x373,
-                       .data = {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
-CAN_frame_t ZOE_POLL_18DADBF1 = {.FIR = {.B =
-                                             {
-                                                 .DLC = 8,
-                                                 .FF = CAN_frame_ext,
-                                             }},
-                                 .MsgID = 0x18DADBF1,
-                                 .data = {0x03, 0x22, 0x90, 0x00, 0xff, 0xff, 0xff, 0xff}};
+CAN_frame ZOE_373 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x373,
+                     .data = {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
+CAN_frame ZOE_POLL_18DADBF1 = {.FD = false,
+                               .ext_ID = true,
+                               .DLC = 8,
+                               .ID = 0x18DADBF1,
+                               .data = {0x03, 0x22, 0x90, 0x00, 0xff, 0xff, 0xff, 0xff}};
 
 static unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was sent
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -71,9 +71,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x18daf1db:  // LBC Reply from active polling
       break;
     default:

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -71,7 +71,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18daf1db:  // LBC Reply from active polling

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef RENAULT_ZOE_GEN2_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "RENAULT-ZOE-GEN2-BATTERY.h"
 
 /* Information in this file is based of the OVMS V3 vehicle_renaultzoe.cpp component 
@@ -96,8 +94,8 @@ void send_can_battery() {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis200));
     }
     previousMillis200 = currentMillis;
-    ESP32Can.CANWriteFrame(&ZOE_373);
-    ESP32Can.CANWriteFrame(&ZOE_POLL_18DADBF1);
+    transmit_can(&ZOE_373, can_config.battery);
+    transmit_can(&ZOE_POLL_18DADBF1, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -10,6 +10,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -10,5 +10,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -1,7 +1,6 @@
 #ifndef RENAULT_ZOE_GEN2_BATTERY_H
 #define RENAULT_ZOE_GEN2_BATTERY_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef SANTA_FE_PHEV_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "SANTA-FE-PHEV-BATTERY.h"
 
 /* Credits go to maciek16c for these findings!
@@ -175,7 +173,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
-            ESP32Can.CANWriteFrame(&SANTAFE_7E4_ack);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can(&SANTAFE_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -355,11 +353,11 @@ void send_can_battery() {
 
     SANTAFE_200.data.u8[7] = checksum_200;
 
-    ESP32Can.CANWriteFrame(&SANTAFE_200);
+    transmit_can(&SANTAFE_200, can_config.battery);
 
-    ESP32Can.CANWriteFrame(&SANTAFE_2A1);
+    transmit_can(&SANTAFE_2A1, can_config.battery);
 
-    ESP32Can.CANWriteFrame(&SANTAFE_2F0);
+    transmit_can(&SANTAFE_2F0, can_config.battery);
 
     counter_200++;
     if (counter_200 > 0xF) {
@@ -371,7 +369,7 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    ESP32Can.CANWriteFrame(&SANTAFE_523);
+    transmit_can(&SANTAFE_523, can_config.battery);
   }
 
   // Send 500ms CAN Message
@@ -385,19 +383,19 @@ void send_can_battery() {
     poll_data_pid++;
     if (poll_data_pid == 1) {
       SANTAFE_7E4_poll.data.u8[3] = 0x01;
-      ESP32Can.CANWriteFrame(&SANTAFE_7E4_poll);
+      transmit_can(&SANTAFE_7E4_poll, can_config.battery);
     } else if (poll_data_pid == 2) {
       SANTAFE_7E4_poll.data.u8[3] = 0x02;
-      ESP32Can.CANWriteFrame(&SANTAFE_7E4_poll);
+      transmit_can(&SANTAFE_7E4_poll, can_config.battery);
     } else if (poll_data_pid == 3) {
       SANTAFE_7E4_poll.data.u8[3] = 0x03;
-      ESP32Can.CANWriteFrame(&SANTAFE_7E4_poll);
+      transmit_can(&SANTAFE_7E4_poll, can_config.battery);
     } else if (poll_data_pid == 4) {
       SANTAFE_7E4_poll.data.u8[3] = 0x04;
-      ESP32Can.CANWriteFrame(&SANTAFE_7E4_poll);
+      transmit_can(&SANTAFE_7E4_poll, can_config.battery);
     } else if (poll_data_pid == 5) {
       SANTAFE_7E4_poll.data.u8[3] = 0x05;
-      ESP32Can.CANWriteFrame(&SANTAFE_7E4_poll);
+      transmit_can(&SANTAFE_7E4_poll, can_config.battery);
     }
   }
 }

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -37,48 +37,36 @@ static uint8_t checksum_200 = 0;
 static uint8_t StatusBattery = 0;
 static uint16_t cellvoltages_mv[96];
 
-CAN_frame_t SANTAFE_200 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x200,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
-CAN_frame_t SANTAFE_2A1 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x2A1,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x02}};
-CAN_frame_t SANTAFE_2F0 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x2F0,
-                           .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00}};
-CAN_frame_t SANTAFE_523 = {.FIR = {.B =
-                                       {
-                                           .DLC = 8,
-                                           .FF = CAN_frame_std,
-                                       }},
-                           .MsgID = 0x523,
-                           .data = {0x60, 0x00, 0x60, 0, 0, 0, 0, 0}};
-CAN_frame_t SANTAFE_7E4_poll = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x7E4,  //Polling frame, 0x22 01 0X
-                                .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SANTAFE_7E4_ack = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
-                               .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SANTAFE_200 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x200,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
+CAN_frame SANTAFE_2A1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x2A1,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x02}};
+CAN_frame SANTAFE_2F0 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x2F0,
+                         .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00}};
+CAN_frame SANTAFE_523 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x523,
+                         .data = {0x60, 0x00, 0x60, 0, 0, 0, 0, 0}};
+CAN_frame SANTAFE_7E4_poll = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x7E4,  //Polling frame, 0x22 01 0X
+                              .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SANTAFE_7E4_ack = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
+                             .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -388,7 +388,7 @@ void send_can_battery() {
   }
 }
 
-uint8_t CalculateCRC8(CAN_frame_t rx_frame) {
+uint8_t CalculateCRC8(CAN_frame rx_frame) {
   int crc = 0;
 
   for (uint8_t framepos = 0; framepos < 8; framepos++) {

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -106,7 +106,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -106,8 +106,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+receive_can_battery(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       StatusBattery = (rx_frame.data.u8[0] & 0x0F);

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -6,7 +6,7 @@
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 250
 
-uint8_t CalculateCRC8(CAN_frame_t rx_frame);
+uint8_t CalculateCRC8(CAN_frame rx_frame);
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);
 

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -9,5 +9,6 @@
 
 uint8_t CalculateCRC8(CAN_frame_t rx_frame);
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -9,6 +9,6 @@
 
 uint8_t CalculateCRC8(CAN_frame_t rx_frame);
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -2,7 +2,6 @@
 #define SANTA_FE_PHEV_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 250

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -221,7 +221,9 @@ void update_values_serial_link() {
 void setup_battery(void) {
   Serial.println("SERIAL_DATA_LINK_RECEIVER selected");
 }
+// Needed to make the compiler happy
 void update_values_battery() {}
 void send_can_battery() {}
+void receive_can_battery(CAN_frame rx_frame) {}
 
 #endif

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -444,7 +444,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif  //DEBUG_VIA_USB
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef TESLA_MODEL_3_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "TESLA-MODEL-3-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -650,17 +648,6 @@ void receive_can_battery(CAN_frame_t rx_frame) {
 
 #ifdef DOUBLE_BATTERY
 
-void CAN_WriteFrame(CAN_frame_t* tx_frame) {
-  CANMessage MCP2515Frame;  //Struct with ACAN2515 library format, needed to use the MCP2515 library for CAN2
-  MCP2515Frame.id = tx_frame->MsgID;
-  //MCP2515Frame.ext = tx_frame->FIR.B.FF;
-  MCP2515Frame.len = tx_frame->FIR.B.DLC;
-  for (uint8_t i = 0; i < MCP2515Frame.len; i++) {
-    MCP2515Frame.data[i] = tx_frame->data.u8[i];
-  }
-  can.tryToSend(MCP2515Frame);
-}
-
 void receive_can_battery2(CAN_frame_t rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
@@ -1067,12 +1054,12 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
     previousMillis30 = currentMillis;
 
     if (datalayer.system.status.inverter_allows_contactor_closing) {
-      ESP32Can.CANWriteFrame(&TESLA_221_1);
-      ESP32Can.CANWriteFrame(&TESLA_221_2);
+      transmit_can(&TESLA_221_1, can_config.battery);
+      transmit_can(&TESLA_221_2, can_config.battery);
 #ifdef DOUBLE_BATTERY
       if (datalayer.system.status.battery2_allows_contactor_closing) {
-        CAN_WriteFrame(&TESLA_221_1);  // CAN2 connected to battery 2
-        CAN_WriteFrame(&TESLA_221_2);
+        transmit_can(&TESLA_221_1, can_config.battery_double);  // CAN2 connected to battery 2
+        transmit_can(&TESLA_221_2, can_config.battery_double);
       }
 #endif  //DOUBLE_BATTERY
     }

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -444,11 +444,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif  //DEBUG_VIA_USB
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x352:
       //SOC
       battery_nominal_full_pack_energy =
@@ -644,11 +644,11 @@ void receive_can_battery(CAN_frame_t rx_frame) {
 
 #ifdef DOUBLE_BATTERY
 
-void receive_can_battery2(CAN_frame_t rx_frame) {
+void receive_can_battery2(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x352:
       //SOC
       battery2_nominal_full_pack_energy =

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -9,21 +9,17 @@
 
 static unsigned long previousMillis30 = 0;  // will store last time a 30ms CAN Message was send
 
-CAN_frame_t TESLA_221_1 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x221,
+CAN_frame TESLA_221_1 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x221,
     .data = {0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96}};  //Contactor frame 221 - close contactors
-CAN_frame_t TESLA_221_2 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x221,
+CAN_frame TESLA_221_2 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x221,
     .data = {0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA}};  //Contactor Frame 221 - hv_up_for_drive
 
 static uint32_t battery_total_discharge = 0;

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -24,7 +24,7 @@ void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);
 void print_SOC(char* header, int SOC);
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 #ifdef DOUBLE_BATTERY
 void printFaultCodesIfActive_battery2();
 #endif  //DOUBLE_BATTERY

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -1,7 +1,6 @@
 #ifndef TESLA_MODEL_3_BATTERY_H
 #define TESLA_MODEL_3_BATTERY_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -24,9 +24,8 @@ void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);
 void print_SOC(char* header, int SOC);
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 #ifdef DOUBLE_BATTERY
-#include "../lib/pierremolinaro-acan2515/ACAN2515.h"
-extern ACAN2515 can;
 void printFaultCodesIfActive_battery2();
 #endif  //DOUBLE_BATTERY
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -71,7 +71,7 @@ void update_values_battery() { /* This function puts fake values onto the parame
 #endif
 }
 
-receive_can_battery(CAN_frame rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   // All CAN messages recieved will be logged via serial
   Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -8,13 +8,11 @@ static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN 
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
 
-CAN_frame_t TEST = {.FIR = {.B =
-                                {
-                                    .DLC = 8,
-                                    .FF = CAN_frame_std,
-                                }},
-                    .MsgID = 0x123,
-                    .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
+CAN_frame TEST = {.FD = false,
+                  .ext_ID = false,
+                  .DLC = 8,
+                  .ID = 0x123,
+                  .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
 
 void print_units(char* header, int value, char* units) {
   Serial.print(header);

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -9,6 +9,14 @@ static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN 
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
 
+CAN_frame_t TEST = {.FIR = {.B =
+                                {
+                                    .DLC = 8,
+                                    .FF = CAN_frame_std,
+                                }},
+                    .MsgID = 0x123,
+                    .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
+
 void print_units(char* header, int value, char* units) {
   Serial.print(header);
   Serial.print(value);
@@ -87,6 +95,7 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     // Put fake messages here incase you want to test sending CAN
+    transmit_can(&TEST, can_config.battery);
   }
 }
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -71,16 +71,16 @@ void update_values_battery() { /* This function puts fake values onto the parame
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   // All CAN messages recieved will be logged via serial
   Serial.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   Serial.print("  ");
-  Serial.print(rx_frame.MsgID, HEX);
+  Serial.print(rx_frame.ID, HEX);
   Serial.print("  ");
-  Serial.print(rx_frame.FIR.B.DLC);
+  Serial.print(rx_frame.DLC);
   Serial.print("  ");
-  for (int i = 0; i < rx_frame.FIR.B.DLC; ++i) {
+  for (int i = 0; i < rx_frame.DLC; ++i) {
     Serial.print(rx_frame.data.u8[i], HEX);
     Serial.print(" ");
   }

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -1,7 +1,6 @@
 #include "../include.h"
 #ifdef TEST_FAKE_BATTERY
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "TEST-FAKE-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -1,10 +1,12 @@
 #ifndef TEST_FAKE_BATTERY_H
 #define TEST_FAKE_BATTERY_H
 #include "../include.h"
+#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -7,6 +7,6 @@
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -1,7 +1,6 @@
 #ifndef TEST_FAKE_BATTERY_H
 #define TEST_FAKE_BATTERY_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -144,7 +144,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-receive_can_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame_t rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef VOLVO_SPA_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "VOLVO-SPA-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -279,7 +277,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
       {
         cell_voltages[battery_request_idx++] = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
         cell_voltages[battery_request_idx] = (rx_frame.data.u8[7] << 8);
-        ESP32Can.CANWriteFrame(&VOLVO_FlowControl);  // Send flow control
+        transmit_can(&VOLVO_FlowControl, can_config.battery);  // Send flow control
         rxConsecutiveFrames = 1;
       } else if ((rx_frame.data.u8[0] == 0x21) && (rxConsecutiveFrames == 1)) {
         cell_voltages[battery_request_idx++] = cell_voltages[battery_request_idx] | rx_frame.data.u8[1];
@@ -289,7 +287,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
         if (batteryModuleNumber <= 0x2A)  // Run until last pack is read
         {
           VOLVO_CELL_U_Req.data.u8[3] = batteryModuleNumber++;
-          ESP32Can.CANWriteFrame(&VOLVO_CELL_U_Req);  //Send cell voltage read request for next module
+          transmit_can(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for next module
         } else {
           min_max_voltage[0] = 9999;
           min_max_voltage[1] = 0;
@@ -306,7 +304,7 @@ void receive_can_battery(CAN_frame_t rx_frame) {
           if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
             set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
           }
-          ESP32Can.CANWriteFrame(&VOLVO_SOH_Req);  //Send SOH read request
+          transmit_can(&VOLVO_SOH_Req, can_config.battery);  //Send SOH read request
         }
         rxConsecutiveFrames = 0;
       }
@@ -321,7 +319,7 @@ void readCellVoltages() {
   batteryModuleNumber = 0x10;
   rxConsecutiveFrames = 0;
   VOLVO_CELL_U_Req.data.u8[3] = batteryModuleNumber++;
-  ESP32Can.CANWriteFrame(&VOLVO_CELL_U_Req);  //Send cell voltage read request for first module
+  transmit_can(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
 void send_can_battery() {
@@ -336,8 +334,8 @@ void send_can_battery() {
     }
     previousMillis100 = currentMillis;
 
-    ESP32Can.CANWriteFrame(&VOLVO_536);  //Send 0x536 Network managing frame to keep BMS alive
-    ESP32Can.CANWriteFrame(&VOLVO_372);  //Send 0x372 ECMAmbientTempCalculated
+    transmit_can(&VOLVO_536, can_config.battery);  //Send 0x536 Network managing frame to keep BMS alive
+    transmit_can(&VOLVO_372, can_config.battery);  //Send 0x372 ECMAmbientTempCalculated
 
     if (datalayer.battery.status.bms_status == ACTIVE) {
       datalayer.system.status.battery_allows_contactor_closing = true;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -144,9 +144,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+receive_can_battery(CAN_frame_t rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x3A:
       if ((rx_frame.data.u8[6] & 0x80) == 0x80)
         BATT_I = (0 - ((((rx_frame.data.u8[6] & 0x7F) * 256.0 + rx_frame.data.u8[7]) * 0.1) - 1638));

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -144,7 +144,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame_t rx_frame) {
+void receive_can_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -34,42 +34,32 @@ static uint8_t cellcounter = 0;
 static uint32_t remaining_capacity = 0;
 static uint16_t cell_voltages[108];  //array with all the cellvoltages
 
-CAN_frame_t VOLVO_536 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x536,
-                         .data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-CAN_frame_t VOLVO_372 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x372,
+CAN_frame VOLVO_536 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x536,
+                       .data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+CAN_frame VOLVO_372 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x372,
     .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
-CAN_frame_t VOLVO_CELL_U_Req = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x735,
-                                .data = {0x03, 0x22, 0x4B, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame
-CAN_frame_t VOLVO_FlowControl = {.FIR = {.B =
-                                             {
-                                                 .DLC = 8,
-                                                 .FF = CAN_frame_std,
-                                             }},
-                                 .MsgID = 0x735,
-                                 .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
-CAN_frame_t VOLVO_SOH_Req = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x735,
-                             .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
+CAN_frame VOLVO_CELL_U_Req = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x735,
+                              .data = {0x03, 0x22, 0x4B, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame
+CAN_frame VOLVO_FlowControl = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x735,
+                               .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
+CAN_frame VOLVO_SOH_Req = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x735,
+                           .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
   uint8_t cnt = 0;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -8,6 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 250
 
 void setup_battery(void);
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -2,7 +2,6 @@
 #define VOLVO_SPA_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 250

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -8,5 +8,6 @@
 #define MAX_CELL_DEVIATION_MV 250
 
 void setup_battery(void);
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -1,7 +1,6 @@
 #ifndef CHARGERS_H
 #define CHARGERS_H
 #include "../../USER_SETTINGS.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"  // This include is annoying, consider defining a frame type in types.h
 
 #ifdef CHEVYVOLT_CHARGER
 #include "CHEVY-VOLT-CHARGER.h"
@@ -11,7 +10,7 @@
 #include "NISSAN-LEAF-CHARGER.h"
 #endif
 
-void receive_can_charger(CAN_frame_t rx_frame);
+void receive_can_charger(CAN_frame rx_frame);
 void send_can_charger();
 
 #endif

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -2,8 +2,6 @@
 #ifdef CHEVYVOLT_CHARGER
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "CHEVY-VOLT-CHARGER.h"
 
 /* This implements Chevy Volt / Ampera charger support (2011-2015 model years).
@@ -145,7 +143,7 @@ void send_can_charger() {
 
     charger_keepalive_frame.data.u8[0] = charger_mode;
 
-    ESP32Can.CANWriteFrame(&charger_keepalive_frame);
+    transmit_can(&charger_keepalive_frame, can_config.charger);
   }
 
   /* Send current targets every 200ms */
@@ -182,7 +180,7 @@ void send_can_charger() {
     /* LSB of the voltage command. Then MSB LSB is divided by 2 */
     charger_set_targets.data.u8[3] = lowByte(Vol_temp);
 
-    ESP32Can.CANWriteFrame(&charger_set_targets);
+    transmit_can(&charger_set_targets, can_config.charger);
   }
 
 #ifdef DEBUG_VIA_USB

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -42,24 +42,18 @@ extern float charger_stat_LVvol;
 enum CHARGER_MODES : uint8_t { MODE_DISABLED = 0, MODE_LV, MODE_HV, MODE_HVLV };
 
 //Actual content messages
-static CAN_frame_t charger_keepalive_frame = {.FIR = {.B =
-                                                          {
-                                                              //one byte only, indicating enabled or disabled
-                                                              .DLC = 1,
-                                                              .FF = CAN_frame_std,
-                                                          }},
-                                              .MsgID = 0x30E,
-                                              .data = {MODE_DISABLED}};
+static CAN_frame charger_keepalive_frame = {.FD = false,
+                                            .ext_ID = false,
+                                            .DLC = 1,
+                                            .ID = 0x30E,  //one byte only, indicating enabled or disabled
+                                            .data = {MODE_DISABLED}};
 
-static CAN_frame_t charger_set_targets = {.FIR = {.B =
-                                                      {
-                                                          .DLC = 4,
-                                                          .FF = CAN_frame_std,
-                                                      }},
-                                          .MsgID = 0x304,
-
-                                          // data[0] is a static value, meaning unknown
-                                          .data = {0x40, 0x00, 0x00, 0x00}};
+static CAN_frame charger_set_targets = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 4,
+    .ID = 0x304,
+    .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a static value, meaning unknown
 
 /* We are mostly sending out not receiving */
 void receive_can_charger(CAN_frame_t rx_frame) {

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -64,7 +64,7 @@ void receive_can_charger(CAN_frame_t rx_frame) {
   uint16_t charger_stat_ACcur_temp = 0;
   uint16_t charger_stat_ACvol_temp = 0;
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     //ID 0x212 conveys instantaneous DC charger stats
     case 0x212:
       charger_stat_HVcur_temp = (uint16_t)(rx_frame.data.u8[0] << 8 | rx_frame.data.u8[1]);

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -56,7 +56,7 @@ static CAN_frame charger_set_targets = {
     .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a static value, meaning unknown
 
 /* We are mostly sending out not receiving */
-void receive_can_charger(CAN_frame_t rx_frame) {
+void receive_can_charger(CAN_frame rx_frame) {
   uint16_t charger_stat_HVcur_temp = 0;
   uint16_t charger_stat_HVvol_temp = 0;
   uint16_t charger_stat_LVcur_temp = 0;

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -2,7 +2,6 @@
 #define CHEVYVOLT_CHARGER_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CHARGER_SELECTED
 

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -60,56 +60,42 @@ extern float charger_stat_LVcur;
 extern float charger_stat_LVvol;
 
 //Actual content messages
-static CAN_frame_t LEAF_1DB = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x1DB,
-                               .data = {0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00}};
-static CAN_frame_t LEAF_1DC = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x1DC,
-                               .data = {0x6E, 0x0A, 0x05, 0xD5, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t LEAF_1F2 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x1F2,
-                               .data = {0x30, 0x00, 0x20, 0xAC, 0x00, 0x3C, 0x00, 0x8F}};
-static CAN_frame_t LEAF_50B = {.FIR = {.B =
-                                           {
-                                               .DLC = 7,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x50B,
-                               .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
-static CAN_frame_t LEAF_55B = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x55B,
-                               .data = {0xA4, 0x40, 0xAA, 0x00, 0xDF, 0xC0, 0x10, 0x00}};
-static CAN_frame_t LEAF_5BC = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x5BC,
-                               .data = {0x3D, 0x80, 0xF0, 0x64, 0xB0, 0x01, 0x00, 0x32}};
+static CAN_frame LEAF_1DB = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x1DB,
+                             .data = {0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00}};
+static CAN_frame LEAF_1DC = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x1DC,
+                             .data = {0x6E, 0x0A, 0x05, 0xD5, 0x00, 0x00, 0x00, 0x00}};
+static CAN_frame LEAF_1F2 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x1F2,
+                             .data = {0x30, 0x00, 0x20, 0xAC, 0x00, 0x3C, 0x00, 0x8F}};
+static CAN_frame LEAF_50B = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 7,
+                             .ID = 0x50B,
+                             .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
+static CAN_frame LEAF_55B = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x55B,
+                             .data = {0xA4, 0x40, 0xAA, 0x00, 0xDF, 0xC0, 0x10, 0x00}};
+static CAN_frame LEAF_5BC = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x5BC,
+                             .data = {0x3D, 0x80, 0xF0, 0x64, 0xB0, 0x01, 0x00, 0x32}};
 
-static CAN_frame_t LEAF_59E = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x59E,
-                               .data = {0x00, 0x00, 0x0C, 0x76, 0x18, 0x00, 0x00, 0x00}};
+static CAN_frame LEAF_59E = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x59E,
+                             .data = {0x00, 0x00, 0x0C, 0x76, 0x18, 0x00, 0x00, 0x00}};
 
 static uint8_t crctable[256] = {
     0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -2,8 +2,6 @@
 #ifdef NISSANLEAF_CHARGER
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "NISSAN-LEAF-CHARGER.h"
 
 /* This implements Nissan LEAF PDM charger support. 2013-2024 Gen2/3 PDMs are supported
@@ -198,13 +196,13 @@ void send_can_charger() {
 #ifndef NISSAN_LEAF_BATTERY
 
     // VCM message, containing info if battery should sleep or stay awake
-    ESP32Can.CANWriteFrame(&LEAF_50B);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
+    transmit_can(&LEAF_50B, can_config.charger);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 
     LEAF_1DB.data.u8[7] = calculate_CRC_Nissan(&LEAF_1DB);
-    ESP32Can.CANWriteFrame(&LEAF_1DB);
+    transmit_can(&LEAF_1DB, can_config.charger);
 
     LEAF_1DC.data.u8[7] = calculate_CRC_Nissan(&LEAF_1DC);
-    ESP32Can.CANWriteFrame(&LEAF_1DC);
+    transmit_can(&LEAF_1DC, can_config.charger);
 #endif
 
     OBCpowerSetpoint = ((charger_setpoint_HV_IDC * 4) + 0x64);
@@ -249,8 +247,8 @@ void send_can_charger() {
     LEAF_1F2.data.u8[6] = mprun10;
     LEAF_1F2.data.u8[7] = calculate_checksum_nibble(&LEAF_1F2);
 
-    ESP32Can.CANWriteFrame(
-        &LEAF_1F2);  // Sending of 1F2 message is halted in LEAF-BATTERY function incase charger is used!
+    transmit_can(&LEAF_1F2,
+                 can_config.charger);  // Sending of 1F2 message is halted in LEAF-BATTERY function incase used here
   }
 
   /* Send messages every 100ms here */
@@ -268,11 +266,11 @@ void send_can_charger() {
     LEAF_55B.data.u8[6] = ((0x1 << 4) | (mprun100));
 
     LEAF_55B.data.u8[7] = calculate_CRC_Nissan(&LEAF_55B);
-    ESP32Can.CANWriteFrame(&LEAF_55B);
+    transmit_can(&LEAF_55B, can_config.charger);
 
-    ESP32Can.CANWriteFrame(&LEAF_59E);
+    transmit_can(&LEAF_59E, can_config.charger);
 
-    ESP32Can.CANWriteFrame(&LEAF_5BC);
+    transmit_can(&LEAF_5BC, can_config.charger);
 #endif
   }
 }

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -111,7 +111,7 @@ static uint8_t crctable[256] = {
     196, 65,  75,  206, 76,  201, 195, 70,  215, 82,  88,  221, 255, 122, 112, 245, 100, 225, 235, 110, 175, 42,
     32,  165, 52,  177, 187, 62,  28,  153, 147, 22,  135, 2,   8,   141};
 
-static uint8_t calculate_CRC_Nissan(CAN_frame_t* frame) {
+static uint8_t calculate_CRC_Nissan(CAN_frame* frame) {
   uint8_t crc = 0;
   for (uint8_t j = 0; j < 7; j++) {
     crc = crctable[(crc ^ static_cast<uint8_t>(frame->data.u8[j])) % 256];
@@ -119,7 +119,7 @@ static uint8_t calculate_CRC_Nissan(CAN_frame_t* frame) {
   return crc;
 }
 
-static uint8_t calculate_checksum_nibble(CAN_frame_t* frame) {
+static uint8_t calculate_checksum_nibble(CAN_frame* frame) {
   uint8_t sum = 0;
   for (uint8_t i = 0; i < 7; i++) {
     sum += frame->data.u8[i] >> 4;

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -129,9 +129,9 @@ static uint8_t calculate_checksum_nibble(CAN_frame* frame) {
   return sum;
 }
 
-void receive_can_charger(CAN_frame_t rx_frame) {
+void receive_can_charger(CAN_frame rx_frame) {
 
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x679:  // This message fires once when charging cable is plugged in
       OBCwakeup = true;
       charger_aux12V_enabled = true;  //Not possible to turn off 12V charging

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -2,7 +2,6 @@
 #define NISSANLEAF_CHARGER_H
 #include <Arduino.h>
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CHARGER_SELECTED
 

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -3,22 +3,6 @@
 
 #include "../../../USER_SETTINGS.h"
 
-/* Enumeration for CAN interfaces 
-typedef enum {
-    CAN_NATIVE = 0,
-    CANFD_NATIVE = 1,
-    CAN_ADDON_MCP2515 = 2,
-    CAN_ADDON_FD_MCP2518 = 3
-} CAN_Interface;
-
-/* Struct to hold CAN assignments for components
-typedef struct {
-    CAN_Interface battery;
-    CAN_Interface battery_double;
-    CAN_Interface inverter;
-} CAN_Configuration;
-*/
-
 #if defined(HW_LILYGO)
 #include "hw_lilygo.h"
 #elif defined(HW_STARK)

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -3,6 +3,22 @@
 
 #include "../../../USER_SETTINGS.h"
 
+/* Enumeration for CAN interfaces 
+typedef enum {
+    CAN_NATIVE = 0,
+    CANFD_NATIVE = 1,
+    CAN_ADDON_MCP2515 = 2,
+    CAN_ADDON_FD_MCP2518 = 3
+} CAN_Interface;
+
+/* Struct to hold CAN assignments for components
+typedef struct {
+    CAN_Interface battery;
+    CAN_Interface battery_double;
+    CAN_Interface inverter;
+} CAN_Configuration;
+*/
+
 #if defined(HW_LILYGO)
 #include "hw_lilygo.h"
 #elif defined(HW_STARK)

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -163,6 +163,7 @@ void init_events(void) {
   events.entries[EVENT_PRECHARGE_FAILURE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_INTERNAL_OPEN_FAULT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_INVERTER_OPEN_CONTACTOR].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_INTERFACE_MISSING].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MODBUS_INVERTER_MISSING].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_ERROR_OPEN_CONTACTOR].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CELL_UNDER_VOLTAGE].level = EVENT_LEVEL_ERROR;
@@ -291,6 +292,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "ERROR: High voltage cable removed while battery running. Opening contactors!";
     case EVENT_INVERTER_OPEN_CONTACTOR:
       return "Info: Inverter side opened contactors. Normal operation.";
+    case EVENT_INTERFACE_MISSING:
+      return "Info: Configuration trying to use CAN interface not baked into the software. Recompile software!";
     case EVENT_ERROR_OPEN_CONTACTOR:
       return "Info: Too much time spent in error state. Opening contactors, not safe to continue charging. "
              "Check other error code for reason!";

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0010  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0011  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -59,6 +59,7 @@
   XX(EVENT_PRECHARGE_FAILURE)           \
   XX(EVENT_INTERNAL_OPEN_FAULT)         \
   XX(EVENT_INVERTER_OPEN_CONTACTOR)     \
+  XX(EVENT_INTERFACE_MISSING)           \
   XX(EVENT_MODBUS_INVERTER_MISSING)     \
   XX(EVENT_ERROR_OPEN_CONTACTOR)        \
   XX(EVENT_CELL_UNDER_VOLTAGE)          \

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -30,7 +30,20 @@ enum led_color { GREEN, YELLOW, RED, BLUE, RGB };
 #define INTERVAL_200_MS_DELAYED 240
 #define INTERVAL_500_MS_DELAYED 550
 
-#define CAN_STILL_ALIVE \
-  12  // Set by battery each time we get a CAN message. Decrements every 5seconds. Incase we reach 0 (after 60 seconds of inactivity)
+#define CAN_STILL_ALIVE 12
+// Set by battery each time we get a CAN message. Decrements every 5seconds. When reaching 0, sets event
+
+/* CAN Frame structure */
+typedef struct {
+  bool FD;
+  bool ext_ID;
+  uint8_t DLC;
+  uint32_t ID;
+  union {
+    uint8_t u8[64];
+    uint32_t u32[2];
+    uint64_t u64;
+  } data;
+} CAN_frame;
 
 #endif

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -19,6 +19,22 @@ String settings_processor(const String& var) {
         "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
         "onclick='editPassword()'>Edit</button></h4>";
 
+    /*
+    If LilyGo used:
+    Battery CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
+    Inverter CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
+    Battery#2 CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
+    If Stark board used
+    Battery CAN channel: DISABLED / CAN / CAN-FD
+    Inverter CAN channel: DISABLED / CAN / CAN-FD
+    Battery#2 CAN channel: DISABLED / CAN / CAN-FD
+    */
+
+    content +=
+    "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
+    "onclick='editPassword()'>Edit</button></h4>";
+
+
     // Close the block
     content += "</div>";
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -19,21 +19,24 @@ String settings_processor(const String& var) {
         "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
         "onclick='editPassword()'>Edit</button></h4>";
 
-    /*
-    If LilyGo used:
-    Battery CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
-    Inverter CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
-    Battery#2 CAN channel: DISABLED / CAN / ADD-ON CAN MCP2515 / ADD-ON CAN-FD
-    If Stark board used
-    Battery CAN channel: DISABLED / CAN / CAN-FD
-    Inverter CAN channel: DISABLED / CAN / CAN-FD
-    Battery#2 CAN channel: DISABLED / CAN / CAN-FD
-    */
+    content += "<h4 style='color: white;'>Battery interface: <span id='Battery'>" +
+               String(getCANInterfaceName(can_config.battery)) + "</span></h4>";
 
-    content +=
-    "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
-    "onclick='editPassword()'>Edit</button></h4>";
+#ifdef DOUBLE_BATTERY
+    content += "<h4 style='color: white;'>Battery #2 interface: <span id='Battery'>" +
+               String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
+#else
+    content += "<h4 style='color: gray;'>Battery #2 interface: <span id='Battery'>" +
+               String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
+#endif  // DOUBLE_BATTERY
 
+#ifdef CAN_INVERTER_SELECTED
+    content += "<h4 style='color: white;'>Inverter interface: <span id='Inverter'>" +
+               String(getCANInterfaceName(can_config.inverter)) + "</span></h4>";
+#endif  //CAN_INVERTER_SELECTED
+#ifdef MODBUS_INVERTER_SELECTED
+    content += "<h4 style='color: white;'>Inverter interface: RS485<span id='Inverter'></span></h4>";
+#endif
 
     // Close the block
     content += "</div>";
@@ -209,4 +212,31 @@ String settings_processor(const String& var) {
     return content;
   }
   return String();
+}
+
+const char* getCANInterfaceName(CAN_Interface interface) {
+#ifdef HW_LILYGO
+  switch (interface) {
+    case CAN_NATIVE:
+      return "CAN";
+    case CAN_ADDON_MCP2515:
+      return "Add-on CAN via GPIO MCP2515";
+    case CAN_ADDON_FD_MCP2518:
+      return "Add-on CAN-FD via GPIO MCP2518";
+    default:
+      return "UNKNOWN";
+  }
+#endif
+#ifdef HW_STARK
+  switch (interface) {
+    case CAN_NATIVE:
+      return "CAN";
+    case CAN_ADDON_MCP2515:
+      return "CAN_ADDON_MCP2515";
+    case CAN_ADDON_FD_MCP2518:
+      return "CAN_ADDON_FD_MCP2518";
+    default:
+      return "UNKNOWN";
+  }
+#endif
 }

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -25,9 +25,6 @@ String settings_processor(const String& var) {
 #ifdef DOUBLE_BATTERY
     content += "<h4 style='color: white;'>Battery #2 interface: <span id='Battery'>" +
                String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
-#else
-    content += "<h4 style='color: gray;'>Battery #2 interface: <span id='Battery'>" +
-               String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
 #endif  // DOUBLE_BATTERY
 
 #ifdef CAN_INVERTER_SELECTED

--- a/Software/src/devboard/webserver/settings_html.h
+++ b/Software/src/devboard/webserver/settings_html.h
@@ -17,5 +17,13 @@ extern std::string password;
  * @return String
  */
 String settings_processor(const String& var);
+/**
+ * @brief Maps the value to a string of characters
+ *
+ * @param[in] char
+ *
+ * @return String
+ */
+const char* getCANInterfaceName(CAN_Interface interface);
 
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -177,8 +177,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 #endif
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+void receive_can_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x151:  //Message originating from BYD HVS compatible inverter. Reply with CAN identifier!
       if (rx_frame.data.u8[0] & 0x01) {  //Battery requests identification
         send_intial_data();

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -15,94 +15,69 @@ static uint8_t char5_151 = 0;
 static uint8_t char6_151 = 0;
 static uint8_t char7_151 = 0;
 
-//Startup messages
-CAN_frame_t BYD_250 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x250,
+CAN_frame BYD_250 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x250,
     .data = {0x03, 0x16, 0x00, 0x66, (uint8_t)((BATTERY_WH_MAX / 100) >> 8), (uint8_t)(BATTERY_WH_MAX / 100), 0x02,
              0x09}};  //3.16 FW , Capacity kWh byte4&5 (example 24kWh = 240)
-CAN_frame_t BYD_290 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x290,
-                       .data = {0x06, 0x37, 0x10, 0xD9, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t BYD_2D0 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x2D0,
-                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //BYD
-CAN_frame_t BYD_3D0_0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x3D0,
-                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //Battery
-CAN_frame_t BYD_3D0_1 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x3D0,
-                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
-CAN_frame_t BYD_3D0_2 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x3D0,
-                         .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
-CAN_frame_t BYD_3D0_3 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_std,
-                                     }},
-                         .MsgID = 0x3D0,
-                         .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
+CAN_frame BYD_290 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x290,
+                     .data = {0x06, 0x37, 0x10, 0xD9, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame BYD_2D0 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x2D0,
+                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //BYD
+CAN_frame BYD_3D0_0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D0,
+                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //Battery
+CAN_frame BYD_3D0_1 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D0,
+                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
+CAN_frame BYD_3D0_2 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D0,
+                       .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
+CAN_frame BYD_3D0_3 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D0,
+                       .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
 //Actual content messages
-CAN_frame_t BYD_110 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x110,
-                       .data = {0x01, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t BYD_150 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x150,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x10, 0x27, 0x00, 0x00}};
-CAN_frame_t BYD_190 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x190,
-                       .data = {0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t BYD_1D0 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x1D0,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x08}};
-CAN_frame_t BYD_210 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x210,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame BYD_110 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x110,
+                     .data = {0x01, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame BYD_150 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x150,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x10, 0x27, 0x00, 0x00}};
+CAN_frame BYD_190 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x190,
+                     .data = {0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame BYD_1D0 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x1D0,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x08}};
+CAN_frame BYD_210 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x210,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static uint16_t discharge_current = 0;
 static uint16_t charge_current = 0;

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -1,8 +1,6 @@
 #include "../include.h"
 #ifdef BYD_CAN
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "BYD-CAN.h"
 
 /* Do not change code below unless you are sure what you are doing */
@@ -18,7 +16,7 @@ static uint8_t char6_151 = 0;
 static uint8_t char7_151 = 0;
 
 //Startup messages
-const CAN_frame_t BYD_250 = {
+CAN_frame_t BYD_250 = {
     .FIR = {.B =
                 {
                     .DLC = 8,
@@ -27,48 +25,48 @@ const CAN_frame_t BYD_250 = {
     .MsgID = 0x250,
     .data = {0x03, 0x16, 0x00, 0x66, (uint8_t)((BATTERY_WH_MAX / 100) >> 8), (uint8_t)(BATTERY_WH_MAX / 100), 0x02,
              0x09}};  //3.16 FW , Capacity kWh byte4&5 (example 24kWh = 240)
-const CAN_frame_t BYD_290 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x290,
-                             .data = {0x06, 0x37, 0x10, 0xD9, 0x00, 0x00, 0x00, 0x00}};
-const CAN_frame_t BYD_2D0 = {.FIR = {.B =
-                                         {
-                                             .DLC = 8,
-                                             .FF = CAN_frame_std,
-                                         }},
-                             .MsgID = 0x2D0,
-                             .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //BYD
-const CAN_frame_t BYD_3D0_0 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x3D0,
-                               .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //Battery
-const CAN_frame_t BYD_3D0_1 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x3D0,
-                               .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
-const CAN_frame_t BYD_3D0_2 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x3D0,
-                               .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
-const CAN_frame_t BYD_3D0_3 = {.FIR = {.B =
-                                           {
-                                               .DLC = 8,
-                                               .FF = CAN_frame_std,
-                                           }},
-                               .MsgID = 0x3D0,
-                               .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
+CAN_frame_t BYD_290 = {.FIR = {.B =
+                                   {
+                                       .DLC = 8,
+                                       .FF = CAN_frame_std,
+                                   }},
+                       .MsgID = 0x290,
+                       .data = {0x06, 0x37, 0x10, 0xD9, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame_t BYD_2D0 = {.FIR = {.B =
+                                   {
+                                       .DLC = 8,
+                                       .FF = CAN_frame_std,
+                                   }},
+                       .MsgID = 0x2D0,
+                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //BYD
+CAN_frame_t BYD_3D0_0 = {.FIR = {.B =
+                                     {
+                                         .DLC = 8,
+                                         .FF = CAN_frame_std,
+                                     }},
+                         .MsgID = 0x3D0,
+                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //Battery
+CAN_frame_t BYD_3D0_1 = {.FIR = {.B =
+                                     {
+                                         .DLC = 8,
+                                         .FF = CAN_frame_std,
+                                     }},
+                         .MsgID = 0x3D0,
+                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
+CAN_frame_t BYD_3D0_2 = {.FIR = {.B =
+                                     {
+                                         .DLC = 8,
+                                         .FF = CAN_frame_std,
+                                     }},
+                         .MsgID = 0x3D0,
+                         .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
+CAN_frame_t BYD_3D0_3 = {.FIR = {.B =
+                                     {
+                                         .DLC = 8,
+                                         .FF = CAN_frame_std,
+                                     }},
+                         .MsgID = 0x3D0,
+                         .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
 //Actual content messages
 CAN_frame_t BYD_110 = {.FIR = {.B =
                                    {
@@ -246,31 +244,31 @@ void send_can_inverter() {
   if (currentMillis - previousMillis2s >= INTERVAL_2_S) {
     previousMillis2s = currentMillis;
 
-    ESP32Can.CANWriteFrame(&BYD_110);
+    transmit_can(&BYD_110, can_config.inverter);
   }
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
     previousMillis10s = currentMillis;
 
-    ESP32Can.CANWriteFrame(&BYD_150);
-    ESP32Can.CANWriteFrame(&BYD_1D0);
-    ESP32Can.CANWriteFrame(&BYD_210);
+    transmit_can(&BYD_150, can_config.inverter);
+    transmit_can(&BYD_1D0, can_config.inverter);
+    transmit_can(&BYD_210, can_config.inverter);
   }
   //Send 60s message
   if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
     previousMillis60s = currentMillis;
 
-    ESP32Can.CANWriteFrame(&BYD_190);
+    transmit_can(&BYD_190, can_config.inverter);
   }
 }
 
 void send_intial_data() {
-  ESP32Can.CANWriteFrame(&BYD_250);
-  ESP32Can.CANWriteFrame(&BYD_290);
-  ESP32Can.CANWriteFrame(&BYD_2D0);
-  ESP32Can.CANWriteFrame(&BYD_3D0_0);
-  ESP32Can.CANWriteFrame(&BYD_3D0_1);
-  ESP32Can.CANWriteFrame(&BYD_3D0_2);
-  ESP32Can.CANWriteFrame(&BYD_3D0_3);
+  transmit_can(&BYD_250, can_config.inverter);
+  transmit_can(&BYD_290, can_config.inverter);
+  transmit_can(&BYD_2D0, can_config.inverter);
+  transmit_can(&BYD_3D0_0, can_config.inverter);
+  transmit_can(&BYD_3D0_1, can_config.inverter);
+  transmit_can(&BYD_3D0_2, can_config.inverter);
+  transmit_can(&BYD_3D0_3, can_config.inverter);
 }
 #endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -1,10 +1,10 @@
 #ifndef BYD_CAN_H
 #define BYD_CAN_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CAN_INVERTER_SELECTED
 
 void send_intial_data();
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -5,6 +5,6 @@
 #define CAN_INVERTER_SELECTED
 
 void send_intial_data();
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -40,9 +40,8 @@
 #endif
 
 #ifdef CAN_INVERTER_SELECTED
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"  // This include is annoying, consider defining a frame type in types.h
 void update_values_can_inverter();
-void receive_can_inverter(CAN_frame_t rx_frame);
+void receive_can_inverter(CAN_frame rx_frame);
 void send_can_inverter();
 #endif
 

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -435,7 +435,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
+void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       if (rx_frame.data.u8[0] == 0x02) {

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -1,8 +1,6 @@
 #include "../include.h"
 #ifdef PYLON_CAN
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "PYLON-CAN.h"
 
 #define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
@@ -511,37 +509,37 @@ void send_setup_info() {  //Ensemble information
   }
 
 #ifdef SEND_0
-  ESP32Can.CANWriteFrame(&PYLON_7310);
-  ESP32Can.CANWriteFrame(&PYLON_7320);
+  transmit_can(&PYLON_7310, can_config.inverter);
+  transmit_can(&PYLON_7320, can_config.inverter);
 #endif
 #ifdef SEND_1
-  ESP32Can.CANWriteFrame(&PYLON_7311);
-  ESP32Can.CANWriteFrame(&PYLON_7321);
+  transmit_can(&PYLON_7311, can_config.inverter);
+  transmit_can(&PYLON_7321, can_config.inverter);
 #endif
 }
 
 void send_system_data() {  //System equipment information
 #ifdef SEND_0
-  ESP32Can.CANWriteFrame(&PYLON_4210);
-  ESP32Can.CANWriteFrame(&PYLON_4220);
-  ESP32Can.CANWriteFrame(&PYLON_4230);
-  ESP32Can.CANWriteFrame(&PYLON_4240);
-  ESP32Can.CANWriteFrame(&PYLON_4250);
-  ESP32Can.CANWriteFrame(&PYLON_4260);
-  ESP32Can.CANWriteFrame(&PYLON_4270);
-  ESP32Can.CANWriteFrame(&PYLON_4280);
-  ESP32Can.CANWriteFrame(&PYLON_4290);
+  transmit_can(&PYLON_4210, can_config.inverter);
+  transmit_can(&PYLON_4220, can_config.inverter);
+  transmit_can(&PYLON_4230, can_config.inverter);
+  transmit_can(&PYLON_4240, can_config.inverter);
+  transmit_can(&PYLON_4250, can_config.inverter);
+  transmit_can(&PYLON_4260, can_config.inverter);
+  transmit_can(&PYLON_4270, can_config.inverter);
+  transmit_can(&PYLON_4280, can_config.inverter);
+  transmit_can(&PYLON_4290, can_config.inverter);
 #endif
 #ifdef SEND_1
-  ESP32Can.CANWriteFrame(&PYLON_4211);
-  ESP32Can.CANWriteFrame(&PYLON_4221);
-  ESP32Can.CANWriteFrame(&PYLON_4231);
-  ESP32Can.CANWriteFrame(&PYLON_4241);
-  ESP32Can.CANWriteFrame(&PYLON_4251);
-  ESP32Can.CANWriteFrame(&PYLON_4261);
-  ESP32Can.CANWriteFrame(&PYLON_4271);
-  ESP32Can.CANWriteFrame(&PYLON_4281);
-  ESP32Can.CANWriteFrame(&PYLON_4291);
+  transmit_can(&PYLON_4211, can_config.inverter);
+  transmit_can(&PYLON_4221, can_config.inverter);
+  transmit_can(&PYLON_4231, can_config.inverter);
+  transmit_can(&PYLON_4241, can_config.inverter);
+  transmit_can(&PYLON_4251, can_config.inverter);
+  transmit_can(&PYLON_4261, can_config.inverter);
+  transmit_can(&PYLON_4271, can_config.inverter);
+  transmit_can(&PYLON_4281, can_config.inverter);
+  transmit_can(&PYLON_4291, can_config.inverter);
 #endif
 }
 #endif

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -436,7 +436,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 }
 
 void receive_can_inverter(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+  switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       if (rx_frame.data.u8[0] == 0x02) {
         send_setup_info();

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -11,163 +11,119 @@
 
 /* Do not change code below unless you are sure what you are doing */
 //Actual content messages
-CAN_frame_t PYLON_7310 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x7310,
-                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame_t PYLON_7320 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x7320,
-                          .data = {0x4B, 0x00, 0x05, 0x0F, 0x2D, 0x00, 0x56, 0x00}};
+CAN_frame PYLON_7310 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7310,
+                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+CAN_frame PYLON_7320 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7320,
+                        .data = {0x4B, 0x00, 0x05, 0x0F, 0x2D, 0x00, 0x56, 0x00}};
 
-CAN_frame_t PYLON_4210 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4210,
-                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame_t PYLON_4220 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4220,
-                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame_t PYLON_4230 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4230,
-                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame_t PYLON_4240 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4240,
-                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame_t PYLON_4250 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4250,
-                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_4260 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4260,
-                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame_t PYLON_4270 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4270,
-                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame_t PYLON_4280 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4280,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_4290 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4290,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4210 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4210,
+                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+CAN_frame PYLON_4220 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4220,
+                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+CAN_frame PYLON_4230 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4230,
+                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+CAN_frame PYLON_4240 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4240,
+                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+CAN_frame PYLON_4250 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4250,
+                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4260 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4260,
+                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+CAN_frame PYLON_4270 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4270,
+                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+CAN_frame PYLON_4280 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4280,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4290 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4290,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-CAN_frame_t PYLON_7311 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x7311,
-                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame_t PYLON_7321 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x7321,
-                          .data = {0x4B, 0x00, 0x05, 0x0F, 0x2D, 0x00, 0x56, 0x00}};
+CAN_frame PYLON_7311 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7311,
+                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+CAN_frame PYLON_7321 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7321,
+                        .data = {0x4B, 0x00, 0x05, 0x0F, 0x2D, 0x00, 0x56, 0x00}};
 
-CAN_frame_t PYLON_4211 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4211,
-                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame_t PYLON_4221 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4221,
-                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame_t PYLON_4231 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4231,
-                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame_t PYLON_4241 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4241,
-                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame_t PYLON_4251 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4251,
-                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_4261 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4261,
-                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame_t PYLON_4271 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4271,
-                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame_t PYLON_4281 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4281,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t PYLON_4291 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x4291,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4211 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4211,
+                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+CAN_frame PYLON_4221 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4221,
+                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+CAN_frame PYLON_4231 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4231,
+                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+CAN_frame PYLON_4241 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4241,
+                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+CAN_frame PYLON_4251 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4251,
+                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4261 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4261,
+                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+CAN_frame PYLON_4271 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4271,
+                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+CAN_frame PYLON_4281 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4281,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_4291 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x4291,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static int16_t max_charge_current = 0;
 static int16_t max_discharge_current = 0;

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -6,6 +6,6 @@
 
 void send_system_data();
 void send_setup_info();
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -1,7 +1,6 @@
 #ifndef PYLON_CAN_H
 #define PYLON_CAN_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CAN_INVERTER_SELECTED
 

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -6,5 +6,6 @@
 
 void send_system_data();
 void send_setup_info();
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -202,8 +202,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+void receive_can_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       //Frame0-1 Voltage
       //Frame2-3 Current

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -1,8 +1,6 @@
 #include "../include.h"
 #ifdef SMA_CAN
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "SMA-CAN.h"
 
 /* TODO: Map error bits in 0x158 */
@@ -11,7 +9,7 @@
 static unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
 
 //Actual content messages
-static const CAN_frame_t SMA_558 = {
+static CAN_frame_t SMA_558 = {
     .FIR = {.B =
                 {
                     .DLC = 8,
@@ -19,42 +17,41 @@ static const CAN_frame_t SMA_558 = {
                 }},
     .MsgID = 0x558,
     .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
-static const CAN_frame_t SMA_598 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x598,
-    .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
-static const CAN_frame_t SMA_5D8 = {.FIR = {.B =
-                                                {
-                                                    .DLC = 8,
-                                                    .FF = CAN_frame_std,
-                                                }},
-                                    .MsgID = 0x5D8,
-                                    .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-static const CAN_frame_t SMA_618_1 = {.FIR = {.B =
-                                                  {
-                                                      .DLC = 8,
-                                                      .FF = CAN_frame_std,
-                                                  }},
-                                      .MsgID = 0x618,
-                                      .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-static const CAN_frame_t SMA_618_2 = {.FIR = {.B =
-                                                  {
-                                                      .DLC = 8,
-                                                      .FF = CAN_frame_std,
-                                                  }},
-                                      .MsgID = 0x618,
-                                      .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
-static const CAN_frame_t SMA_618_3 = {.FIR = {.B =
-                                                  {
-                                                      .DLC = 8,
-                                                      .FF = CAN_frame_std,
-                                                  }},
-                                      .MsgID = 0x618,
-                                      .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
+static CAN_frame_t SMA_598 = {.FIR = {.B =
+                                          {
+                                              .DLC = 8,
+                                              .FF = CAN_frame_std,
+                                          }},
+                              .MsgID = 0x598,
+                              .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
+static CAN_frame_t SMA_5D8 = {.FIR = {.B =
+                                          {
+                                              .DLC = 8,
+                                              .FF = CAN_frame_std,
+                                          }},
+                              .MsgID = 0x5D8,
+                              .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+static CAN_frame_t SMA_618_1 = {.FIR = {.B =
+                                            {
+                                                .DLC = 8,
+                                                .FF = CAN_frame_std,
+                                            }},
+                                .MsgID = 0x618,
+                                .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+static CAN_frame_t SMA_618_2 = {.FIR = {.B =
+                                            {
+                                                .DLC = 8,
+                                                .FF = CAN_frame_std,
+                                            }},
+                                .MsgID = 0x618,
+                                .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
+static CAN_frame_t SMA_618_3 = {.FIR = {.B =
+                                            {
+                                                .DLC = 8,
+                                                .FF = CAN_frame_std,
+                                            }},
+                                .MsgID = 0x618,
+                                .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
 CAN_frame_t SMA_358 = {.FIR = {.B =
                                    {
                                        .DLC = 8,
@@ -257,18 +254,18 @@ void send_can_inverter() {
   if (currentMillis - previousMillis100ms >= INTERVAL_100_MS) {
     previousMillis100ms = currentMillis;
 
-    ESP32Can.CANWriteFrame(&SMA_558);
-    ESP32Can.CANWriteFrame(&SMA_598);
-    ESP32Can.CANWriteFrame(&SMA_5D8);
-    ESP32Can.CANWriteFrame(&SMA_618_1);  // TODO, should these 3x
-    ESP32Can.CANWriteFrame(&SMA_618_2);  // be sent as batch?
-    ESP32Can.CANWriteFrame(&SMA_618_3);  // or alternate on each send?
-    ESP32Can.CANWriteFrame(&SMA_358);
-    ESP32Can.CANWriteFrame(&SMA_3D8);
-    ESP32Can.CANWriteFrame(&SMA_458);
-    ESP32Can.CANWriteFrame(&SMA_518);
-    ESP32Can.CANWriteFrame(&SMA_4D8);
-    ESP32Can.CANWriteFrame(&SMA_158);
+    transmit_can(&SMA_558, can_config.inverter);
+    transmit_can(&SMA_598, can_config.inverter);
+    transmit_can(&SMA_5D8, can_config.inverter);
+    transmit_can(&SMA_618_1, can_config.inverter);  // TODO, should these 3x
+    transmit_can(&SMA_618_2, can_config.inverter);  // be sent as batch?
+    transmit_can(&SMA_618_3, can_config.inverter);  // or alternate on each send?
+    transmit_can(&SMA_358, can_config.inverter);
+    transmit_can(&SMA_3D8, can_config.inverter);
+    transmit_can(&SMA_458, can_config.inverter);
+    transmit_can(&SMA_518, can_config.inverter);
+    transmit_can(&SMA_4D8, can_config.inverter);
+    transmit_can(&SMA_158, can_config.inverter);
   }
 }
 #endif

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -9,90 +9,65 @@
 static unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
 
 //Actual content messages
-static CAN_frame_t SMA_558 = {
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x558,
-    .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
-static CAN_frame_t SMA_598 = {.FIR = {.B =
-                                          {
-                                              .DLC = 8,
-                                              .FF = CAN_frame_std,
-                                          }},
-                              .MsgID = 0x598,
-                              .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
-static CAN_frame_t SMA_5D8 = {.FIR = {.B =
-                                          {
-                                              .DLC = 8,
-                                              .FF = CAN_frame_std,
-                                          }},
-                              .MsgID = 0x5D8,
-                              .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-static CAN_frame_t SMA_618_1 = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x618,
-                                .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-static CAN_frame_t SMA_618_2 = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x618,
-                                .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
-static CAN_frame_t SMA_618_3 = {.FIR = {.B =
-                                            {
-                                                .DLC = 8,
-                                                .FF = CAN_frame_std,
-                                            }},
-                                .MsgID = 0x618,
-                                .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
-CAN_frame_t SMA_358 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x358,
+CAN_frame SMA_558 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x558,
+                     .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
+CAN_frame SMA_598 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x598,
+                     .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
+CAN_frame SMA_5D8 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x5D8,
+                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+CAN_frame SMA_618_1 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x618,
+                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+CAN_frame SMA_618_2 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x618,
+                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
+CAN_frame SMA_618_3 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x618,
+                       .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
+CAN_frame_t SMA_358 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x358,
                        .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SMA_3D8 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x3D8,
+CAN_frame_t SMA_3D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D8,
                        .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
-CAN_frame_t SMA_458 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x458,
+CAN_frame_t SMA_458 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x458,
                        .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
-CAN_frame_t SMA_518 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x518,
+CAN_frame_t SMA_518 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x518,
                        .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
-CAN_frame_t SMA_4D8 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x4D8,
+CAN_frame_t SMA_4D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x4D8,
                        .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
-CAN_frame_t SMA_158 = {.FIR = {.B =
-                                   {
-                                       .DLC = 8,
-                                       .FF = CAN_frame_std,
-                                   }},
-                       .MsgID = 0x158,
+CAN_frame_t SMA_158 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x158,
                        .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
 
 static int16_t discharge_current = 0;

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -39,36 +39,36 @@ CAN_frame SMA_618_3 = {.FD = false,
                        .DLC = 8,
                        .ID = 0x618,
                        .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
-CAN_frame_t SMA_358 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x358,
-                       .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SMA_3D8 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x3D8,
-                       .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
-CAN_frame_t SMA_458 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x458,
-                       .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
-CAN_frame_t SMA_518 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x518,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
-CAN_frame_t SMA_4D8 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x4D8,
-                       .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
-CAN_frame_t SMA_158 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x158,
-                       .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
+CAN_frame SMA_358 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x358,
+                     .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_3D8 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x3D8,
+                     .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
+CAN_frame SMA_458 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x458,
+                     .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
+CAN_frame SMA_518 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x518,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
+CAN_frame SMA_4D8 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x4D8,
+                     .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
+CAN_frame SMA_158 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x158,
+                     .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
 
 static int16_t discharge_current = 0;
 static int16_t charge_current = 0;

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -1,7 +1,6 @@
 #ifndef SMA_CAN_H
 #define SMA_CAN_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CAN_INVERTER_SELECTED
 

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -7,6 +7,6 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -7,4 +7,6 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
+void transmit_can(CAN_frame_t* tx_frame, int interface);
+
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -289,8 +289,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //SMA_018.data.u8[7] = BatteryName;
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {
+void receive_can_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
     case 0x00D:  //Inverter Measurements
       break;
     case 0x00F:  //Inverter Feedback

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -1,8 +1,6 @@
 #include "../include.h"
 #ifdef SMA_TRIPOWER_CAN
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "SMA-TRIPOWER-CAN.h"
 
 /* TODO:
@@ -356,28 +354,28 @@ void send_can_inverter() {
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
 
-    ESP32Can.CANWriteFrame(&SMA_00D);  //Battery limits
-    ESP32Can.CANWriteFrame(&SMA_00F);  // Battery state
-    ESP32Can.CANWriteFrame(&SMA_011);  // Battery Energy
-    ESP32Can.CANWriteFrame(&SMA_013);  // Battery Measurements
-    ESP32Can.CANWriteFrame(&SMA_014);  // Battery Temperatures and cellvoltages
+    transmit_can(&SMA_00D, can_config.inverter);  //Battery limits
+    transmit_can(&SMA_00F, can_config.inverter);  // Battery state
+    transmit_can(&SMA_011, can_config.inverter);  // Battery Energy
+    transmit_can(&SMA_013, can_config.inverter);  // Battery Measurements
+    transmit_can(&SMA_014, can_config.inverter);  // Battery Temperatures and cellvoltages
   }
 
-  if (batteryAlarm) {                  //Non-cyclic
-    ESP32Can.CANWriteFrame(&SMA_005);  // Battery Alarms 1
-    ESP32Can.CANWriteFrame(&SMA_007);  // Battery Alarms 2
+  if (batteryAlarm) {                             //Non-cyclic
+    transmit_can(&SMA_005, can_config.inverter);  // Battery Alarms 1
+    transmit_can(&SMA_007, can_config.inverter);  // Battery Alarms 2
   }
 
-  if (BMSevent) {                      //Non-cyclic
-    ESP32Can.CANWriteFrame(&SMA_006);  // Battery Errorcode
-    ESP32Can.CANWriteFrame(&SMA_008);  // Battery Events
+  if (BMSevent) {                                 //Non-cyclic
+    transmit_can(&SMA_006, can_config.inverter);  // Battery Errorcode
+    transmit_can(&SMA_008, can_config.inverter);  // Battery Events
   }
 }
 
 void send_tripower_init() {
-  ESP32Can.CANWriteFrame(&SMA_015);  // Battery Data 1
-  ESP32Can.CANWriteFrame(&SMA_016);  // Battery Data 2
-  ESP32Can.CANWriteFrame(&SMA_017);  // Battery Manufacturer
-  ESP32Can.CANWriteFrame(&SMA_018);  // Battery Name
+  transmit_can(&SMA_015, can_config.inverter);  // Battery Data 1
+  transmit_can(&SMA_016, can_config.inverter);  // Battery Data 2
+  transmit_can(&SMA_017, can_config.inverter);  // Battery Manufacturer
+  transmit_can(&SMA_018, can_config.inverter);  // Battery Name
 }
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -15,110 +15,71 @@
 static unsigned long previousMillis500ms = 0;  // will store last time a 100ms CAN Message was send
 
 //Actual content messages
-static CAN_frame_t SMA_00D = {  // Battery Limits
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x00D,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_00F = {  // Battery State
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x00F,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_011 = {  // Battery Energy
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x011,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_013 = {  // Battery Measurements
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x013,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_014 = {  // Battery Tempeartures and Cellvoltages
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x014,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_005 = {  // Battery Alarms 1
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x005,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_007 = {  // Battery Alarms 2
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x007,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_006 = {  // Battery Error Codes
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x006,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_008 = {  // Battery Events
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x008,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_015 = {  // Battery Data 1
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x015,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_016 = {  // Battery Data 2
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x016,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_017 = {  // Battery Manufacturer
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x017,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame_t SMA_018 = {  // Battery Name
-    .FIR = {.B =
-                {
-                    .DLC = 8,
-                    .FF = CAN_frame_std,
-                }},
-    .MsgID = 0x018,
-    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_00D = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x00D,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_00F = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x00F,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_011 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x011,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_013 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x013,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_014 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x014,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_005 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x005,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_007 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x007,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_006 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x006,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_008 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x008,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_015 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x015,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_016 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x016,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_017 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x017,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SMA_018 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x018,
+                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 static uint16_t discharge_current = 0;
 static uint16_t charge_current = 0;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -5,5 +5,6 @@
 #define CAN_INVERTER_SELECTED
 
 void send_tripower_init();
+void transmit_can(CAN_frame_t* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -5,6 +5,6 @@
 #define CAN_INVERTER_SELECTED
 
 void send_tripower_init();
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -1,7 +1,6 @@
 #ifndef SMA_CAN_TRIPOWER_H
 #define SMA_CAN_TRIPOWER_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CAN_INVERTER_SELECTED
 

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -1,8 +1,6 @@
 #include "../include.h"
 #ifdef SOFAR_CAN
 #include "../datalayer/datalayer.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "SOFAR-CAN.h"
 
 /* This implementation of the SOFAR can protocol is halfway done. What's missing is implementing the inverter replies, all the CAN messages are listed, but the can sending is missing. */
@@ -329,14 +327,14 @@ void send_can_inverter() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     //Frames actively reported by BMS
-    ESP32Can.CANWriteFrame(&SOFAR_351);
-    ESP32Can.CANWriteFrame(&SOFAR_355);
-    ESP32Can.CANWriteFrame(&SOFAR_356);
-    ESP32Can.CANWriteFrame(&SOFAR_30F);
-    ESP32Can.CANWriteFrame(&SOFAR_359);
-    ESP32Can.CANWriteFrame(&SOFAR_35E);
-    ESP32Can.CANWriteFrame(&SOFAR_35F);
-    ESP32Can.CANWriteFrame(&SOFAR_35A);
+    transmit_can(&SOFAR_351, can_config.inverter);
+    transmit_can(&SOFAR_355, can_config.inverter);
+    transmit_can(&SOFAR_356, can_config.inverter);
+    transmit_can(&SOFAR_30F, can_config.inverter);
+    transmit_can(&SOFAR_359, can_config.inverter);
+    transmit_can(&SOFAR_35E, can_config.inverter);
+    transmit_can(&SOFAR_35F, can_config.inverter);
+    transmit_can(&SOFAR_35A, can_config.inverter);
   }
 }
 #endif

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -230,8 +230,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOFAR_356.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
-  switch (rx_frame.MsgID) {  //In here we need to respond to the inverter. TODO: make logic
+void receive_can_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
       //frame1_605 = rx_frame.data.u8[1];
       //frame3_605 = rx_frame.data.u8[3];

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -10,273 +10,197 @@ static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN
 
 //Actual content messages
 //Note that these are technically extended frames. If more batteries are put in parallel,the first battery sends 0x351 the next battery sends 0x1351 etc. 16 batteries in parallel supported
-CAN_frame_t SOFAR_351 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x351,
-                         .data = {0xC6, 0x08, 0xFA, 0x00, 0xFA, 0x00, 0x80, 0x07}};
-CAN_frame_t SOFAR_355 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x355,
-                         .data = {0x31, 0x00, 0x64, 0x00, 0xFF, 0xFF, 0xF6, 0x00}};
-CAN_frame_t SOFAR_356 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x356,
-                         .data = {0x36, 0x08, 0x10, 0x00, 0xD0, 0x00, 0x01, 0x00}};
-CAN_frame_t SOFAR_30F = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x30F,
-                         .data = {0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_359 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x359,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x04, 0x10, 0x27, 0x10}};
-CAN_frame_t SOFAR_35E = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x35E,
-                         .data = {0x41, 0x4D, 0x41, 0x53, 0x53, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_35F = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x35F,
-                         .data = {0x00, 0x00, 0x24, 0x4E, 0x32, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_35A = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x35A,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_351 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x351,
+                       .data = {0xC6, 0x08, 0xFA, 0x00, 0xFA, 0x00, 0x80, 0x07}};
+CAN_frame SOFAR_355 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x355,
+                       .data = {0x31, 0x00, 0x64, 0x00, 0xFF, 0xFF, 0xF6, 0x00}};
+CAN_frame SOFAR_356 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x356,
+                       .data = {0x36, 0x08, 0x10, 0x00, 0xD0, 0x00, 0x01, 0x00}};
+CAN_frame SOFAR_30F = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x30F,
+                       .data = {0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_359 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x359,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x04, 0x10, 0x27, 0x10}};
+CAN_frame SOFAR_35E = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x35E,
+                       .data = {0x41, 0x4D, 0x41, 0x53, 0x53, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_35F = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x35F,
+                       .data = {0x00, 0x00, 0x24, 0x4E, 0x32, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_35A = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x35A,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-CAN_frame_t SOFAR_670 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x670,
-                         .data = {0x00, 0x8A, 0x33, 0x11, 0x59, 0x1A, 0x00, 0x00}};
-CAN_frame_t SOFAR_671 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x671,
-                         .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
-CAN_frame_t SOFAR_672 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x672,
-                         .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
-CAN_frame_t SOFAR_673 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x673,
-                         .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
-CAN_frame_t SOFAR_680 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x680,
-                         .data = {0x00, 0xB7, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame_t SOFAR_681 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x681,
-                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame_t SOFAR_682 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x682,
-                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame_t SOFAR_683 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x683,
-                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame_t SOFAR_684 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x684,
-                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame_t SOFAR_685 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x685,
-                         .data = {0x00, 0xB3, 0x0C, 0xBB, 0x0C, 0xB3, 0x0C, 0x00}};
-CAN_frame_t SOFAR_690 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x690,
-                         .data = {0x00, 0xD7, 0x00, 0xD4, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_691 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x691,
-                         .data = {0x00, 0xD4, 0x00, 0xD1, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_6A0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x6A0,
-                         .data = {0x00, 0xFA, 0x00, 0xDD, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_6B0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x6B0,
-                         .data = {0x00, 0xF6, 0x00, 0x06, 0x02, 0x01, 0x00, 0x00}};
-CAN_frame_t SOFAR_6C0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x6C0,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_770 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x770,
-                         .data = {0x00, 0x56, 0x0B, 0xF0, 0x58, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_771 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x771,
-                         .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
-CAN_frame_t SOFAR_772 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x772,
-                         .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
-CAN_frame_t SOFAR_773 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x773,
-                         .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
-CAN_frame_t SOFAR_780 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x780,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_781 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x781,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_782 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x782,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_783 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x783,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_784 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x784,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_785 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x785,
-                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame_t SOFAR_790 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x790,
-                         .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_791 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x791,
-                         .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_7A0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x7A0,
-                         .data = {0x00, 0xFA, 0x00, 0xE1, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame_t SOFAR_7B0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x7B0,
-                         .data = {0x00, 0xF9, 0x00, 0x06, 0x02, 0xE9, 0x5D, 0x00}};
-CAN_frame_t SOFAR_7C0 = {.FIR = {.B =
-                                     {
-                                         .DLC = 8,
-                                         .FF = CAN_frame_ext,
-                                     }},
-                         .MsgID = 0x7C0,
-                         .data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x80, 0x00}};
+CAN_frame SOFAR_670 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x670,
+                       .data = {0x00, 0x8A, 0x33, 0x11, 0x59, 0x1A, 0x00, 0x00}};
+CAN_frame SOFAR_671 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x671,
+                       .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
+CAN_frame SOFAR_672 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x672,
+                       .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
+CAN_frame SOFAR_673 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x673,
+                       .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
+CAN_frame SOFAR_680 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x680,
+                       .data = {0x00, 0xB7, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+CAN_frame SOFAR_681 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x681,
+                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+CAN_frame SOFAR_682 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x682,
+                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+CAN_frame SOFAR_683 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x683,
+                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+CAN_frame SOFAR_684 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x684,
+                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+CAN_frame SOFAR_685 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x685,
+                       .data = {0x00, 0xB3, 0x0C, 0xBB, 0x0C, 0xB3, 0x0C, 0x00}};
+CAN_frame SOFAR_690 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x690,
+                       .data = {0x00, 0xD7, 0x00, 0xD4, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_691 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x691,
+                       .data = {0x00, 0xD4, 0x00, 0xD1, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_6A0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x6A0,
+                       .data = {0x00, 0xFA, 0x00, 0xDD, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_6B0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x6B0,
+                       .data = {0x00, 0xF6, 0x00, 0x06, 0x02, 0x01, 0x00, 0x00}};
+CAN_frame SOFAR_6C0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x6C0,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_770 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x770,
+                       .data = {0x00, 0x56, 0x0B, 0xF0, 0x58, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_771 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x771,
+                       .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
+CAN_frame SOFAR_772 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x772,
+                       .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
+CAN_frame SOFAR_773 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x773,
+                       .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
+CAN_frame SOFAR_780 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x780,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_781 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x781,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_782 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x782,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_783 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x783,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_784 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x784,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_785 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x785,
+                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+CAN_frame SOFAR_790 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x790,
+                       .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_791 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x791,
+                       .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_7A0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x7A0,
+                       .data = {0x00, 0xFA, 0x00, 0xE1, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame SOFAR_7B0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x7B0,
+                       .data = {0x00, 0xF9, 0x00, 0x06, 0x02, 0xE9, 0x5D, 0x00}};
+CAN_frame SOFAR_7C0 = {.FD = false,
+                       .ext_ID = true,
+                       .DLC = 8,
+                       .ID = 0x7C0,
+                       .data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x80, 0x00}};
 
 void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -4,6 +4,6 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -1,7 +1,6 @@
 #ifndef SOFAR_CAN_H
 #define SOFAR_CAN_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 #define CAN_INVERTER_SELECTED
 

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -4,4 +4,6 @@
 
 #define CAN_INVERTER_SELECTED
 
+void transmit_can(CAN_frame_t* tx_frame, int interface);
+
 #endif

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -16,90 +16,62 @@ static uint16_t capped_remaining_capacity_Wh;
 
 //CAN message translations from this amazing repository: https://github.com/rand12345/solax_can_bus
 
-CAN_frame_t SOLAX_1801 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1801,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame_t SOLAX_1872 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1872,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Limits
-CAN_frame_t SOLAX_1873 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1873,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackData
-CAN_frame_t SOLAX_1874 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1874,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_CellData
-CAN_frame_t SOLAX_1875 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1875,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Status
-CAN_frame_t SOLAX_1876 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1876,
-                          .data = {0x0, 0x0, 0xE2, 0x0C, 0x0, 0x0, 0xD7, 0x0C}};  //BMS_PackTemps
-CAN_frame_t SOLAX_1877 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1877,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame_t SOLAX_1878 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1878,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackStats
-CAN_frame_t SOLAX_1879 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1879,
-                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame_t SOLAX_1881 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1881,
-                          .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 6 S B M S F A
-CAN_frame_t SOLAX_1882 = {.FIR = {.B =
-                                      {
-                                          .DLC = 8,
-                                          .FF = CAN_frame_ext,
-                                      }},
-                          .MsgID = 0x1882,
-                          .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 2 3 A B 0 5 2
-CAN_frame_t SOLAX_100A001 = {.FIR = {.B =
-                                         {
-                                             .DLC = 0,
-                                             .FF = CAN_frame_ext,
-                                         }},
-                             .MsgID = 0x100A001,
-                             .data = {}};
+CAN_frame SOLAX_1801 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1801,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+CAN_frame SOLAX_1872 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1872,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Limits
+CAN_frame SOLAX_1873 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1873,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackData
+CAN_frame SOLAX_1874 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1874,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_CellData
+CAN_frame SOLAX_1875 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1875,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Status
+CAN_frame SOLAX_1876 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1876,
+                        .data = {0x0, 0x0, 0xE2, 0x0C, 0x0, 0x0, 0xD7, 0x0C}};  //BMS_PackTemps
+CAN_frame SOLAX_1877 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1877,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+CAN_frame SOLAX_1878 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1878,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackStats
+CAN_frame SOLAX_1879 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1879,
+                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+CAN_frame SOLAX_1881 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1881,
+                        .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 6 S B M S F A
+CAN_frame SOLAX_1882 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1882,
+                        .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 2 3 A B 0 5 2
+CAN_frame SOLAX_100A001 = {.FD = false, .ext_ID = true, .DLC = 0, .ID = 0x100A001, .data = {}};
 
 // __builtin_bswap64 needed to convert to ESP32 little endian format
 // Byte[4] defines the requested contactor state: 1 = Closed , 0 = Open
@@ -236,9 +208,9 @@ void send_can_inverter() {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
-void receive_can_inverter(CAN_frame_t rx_frame) {
-  if (rx_frame.MsgID == 0x1871 && rx_frame.data.u8[0] == (0x01) ||
-      rx_frame.MsgID == 0x1871 && rx_frame.data.u8[0] == (0x02)) {
+void receive_can_inverter(CAN_frame rx_frame) {
+  if (rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x01) ||
+      rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x02)) {
     LastFrameTime = millis();
     switch (STATE) {
       case (BATTERY_ANNOUNCE):
@@ -299,14 +271,14 @@ void receive_can_inverter(CAN_frame_t rx_frame) {
     }
   }
 
-  if (rx_frame.MsgID == 0x1871 && rx_frame.data.u64 == __builtin_bswap64(0x0500010000000000)) {
+  if (rx_frame.ID == 0x1871 && rx_frame.data.u64 == __builtin_bswap64(0x0500010000000000)) {
     transmit_can(&SOLAX_1881, can_config.inverter);
     transmit_can(&SOLAX_1882, can_config.inverter);
 #ifdef DEBUG_VIA_USB
     Serial.println("1871 05-frame received from inverter");
 #endif
   }
-  if (rx_frame.MsgID == 0x1871 && rx_frame.data.u8[0] == (0x03)) {
+  if (rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x03)) {
 #ifdef DEBUG_VIA_USB
     Serial.println("1871 03-frame received from inverter");
 #endif

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -83,10 +83,6 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   if (millis() - LastFrameTime >= SolaxTimeout) {
     datalayer.system.status.inverter_allows_contactor_closing = false;
     STATE = BATTERY_ANNOUNCE;
-#ifndef DUAL_CAN
-    ESP32Can.CANStop();  // Baud rate switching might have taken down the interface. Reboot it!
-    ESP32Can.CANInit();  // TODO: Incase this gets implemented in ESP32Can.cpp, remove these two lines!
-#endif
   }
   //Calculate the required values
   temperature_average =

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -1,12 +1,8 @@
 #ifndef SOLAX_CAN_H
 #define SOLAX_CAN_H
 #include "../include.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
-#include "../lib/pierremolinaro-acan2515/ACAN2515.h"
 
 #define CAN_INVERTER_SELECTED
-
-extern ACAN2515 can;
 
 // Timeout in milliseconds
 #define SolaxTimeout 2000
@@ -18,5 +14,4 @@ extern ACAN2515 can;
 #define FAULT_SOLAX 3
 #define UPDATING_FW 4
 
-void receive_can_solax(CAN_frame_t rx_frame);
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,4 +14,6 @@
 #define FAULT_SOLAX 3
 #define UPDATING_FW 4
 
+void transmit_can(CAN_frame_t* tx_frame, int interface);
+
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,6 +14,6 @@
 #define FAULT_SOLAX 3
 #define UPDATING_FW 4
 
-void transmit_can(CAN_frame_t* tx_frame, int interface);
+void transmit_can(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -36,16 +36,13 @@
 
 #include "esp_intr_alloc.h" // Renamed when migrating ESP32 2.x -> 3.x
 #include "soc/dport_reg.h"
+#include "soc/gpio_sig_map.h"
 #include <math.h>
 
 #include "driver/gpio.h"
 
 #include "can_regdef.h"
 #include "CAN_config.h"
-
-#define TWAI_TX_IDX 123 // TODO: Are these OK? 
-// not sure what file is needed now, maybe "soc/gpio_sig_map.h" but using hard coded values for now
-#define TWAI_RX_IDX 94  // TODO: Are these OK? 
 
 // CAN Filter - no acceptance filter
 static CAN_filter_t __filter = { Dual_Mode, 0, 0, 0, 0, 0Xff, 0Xff, 0Xff, 0Xff };


### PR DESCRIPTION
### What
This PR refactors all CAN message handling by adding our own CAN struct. The project no longer relies on the miwagner struct for CAN, we have our own definition in place now!

### Why
The amount of variations is starting to grow out of hand. There are so many battery/inverter specific hardcoded combinations in the code. This PR makes it free for the end user to specify any combination of hardware, and on which CAN interface the parts are connected. 

#### Bonus
- CAN-FD add-on chip can now be used for normal CAN also! Just enable `USE_CANFD_INTERFACE_AS_CLASSIC_CAN `in USER_SETTINGS
- This also makes it easier to integrate new hardware boards with the Battery-Emulator
- Compile time is faster, since less includes

### How
The user now configures on which CAN interface each component is connected to. This simplifies all code logic massively.

In the USER_SETTINGS file, you configure how everything is connected
![image](https://github.com/user-attachments/assets/1793a382-57ec-4317-9645-f17ba82bbb98)

The Webserver also shows what the current configuration is:
![image](https://github.com/user-attachments/assets/42789e55-29e0-4b67-94bf-81639e30c246)

