### PR TITLE
BMW i3: Fix initialization of WUP_PIN

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1075,7 +1075,7 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery2.status.voltage_dV =
       0;  //Init voltage to 0 to allow contactor check to operate without fear of default values colliding
 #endif
-
+  pinMode(WUP_PIN, OUTPUT);
   digitalWrite(WUP_PIN, HIGH);  // Wake up the battery
 }
 


### PR DESCRIPTION
### What
The Pin25 used for 3.3V SSR output was not working for the BMW i3. The output was floating between 0-1V.

### Why
The pinMode init function was not called on setup

### How
Added the setup function, to allow the pin to work as intended