### PR TITLE
Remove extra closing script tag

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -155,7 +155,6 @@ String settings_processor(const String& var) {
         "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
         "updateMaxDischargeA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
         "and 1000.0');}}}";
-    content += "</script>";
 
 #ifdef TEST_FAKE_BATTERY
     content +=


### PR DESCRIPTION
This was prematurely closing the tag, preventing TEST_FAKE_BATTERY, CHEVYVOLT_CHARGER and NISSANLEAF_CHARGER from inserting their scripts.

Before

![image](https://github.com/user-attachments/assets/9a1b4d40-ad4b-4ac9-a19e-be473303e59c)

After

![image](https://github.com/user-attachments/assets/0d3d7940-4185-4346-8f6d-dcc5c2a7d447)
