### PR TITLE
Triage: Remove EEPROM writing

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -82,7 +82,7 @@ static void check_ee_write(void);
 void run_event_handling(void) {
   update_event_time();
   run_sequence_on_target();
-  check_ee_write();
+  //check_ee_write();
   update_event_level();
 }
 


### PR DESCRIPTION
### What
This PR removes EEPROM writing for storing events

### Why
This feature is using too much CPU when executed, causing CAN message transmission to be delayed by 70 milliseconds. We will disable it until we can get it optimized

