### PR TITLE
Tesla S3XY: Change how power ramping is performed

### DIFF
--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.cpp
@@ -291,7 +291,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   } else if (battery_soc_vi >
              RAMPDOWN_SOC) {  // When real SOC is between RAMPDOWN_SOC-99%, ramp the value between Max<->0
     datalayer.battery.status.max_charge_power_W =
-        MAXCHARGEPOWERALLOWED * (1 - (battery_soc_vi - RAMPDOWN_SOC) / (1000.0 - RAMPDOWN_SOC));
+        RAMPDOWNPOWERALLOWED * (1 - (battery_soc_vi - RAMPDOWN_SOC) / (1000.0 - RAMPDOWN_SOC));
     //If the cellvoltages start to reach overvoltage, only allow a small amount of power in
     if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
       if (battery_cell_max_v > (MAX_CELL_VOLTAGE_LFP - FLOAT_START_MV)) {

--- a/Software/src/battery/TESLA-MODEL-3-BATTERY.h
+++ b/Software/src/battery/TESLA-MODEL-3-BATTERY.h
@@ -4,19 +4,21 @@
 
 #define BATTERY_SELECTED
 
+/* Modify these if needed */
 //#define LFP_CHEMISTRY // Enable this line to startup in LFP mode
+#define MAXCHARGEPOWERALLOWED 15000     // 15000W we use a define since the value supplied by Tesla is always 0
+#define MAXDISCHARGEPOWERALLOWED 60000  // 60000W we use a define since the value supplied by Tesla is always 0
 
-#define RAMPDOWN_SOC 900             // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
-#define MAX_CELL_DEVIATION_MV 9999   // Handled inside the Tesla.cpp file, just for compilation
-#define FLOAT_MAX_POWER_W 200        // W, what power to allow for top balancing battery
-#define FLOAT_START_MV 20            // mV, how many mV under overvoltage to start float charging
-#define MAXCHARGEPOWERALLOWED 15000  // 15000W we use a define since the value supplied by Tesla is always 0
-#define MAXDISCHARGEPOWERALLOWED \
-  60000                             // 60000W we need to cap this value to max 60kW, most inverters overflow otherwise
+/* Do not change the defines below */
+#define RAMPDOWN_SOC 900            // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
+#define RAMPDOWNPOWERALLOWED 15000  // What power we ramp down from towards top balancing
+#define FLOAT_MAX_POWER_W 200       // W, what power to allow for top balancing battery
+#define FLOAT_START_MV 20           // mV, how many mV under overvoltage to start float charging
 #define MAX_PACK_VOLTAGE_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
 #define MIN_PACK_VOLTAGE_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
 #define MAX_PACK_VOLTAGE_LFP 3880   // V+1, if pack voltage goes over this, charge stops
 #define MIN_PACK_VOLTAGE_LFP 2968   // V+1, if pack voltage goes below this, discharge stops
+#define MAX_CELL_DEVIATION_MV 9999  // Handled inside the Tesla.cpp file, just for compilation
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);


### PR DESCRIPTION
### What
This PR fixes the issue noticed in #432 

### Why
For safer battery operation

### How
We now do two things differently.
- Power ramping is no longer tied to normal charge speed define. This avoids battery possibly being charged with 50kW while nearing 100% SOC.
- The Tesla.h file now has a clear distinction which defines should be edited by users
![image](https://github.com/user-attachments/assets/3ac18eb3-ba57-497a-aa45-6bd6984647e4)

Note, for future implementations, we should:

- Try sending the entire vehicle CAN bus towards the battery
- This should at the same time fix that the battery sends 0A allowed Charge/Discharge, so we can stop using estimated value
- Once allowed A is available, use this to perform balancing / graceful stopping of charge at 100% soc
