### PR TITLE
Feature: Show CONTACTOR_CONTROL status in the WebUI

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -462,7 +462,7 @@ void init_contactors() {
   digitalWrite(PRECHARGE_PIN, LOW);
 #endif
 // Init BMS contactor
-#ifdef HW_STARK  // TODO: Rewrite this so LilyGo can aslo handle this BMS contactor
+#ifdef HW_STARK  // TODO: Rewrite this so LilyGo can also handle this BMS contactor
   pinMode(BMS_POWER, OUTPUT);
   digitalWrite(BMS_POWER, HIGH);
 #endif
@@ -653,6 +653,7 @@ void handle_contactors() {
     digitalWrite(NEGATIVE_CONTACTOR_PIN, LOW);
     digitalWrite(POSITIVE_CONTACTOR_PIN, LOW);
     set_event(EVENT_ERROR_OPEN_CONTACTOR, 0);
+    datalayer.system.status.contactor_control_closed = false;
     return;  // A fault scenario latches the contactor control. It is not possible to recover without a powercycle (and investigation why fault occured)
   }
 
@@ -718,6 +719,7 @@ void handle_contactors() {
         ledcWrite(POSITIVE_PWM_Ch, PWM_Hold_Duty);
 #endif
         contactorStatus = COMPLETED;
+        datalayer.system.status.contactor_control_closed = true;
       }
       break;
     default:

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -165,6 +165,10 @@ typedef struct {
   bool battery2_allows_contactor_closing = false;
   /** True if the inverter allows for the contactors to close */
   bool inverter_allows_contactor_closing = true;
+#ifdef CONTACTOR_CONTROL
+  /** True if the contactor controlled by battery-emulator is closed */
+  bool contactor_control_closed = false;
+#endif
 } DATALAYER_SYSTEM_STATUS_TYPE;
 
 typedef struct {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -645,6 +645,16 @@ String processor(const String& var) {
     else
       content += "<h4 style='color: red;'>Pause status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
 
+#ifdef CONTACTOR_CONTROL
+    content += "<h4>Contactors controlled by Battery-Emulator: ";
+    if (datalayer.system.status.contactor_control_closed) {
+      content += "<span style='color: green;'>ON</span>";
+    } else {
+      content += "<span style='color: red;'>OFF</span>";
+    }
+    content += "</h4>";
+#endif
+
     // Close the block
     content += "</div>";
 
@@ -720,6 +730,17 @@ String processor(const String& var) {
     } else {
       content += "<span style='color: red;'>&#10005;</span></h4>";
     }
+
+#ifdef CONTACTOR_CONTROL
+    content += "<h4>Contactors controlled by Battery-Emulator: ";
+    if (datalayer.system.status.contactor_control_closed) {
+      content += "<span style='color: green;'>ON</span>";
+    } else {
+      content += "<span style='color: red;'>OFF</span>";
+    }
+    content += "</h4>";
+#endif
+
     if (emulator_pause_status == NORMAL)
       content += "<h4>Pause status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
     else


### PR DESCRIPTION
When CONTACTOR_CONTROL is used, the battery-emulator controls
its own contactors. There is nowhere on the WebUI to show if
the contactors are engaged or not, only an error event is shown
if the contactors are disengaged.
    
Add an entry in the WebUI to show the CONTACTOR_CONTROL status.