### PR TITLE
Tesla: Add support for 108S Model X +refactor

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -23,7 +23,10 @@
 //#define RENAULT_ZOE_GEN1_BATTERY
 //#define RENAULT_ZOE_GEN2_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
+//#define TESLA_MODEL_S_BATTERY
 //#define TESLA_MODEL_3_BATTERY
+//#define TESLA_MODEL_X_BATTERY
+//#define TESLA_MODEL_Y_BATTERY
 //#define VOLVO_SPA_BATTERY
 //#define TEST_FAKE_BATTERY
 //#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires DUAL_CAN setup)

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -64,6 +64,7 @@
 
 #if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || \
     defined(TESLA_MODEL_Y_BATTERY)
+#define TESLA_BATTERY
 #include "TESLA-BATTERY.h"
 #endif
 

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -62,7 +62,8 @@
 #include "SANTA-FE-PHEV-BATTERY.h"
 #endif
 
-#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || \
+    defined(TESLA_MODEL_Y_BATTERY)
 #include "TESLA-BATTERY.h"
 #endif
 

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -62,8 +62,8 @@
 #include "SANTA-FE-PHEV-BATTERY.h"
 #endif
 
-#ifdef TESLA_MODEL_3_BATTERY
-#include "TESLA-MODEL-3-BATTERY.h"
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+#include "TESLA-BATTERY.h"
 #endif
 
 #ifdef TEST_FAKE_BATTERY

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -327,14 +327,14 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   battery_cell_deviation_mV = (battery_cell_max_v - battery_cell_min_v);
 
-  #if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+#if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
   // Autodetect algoritm for chemistry on 3/Y packs.
   // NCM/A batteries have 96s, LFP has 102-106s
   // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
   if (datalayer.battery.info.number_of_cells > 101) {
     datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   }
-  #endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
+#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
@@ -909,14 +909,14 @@ void update_values_battery2() {  //This function maps all the values fetched via
 
   battery2_cell_deviation_mV = (battery2_cell_max_v - battery2_cell_min_v);
 
-  #if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+#if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
   // Autodetect algoritm for chemistry on 3/Y packs.
   // NCM/A batteries have 96s, LFP has 102-106s
   // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
   if (datalayer.battery2.info.number_of_cells > 101) {
     datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
   }
-  #endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
+#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery2.info.chemistry == battery_chemistry_enum::LFP) {
@@ -1250,16 +1250,16 @@ void setup_battery(void) {  // Performs one time setup at startup
 
   datalayer.system.status.battery_allows_contactor_closing = true;
 
-#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_X_BATTERY) // Always use NCM/A mode on S/X packs
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_X_BATTERY)  // Always use NCM/A mode on S/X packs
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
-#endif // DOUBLE_BATTERY
-#endif // TESLA_MODEL_S_BATTERY || TESLA_MODEL_X_BATTERY
+#endif  // DOUBLE_BATTERY
+#endif  // TESLA_MODEL_S_BATTERY || TESLA_MODEL_X_BATTERY
 
-#if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY) // Model 3/Y can be either LFP or NCM/A
+#if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)  // Model 3/Y can be either LFP or NCM/A
 #ifdef LFP_CHEMISTRY
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
@@ -1268,16 +1268,16 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
   datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
-#endif // DOUBLE_BATTERY
-#else  // Startup in NCM/A mode
+#endif  // DOUBLE_BATTERY
+#else   // Startup in NCM/A mode
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
   datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
-#endif // DOUBLE_BATTERY
-#endif // !LFP_CHEMISTRY
-#endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
+#endif  // DOUBLE_BATTERY
+#endif  // !LFP_CHEMISTRY
+#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 }
 
-#endif // TESLA_BATTERY
+#endif  // TESLA_BATTERY

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1,8 +1,8 @@
 #include "../include.h"
-#ifdef TESLA_MODEL_3_BATTERY
+#ifdef TESLA_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "TESLA-MODEL-3-BATTERY.h"
+#include "TESLA-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
 /* Credits: Most of the code comes from Per Carlen's bms_comms_tesla_model3.py (https://gitlab.com/pelle8/batt2gen24/) */
@@ -327,11 +327,14 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   battery_cell_deviation_mV = (battery_cell_max_v - battery_cell_min_v);
 
+  #if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+  // Autodetect algoritm for chemistry on 3/Y packs.
   // NCM/A batteries have 96s, LFP has 102-106s
   // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
   if (datalayer.battery.info.number_of_cells > 101) {
     datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   }
+  #endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
@@ -906,11 +909,14 @@ void update_values_battery2() {  //This function maps all the values fetched via
 
   battery2_cell_deviation_mV = (battery2_cell_max_v - battery2_cell_min_v);
 
+  #if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+  // Autodetect algoritm for chemistry on 3/Y packs.
   // NCM/A batteries have 96s, LFP has 102-106s
   // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
   if (datalayer.battery2.info.number_of_cells > 101) {
     datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
   }
+  #endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery2.info.chemistry == battery_chemistry_enum::LFP) {
@@ -1239,28 +1245,39 @@ void printDebugIfActive(uint8_t symbol, const char* message) {
 
 void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
-  Serial.println("Tesla Model 3 battery selected");
+  Serial.println("Tesla Model S/3/X/Y battery selected");
 #endif
 
   datalayer.system.status.battery_allows_contactor_closing = true;
 
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_X_BATTERY) // Always use NCM/A mode on S/X packs
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
+#ifdef DOUBLE_BATTERY
+  datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
+  datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
+#endif // DOUBLE_BATTERY
+#endif // TESLA_MODEL_S_BATTERY || TESLA_MODEL_X_BATTERY
+
+#if defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_Y_BATTERY) // Model 3/Y can be either LFP or NCM/A
 #ifdef LFP_CHEMISTRY
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
-  datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
-  datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
-#endif
+  datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+  datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
+#endif // DOUBLE_BATTERY
 #else  // Startup in NCM/A mode
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
 #ifdef DOUBLE_BATTERY
-  datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
-  datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
-#endif
-#endif
+  datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+  datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
+#endif // DOUBLE_BATTERY
+#endif // !LFP_CHEMISTRY
+#endif // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 }
 
-#endif
+#endif // TESLA_BATTERY

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -334,16 +334,16 @@ void update_values_battery() {  //This function maps all the values fetched via 
   if (datalayer.battery.info.number_of_cells > 101) {
     datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   }
-#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
-    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
-    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
+    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
   } else {  // NCM/A chemistry
-    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
-    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
+    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
   }
+#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Check if SOC% is plausible
   if (datalayer.battery.status.voltage_dV >
@@ -916,16 +916,17 @@ void update_values_battery2() {  //This function maps all the values fetched via
   if (datalayer.battery2.info.number_of_cells > 101) {
     datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
   }
-#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
   if (datalayer.battery2.info.chemistry == battery_chemistry_enum::LFP) {
-    datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_LFP;
-    datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_LFP;
+    datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+    datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
   } else {  // NCM/A chemistry
-    datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_NCMA;
-    datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_NCMA;
+    datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+    datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
   }
+
+#endif  // TESLA_MODEL_3_BATTERY || TESLA_MODEL_Y_BATTERY
 
   //Check if SOC% is plausible
   if (datalayer.battery2.status.voltage_dV >

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -6,7 +6,6 @@
 
 /* Modify these if needed */
 //#define LFP_CHEMISTRY // Enable this line to startup in LFP mode
-//#define NCM_CHEMISTRY // Enable this line to startup in NCM/A mode
 #define MAXCHARGEPOWERALLOWED 15000     // 15000W we use a define since the value supplied by Tesla is always 0
 #define MAXDISCHARGEPOWERALLOWED 60000  // 60000W we use a define since the value supplied by Tesla is always 0
 
@@ -18,11 +17,11 @@
 
 #define MAX_PACK_VOLTAGE_SX_NCMA 4600  // V+1, if pack voltage goes over this, charge stops
 #define MIN_PACK_VOLTAGE_SX_NCMA 3100  // V+1, if pack voltage goes over this, charge stops
-#define MAX_PACK_VOLTAGE_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
-#define MIN_PACK_VOLTAGE_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
-#define MAX_PACK_VOLTAGE_LFP 3880   // V+1, if pack voltage goes over this, charge stops
-#define MIN_PACK_VOLTAGE_LFP 2968   // V+1, if pack voltage goes below this, discharge stops
-#define MAX_CELL_DEVIATION_MV 9999  // Handled inside the Tesla.cpp file, just for compilation
+#define MAX_PACK_VOLTAGE_3Y_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_3Y_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
+#define MAX_PACK_VOLTAGE_3Y_LFP 3880   // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_3Y_LFP 2968   // V+1, if pack voltage goes below this, discharge stops
+#define MAX_CELL_DEVIATION_MV 9999     // Handled inside the Tesla.cpp file, just for compilation
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -1,11 +1,12 @@
-#ifndef TESLA_MODEL_3_BATTERY_H
-#define TESLA_MODEL_3_BATTERY_H
+#ifndef TESLA_BATTERY_H
+#define TESLA_BATTERY_H
 #include "../include.h"
 
 #define BATTERY_SELECTED
 
 /* Modify these if needed */
 //#define LFP_CHEMISTRY // Enable this line to startup in LFP mode
+//#define NCM_CHEMISTRY // Enable this line to startup in NCM/A mode
 #define MAXCHARGEPOWERALLOWED 15000     // 15000W we use a define since the value supplied by Tesla is always 0
 #define MAXDISCHARGEPOWERALLOWED 60000  // 60000W we use a define since the value supplied by Tesla is always 0
 
@@ -14,6 +15,9 @@
 #define RAMPDOWNPOWERALLOWED 15000  // What power we ramp down from towards top balancing
 #define FLOAT_MAX_POWER_W 200       // W, what power to allow for top balancing battery
 #define FLOAT_START_MV 20           // mV, how many mV under overvoltage to start float charging
+
+#define MAX_PACK_VOLTAGE_SX_NCMA 4600  // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_SX_NCMA 3100  // V+1, if pack voltage goes over this, charge stops
 #define MAX_PACK_VOLTAGE_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
 #define MIN_PACK_VOLTAGE_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
 #define MAX_PACK_VOLTAGE_LFP 3880   // V+1, if pack voltage goes over this, charge stops

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -526,7 +526,8 @@ String processor(const String& var) {
 #ifdef SERIAL_LINK_RECEIVER
     content += "Serial link to another LilyGo board";
 #endif  // SERIAL_LINK_RECEIVER
-#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || \
+    defined(TESLA_MODEL_Y_BATTERY)
     content += "Tesla Model S/3/X/Y";
 #endif  // TESLA_MODEL_#_BATTERY
 #ifdef VOLVO_SPA_BATTERY

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -526,10 +526,18 @@ String processor(const String& var) {
 #ifdef SERIAL_LINK_RECEIVER
     content += "Serial link to another LilyGo board";
 #endif  // SERIAL_LINK_RECEIVER
-#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || \
-    defined(TESLA_MODEL_Y_BATTERY)
-    content += "Tesla Model S/3/X/Y";
-#endif  // TESLA_MODEL_#_BATTERY
+#ifdef TESLA_MODEL_S_BATTERY
+    content += "Tesla Model S";
+#endif  // TESLA_MODEL_S_BATTERY
+#ifdef TESLA_MODEL_3_BATTERY
+    content += "Tesla Model 3";
+#endif  // TESLA_MODEL_3_BATTERY
+#ifdef TESLA_MODEL_X_BATTERY
+    content += "Tesla Model X";
+#endif  // TESLA_MODEL_X_BATTERY
+#ifdef TESLA_MODEL_Y_BATTERY
+    content += "Tesla Model Y";
+#endif  // TESLA_MODEL_Y_BATTERY
 #ifdef VOLVO_SPA_BATTERY
     content += "Volvo / Polestar 78kWh battery";
 #endif  // VOLVO_SPA_BATTERY
@@ -538,6 +546,9 @@ String processor(const String& var) {
 #endif  // TEST_FAKE_BATTERY
 #ifdef DOUBLE_BATTERY
     content += " (Double battery)";
+    if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
+      content += " (LFP)";
+    }
 #endif  // DOUBLE_BATTERY
     content += "</h4>";
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -526,9 +526,9 @@ String processor(const String& var) {
 #ifdef SERIAL_LINK_RECEIVER
     content += "Serial link to another LilyGo board";
 #endif  // SERIAL_LINK_RECEIVER
-#ifdef TESLA_MODEL_3_BATTERY
+#if defined(TESLA_MODEL_S_BATTERY) || defined(TESLA_MODEL_3_BATTERY) || defined(TESLA_MODEL_X_BATTERY) || defined(TESLA_MODEL_Y_BATTERY)
     content += "Tesla Model S/3/X/Y";
-#endif  // TESLA_MODEL_3_BATTERY
+#endif  // TESLA_MODEL_#_BATTERY
 #ifdef VOLVO_SPA_BATTERY
     content += "Volvo / Polestar 78kWh battery";
 #endif  // VOLVO_SPA_BATTERY


### PR DESCRIPTION
### What
This PR adds support for the 108s Model X battery.

### Why
In the current code if you tried to use this battery, you would get overvoltage and cellvoltage errors.

### How
The PR fixes this by refactoring how Tesla packs are defined when compiling. You can now specify which Tesla battery you are using, previously it was all Model 3. Now there are specific rows for each battery:

![image](https://github.com/user-attachments/assets/35710530-bbbc-43fd-a668-4b0938b5f669)
