### PR TITLE
Bugfix: SMA pairing reliability

### DIFF
--- a/Software/src/inverter/BYD-SMA.cpp
+++ b/Software/src/inverter/BYD-SMA.cpp
@@ -51,7 +51,7 @@ CAN_frame SMA_598 = {.FD = false,
                      .ext_ID = false,
                      .DLC = 8,
                      .ID = 0x598,
-                     .data = {0x00, 0xD3, 0x00, 0x01, 0x5C, 0x98, 0xB6, 0xEE}};
+                     .data = {0x00, 0x01, 0x0F, 0x2C, 0x5C, 0x98, 0xB6, 0xEE}};
 CAN_frame SMA_5D8 = {.FD = false,
                      .ext_ID = false,
                      .DLC = 8,
@@ -221,12 +221,14 @@ void receive_can_inverter(CAN_frame rx_frame) {
       break;
     case 0x420:  //Message originating from SMA inverter - Timestamp
                  //Frame0-3 Timestamp
+      /*
       transmit_can(&SMA_158, can_config.inverter);
       transmit_can(&SMA_358, can_config.inverter);
       transmit_can(&SMA_3D8, can_config.inverter);
       transmit_can(&SMA_458, can_config.inverter);
       transmit_can(&SMA_518, can_config.inverter);
       transmit_can(&SMA_4D8, can_config.inverter);
+      */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
       break;
@@ -254,15 +256,17 @@ void receive_can_inverter(CAN_frame rx_frame) {
 void send_can_inverter() {
   unsigned long currentMillis = millis();
 
-  // Send CAN Message every 60s
-  if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
-    previousMillis60s = currentMillis;
-    transmit_can(&SMA_158, can_config.inverter);
-    transmit_can(&SMA_358, can_config.inverter);
-    transmit_can(&SMA_3D8, can_config.inverter);
-    transmit_can(&SMA_458, can_config.inverter);
-    transmit_can(&SMA_518, can_config.inverter);
-    transmit_can(&SMA_4D8, can_config.inverter);
+  // Send CAN Message every 100ms if we're enabled
+  if (datalayer.system.status.inverter_allows_contactor_closing) {
+    if (currentMillis - previousMillis60s >= 100) {
+      previousMillis60s = currentMillis;
+      transmit_can(&SMA_158, can_config.inverter);
+      transmit_can(&SMA_358, can_config.inverter);
+      transmit_can(&SMA_3D8, can_config.inverter);
+      transmit_can(&SMA_458, can_config.inverter);
+      transmit_can(&SMA_518, can_config.inverter);
+      transmit_can(&SMA_4D8, can_config.inverter);
+    }
   }
 }
 #endif

--- a/Software/src/inverter/BYD-SMA.cpp
+++ b/Software/src/inverter/BYD-SMA.cpp
@@ -6,7 +6,7 @@
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis60s = 0;
+static unsigned long previousMillis100ms = 0;
 
 //Actual content messages
 CAN_frame SMA_358 = {.FD = false,
@@ -258,8 +258,8 @@ void send_can_inverter() {
 
   // Send CAN Message every 100ms if we're enabled
   if (datalayer.system.status.inverter_allows_contactor_closing) {
-    if (currentMillis - previousMillis60s >= 100) {
-      previousMillis60s = currentMillis;
+    if (currentMillis - previousMillis100ms >= 100) {
+      previousMillis100ms = currentMillis;
       transmit_can(&SMA_158, can_config.inverter);
       transmit_can(&SMA_358, can_config.inverter);
       transmit_can(&SMA_3D8, can_config.inverter);

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -266,4 +266,5 @@ void send_can_inverter() {
       transmit_can(&SMA_4D8, can_config.inverter);
     }
   }
+}
 #endif

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -6,7 +6,7 @@
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis60s = 0;
+static unsigned long previousMillis100ms = 0;
 
 //Actual content messages
 CAN_frame SMA_558 = {.FD = false,
@@ -218,12 +218,14 @@ void receive_can_inverter(CAN_frame rx_frame) {
       break;
     case 0x420:  //Message originating from SMA inverter - Timestamp
       //Frame0-3 Timestamp
+      /*
       transmit_can(&SMA_158, can_config.inverter);
       transmit_can(&SMA_358, can_config.inverter);
       transmit_can(&SMA_3D8, can_config.inverter);
       transmit_can(&SMA_458, can_config.inverter);
       transmit_can(&SMA_518, can_config.inverter);
       transmit_can(&SMA_4D8, can_config.inverter);
+      */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
       break;
@@ -251,16 +253,17 @@ void receive_can_inverter(CAN_frame rx_frame) {
 void send_can_inverter() {
   unsigned long currentMillis = millis();
 
-  // Send CAN Message every 60s
-  if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
-    previousMillis60s = currentMillis;
+  // Send CAN Message every 100ms if Enable line is HIGH
+  if (datalayer.system.status.inverter_allows_contactor_closing) {
+    if (currentMillis - previousMillis100ms >= 100) {
+      previousMillis100ms = currentMillis;
 
-    transmit_can(&SMA_158, can_config.inverter);
-    transmit_can(&SMA_358, can_config.inverter);
-    transmit_can(&SMA_3D8, can_config.inverter);
-    transmit_can(&SMA_458, can_config.inverter);
-    transmit_can(&SMA_518, can_config.inverter);
-    transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can(&SMA_158, can_config.inverter);
+      transmit_can(&SMA_358, can_config.inverter);
+      transmit_can(&SMA_3D8, can_config.inverter);
+      transmit_can(&SMA_458, can_config.inverter);
+      transmit_can(&SMA_518, can_config.inverter);
+      transmit_can(&SMA_4D8, can_config.inverter);
+    }
   }
-}
 #endif


### PR DESCRIPTION
### What
This PR improves the success rate of getting a SMA battery paired

### Why
..it took pairing time down from ~45 mins and a 20% chance of it working to ~15 minutes and a 70% chance of it working the first time.

### How
We now look at the enable line status (via the inverter allowes closing contactors), and when this is ON, we periodically broadcast messages every 100ms