### PR TITLE
Improvement: Add initial GitHub Issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Expected Behavior
+
+<!-- Write what should happen -->
+
+### Actual Behavior
+
+<!-- Write what DID happen. Try to include serial logs, if possible. -->
+
+### Steps to Reproduce the Problem
+
+<!-- Write some steps of how to reproduce the problem. -->
+
+1.
+1.
+1.
+
+### Settings
+
+<!-- Please fill in the settings used below from USER_SETTINGS.h, as it will help with diagnosis. -->
+
+- Software version: ``
+- Battery used: ``
+- Inverter communication protocol: ``
+- Hardware used for Battery-Emulator: `HW_LILYGO, HW_STARK, Custom`
+- CONTACTOR_CONTROL: `yes/no`
+- DUAL_CAN: `yes/no`
+- WEBSERVER: `yes/no`
+- MQTT: `yes/no`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### What
+This PR implements ...
+
+### Why
+Why does it do it?
+
+### How
+How does it do it?


### PR DESCRIPTION
### What
This PR implements GitHub templates for new issues/PRs.

### Why
This is so I don't annoy @dalathegreat when opening PRs which do not follow the standard format ;-).

### How
Following github documentation to create the templates.

PS: Feel free to improve by editing the commit or commenting here. I will collect all changes.