### PR TITLE
display events in reverse chronological order

### DIFF
--- a/Software/src/devboard/webserver/events_html.h
+++ b/Software/src/devboard/webserver/events_html.h
@@ -2,6 +2,9 @@
 #define EVENTS_H
 
 #include <Arduino.h>
+#include <algorithm>
+#include <vector>
+#include "../utils/events.h"
 
 /**
  * @brief Replaces placeholder with content section in web page
@@ -11,5 +14,10 @@
  * @return String
  */
 String events_processor(const String& var);
+// Define a struct to hold event data
+struct EventData {
+  EVENTS_ENUM_TYPE event_handle;
+  const EVENTS_STRUCT_TYPE* event_pointer;
+};
 
 #endif


### PR DESCRIPTION
### WHAT
This PR changes the events page on the web server to display events in reverse chronological order, showing the most recent event first instead of the internal definition order.

### WHY
Currently, events are displayed based on their internal definition order, which doesn't always reflect the actual sequence in which they occurred. This makes it difficult for users to quickly find the most recent events. Reordering the events based on when they occurred improves the user experience by allowing easier access to the latest activity.
This was also requested by users on https://github.com/dalathegreat/Battery-Emulator/issues/355

### HOW
The events were reordered by timestamp in descending order prior to rendering on the page.
The implementation has been tested to ensure the correct ordering and proper functionality of the events display.