### PR TITLE
Improve emulator Wi-Fi events handling for disconnect/connect

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -155,6 +155,8 @@ static void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 // Event handler for Wi-Fi Got IP
 static void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
+  //clear disconnects events if we got a IP
+  clear_event(EVENT_WIFI_DISCONNECT);
 #ifdef DEBUG_VIA_USB
   Serial.println("Wi-Fi Got IP.");
   Serial.print("IP address: ");

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -139,6 +139,7 @@ static void connectToWiFi() {
 
 // Event handler for successful Wi-Fi connection
 static void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
+  clear_event(EVENT_WIFI_DISCONNECT);
   set_event(EVENT_WIFI_CONNECT, 0);
 #ifdef DEBUG_VIA_USB
   Serial.println("Wi-Fi connected.");
@@ -167,16 +168,14 @@ static void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 #ifdef DEBUG_VIA_USB
   Serial.println("Wi-Fi disconnected.");
 #endif
-  //do not do anything here, the reconnect will be handled by the monitor
+  //we dont do anything here, the reconnect will be handled by the monitor
   //too many events received when the connection is lost
-  //normal reconnects start at fit second
-  clear_event(EVENT_WIFI_DISCONNECT);
+  //normal reconnect retry start at first 2 seconds
 }
 
 #ifdef MDNSRESPONDER
 // Initialise mDNS
 void init_mDNS() {
-
   // Calulate the host name using the last two chars from the MAC address so each one is likely unique on a network.
   // e.g batteryemulator8C.local where the mac address is 08:F9:E0:D1:06:8C
   String mac = WiFi.macAddress();


### PR DESCRIPTION
### WHAT
improves the handling of Wi-Fi disconnect and connect events in the emulator. Specifically, it addresses the issue where the ARDUINO_EVENT_WIFI_STA_DISCONNECTED event was being fired multiple times without any new disconnections occurring. The change ensures that the disconnect event is cleared upon a successful connection or GotIP event (ARDUINO_EVENT_WIFI_STA_CONNECTED or ARDUINO_EVENT_WIFI_STA_GOT_IP), preventing repeated triggers when the system is already disconnected.

### WHY
The emulator disconnect event was being triggered and coounted repeatedly without reflecting actual new wifi real disconnections, leading to inaccurate handling of Wi-Fi status. 

### HOW
The fix was implemented by modifying the event handler logic. Now, the disconnect event is cleared whenever the system successfully reconnects or obtains an IP address.