### PR TITLE
bugfix #ifdefs MQTT without webserver enabled

### DIFF
--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -40,7 +40,7 @@ IPAddress subnet(255, 255, 255, 0);
 const char* http_username = "admin";  // username to webserver authentication;
 const char* http_password = "admin";  // password to webserver authentication;
 
-#endif                                   // WEBSERVER
+#endif  // WEBSERVER
 // MQTT
 #ifdef MQTT
 const char* mqtt_user = "REDACTED";      // Set NULL for no username


### PR DESCRIPTION
### WHAT
This PR fixes an issue where MQTT-related code was defined inside an #ifdef block for the WebServer, preventing compilation when using MQTT without the WebServer.

### WHY
The current code structure incorrectly places MQTT definitions within an #ifdef that requires WebServer functionality. This restricts users from compiling and running the project when they intend to use only Wi-Fi and MQTT, without enabling the WebServer. To allow more flexible configurations, this separation is necessary.

### HOW
The fix involves moving the MQTT-related definitions outside of the WebServer #ifdef block, ensuring that the code can compile successfully when using Wi-Fi and MQTT without the WebServer. This maintains compatibility for both configurations, with or without the WebServer enabled.