### PR TITLE
bugfix - pause state update was in wrong place.

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -304,11 +304,12 @@ void core_loop(void* task_time_us) {
       datalayer.system.status.time_cantx_us = 0;
       datalayer.system.status.core_task_10s_max_us = 0;
     }
+
+#endif
     if (check_pause_2s.elapsed()) {
       emulator_pause_state_send_CAN_battery();
     }
 
-#endif
     vTaskDelayUntil(&xLastWakeTime, xFrequency);
   }
 }


### PR DESCRIPTION
### What
Pause state update (emulator_pause_state_send_CAN_battery) was in wrong place.

### Why
it was just working if FUNCTION_TIME_MEASUREMENT was defined.

### How
moved the code outside FUNCTION_TIME_MEASUREMENT  region
