### PR TITLE
Fix: PWM_CONTACTOR_CONTROL now actually engages contactors

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -42,6 +42,12 @@
 #endif  // MQTT
 #endif  // WIFI
 
+#ifndef CONTACTOR_CONTROL
+#ifdef PWM_CONTACTOR_CONTROL
+#error CONTACTOR_CONTROL needs to be enabled for PWM_CONTACTOR_CONTROL
+#endif
+#endif
+
 Preferences settings;  // Store user settings
 // The current software version, shown on webserver
 const char* version_number = "7.4.dev";

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -50,7 +50,7 @@
 //#define DEBUG_CANFD_DATA    //Enable this line to have the USB port output CAN-FD data while program runs (WARNING, raises CPU load, do not use for production)
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
-//#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM logic for contactors, which lower power consumption and heat generation
+//#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation.
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 chip (Needed for some inverters / double battery)
 //#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2518FD chip / Native CANFD on Stark board
 //#define USE_CANFD_INTERFACE_AS_CLASSIC_CAN // Enable this line if you intend to use the CANFD as normal CAN

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -50,7 +50,7 @@
 //#define DEBUG_CANFD_DATA    //Enable this line to have the USB port output CAN-FD data while program runs (WARNING, raises CPU load, do not use for production)
 //#define INTERLOCK_REQUIRED  //Nissan LEAF specific setting, if enabled requires both high voltage conenctors to be seated before starting
 //#define CONTACTOR_CONTROL     //Enable this line to have pins 25,32,33 handle automatic precharge/contactor+/contactor- closing sequence
-//#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation.
+//#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation. CONTACTOR_CONTROL must be enabled.
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 chip (Needed for some inverters / double battery)
 //#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2518FD chip / Native CANFD on Stark board
 //#define USE_CANFD_INTERFACE_AS_CLASSIC_CAN // Enable this line if you intend to use the CANFD as normal CAN

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -265,6 +265,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = 4546;
   datalayer.battery.info.min_design_voltage_dV = 3370;
+
+  datalayer.system.status.battery_allows_contactor_closing = true;
 }
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -92,7 +92,7 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     // Put fake messages here incase you want to test sending CAN
-    transmit_can(&TEST, can_config.battery);
+    //transmit_can(&TEST, can_config.battery);
   }
 }
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -104,6 +104,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)
   datalayer.battery.info.min_design_voltage_dV = 2450;  // 245.0V under this, discharging further is disabled
+
+  datalayer.system.status.battery_allows_contactor_closing = true;
 }
 
 #endif


### PR DESCRIPTION
### What
This PR fixes the broken PWM_CONTACTOR_CONTROL, as reported in https://github.com/dalathegreat/Battery-Emulator/issues/472 as well some small quality-of-life improvements.

When PWM_CONTACTOR_CONTROL was set the contactor coil pins for positive & negative never actually went high

### Why
It's broken.

### How
Root cause was due to a wrong argument passed to `ledcWrite`: the existing code used the PWM channel; while `ledcWrite` actually expects the PWM pin to be passed.