### PR TITLE
Pylon Battery: Add voltage limits, remove faulty safety

### DIFF
--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -4,6 +4,10 @@
 #include "../devboard/utils/events.h"
 #include "PYLON-BATTERY.h"
 
+/* Change the following to suit your battery */
+#define MAX_PACK_VOLTAGE 5000  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE 1500
+
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis1000 = 0;  // will store last time a 1s CAN Message was sent
 
@@ -179,8 +183,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Pylon battery selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV = 4040;  // 404.0V, charging over this is not possible
-  datalayer.battery.info.min_design_voltage_dV = 3100;  // 310.0V, under this, discharging further is disabled
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE;
 }
 
 #endif

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -88,6 +88,7 @@ void update_machineryprotection() {
     clear_event(EVENT_SOH_LOW);
   }
 
+#ifndef PYLON_BATTERY
   // Check if SOC% is plausible
   if (datalayer.battery.status.voltage_dV >
       (datalayer.battery.info.max_design_voltage_dV -
@@ -98,6 +99,7 @@ void update_machineryprotection() {
       clear_event(EVENT_SOC_PLAUSIBILITY_ERROR);
     }
   }
+#endif
 
   // Check diff between highest and lowest cell
   cell_deviation_mV = (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);


### PR DESCRIPTION
### What
This PR implements a configurable min/max voltage for Pylon batteries. It also omits the reasonable SOC check on pylon packs, since it is very unreliable here due to being voltage based.

### Why
Since we do not know the voltage limits of the pylon battery the user intends to use, it is better if they specify this themselves.

### How
This is set at the top of the PYLON-BATTERY.cpp file
