### PR TITLE
Compilation fix - order_events declared inside wrong #ifdef

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -66,8 +66,6 @@ SensorConfig sensorConfigs[] = {
 
 };
 
-static std::vector<EventData> order_events;
-
 static String generateCommonInfoAutoConfigTopic(const char* object_id, const char* hostname) {
   return String("homeassistant/sensor/battery-emulator_") + String(hostname) + "/" + String(object_id) + "/config";
 }
@@ -82,6 +80,8 @@ static String generateEventsAutoConfigTopic(const char* object_id, const char* h
 }
 
 #endif  // HA_AUTODISCOVERY
+
+static std::vector<EventData> order_events;
 
 static void publish_common_info(void) {
   static JsonDocument doc;


### PR DESCRIPTION
### What
order_events declared inside wrong #ifdef

### Why
when HA_AUTODISCOVERY was not defined it will give a compilation error

### How
move the declaration ouside #ifdef block