### PR TITLE
Fix: Disable Chained CAN Sending During OTA Updates

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -588,8 +588,9 @@ void receive_can_native() {  // This section checks if we have a complete CAN me
 }
 
 void send_can() {
-  if (!can_send_CAN)
+  if (!allowed_to_send_CAN) {
     return;
+  }
 
   send_can_battery();
 
@@ -921,9 +922,11 @@ void check_reset_reason() {
       break;
   }
 }
+
 void transmit_can(CAN_frame* tx_frame, int interface) {
-  if (!can_send_CAN)
+  if (!allowed_to_send_CAN) {
     return;
+  }
 
   switch (interface) {
     case CAN_NATIVE:

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -125,7 +125,7 @@ static void publish_common_info(void) {
     doc["pause_status"] = get_emulator_pause_status();
 
     //only publish these values if BMS is active and we are comunication  with the battery (can send CAN messages to the battery)
-    if (datalayer.battery.status.bms_status == ACTIVE && can_send_CAN && millis() > BOOTUP_TIME) {
+    if (datalayer.battery.status.bms_status == ACTIVE && allowed_to_send_CAN && millis() > BOOTUP_TIME) {
       doc["SOC"] = ((float)datalayer.battery.status.reported_soc) / 100.0;
       doc["SOC_real"] = ((float)datalayer.battery.status.real_soc) / 100.0;
       doc["state_of_health"] = ((float)datalayer.battery.status.soh_pptt) / 100.0;

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -12,7 +12,7 @@ static bool battery_empty_event_fired = false;
 //battery pause status begin
 bool emulator_pause_request_ON = false;
 bool emulator_pause_CAN_send_ON = false;
-bool can_send_CAN = true;
+bool allowed_to_send_CAN = true;
 
 battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
@@ -224,8 +224,9 @@ void setBatteryPause(bool pause_battery, bool pause_CAN) {
 /// @return true if CAN messages should be sent to battery, false if not
 void emulator_pause_state_send_CAN_battery() {
 
-  if (emulator_pause_status == NORMAL)
-    can_send_CAN = true;
+  if (emulator_pause_status == NORMAL) {
+    allowed_to_send_CAN = true;
+  }
 
   // in some inverters this values are not accurate, so we need to check if we are consider 1.8 amps as the limit
   if (emulator_pause_request_ON && emulator_pause_status == PAUSING && datalayer.battery.status.current_dA < 18 &&
@@ -235,10 +236,10 @@ void emulator_pause_state_send_CAN_battery() {
 
   if (!emulator_pause_request_ON && emulator_pause_status == RESUMING) {
     emulator_pause_status = NORMAL;
-    can_send_CAN = true;
+    allowed_to_send_CAN = true;
   }
 
-  can_send_CAN = (!emulator_pause_CAN_send_ON || emulator_pause_status == NORMAL);
+  allowed_to_send_CAN = (!emulator_pause_CAN_send_ON || emulator_pause_status == NORMAL);
 }
 
 std::string get_emulator_pause_status() {

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -12,7 +12,7 @@ enum battery_pause_status { NORMAL = 0, PAUSING = 1, PAUSED = 2, RESUMING = 3 };
 extern bool emulator_pause_request_ON;
 extern bool emulator_pause_CAN_send_ON;
 extern battery_pause_status emulator_pause_status;
-extern bool can_send_CAN;
+extern bool allowed_to_send_CAN;
 //battery pause status end
 
 void update_machineryprotection();


### PR DESCRIPTION
### What
This change disables certain CAN sending operations that are chained within the receiving methods during an OTA (Over-the-Air) update. Previously, only some sending operations were blocked, leading to incomplete coverage of CAN communication control during the update process.

### Why
The prior implementation did not fully prevent CAN communication during OTA, particularly in cases where sending operations were triggered as part of receiving routines. This oversight allowed some chained communications to continue, potentially leading to incomplete or inconsistent behavior during OTA updates. This update corrects that behavior by ensuring these specific sending operations are disabled, thereby preventing any unintended communication during the OTA process.

### How
Logic has been added to disable all CAN sending operations in the transmit_can method. The system now ensures that any sending chained to receiving actions is fully paused until the update process completes.
