### PR TITLE
Improved DEBUG_CANFD_DATA output ... MORE!

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -536,8 +536,11 @@ void init_battery() {
 #ifdef CAN_FD
 // Functions
 #ifdef DEBUG_CANFD_DATA
-void print_canfd_frame(CANFDMessage rx_frame) {
+enum frameDirection { MSG_RX, MSG_TX };
+void print_canfd_frame(CANFDMessage rx_frame, frameDirection msgDir);  // Needs to be declared before it is defined
+void print_canfd_frame(CANFDMessage rx_frame, frameDirection msgDir) {
   int i = 0;
+  (msgDir == 0) ? Serial.print("RX ") : Serial.print("TX ");
   Serial.print(rx_frame.id, HEX);
   Serial.print(" ");
   for (i = 0; i < rx_frame.len; i++) {
@@ -553,7 +556,7 @@ void receive_canfd() {  // This section checks if we have a complete CAN-FD mess
   if (canfd.available()) {
     canfd.receive(frame);
 #ifdef DEBUG_CANFD_DATA
-    print_canfd_frame(frame);
+    print_canfd_frame(frame, frameDirection(MSG_RX));
 #endif
     CAN_frame rx_frame;
     rx_frame.ID = frame.id;
@@ -963,6 +966,10 @@ void transmit_can(CAN_frame* tx_frame, int interface) {
       send_ok = canfd.tryToSend(MCP2518Frame);
       if (!send_ok) {
         set_event(EVENT_CANFD_BUFFER_FULL, interface);
+      } else {
+#ifdef DEBUG_CANFD_DATA
+        print_canfd_frame(MCP2518Frame, frameDirection(MSG_TX));
+#endif
       }
 #else   // Interface not compiled, and settings try to use it
       set_event(EVENT_INTERFACE_MISSING, interface);


### PR DESCRIPTION
This PR adds outgoing canfd messages to the DEBUG_CANFD_DATA serial output as well as direction info to make debug life easier. Updated the solution according to suggestions from PR 495/496

Example output:

07:25:10.968 -> RX 111 66 F9 00 D5 00 00 00 00
07:25:11.125 -> TX 110 0F C8 0A 28 02 3A 02 EE
07:25:11.738 -> RX 91 0E A6 00 03 00 00 02 00
07:25:12.126 -> RX D1 02 08 00 00 00 00 02 00
07:25:12.544 -> RX 111 66 F9 00 D7 00 00 00 00
07:25:13.125 -> TX 110 0F C8 0A 28 02 3A 02 EE
07:25:13.319 -> RX 91 0E A6 00 03 00 00 02 00
07:25:13.740 -> RX D1 02 08 00 00 00 00 02 00
07:25:14.127 -> RX 111 66 F9 00 D8 00 00 00 00
07:25:14.936 -> RX 91 0E A6 00 03 00 00 02 00
07:25:15.097 -> TX 110 0F C8 0A 28 02 3A 02 EE
07:25:15.323 -> RX D1 02 08 00 00 00 00 02 00
07:25:15.743 -> RX 111 66 F9 00 DA 00 00 00 00

I hope I did this PR the right way this time? I don't understand why the "Merge branch main" is included in the PR but that was the result from me syncing my forked repo to dalas.