### PR TITLE
Bugfix iMIEV: Make cellvolt check work with double

### DIFF
--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -90,11 +90,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.status.cell_voltages_mV[i] = (uint16_t)(cell_voltages[i] * 1000);
   }
 
-  if (max_volt_cel > 2200) {  // Only update cellvoltage when we have a value
+  if (max_volt_cel > 2.2) {  // Only update cellvoltage when we have a value
     datalayer.battery.status.cell_max_voltage_mV = (uint16_t)(max_volt_cel * 1000);
   }
 
-  if (min_volt_cel > 2200) {  // Only update cellvoltage when we have a value
+  if (min_volt_cel > 2.2) {  // Only update cellvoltage when we have a value
     datalayer.battery.status.cell_min_voltage_mV = (uint16_t)(min_volt_cel * 1000);
   }
 


### PR DESCRIPTION
### What
This PR fixes a bug that caused cellvoltage min/max to not appear in webserver for iMIEV

### Why
The check was assuming integer values, but we had double datatype

### How
Fixed the if check
