### PR TITLE
Bugfix iMIEV: Set amount of cellvoltages

### DIFF
--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -89,7 +89,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   for (int i = 0; i < 88; ++i) {
     datalayer.battery.status.cell_voltages_mV[i] = (uint16_t)(cell_voltages[i] * 1000);
   }
-
+  datalayer.battery.info.number_of_cells = 88;
   if (max_volt_cel > 2.2) {  // Only update cellvoltage when we have a value
     datalayer.battery.status.cell_max_voltage_mV = (uint16_t)(max_volt_cel * 1000);
   }


### PR DESCRIPTION
### What
This PR fixes a bug on imiev, all cellvoltages were missing on webserver cellmonitor page

### Why
Better monitoring of battery

### How
We set the cell amount, this was missing from the code
