### PR TITLE
Safety: Refactor cellvoltage safeties

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -395,8 +395,37 @@ void update_values_battery2() {  //This function maps all the values fetched via
 
   datalayer.battery2.status.temperature_max_dC = battery2_temperature_max * 10;  // Add a decimal
 
-  datalayer.battery2.status.cell_min_voltage_mV = datalayer.battery2.status.cell_voltages_mV[0];
-  datalayer.battery2.status.cell_max_voltage_mV = datalayer.battery2.status.cell_voltages_mV[1];
+  if (battery2_info_available) {
+    // Start checking safeties. First up, cellvoltages!
+    if (detectedBattery == BATTERY_60AH) {
+      datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
+      datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
+      datalayer.battery2.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_60AH;
+      datalayer.battery2.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_60AH;
+    } else if (detectedBattery == BATTERY_94AH) {
+      datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_94AH;
+      datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_94AH;
+      datalayer.battery2.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_94AH;
+      datalayer.battery2.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_94AH;
+    } else {  // BATTERY_120AH
+      datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_120AH;
+      datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_120AH;
+      datalayer.battery2.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_120AH;
+      datalayer.battery2.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_120AH;
+    }
+  }
+
+  // Perform other safety checks
+  if (battery2_status_error_locking == 2) {  // HVIL seated?
+    set_event(EVENT_HVIL_FAILURE, 2);
+  } else {
+    clear_event(EVENT_HVIL_FAILURE);
+  }
+  if (battery2_status_precharge_locked == 2) {  // Capacitor seated?
+    set_event(EVENT_PRECHARGE_FAILURE, 2);
+  } else {
+    clear_event(EVENT_PRECHARGE_FAILURE);
+  }
 }
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the battery datalayer
@@ -433,30 +462,18 @@ void update_values_battery() {  //This function maps all the values fetched via 
     if (detectedBattery == BATTERY_60AH) {
       datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
       datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
-      if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_60AH) {
-        set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-      }
-      if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_60AH) {
-        set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-      }
+      datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_60AH;
+      datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_60AH;
     } else if (detectedBattery == BATTERY_94AH) {
       datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_94AH;
       datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_94AH;
-      if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_94AH) {
-        set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-      }
-      if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_94AH) {
-        set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-      }
+      datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_94AH;
+      datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_94AH;
     } else {  // BATTERY_120AH
       datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_120AH;
       datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_120AH;
-      if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE_120AH) {
-        set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-      }
-      if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE_120AH) {
-        set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-      }
+      datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_120AH;
+      datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_120AH;
     }
   }
 
@@ -1124,13 +1141,14 @@ void setup_battery(void) {  // Performs one time setup at startup
   //Before we have started up and detected which battery is in use, use 60AH values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
-
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
   datalayer.system.status.battery_allows_contactor_closing = true;
 
 #ifdef DOUBLE_BATTERY
   Serial.println("Another BMW i3 battery also selected!");
   datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
+  datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
   datalayer.battery2.status.voltage_dV =
       0;  //Init voltage to 0 to allow contactor check to operate without fear of default values colliding
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -135,14 +135,14 @@ void update_values_battery() {  //This function maps all the values fetched via 
 }
 
 void receive_can_battery(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {  //Log values taken with 422V from battery
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;
     case 0x245:  //01,00,02,19,3A,25,90,F4 Seems to have a mux in frame0
-                 //02,00,90,01,79,79,90,EA // Point of interest, went from 7E,75 to 7B,7C when discharging
-                 //03,C6,88,12,FD,48,90,5C
-                 //04,00,FF,FF,00,00,90,6D
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      //02,00,90,01,79,79,90,EA // Point of interest, went from 7E,75 to 7B,7C when discharging
+      //03,C6,88,12,FD,48,90,5C
+      //04,00,FF,FF,00,00,90,6D
       if (rx_frame.data.u8[0] == 0x01) {
         temperature_ambient = (rx_frame.data.u8[4] - 40);  // TODO, check if this is actually temperature_ambient
       }
@@ -371,9 +371,13 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("BYD Atto 3 battery selected");
 #endif
-
-  datalayer.battery.info.max_design_voltage_dV = 4410;  // Over this charging is not possible
-  datalayer.battery.info.min_design_voltage_dV = 3800;  // Under this discharging is disabled
+  datalayer.battery.info.number_of_cells = 126;
+  datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 4410  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3800
 #define MAX_CELL_DEVIATION_MV 150
+#define MAX_CELL_VOLTAGE_MV 3800  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -4,7 +4,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CELL_DEVIATION_MV 9999
 
 //Contactor control is required for CHADEMO support
 #define CONTACTOR_CONTROL

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -8,8 +8,6 @@
 //Figure out if CAN messages need to be sent to keep the system happy?
 
 /* Do not change code below unless you are sure what you are doing */
-#define MAX_CELL_VOLTAGE 4150
-#define MIN_CELL_VOLTAGE 2750
 static uint8_t errorCode = 0;  //stores if we have an error code active from battery control logic
 static uint8_t BMU_Detected = 0;
 static uint8_t CMU_Detected = 0;
@@ -104,14 +102,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   if (max_temp_cel > -49) {  // Only update temperature when we have a value
     datalayer.battery.status.temperature_max_dC = (int16_t)(max_temp_cel * 10);
-  }
-
-  //Check safeties
-  if (datalayer.battery.status.cell_max_voltage_mV >= MAX_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, datalayer.battery.status.cell_max_voltage_mV);
-  }
-  if (datalayer.battery.status.cell_min_voltage_mV <= MIN_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, datalayer.battery.status.cell_min_voltage_mV);
   }
 
   if (!BMU_Detected) {
@@ -239,9 +229,11 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
 #endif
-
-  datalayer.battery.info.max_design_voltage_dV = 3696;  // 369.6V
-  datalayer.battery.info.min_design_voltage_dV = 3160;  // 316.0V
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 3696  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3160
 #define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4150  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2750  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -263,8 +263,11 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif
 
   datalayer.battery.info.number_of_cells = 108;
-  datalayer.battery.info.max_design_voltage_dV = 4546;
-  datalayer.battery.info.min_design_voltage_dV = 3370;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 
   datalayer.system.status.battery_allows_contactor_closing = true;
 }

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -3,7 +3,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CELL_DEVIATION_MV 9999  // TODO is this ok ?
+#define MAX_PACK_VOLTAGE_DV 4546  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3370
+#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -15,9 +15,6 @@ static unsigned long previousMillis500ms = 0;  // will store last time a 500ms C
 static unsigned long previousMillis1s = 0;     // will store last time a 1s CAN Message was send
 static unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
 
-#define MAX_CELL_VOLTAGE 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE 2950  //Battery is put into emergency stop if one cell goes below this value
-
 const unsigned char crc8_table[256] =
     {  // CRC8_SAE_J1850_ZER0 formula,0x1D Poly,initial value 0x3F,Final XOR value varies
         0x00, 0x1D, 0x3A, 0x27, 0x74, 0x69, 0x4E, 0x53, 0xE8, 0xF5, 0xD2, 0xCF, 0x9C, 0x81, 0xA6, 0xBB, 0xCD, 0xD0,
@@ -864,14 +861,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
     set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
   }
 
-  // Check if cell voltages are within allowed range
-  if (CellVoltMax_mV >= MAX_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-  }
-  if (CellVoltMin_mV <= MIN_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-  }
-
   /* Safeties verified. Perform USB serial printout if configured to do so */
 
 #ifdef DEBUG_VIA_USB
@@ -1239,11 +1228,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
 
   datalayer.battery.info.number_of_cells = 192;  // TODO: will vary depending on battery
-
-  datalayer.battery.info.max_design_voltage_dV =
-      8064;  // TODO: define when battery is known, charging is not possible (goes into forced discharge)
-  datalayer.battery.info.min_design_voltage_dV =
-      4320;  // TODO: define when battery is known. discharging further is disabled
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -7,7 +7,11 @@
 extern ACAN2517FD canfd;
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 8064  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 4320
 #define MAX_CELL_DEVIATION_MV 150
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2950  //Battery is put into emergency stop if one cell goes below this value
 #define MAXCHARGEPOWERALLOWED 10000
 #define MAXDISCHARGEPOWERALLOWED 10000
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -8,9 +8,6 @@
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static unsigned long previousMillis10 = 0;   // will store last time a 10s CAN Message was send
 
-#define MAX_CELL_VOLTAGE 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE 2950  //Battery is put into emergency stop if one cell goes below this value
-
 static uint16_t soc_calculated = 0;
 static uint16_t SOC_BMS = 0;
 static uint16_t SOC_Display = 0;
@@ -145,14 +142,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   if (leadAcidBatteryVoltage < 110) {
     set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
-  }
-
-  // Check if cell voltages are within allowed range
-  if (CellVoltMax_mV >= MAX_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-  }
-  if (CellVoltMin_mV <= MIN_CELL_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
   }
 
   /* Safeties verified. Perform USB serial printout if configured to do so */
@@ -550,9 +539,10 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
 #endif
-
-  datalayer.battery.info.max_design_voltage_dV = 4040;  // 404.0V
-  datalayer.battery.info.min_design_voltage_dV = 3100;  // 310.0V
+  datalayer.battery.info.max_design_voltage_dV = 4040;  //startup with 98S max value. Precised later
+  datalayer.battery.info.min_design_voltage_dV = 2250;  //startup with 90S min value. Precised later
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -5,6 +5,8 @@
 
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 150
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2950  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void update_number_of_cells();

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -264,9 +264,11 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("Kia/Hyundai Hybrid battery selected");
 #endif
-  datalayer.battery.info.number_of_cells = 56;          // HEV , TODO: Make dynamic according to HEV/PHEV
-  datalayer.battery.info.max_design_voltage_dV = 2550;  //TODO: Values OK?
-  datalayer.battery.info.min_design_voltage_dV = 1700;
+  datalayer.battery.info.number_of_cells = 56;  // HEV , TODO: Make dynamic according to HEV/PHEV
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 2550  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 1700
 #define MAX_CELL_DEVIATION_MV 100
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -141,8 +141,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("MG 5 battery selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV = 4040;  // Over this charging is not possible
-  datalayer.battery.info.min_design_voltage_dV = 3100;  // Under this discharging is disabled
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3100
 #define MAX_CELL_DEVIATION_MV 150
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -75,9 +75,7 @@ static uint8_t crctable[256] = {
 #define ZE1_BATTERY 2
 static uint8_t LEAF_battery_Type = ZE0_BATTERY;
 static bool battery_can_alive = false;
-#define MAX_CELL_VOLTAGE 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE 2700  //Battery is put into emergency stop if one cell goes below this value
-#define WH_PER_GID 77          //One GID is this amount of Watt hours
+#define WH_PER_GID 77                               //One GID is this amount of Watt hours
 static uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
 static uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW
 static int16_t battery_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
@@ -634,12 +632,6 @@ void receive_can_battery2(CAN_frame rx_frame) {
           datalayer.battery2.status.cell_max_voltage_mV = battery2_min_max_voltage[1];
           datalayer.battery2.status.cell_min_voltage_mV = battery2_min_max_voltage[0];
 
-          if (battery2_min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-          }
-          if (battery2_min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-          }
           break;
         }
 
@@ -884,12 +876,6 @@ void receive_can_battery(CAN_frame rx_frame) {
           datalayer.battery.status.cell_max_voltage_mV = battery_min_max_voltage[1];
           datalayer.battery.status.cell_min_voltage_mV = battery_min_max_voltage[0];
 
-          if (battery_min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-          }
-          if (battery_min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-          }
           break;
         }
 
@@ -1221,13 +1207,19 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif
 
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = 4040;  // 404.4V
-  datalayer.battery.info.min_design_voltage_dV = 2600;  // 260.0V
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.number_of_cells = datalayer.battery.info.number_of_cells;
   datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
+  datalayer.battery2.info.max_cell_voltage_mV = datalayer.battery.info.max_cell_voltage_mV;
+  datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
+  datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
 #endif  //DOUBLE_BATTERY
 }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 2600
 #define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame rx_frame);

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -4,10 +4,6 @@
 #include "../devboard/utils/events.h"
 #include "PYLON-BATTERY.h"
 
-/* Change the following to suit your battery */
-#define MAX_PACK_VOLTAGE 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE 1500
-
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis1000 = 0;  // will store last time a 1s CAN Message was sent
 
@@ -183,8 +179,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Pylon battery selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -4,6 +4,12 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+
+/* Change the following to suit your battery */
+#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 1500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -106,13 +106,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.cell_max_voltage_mV = LB_Cell_Max_Voltage;
 
-  if (LB_Cell_Max_Voltage >= ABSOLUTE_CELL_MAX_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, (LB_Cell_Max_Voltage / 20));
-  }
-  if (LB_Cell_Min_Voltage <= ABSOLUTE_CELL_MIN_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, (LB_Cell_Min_Voltage / 20));
-  }
-
 #ifdef DEBUG_VIA_USB
   Serial.println("Values going to inverter:");
   Serial.print("SOH%: ");
@@ -248,9 +241,11 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Renault Kangoo battery selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV =
-      4040;  // 404.0V, over this, charging is not possible (goes into forced discharge)
-  datalayer.battery.info.min_design_voltage_dV = 3100;  // 310.0V under this, discharging further is disabled
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -4,11 +4,12 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-
-#define ABSOLUTE_CELL_MAX_VOLTAGE 4150  // If cellvoltage goes over this mV, we go into FAULT mode
-#define ABSOLUTE_CELL_MIN_VOLTAGE 2500  // If cellvoltage goes under this mV, we go into FAULT mode
-#define MAX_CELL_DEVIATION_MV 500       // If cell mV delta exceeds this, we go into WARNING mode
-#define MAX_CHARGE_POWER_W 5000         // Battery can be charged with this amount of power
+#define MAX_PACK_VOLTAGE_DV 4150  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 2500
+#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
+#define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -148,15 +148,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.cell_min_voltage_mV = min_cell_mv_value;
   datalayer.battery.status.cell_max_voltage_mV = max_cell_mv_value;
-  datalayer.battery.status.voltage_dV =
-      static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // Convert from mV to dV
-
-  if (datalayer.battery.status.cell_max_voltage_mV >= ABSOLUTE_CELL_MAX_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-  }
-  if (datalayer.battery.status.cell_min_voltage_mV <= ABSOLUTE_CELL_MIN_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-  }
+  datalayer.battery.status.voltage_dV = static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // mV to dV
 
 #ifdef DEBUG_VIA_USB
 
@@ -535,8 +527,11 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = 4040;
-  datalayer.battery.info.min_design_voltage_dV = 2700;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -3,10 +3,12 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-
-#define ABSOLUTE_CELL_MAX_VOLTAGE 4200
-#define ABSOLUTE_CELL_MIN_VOLTAGE 3000
 #define MAX_CELL_DEVIATION_MV 500
+#define MAX_PACK_VOLTAGE_DV 4200  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3000
+#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -59,13 +59,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.cell_max_voltage_mV;
 
-  if (LB_Cell_Max_Voltage >= ABSOLUTE_CELL_MAX_VOLTAGE) {
-    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-  }
-  if (LB_Cell_Min_Voltage <= ABSOLUTE_CELL_MIN_VOLTAGE) {
-    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-  }
-
 #ifdef DEBUG_VIA_USB
 
 #endif
@@ -99,9 +92,13 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("Renault Zoe 50kWh battery selected");
 #endif
-
-  datalayer.battery.info.max_design_voltage_dV = 4040;
-  datalayer.battery.info.min_design_voltage_dV = 3100;
+  datalayer.system.status.battery_allows_contactor_closing = true;
+  datalayer.battery.info.number_of_cells = 96;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -3,10 +3,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-
-#define ABSOLUTE_CELL_MAX_VOLTAGE 4100
-#define ABSOLUTE_CELL_MIN_VOLTAGE 3000
+#define MAX_PACK_VOLTAGE_DV 4100  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 3000
 #define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -545,8 +545,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("RJXZS BMS selected");
 #endif
 
-  datalayer.battery.info.max_design_voltage_dV = 5000;
-  datalayer.battery.info.min_design_voltage_dV = 1000;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif  // RJXZS_BMS

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -4,6 +4,10 @@
 #include "../include.h"
 
 /* Tweak these according to your battery build */
+#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 1500
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_MV 250
 #define MAX_DISCHARGE_POWER_ALLOWED_W 5000
 #define MAX_CHARGE_POWER_ALLOWED_W 5000

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -410,8 +410,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   Serial.println("Hyundai Santa Fe PHEV battery selected");
 #endif
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = 4040;
-  datalayer.battery.info.min_design_voltage_dV = 2880;
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
 }
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 2880
 #define MAX_CELL_DEVIATION_MV 250
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
 void setup_battery(void);

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.h
@@ -4,9 +4,6 @@
 #define SERIAL_LINK_RECEIVER_FROM_BATTERY_H
 
 #define BATTERY_SELECTED
-#ifndef MAX_CELL_DEVIATION_MV
-#define MAX_CELL_DEVIATION_MV 9999
-#endif
 
 #include "../include.h"
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -15,13 +15,18 @@
 #define FLOAT_MAX_POWER_W 200       // W, what power to allow for top balancing battery
 #define FLOAT_START_MV 20           // mV, how many mV under overvoltage to start float charging
 
-#define MAX_PACK_VOLTAGE_SX_NCMA 4600  // V+1, if pack voltage goes over this, charge stops
-#define MIN_PACK_VOLTAGE_SX_NCMA 3100  // V+1, if pack voltage goes over this, charge stops
-#define MAX_PACK_VOLTAGE_3Y_NCMA 4030  // V+1, if pack voltage goes over this, charge stops
-#define MIN_PACK_VOLTAGE_3Y_NCMA 3100  // V+1, if pack voltage goes below this, discharge stops
-#define MAX_PACK_VOLTAGE_3Y_LFP 3880   // V+1, if pack voltage goes over this, charge stops
-#define MIN_PACK_VOLTAGE_3Y_LFP 2968   // V+1, if pack voltage goes below this, discharge stops
-#define MAX_CELL_DEVIATION_MV 9999     // Handled inside the Tesla.cpp file, just for compilation
+#define MAX_PACK_VOLTAGE_SX_NCMA 4600   // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_SX_NCMA 3100   // V+1, if pack voltage goes over this, charge stops
+#define MAX_PACK_VOLTAGE_3Y_NCMA 4030   // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_3Y_NCMA 3100   // V+1, if pack voltage goes below this, discharge stops
+#define MAX_PACK_VOLTAGE_3Y_LFP 3880    // V+1, if pack voltage goes over this, charge stops
+#define MIN_PACK_VOLTAGE_3Y_LFP 2968    // V+1, if pack voltage goes below this, discharge stops
+#define MAX_CELL_DEVIATION_NCA_NCM 500  //LED turns yellow on the board if mv delta exceeds this value
+#define MAX_CELL_DEVIATION_LFP 200      //LED turns yellow on the board if mv delta exceeds this value
+#define MAX_CELL_VOLTAGE_NCA_NCM 4250   //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_NCA_NCM 2950   //Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_LFP 3550       //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_LFP 2800       //Battery is put into emergency stop if one cell goes below this value
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -8,9 +8,6 @@
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
 static unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
 
-#define MAX_CELL_VOLTAGE 4210  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE 2700  //Battery is put into emergency stop if one cell goes below this value
-
 static float BATT_U = 0;                 //0x3A
 static float MAX_U = 0;                  //0x3A
 static float MIN_U = 0;                  //0x3A
@@ -22,8 +19,8 @@ static float BATT_T_MIN = 0;             //0x413
 static float BATT_T_AVG = 0;             //0x413
 static uint16_t SOC_BMS = 0;             //0X37D
 static uint16_t SOC_CALC = 0;
-static uint16_t CELL_U_MAX = 0;             //0x37D
-static uint16_t CELL_U_MIN = 0;             //0x37D
+static uint16_t CELL_U_MAX = 3700;          //0x37D
+static uint16_t CELL_U_MIN = 3700;          //0x37D
 static uint8_t CELL_ID_U_MAX = 0;           //0x37D
 static uint16_t HvBattPwrLimDchaSoft = 0;   //0x369
 static uint8_t batteryModuleNumber = 0x10;  // First battery module
@@ -288,12 +285,6 @@ void receive_can_battery(CAN_frame rx_frame) {
               min_max_voltage[1] = cell_voltages[cellcounter];
           }
 
-          if (min_max_voltage[1] >= MAX_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_OVER_VOLTAGE, 0);
-          }
-          if (min_max_voltage[0] <= MIN_CELL_VOLTAGE) {
-            set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
-          }
           transmit_can(&VOLVO_SOH_Req, can_config.battery);  //Send SOH read request
         }
         rxConsecutiveFrames = 0;
@@ -347,8 +338,10 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif
 
   datalayer.battery.info.number_of_cells = 108;
-  datalayer.battery.info.max_design_voltage_dV =
-      4540;  // 454.0V, over this, charging is not possible (goes into forced discharge)
-  datalayer.battery.info.min_design_voltage_dV = 2938;  // 293.8V under this, discharging further is disabled
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 #endif

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -4,7 +4,11 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+#define MAX_PACK_VOLTAGE_DV 4540  //5000 = 500.0V
+#define MIN_PACK_VOLTAGE_DV 2938
 #define MAX_CELL_DEVIATION_MV 250
+#define MAX_CELL_VOLTAGE_MV 4210  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
 void transmit_can(CAN_frame* tx_frame, int interface);

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -13,6 +13,12 @@ typedef struct {
   uint16_t max_design_voltage_dV = 5000;
   /** The minimum intended packvoltage, in deciVolt. 3300 = 330.0 V */
   uint16_t min_design_voltage_dV = 2500;
+  /** The maximum cellvoltage before shutting down, in milliVolt. 4300 = 4.250 V */
+  uint16_t max_cell_voltage_mV = 4300;
+  /** The minimum cellvoltage before shutting down, in milliVolt. 2700 = 2.700 V */
+  uint16_t min_cell_voltage_mV = 2700;
+  /** The maxumum allowed deviation between cells, in milliVolt. 500 = 0.500 V */
+  uint16_t max_cell_voltage_deviation_mV = 500;
   /** BYD CAN specific setting, max charge in deciAmpere. 300 = 30.0 A */
   uint16_t max_charge_amp_dA = BATTERY_MAX_CHARGE_AMP;
   /** BYD CAN specific setting, max discharge in deciAmpere. 300 = 30.0 A */

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -54,6 +54,15 @@ void update_machineryprotection() {
     clear_event(EVENT_BATTERY_UNDERVOLTAGE);
   }
 
+  // Cell overvoltage, critical latching error without automatic reset. Requires user action.
+  if (datalayer.battery.status.cell_max_voltage_mV >= datalayer.battery.info.max_cell_voltage_mV) {
+    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+  }
+  // Cell undervoltage, critical latching error without automatic reset. Requires user action.
+  if (datalayer.battery.status.cell_min_voltage_mV <= datalayer.battery.info.min_cell_voltage_mV) {
+    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+  }
+
   // Battery is fully charged. Dont allow any more power into it
   // Normally the BMS will send 0W allowed, but this acts as an additional layer of safety
   if (datalayer.battery.status.reported_soc == 10000)  //Scaled SOC% value is 100.00%
@@ -103,7 +112,7 @@ void update_machineryprotection() {
 
   // Check diff between highest and lowest cell
   cell_deviation_mV = (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);
-  if (cell_deviation_mV > MAX_CELL_DEVIATION_MV) {
+  if (cell_deviation_mV > datalayer.battery.info.max_cell_voltage_deviation_mV) {
     set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
   } else {
     clear_event(EVENT_CELL_DEVIATION_HIGH);
@@ -173,6 +182,23 @@ void update_machineryprotection() {
     set_event(EVENT_CAN_RX_WARNING, 2);
   } else {
     clear_event(EVENT_CAN_RX_WARNING);
+  }
+
+  // Cell overvoltage, critical latching error without automatic reset. Requires user action.
+  if (datalayer.battery2.status.cell_max_voltage_mV >= datalayer.battery2.info.max_cell_voltage_mV) {
+    set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+  }
+  // Cell undervoltage, critical latching error without automatic reset. Requires user action.
+  if (datalayer.battery2.status.cell_min_voltage_mV <= datalayer.battery2.info.min_cell_voltage_mV) {
+    set_event(EVENT_CELL_UNDER_VOLTAGE, 0);
+  }
+
+  // Check diff between highest and lowest cell
+  cell_deviation_mV = (datalayer.battery2.status.cell_max_voltage_mV - datalayer.battery2.status.cell_min_voltage_mV);
+  if (cell_deviation_mV > datalayer.battery2.info.max_cell_voltage_deviation_mV) {
+    set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
+  } else {
+    clear_event(EVENT_CELL_DEVIATION_HIGH);
   }
 
   // Check if SOH% between the packs is too large


### PR DESCRIPTION
### What
This PR improves overall safety for many battery types, by introducing global min/max cellvoltage events. Previously this feature was only available for some battery types (LEAF,i3,imiev,egmp,kia64,kangoo,zoe,tesla,volvo).

### Why
Instead of having the check inside each battery handler, it is moved to the Safety.cpp file.  This makes it inherently safer, it is no longer possible to add a new battery type without a cellvoltage check.

### How
Each battery type initializes the following on startup, or later on in the code when we detect which battery is actually used (for instance 90S and 98S battery in same battery file)

datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;

From each battery implementation, we just set the min/max allowed cellvoltages and deviation value, in the battery.h file.

This PR also cleans up:
- Unused recalibration&soc check event for tesla battery2
