### PR TITLE
Clarify usage of webserver authentication setting to prevent compilation errors

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -60,7 +60,7 @@
 //#define WIFICONFIG  //Enable this line to set a static IP address / gateway /subnet mask for the device. see USER_SETTINGS.cpp for the settings
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
 #define WEBSERVER_AUTH_REQUIRED \
-  false         //Enable this line to enable webserver authentication. See USER_SETTINGS.cpp  setting the credentials.
+  false  //Set this line to true to activate webserver authentication (this line must not be commented). Refer to USER_SETTINGS.cpp for setting the credentials.
 #define WIFIAP  //Disable this line to permanently disable WIFI AP mode (make sure to hardcode ssid and password of you home wifi network). When enabled WIFI AP can still be disabled by a setting in the future.
 #define MDNSRESPONDER  //Enable this line to enable MDNS, allows battery monitor te be found by .local address. Requires WEBSERVER to be enabled.
 #define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot (overrides Wifi/battery settings set below)


### PR DESCRIPTION
### What
Updated the comment to clarify that the #define line for webserver authentication must be set to true or false and should not be commented out.

### Why
This change addresses an issue where users encountered compilation errors after commenting out the line. The update makes it clear that the line cannot be commented and must be explicitly set. it clarifies and corrects issue #482 

### How
Adjusted the comment to clearly instruct users to set the line to true to activate authentication and specify that it cannot be commented.