### PR TITLE
Feature: Add CAN missing safety for all protocols

### DIFF
--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -165,6 +165,12 @@ typedef struct {
    */
   int64_t time_snap_cantx_us = 0;
 #endif
+  /** uint8_t */
+  /** A counter set each time a new message comes from inverter.
+   * This value then gets decremented each 5 seconds. Incase we reach 0
+   * we report the inverter as missing entirely on the CAN bus.
+   */
+  uint8_t CAN_inverter_still_alive = CAN_STILL_ALIVE;
   /** True if the battery allows for the contactors to close */
   bool battery_allows_contactor_closing = false;
   /** True if the second battery allows for the contactors to close */

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -161,6 +161,16 @@ void update_machineryprotection() {
     clear_event(EVENT_CAN_RX_WARNING);
   }
 
+#ifdef CAN_INVERTER_SELECTED
+  // Check if the inverter is still sending CAN messages. If we go 60s without messages we raise an error
+  if (!datalayer.system.status.CAN_inverter_still_alive) {
+    set_event(EVENT_CAN_INVERTER_MISSING, 0);
+  } else {
+    datalayer.system.status.CAN_inverter_still_alive--;
+    clear_event(EVENT_CAN_INVERTER_MISSING);
+  }
+#endif  //CAN_INVERTER_SELECTED
+
 #ifdef DOUBLE_BATTERY  // Additional Double-Battery safeties are checked here
   // Check if the Battery 2 BMS is still sending CAN messages. If we go 60s without messages we raise an error
 

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -180,6 +180,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x151:  //Message originating from BYD HVS compatible inverter. Reply with CAN identifier!
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[0] & 0x01) {  //Battery requests identification
         send_intial_data();
       } else {  // We can identify what inverter type we are connected to
@@ -193,12 +194,15 @@ void receive_can_inverter(CAN_frame rx_frame) {
       }
       break;
     case 0x091:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       inverter_voltage = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]) * 0.1;
       break;
     case 0x0D1:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       inverter_SOC = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]) * 0.1;
       break;
     case 0x111:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       inverter_timestamp = ((rx_frame.data.u8[3] << 24) | (rx_frame.data.u8[2] << 16) | (rx_frame.data.u8[1] << 8) |
                             rx_frame.data.u8[0]);
       break;

--- a/Software/src/inverter/BYD-SMA.cpp
+++ b/Software/src/inverter/BYD-SMA.cpp
@@ -214,13 +214,16 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Frame0-1 Voltage
       //Frame2-3 Current
       break;
     case 0x3E0:  //Message originating from SMA inverter - ?
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x420:  //Message originating from SMA inverter - Timestamp
-                 //Frame0-3 Timestamp
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      //Frame0-3 Timestamp
       /*
       transmit_can(&SMA_158, can_config.inverter);
       transmit_can(&SMA_358, can_config.inverter);
@@ -231,10 +234,13 @@ void receive_can_inverter(CAN_frame rx_frame) {
       */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x560:  //Message originating from SMA inverter - Init
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x5E7:  //Pairing request
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can(&SMA_558, can_config.inverter);
       transmit_can(&SMA_598, can_config.inverter);
       transmit_can(&SMA_5D8, can_config.inverter);

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -447,6 +447,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[0] == 0x02) {
         send_setup_info();
       }

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -211,12 +211,15 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Frame0-1 Voltage
       //Frame2-3 Current
       break;
     case 0x3E0:  //Message originating from SMA inverter - ?
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x420:  //Message originating from SMA inverter - Timestamp
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Frame0-3 Timestamp
       /*
       transmit_can(&SMA_158, can_config.inverter);
@@ -228,10 +231,13 @@ void receive_can_inverter(CAN_frame rx_frame) {
       */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x560:  //Message originating from SMA inverter - Init
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x5E7:  //Pairing request
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can(&SMA_558, can_config.inverter);
       transmit_can(&SMA_598, can_config.inverter);
       transmit_can(&SMA_5D8, can_config.inverter);

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -292,15 +292,20 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x00D:  //Inverter Measurements
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x00F:  //Inverter Feedback
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x010:  //Time from inverter
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x015:  //Initialization message from inverter
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       send_tripower_init();
       break;
     case 0x017:  //Initialization message from inverter 2
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //send_tripower_init();
       break;
     default:

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -233,10 +233,12 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //frame1_605 = rx_frame.data.u8[1];
       //frame3_605 = rx_frame.data.u8[3];
       break;
     case 0x705:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //frame1_705 = rx_frame.data.u8[1];
       //frame3_705 = rx_frame.data.u8[3];
       break;

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -18,7 +18,6 @@ static unsigned long LastFrameTime = 0;
 static uint8_t number_of_batteries = 1;
 static uint16_t capped_capacity_Wh;
 static uint16_t capped_remaining_capacity_Wh;
-static uint16_t inverter_missing_on_can = 0;
 
 //CAN message translations from this amazing repository: https://github.com/rand12345/solax_can_bus
 
@@ -89,12 +88,6 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   if (millis() - LastFrameTime >= SolaxTimeout) {
     datalayer.system.status.inverter_allows_contactor_closing = false;
     STATE = BATTERY_ANNOUNCE;
-    inverter_missing_on_can++;
-    if (inverter_missing_on_can > CAN_STILL_ALIVE) {
-      set_event(EVENT_CAN_INVERTER_MISSING, 0);
-    } else {
-      clear_event(EVENT_CAN_INVERTER_MISSING);
-    }
   }
   //Calculate the required values
   temperature_average =
@@ -225,6 +218,11 @@ void send_can_inverter() {
 }
 
 void receive_can_inverter(CAN_frame rx_frame) {
+
+  if (rx_frame.ID == 0x1871) {
+    datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+  }
+
   if (rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x01) ||
       rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x02)) {
     LastFrameTime = millis();


### PR DESCRIPTION
### What
This PR implements a check for all CAN based inverter protocols. The check verifies that CAN messages are still sent by the inverter

### Why
To make troubleshooting easier

### How
If we go 60 seconds without seeing a CAN message from the inverter, we raise an event
