### PR TITLE
Improvement: Kia64: Make autodetect kWh size

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -214,10 +214,12 @@ void update_number_of_cells() {
       datalayer.battery.info.number_of_cells = 98;
       datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;
       datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_98S_DV;
+      datalayer.battery.info.total_capacity_Wh = 64000;
     } else {
       datalayer.battery.info.number_of_cells = 90;
       datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_90S_DV;
       datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;
+      datalayer.battery.info.total_capacity_Wh = 40000;
     }
   }
 }


### PR DESCRIPTION
### What
This PR makes the capacity autodetect on Kia/Hyundai 64/40kWh packs

### Why
Simplified for users, no longer needed to set correct capacity in USER_SETTINGS when using these Kia/Hyundai batteries

### How
Based on amounts of cells detected, we can determine what pack size in kWh is. 98S = 64kWh, 90S = 40kWh
