### PR TITLE
Keep CAN communications active during Equipment Stop

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -584,7 +584,7 @@ void monitor_equipment_stop_button() {
   if (equipment_stop_behavior == LATCHING_SWITCH) {
     if (changed_state == PRESSED) {
       // Changed to ON – initiating equipment stop.
-      setBatteryPause(true, true, true);
+      setBatteryPause(true, false, true);
     } else if (changed_state == RELEASED) {
       // Changed to OFF – ending equipment stop.
       setBatteryPause(false, false, false);
@@ -594,7 +594,7 @@ void monitor_equipment_stop_button() {
 
       if (timeSincePress < equipment_button_long_press_duration) {
         // Short press detected, trigger equipment stop
-        setBatteryPause(true, true, true);
+        setBatteryPause(true, false, true);
       } else {
         // Long press detected, reset equipment stop state
         setBatteryPause(false, false, false);

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -179,7 +179,7 @@ void init_webserver() {
     if (request->hasParam("stop")) {
       String valueStr = request->getParam("stop")->value();
       if (valueStr == "true" || valueStr == "1") {
-        setBatteryPause(true, true, true);
+        setBatteryPause(true, false, true);
       } else {
         setBatteryPause(false, false, false);
       }


### PR DESCRIPTION
### What
Keep CAN communications active during Equipment Stop

### Why

After reconsidering the equipmentstop functionality, particularly following some users feedback I believe it’s better to keep CAN communications active. This would allow us to monitor battery status (voltage, temperature, etc.) during stop while improving safety.

### How
Changing the call to pause functionality so it does not halt CAN.
