### PR TITLE
Add new inverter implementation "Pylontech LV"

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -36,7 +36,8 @@
 //#define BYD_SMA //Enable this line to emulate a SMA compatible "BYD Battery-Box HVS 10.2KW battery" over CAN bus
 //#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define FOXESS_CAN       //Enable this line to emulate a "HV2600/ECS4100 battery" over CAN bus
-//#define PYLON_CAN        //Enable this line to emulate a "Pylontech battery" over CAN bus
+//#define PYLON_LV_CAN     //Enable this line to emulate a "48V Pylontech battery" over CAN bus
+//#define PYLON_CAN        //Enable this line to emulate a "High Voltage Pylontech battery" over CAN bus
 //#define SMA_CAN          //Enable this line to emulate a "BYD Battery-Box H 8.9kWh, 7 mod" over CAN bus
 //#define SMA_TRIPOWER_CAN //Enable this line to emulate a "SMA Home Storage battery" over CAN bus
 //#define SOFAR_CAN        //Enable this line to emulate a "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame)" over CAN bus
@@ -93,6 +94,10 @@
 #define BATTERY_MAXPERCENTAGE 8000
 // 2000 = 20.0% , Min percentage the battery will discharge to (Inverter gets 0% when reached)
 #define BATTERY_MINPERCENTAGE 2000
+// 500 = 50.0 °C , Max temperature (Will produce a battery overheat event if above)
+#define BATTERY_MAXTEMPERATURE 500
+// -250 = -25.0 °C , Min temperature (Will produce a battery frozen event if below)
+#define BATTERY_MINTEMPERATURE -250
 // 300 = 30.0A , BYD CAN specific setting, Max charge in Amp (Some inverters needs to be limited)
 #define BATTERY_MAX_CHARGE_AMP 300
 // 300 = 30.0A , BYD CAN specific setting, Max discharge in Amp (Some inverters needs to be limited)

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -27,14 +27,14 @@ void update_machineryprotection() {
   }
 
   // Battery is overheated!
-  if (datalayer.battery.status.temperature_max_dC > 500) {
+  if (datalayer.battery.status.temperature_max_dC > BATTERY_MAXTEMPERATURE) {
     set_event(EVENT_BATTERY_OVERHEAT, datalayer.battery.status.temperature_max_dC);
   } else {
     clear_event(EVENT_BATTERY_OVERHEAT);
   }
 
   // Battery is frozen!
-  if (datalayer.battery.status.temperature_min_dC < -250) {
+  if (datalayer.battery.status.temperature_min_dC < BATTERY_MINTEMPERATURE) {
     set_event(EVENT_BATTERY_FROZEN, datalayer.battery.status.temperature_min_dC);
   } else {
     clear_event(EVENT_BATTERY_FROZEN);

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -495,6 +495,9 @@ String processor(const String& var) {
 #ifdef PYLON_CAN
     content += "Pylontech battery over CAN bus";
 #endif  // PYLON_CAN
+#ifdef PYLON_LV_CAN
+    content += "Pylontech LV battery over CAN bus";
+#endif  // PYLON_LV_CAN
 #ifdef SERIAL_LINK_TRANSMITTER
     content += "Serial link to another LilyGo board";
 #endif  // SERIAL_LINK_TRANSMITTER

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -23,6 +23,10 @@
 #include "PYLON-CAN.h"
 #endif
 
+#ifdef PYLON_LV_CAN
+#include "PYLON-LV-CAN.h"
+#endif
+
 #ifdef SMA_CAN
 #include "SMA-CAN.h"
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -43,6 +43,10 @@ CAN_frame PYLON_35E = {.FD = false,
 void update_values_can_inverter() {
   // This function maps all the values fetched from battery CAN to the correct CAN messages
 
+  // do not update values unless we have some voltage, as we will run into IntegerDivideByZero exceptions otherwise
+  if (datalayer.battery.status.voltage_dV == 0)
+    return;
+
   // TODO: officially this value is "battery charge voltage". Do we need to add something here to the actual voltage?
   PYLON_351.data.u8[0] = datalayer.battery.status.voltage_dV & 0xff;
   PYLON_351.data.u8[1] = datalayer.battery.status.voltage_dV >> 8;

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -5,7 +5,6 @@
 
 /* Do not change code below unless you are sure what you are doing */
 
-static unsigned long previousInverterPacketMillis = 0;
 static unsigned long previousMillis1000ms = 0;
 
 CAN_frame PYLON_351 = {.FD = false,
@@ -119,8 +118,7 @@ void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  //Message originating from inverter.
       // according to the spec, this message includes only 0-bytes
-      datalayer.system.status.CAN_inverter_still_alive = true;
-      previousInverterPacketMillis = millis();
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     default:
       break;
@@ -129,10 +127,6 @@ void receive_can_inverter(CAN_frame rx_frame) {
 
 void send_can_inverter() {
   unsigned long currentMillis = millis();
-
-  if (currentMillis - previousInverterPacketMillis >= 3000) {
-    datalayer.system.status.CAN_inverter_still_alive = false;
-  }
 
   if (currentMillis - previousMillis1000ms >= 1000) {
     previousMillis1000ms = currentMillis;

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -85,9 +85,9 @@ void update_values_can_inverter() {
   // ERRORS
   if(datalayer.battery.status.current_dA >= maxDischargeCurrent)
     PYLON_359.data.u8[0] |= 0x80;
-  if(datalayer.battery.status.temperature_min_dC <= MIN_TEMPERATURE)
+  if(datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE)
     PYLON_359.data.u8[0] |= 0x10;
-  if(datalayer.battery.status.temperature_max_dC >= 500)
+  if(datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE)
     PYLON_359.data.u8[0] |= 0x0C;
   if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV)
     PYLON_359.data.u8[0] |= 0x04;
@@ -98,9 +98,9 @@ void update_values_can_inverter() {
   // WARNINGS (using same rules as errors but reporting earlier)
   if(datalayer.battery.status.current_dA >= maxDischargeCurrent * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x80;
-  if(datalayer.battery.status.temperature_min_dC <= MIN_TEMPERATURE * WARNINGS_PERCENT / 100)
+  if(datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x10;
-  if(datalayer.battery.status.temperature_max_dC >= MAX_TEMPERATURE * WARNINGS_PERCENT / 100)
+  if(datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x0C;
   if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV + 100)
     PYLON_359.data.u8[2] |= 0x04;

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -1,0 +1,145 @@
+#include "../include.h"
+#ifdef PYLON_LV_CAN
+#include "../datalayer/datalayer.h"
+#include "PYLON-LV-CAN.h"
+
+/* Do not change code below unless you are sure what you are doing */
+
+static unsigned long previousMillis1000ms = 0;
+
+CAN_frame PYLON_351 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x351,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_355 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 4,
+                       .ID = 0x355,
+                       .data = {0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_356 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x356,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_359 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 7,
+                       .ID = 0x359,
+                       .data = {0x00, 0x00, 0x00, 0x00, PACK_NUMBER, 'P', 'N'}};
+CAN_frame PYLON_35C = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 2,
+                       .ID = 0x35C,
+                       .data = {0x00, 0x00}};
+CAN_frame PYLON_35E = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x35E,
+                       .data = {
+                          MANUFACTURER_NAME[0],
+                          MANUFACTURER_NAME[1],
+                          MANUFACTURER_NAME[2],
+                          MANUFACTURER_NAME[3],
+                          MANUFACTURER_NAME[4],
+                          MANUFACTURER_NAME[5],
+                          MANUFACTURER_NAME[6],
+                          MANUFACTURER_NAME[7],
+                        }};
+
+void update_values_can_inverter() { 
+  // This function maps all the values fetched from battery CAN to the correct CAN messages
+
+  // TODO: officially this value is "battery charge voltage". Do we need to add something here to the actual voltage?
+  PYLON_351.data.u8[0] = datalayer.battery.status.voltage_dV & 0xff;
+  PYLON_351.data.u8[1] = datalayer.battery.status.voltage_dV >> 8;
+  int16_t maxChargeCurrent = datalayer.battery.status.max_charge_power_W * 10 / datalayer.battery.status.voltage_dV;
+  PYLON_351.data.u8[2] = maxChargeCurrent & 0xff;
+  PYLON_351.data.u8[3] = maxChargeCurrent >> 8;
+  int16_t maxDischargeCurrent = datalayer.battery.status.max_discharge_power_W * 10 / datalayer.battery.status.voltage_dV;
+  PYLON_351.data.u8[4] = maxDischargeCurrent & 0xff;
+  PYLON_351.data.u8[5] = maxDischargeCurrent >> 8;
+
+  PYLON_355.data.u8[0] = (datalayer.battery.status.reported_soc / 10) & 0xff;
+  PYLON_355.data.u8[1] = (datalayer.battery.status.reported_soc / 10) >> 8;
+  PYLON_355.data.u8[2] = (datalayer.battery.status.soh_pptt / 10) & 0xff;
+  PYLON_355.data.u8[3] = (datalayer.battery.status.soh_pptt / 10) >> 8;
+
+  PYLON_356.data.u8[0] = datalayer.battery.status.voltage_dV & 0xff;
+  PYLON_356.data.u8[1] = datalayer.battery.status.voltage_dV >> 8;
+  PYLON_356.data.u8[2] = datalayer.battery.status.current_dA & 0xff;
+  PYLON_356.data.u8[3] = datalayer.battery.status.current_dA >> 8;
+  PYLON_356.data.u8[4] = datalayer.battery.status.temperature_max_dC & 0xff;
+  PYLON_356.data.u8[5] = datalayer.battery.status.temperature_max_dC >> 8;
+
+  // initialize all errors and warnings to 0
+  PYLON_359.data.u8[0] = 0x00;
+  PYLON_359.data.u8[1] = 0x00;
+  PYLON_359.data.u8[2] = 0x00;
+  PYLON_359.data.u8[3] = 0x00;
+  PYLON_359.data.u8[4] = PACK_NUMBER;
+  PYLON_359.data.u8[5] = 'P';
+  PYLON_359.data.u8[6] = 'N';
+
+  // ERRORS
+  if(datalayer.battery.status.current_dA >= maxDischargeCurrent)
+    PYLON_359.data.u8[0] |= 0x80;
+  if(datalayer.battery.status.temperature_min_dC <= MIN_TEMPERATURE)
+    PYLON_359.data.u8[0] |= 0x10;
+  if(datalayer.battery.status.temperature_max_dC >= 500)
+    PYLON_359.data.u8[0] |= 0x0C;
+  if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV)
+    PYLON_359.data.u8[0] |= 0x04;
+  // we never set PYLON_359.data.u8[1] |= 0x80 called "BMS internal"
+  if(datalayer.battery.status.current_dA <= -1 * maxChargeCurrent)
+    PYLON_359.data.u8[1] |= 0x01;
+
+  // WARNINGS (using same rules as errors but reporting earlier)
+  if(datalayer.battery.status.current_dA >= maxDischargeCurrent * WARNINGS_PERCENT / 100)
+    PYLON_359.data.u8[2] |= 0x80;
+  if(datalayer.battery.status.temperature_min_dC <= MIN_TEMPERATURE * WARNINGS_PERCENT / 100)
+    PYLON_359.data.u8[2] |= 0x10;
+  if(datalayer.battery.status.temperature_max_dC >= MAX_TEMPERATURE * WARNINGS_PERCENT / 100)
+    PYLON_359.data.u8[2] |= 0x0C;
+  if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV + 100)
+    PYLON_359.data.u8[2] |= 0x04;
+  // we never set PYLON_359.data.u8[3] |= 0x80 called "BMS internal"
+  if(datalayer.battery.status.current_dA <= -1 * maxChargeCurrent * WARNINGS_PERCENT / 100)
+    PYLON_359.data.u8[3] |= 0x01;
+
+  PYLON_35C.data.u8[0] = 0xC0; // enable charging and discharging
+  PYLON_35C.data.u8[1] = 0x00;
+  if(datalayer.battery.status.real_soc <= datalayer.battery.settings.min_percentage)
+    PYLON_35C.data.u8[0] = 0xA0; // enable charing, set charge immediately
+  if(datalayer.battery.status.real_soc >= datalayer.battery.settings.max_percentage)
+    PYLON_35C.data.u8[0] = 0x40; // enable discharging only
+
+  // PYLON_35E is pre-filled with the manufacturer name
+}
+
+void receive_can_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
+    case 0x305:  //Message originating from inverter.
+      // TODO: according to the spec, this message includes only 0-bytes
+      // we could however use this to check if the inverter is still alive
+      break;
+    default:
+      break;
+  }
+}
+
+void send_can_inverter() {
+  unsigned long currentMillis = millis();
+
+  if (currentMillis - previousMillis1000ms >= 1000) {
+    previousMillis1000ms = currentMillis;
+
+    transmit_can(&PYLON_351, can_config.inverter);
+    transmit_can(&PYLON_355, can_config.inverter);
+    transmit_can(&PYLON_356, can_config.inverter);
+    transmit_can(&PYLON_359, can_config.inverter);
+    transmit_can(&PYLON_35C, can_config.inverter);
+    transmit_can(&PYLON_35E, can_config.inverter);
+  }
+}
+#endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -50,11 +50,11 @@ void update_values_can_inverter() {
   // TODO: officially this value is "battery charge voltage". Do we need to add something here to the actual voltage?
   PYLON_351.data.u8[0] = datalayer.battery.status.voltage_dV & 0xff;
   PYLON_351.data.u8[1] = datalayer.battery.status.voltage_dV >> 8;
-  int16_t maxChargeCurrent = datalayer.battery.status.max_charge_power_W * 10 / datalayer.battery.status.voltage_dV;
+  int16_t maxChargeCurrent = datalayer.battery.status.max_charge_power_W * 100 / datalayer.battery.status.voltage_dV;
   PYLON_351.data.u8[2] = maxChargeCurrent & 0xff;
   PYLON_351.data.u8[3] = maxChargeCurrent >> 8;
   int16_t maxDischargeCurrent =
-      datalayer.battery.status.max_discharge_power_W * 10 / datalayer.battery.status.voltage_dV;
+      datalayer.battery.status.max_discharge_power_W * 100 / datalayer.battery.status.voltage_dV;
   PYLON_351.data.u8[4] = maxDischargeCurrent & 0xff;
   PYLON_351.data.u8[5] = maxDischargeCurrent >> 8;
 

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -13,11 +13,7 @@ CAN_frame PYLON_351 = {.FD = false,
                        .DLC = 6,
                        .ID = 0x351,
                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_355 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 4,
-                       .ID = 0x355,
-                       .data = {0x00, 0x00, 0x00, 0x00}};
+CAN_frame PYLON_355 = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x355, .data = {0x00, 0x00, 0x00, 0x00}};
 CAN_frame PYLON_356 = {.FD = false,
                        .ext_ID = false,
                        .DLC = 6,
@@ -28,27 +24,23 @@ CAN_frame PYLON_359 = {.FD = false,
                        .DLC = 7,
                        .ID = 0x359,
                        .data = {0x00, 0x00, 0x00, 0x00, PACK_NUMBER, 'P', 'N'}};
-CAN_frame PYLON_35C = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 2,
-                       .ID = 0x35C,
-                       .data = {0x00, 0x00}};
+CAN_frame PYLON_35C = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x35C, .data = {0x00, 0x00}};
 CAN_frame PYLON_35E = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
                        .ID = 0x35E,
                        .data = {
-                          MANUFACTURER_NAME[0],
-                          MANUFACTURER_NAME[1],
-                          MANUFACTURER_NAME[2],
-                          MANUFACTURER_NAME[3],
-                          MANUFACTURER_NAME[4],
-                          MANUFACTURER_NAME[5],
-                          MANUFACTURER_NAME[6],
-                          MANUFACTURER_NAME[7],
-                        }};
+                           MANUFACTURER_NAME[0],
+                           MANUFACTURER_NAME[1],
+                           MANUFACTURER_NAME[2],
+                           MANUFACTURER_NAME[3],
+                           MANUFACTURER_NAME[4],
+                           MANUFACTURER_NAME[5],
+                           MANUFACTURER_NAME[6],
+                           MANUFACTURER_NAME[7],
+                       }};
 
-void update_values_can_inverter() { 
+void update_values_can_inverter() {
   // This function maps all the values fetched from battery CAN to the correct CAN messages
 
   // TODO: officially this value is "battery charge voltage". Do we need to add something here to the actual voltage?
@@ -57,7 +49,8 @@ void update_values_can_inverter() {
   int16_t maxChargeCurrent = datalayer.battery.status.max_charge_power_W * 10 / datalayer.battery.status.voltage_dV;
   PYLON_351.data.u8[2] = maxChargeCurrent & 0xff;
   PYLON_351.data.u8[3] = maxChargeCurrent >> 8;
-  int16_t maxDischargeCurrent = datalayer.battery.status.max_discharge_power_W * 10 / datalayer.battery.status.voltage_dV;
+  int16_t maxDischargeCurrent =
+      datalayer.battery.status.max_discharge_power_W * 10 / datalayer.battery.status.voltage_dV;
   PYLON_351.data.u8[4] = maxDischargeCurrent & 0xff;
   PYLON_351.data.u8[5] = maxDischargeCurrent >> 8;
 
@@ -83,37 +76,37 @@ void update_values_can_inverter() {
   PYLON_359.data.u8[6] = 'N';
 
   // ERRORS
-  if(datalayer.battery.status.current_dA >= maxDischargeCurrent)
+  if (datalayer.battery.status.current_dA >= maxDischargeCurrent)
     PYLON_359.data.u8[0] |= 0x80;
-  if(datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE)
+  if (datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE)
     PYLON_359.data.u8[0] |= 0x10;
-  if(datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE)
+  if (datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE)
     PYLON_359.data.u8[0] |= 0x0C;
-  if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV)
+  if (datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV)
     PYLON_359.data.u8[0] |= 0x04;
   // we never set PYLON_359.data.u8[1] |= 0x80 called "BMS internal"
-  if(datalayer.battery.status.current_dA <= -1 * maxChargeCurrent)
+  if (datalayer.battery.status.current_dA <= -1 * maxChargeCurrent)
     PYLON_359.data.u8[1] |= 0x01;
 
   // WARNINGS (using same rules as errors but reporting earlier)
-  if(datalayer.battery.status.current_dA >= maxDischargeCurrent * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.current_dA >= maxDischargeCurrent * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x80;
-  if(datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x10;
-  if(datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.temperature_max_dC >= BATTERY_MAXTEMPERATURE * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[2] |= 0x0C;
-  if(datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV + 100)
+  if (datalayer.battery.status.voltage_dV * 100 <= datalayer.battery.info.min_cell_voltage_mV + 100)
     PYLON_359.data.u8[2] |= 0x04;
   // we never set PYLON_359.data.u8[3] |= 0x80 called "BMS internal"
-  if(datalayer.battery.status.current_dA <= -1 * maxChargeCurrent * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.current_dA <= -1 * maxChargeCurrent * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[3] |= 0x01;
 
-  PYLON_35C.data.u8[0] = 0xC0; // enable charging and discharging
+  PYLON_35C.data.u8[0] = 0xC0;  // enable charging and discharging
   PYLON_35C.data.u8[1] = 0x00;
-  if(datalayer.battery.status.real_soc <= datalayer.battery.settings.min_percentage)
-    PYLON_35C.data.u8[0] = 0xA0; // enable charing, set charge immediately
-  if(datalayer.battery.status.real_soc >= datalayer.battery.settings.max_percentage)
-    PYLON_35C.data.u8[0] = 0x40; // enable discharging only
+  if (datalayer.battery.status.real_soc <= datalayer.battery.settings.min_percentage)
+    PYLON_35C.data.u8[0] = 0xA0;  // enable charing, set charge immediately
+  if (datalayer.battery.status.real_soc >= datalayer.battery.settings.max_percentage)
+    PYLON_35C.data.u8[0] = 0x40;  // enable discharging only
 
   // PYLON_35E is pre-filled with the manufacturer name
 }
@@ -133,7 +126,7 @@ void receive_can_inverter(CAN_frame rx_frame) {
 void send_can_inverter() {
   unsigned long currentMillis = millis();
 
-  if(currentMillis - previousInverterPacketMillis >= 3000) {
+  if (currentMillis - previousInverterPacketMillis >= 3000) {
     datalayer.system.status.CAN_inverter_still_alive = false;
   }
 

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -5,6 +5,7 @@
 
 /* Do not change code below unless you are sure what you are doing */
 
+static unsigned long previousInverterPacketMillis = 0;
 static unsigned long previousMillis1000ms = 0;
 
 CAN_frame PYLON_351 = {.FD = false,
@@ -120,8 +121,9 @@ void update_values_can_inverter() {
 void receive_can_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  //Message originating from inverter.
-      // TODO: according to the spec, this message includes only 0-bytes
-      // we could however use this to check if the inverter is still alive
+      // according to the spec, this message includes only 0-bytes
+      datalayer.system.status.CAN_inverter_still_alive = true;
+      previousInverterPacketMillis = millis();
       break;
     default:
       break;
@@ -130,6 +132,10 @@ void receive_can_inverter(CAN_frame rx_frame) {
 
 void send_can_inverter() {
   unsigned long currentMillis = millis();
+
+  if(currentMillis - previousInverterPacketMillis >= 3000) {
+    datalayer.system.status.CAN_inverter_still_alive = false;
+  }
 
   if (currentMillis - previousMillis1000ms >= 1000) {
     previousMillis1000ms = currentMillis;

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -1,0 +1,17 @@
+#ifndef PYLON_LV_CAN_H
+#define PYLON_LV_CAN_H
+#include "../include.h"
+
+#define CAN_INVERTER_SELECTED
+
+#define MANUFACTURER_NAME "BatEmuLV"
+#define PACK_NUMBER 0x01
+#define MIN_TEMPERATURE 40 // 40 for 4.0 °C
+#define MAX_TEMPERATURE 500 // 500 for 50.0 °C
+#define WARNINGS_PERCENT 80 // 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
+
+void send_system_data();
+void send_setup_info();
+void transmit_can(CAN_frame* tx_frame, int interface);
+
+#endif

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -6,7 +6,8 @@
 
 #define MANUFACTURER_NAME "BatEmuLV"
 #define PACK_NUMBER 0x01
-#define WARNINGS_PERCENT 80 // 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
+// 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
+#define WARNINGS_PERCENT 80
 
 void send_system_data();
 void send_setup_info();

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -6,8 +6,6 @@
 
 #define MANUFACTURER_NAME "BatEmuLV"
 #define PACK_NUMBER 0x01
-#define MIN_TEMPERATURE 40 // 40 for 4.0 °C
-#define MAX_TEMPERATURE 500 // 500 for 50.0 °C
 #define WARNINGS_PERCENT 80 // 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
 
 void send_system_data();


### PR DESCRIPTION
### What
Implementation of the talking-to-inverter side of the pylontech protocol

### Why
This is by far the most common protocol for LV batteries. Having this allows to talk to a wide range of inverters (Victron, SMA, Deye, ...).  See [this list starting on page 2](https://www.photovoltaikforum.com/core/attachment/307672-pylontech-compatible-list-v2-11-ess-neu-20221212-pdf/)

### How
Straightforward implementation of the CAN bus messages as documented [here](https://www.photovoltaikforum.com/core/attachment/77135-pylon-bms-protocol-can-can-20161103-pdf/)
