### PR TITLE
Tesla SX 2021+ batteries support

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -969,6 +969,42 @@ void update_values_battery2() {  //This function maps all the values fetched via
 
 #endif  //DOUBLE_BATTERY
 
+#if defined(TESLA_MODEL_SX_BATTERY) || defined(EXP_TESLA_BMS_DIGITAL_HVIL)
+CAN_frame can_msg_1CF[] = {
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0x60, 0x69}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0x80, 0x89}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0xA0, 0xA9}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0xC0, 0xC9}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0xE0, 0xE9}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0x00, 0x09}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0x20, 0x29}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x1CF, .data = {0x01, 0x00, 0x00, 0x1A, 0x1C, 0x02, 0x40, 0x49}}};
+
+CAN_frame can_msg_118[] = {
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x61, 0x80, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x62, 0x81, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x63, 0x82, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x64, 0x83, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x65, 0x84, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x66, 0x85, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x67, 0x86, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x68, 0x87, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x69, 0x88, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6A, 0x89, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6B, 0x8A, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6C, 0x8B, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6D, 0x8C, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6E, 0x8D, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x6F, 0x8E, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}},
+    {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x118, .data = {0x70, 0x8F, 0x30, 0x10, 0x00, 0x08, 0x00, 0x80}}};
+
+unsigned long lastSend1CF = 0;
+unsigned long lastSend118 = 0;
+
+int index_1CF = 0;
+int index_118 = 0;
+#endif
+
 void send_can_battery() {
   /*From bielec: My fist 221 message, to close the contactors is 0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96 and then, 
 to cause "hv_up_for_drive" I send an additional 221 message 0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA  so 
@@ -976,6 +1012,35 @@ two 221 messages are being continuously transmitted.   When I want to shut down,
 the first, for a few cycles, then stop all  messages which causes the contactor to open. */
 
   unsigned long currentMillis = millis();
+
+#if defined(TESLA_MODEL_SX_BATTERY) || defined(EXP_TESLA_BMS_DIGITAL_HVIL)
+  if (datalayer.system.status.inverter_allows_contactor_closing) {
+    if (currentMillis - lastSend1CF >= 10) {
+      transmit_can(&can_msg_1CF[index_1CF], can_config.battery);
+
+#ifdef DOUBLE_BATTERY
+      transmit_can(&can_msg_1CF[index_1CF], can_config.battery_double);
+#endif
+
+      index_1CF = (index_1CF + 1) % 8;
+      lastSend1CF = currentMillis;
+    }
+
+    if (currentMillis - lastSend118 >= 10) {
+      transmit_can(&can_msg_118[index_118], can_config.battery);
+#ifdef DOUBLE_BATTERY
+      transmit_can(&can_msg_1CF[index_1CF], can_config.battery_double);
+#endif
+
+      index_118 = (index_118 + 1) % 16;
+      lastSend118 = currentMillis;
+    }
+  } else {
+    index_1CF = 0;
+    index_118 = 0;
+  }
+#endif
+
   //Send 30ms message
   if (currentMillis - previousMillis30 >= INTERVAL_30_MS) {
     // Check if sending of CAN messages has been delayed too much.

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -28,7 +28,10 @@
 #define MAX_CELL_VOLTAGE_LFP 3550       //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800       //Battery is put into emergency stop if one cell goes below this value
 
-//#define EXP_TESLA_BMS_DIGITAL_HVIL // Experimental mode. Enables the sending of additional CAN messages, required for new firmwares
+// Forces the transmission of additional CAN frames for experimental purposes.
+// Can be used with any Tesla battery configuration, including Model 3/Y, to test potential firmware-related issues.
+// Needed to validate the hypothesis that newer BMS firmware versions for Model 3/Y, which will include a 16V battery, may also require these CAN frames.
+//#define EXP_TESLA_BMS_DIGITAL_HVIL
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -28,9 +28,9 @@
 #define MAX_CELL_VOLTAGE_LFP 3550       //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800       //Battery is put into emergency stop if one cell goes below this value
 
-// Forces the transmission of additional CAN frames for experimental purposes.
+// Experimental parameter. Forces the transmission of additional CAN frames for experimental purposes.
 // Can be used with any Tesla battery configuration, including Model 3/Y, to test potential firmware-related issues.
-// Needed to validate the hypothesis that newer BMS firmware versions for Model 3/Y, which will include a 16V battery, may also require these CAN frames.
+// Needed to validate the hypothesis that newer BMS firmware versions for Model 3/Y, which work with a 16V li-ion battery, may also require these CAN frames.
 //#define EXP_TESLA_BMS_DIGITAL_HVIL
 
 void printFaultCodesIfActive();

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -28,10 +28,7 @@
 #define MAX_CELL_VOLTAGE_LFP 3550       //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800       //Battery is put into emergency stop if one cell goes below this value
 
-// Experimental parameter. Forces the transmission of additional CAN frames for experimental purposes.
-// Can be used with any Tesla battery configuration, including Model 3/Y, to test potential firmware-related issues.
-// Needed to validate the hypothesis that newer BMS firmware versions for Model 3/Y, which work with a 16V li-ion battery, may also require these CAN frames.
-//#define EXP_TESLA_BMS_DIGITAL_HVIL
+//#define EXP_TESLA_BMS_DIGITAL_HVIL    // Experimental parameter. Forces the transmission of additional CAN frames for experimental purposes, to test potential HVIL issues in 3/Y packs with newer firmware.
 
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -28,6 +28,8 @@
 #define MAX_CELL_VOLTAGE_LFP 3550       //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_LFP 2800       //Battery is put into emergency stop if one cell goes below this value
 
+//#define EXP_TESLA_BMS_DIGITAL_HVIL // Experimental mode. Enables the sending of additional CAN messages, required for new firmwares
+
 void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);


### PR DESCRIPTION
### What
This PR implements experimental support for new 100 kW Tesla Model X and S batteries starting from the 2021 model year.

### Why
These batteries use a different communication protocol with the BMS, requiring the transmission of additional CAN frames for proper battery operation.

### How
This implementation introduces the transmission of additional CAN events with timing closely matching the original protocol.

By default, when the TESLA_MODEL_SX_BATTERY configuration is selected, the additional CAN frame transmission will be enabled. 

Additionally, a new experimental define EXP_TESLA_BMS_DIGITAL_HVIL has been added, which triggers the transmission of these extra frames. This is necessary for testing with the latest BMS firmware for Model 3/Y batteries, as there is a hypothesis that the BMS firmware update, which communicates through the new 1CF and 118 frames, may also apply to these vehicles.
