### PR TITLE
Feature: Add more battery info for BMW i3

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1,6 +1,7 @@
 #include "../include.h"
 #ifdef BMW_I3_BATTERY
 #include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/events.h"
 #include "BMW-I3-BATTERY.h"
 
@@ -489,33 +490,20 @@ void update_values_battery() {  //This function maps all the values fetched via 
     clear_event(EVENT_PRECHARGE_FAILURE);
   }
 
-#ifdef DEBUG_VIA_USB
-  Serial.println(" ");
-  Serial.print("Battery display SOC%: ");
-  Serial.print(battery_display_SOC * 50);
-  Serial.print("Battery display SOC%: ");
-  Serial.print(battery_HVBatt_SOC * 10);
-  Serial.print("Battery polled SOC%: ");
-  Serial.print(battery_soc);
-  Serial.print(" Battery voltage: ");
-  Serial.print(datalayer.battery.status.voltage_dV * 0.1);
-  Serial.print(" Battery current: ");
-  Serial.print(datalayer.battery.status.current_dA * 0.1);
-  Serial.print(" Wh when full: ");
-  Serial.print(datalayer.battery.info.total_capacity_Wh);
-  Serial.print(" Remaining Wh: ");
-  Serial.print(datalayer.battery.status.remaining_capacity_Wh);
-  Serial.print(" Max charge power: ");
-  Serial.print(datalayer.battery.status.max_charge_power_W);
-  Serial.print(" Max discharge power: ");
-  Serial.print(datalayer.battery.status.max_discharge_power_W);
-  Serial.print(" Active power: ");
-  Serial.print(datalayer.battery.status.active_power_W);
-  Serial.print(" Min temp: ");
-  Serial.print(datalayer.battery.status.temperature_min_dC * 0.1);
-  Serial.print(" Max temp: ");
-  Serial.print(datalayer.battery.status.temperature_max_dC * 0.1);
-#endif
+  // Update webserver datalayer
+  datalayer_extended.bmwi3.SOC_raw = (battery_display_SOC * 50);
+  datalayer_extended.bmwi3.SOC_dash = (battery_HVBatt_SOC * 10);
+  datalayer_extended.bmwi3.SOC_OBD2 = battery_soc;
+  datalayer_extended.bmwi3.ST_iso_ext = battery_status_error_isolation_external_Bordnetz;
+  datalayer_extended.bmwi3.ST_iso_int = battery_status_error_isolation_internal_Bordnetz;
+  datalayer_extended.bmwi3.ST_valve_cooling = battery_status_valve_cooling;
+  datalayer_extended.bmwi3.ST_interlock = battery_status_error_locking;
+  datalayer_extended.bmwi3.ST_precharge = battery_status_precharge_locked;
+  datalayer_extended.bmwi3.ST_DCSW = battery_status_disconnecting_switch;
+  datalayer_extended.bmwi3.ST_EMG = battery_status_emergency_mode;
+  datalayer_extended.bmwi3.ST_WELD = battery_status_error_disconnecting_switch;
+  datalayer_extended.bmwi3.ST_isolation = battery_status_warning_isolation;
+  datalayer_extended.bmwi3.ST_cold_shutoff_valve = battery_status_cold_shutoff_valve;
 }
 
 void receive_can_battery(CAN_frame rx_frame) {
@@ -1136,7 +1124,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
 #ifdef DEBUG_VIA_USB
   Serial.println("BMW i3 battery selected");
-#endif
+#endif  //DEBUG_VIA_USB
 
   //Before we have started up and detected which battery is in use, use 60AH values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
@@ -1145,7 +1133,9 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
 
 #ifdef DOUBLE_BATTERY
+#ifdef DEBUG_VIA_USB
   Serial.println("Another BMW i3 battery also selected!");
+#endif  //DEBUG_VIA_USB
   datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
   datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -4,6 +4,48 @@
 #include "../include.h"
 
 typedef struct {
+  /** uint16_t */
+  /** SOC% raw battery value. Might not always reach 100% */
+  uint16_t SOC_raw = 0;
+  /** uint16_t */
+  /** SOC% instrumentation cluster value. Will always reach 100% */
+  uint16_t SOC_dash = 0;
+  /** uint16_t */
+  /** SOC% OBD2 value, polled actively */
+  uint16_t SOC_OBD2 = 0;
+  /** uint8_t */
+  /** Status isolation external, 0 not evaluated, 1 OK, 2 error active, 3 Invalid signal*/
+  uint8_t ST_iso_ext = 0;
+  /** uint8_t */
+  /** Status isolation external, 0 not evaluated, 1 OK, 2 error active, 3 Invalid signal*/
+  uint8_t ST_iso_int = 0;
+  /** uint8_t */
+  /** Status cooling valve error, 0 not evaluated, 1 OK valve closed, 2 error active valve open, 3 Invalid signal*/
+  uint8_t ST_valve_cooling = 0;
+  /** uint8_t */
+  /** Status interlock error, 0 not evaluated, 1 OK, 2 error active, 3 Invalid signal*/
+  uint8_t ST_interlock = 0;
+  /** uint8_t */
+  /** Status precharge, 0 no statement, 1 Not active closing not blocked, 2 error precharge blocked, 3 Invalid signal*/
+  uint8_t ST_precharge = 0;
+  /** uint8_t */
+  /** Status DC switch, 0 contactors open, 1 precharge ongoing, 2 contactors engaged, 3 Invalid signal*/
+  uint8_t ST_DCSW = 0;
+  /** uint8_t */
+  /** Status emergency, 0 not evaluated, 1 OK, 2 error active, 3 Invalid signal*/
+  uint8_t ST_EMG = 0;
+  /** uint8_t */
+  /** Status welding detection, 0 Contactors OK, 1 One contactor welded, 2 Two contactors welded, 3 Invalid signal*/
+  uint8_t ST_WELD = 0;
+  /** uint8_t */
+  /** Status isolation, 0 not evaluated, 1 OK, 2 error active, 3 Invalid signal*/
+  uint8_t ST_isolation = 0;
+  /** uint8_t */
+  /** Status cold shutoff valve, 0 OK, 1 Short circuit to GND, 2 Short circuit to 12V, 3 Line break, 6 Driver error, 12 Stuck, 13 Stuck, 15 Invalid Signal*/
+  uint8_t ST_cold_shutoff_valve = 0;
+} DATALAYER_INFO_BMWI3;
+
+typedef struct {
   /** uint8_t */
   /** Contactor status */
   uint8_t status_contactor = 0;
@@ -76,6 +118,7 @@ typedef struct {
 
 class DataLayerExtended {
  public:
+  DATALAYER_INFO_BMWI3 bmwi3;
   DATALAYER_INFO_TESLA tesla;
   DATALAYER_INFO_NISSAN_LEAF nissanleaf;
 };

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -16,6 +16,90 @@ String advanced_battery_processor(const String& var) {
     // Start a new block with a specific background color
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
+#ifdef BMW_I3_BATTERY
+    content += "<h4>SOC raw: " + String(datalayer_extended.bmwi3.SOC_raw) + "</h4>";
+    content += "<h4>SOC dash: " + String(datalayer_extended.bmwi3.SOC_dash) + "</h4>";
+    content += "<h4>SOC OBD2: " + String(datalayer_extended.bmwi3.SOC_OBD2) + "</h4>";
+    static const char* statusText[16] = {
+        "Not evaluated", "OK", "Error!", "Invalid signal", "", "", "", "", "", "", "", "", "", "", "", ""};
+    content += "<h4>Interlock: " + String(statusText[datalayer_extended.bmwi3.ST_interlock]) + "</h4>";
+    content += "<h4>Isolation external: " + String(statusText[datalayer_extended.bmwi3.ST_iso_ext]) + "</h4>";
+    content += "<h4>Isolation internal: " + String(statusText[datalayer_extended.bmwi3.ST_iso_int]) + "</h4>";
+    content += "<h4>Isolation: " + String(statusText[datalayer_extended.bmwi3.ST_isolation]) + "</h4>";
+    content += "<h4>Cooling valve: " + String(statusText[datalayer_extended.bmwi3.ST_valve_cooling]) + "</h4>";
+    content += "<h4>Emergency: " + String(statusText[datalayer_extended.bmwi3.ST_EMG]) + "</h4>";
+    static const char* prechargeText[16] = {"Not evaluated",
+                                            "Not active, closing not blocked",
+                                            "Error precharge blocked",
+                                            "Invalid signal",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            ""};
+    content += "<h4>Precharge: " + String(prechargeText[datalayer_extended.bmwi3.ST_precharge]) +
+               "</h4>";  //Still unclear of enum
+    static const char* DCSWText[16] = {"Contactors open",
+                                       "Precharge ongoing",
+                                       "Contactors engaged",
+                                       "Invalid signal",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       ""};
+    content += "<h4>Contactor status: " + String(DCSWText[datalayer_extended.bmwi3.ST_DCSW]) + "</h4>";
+    static const char* contText[16] = {"Contactors OK",
+                                       "One contactor welded!",
+                                       "Two contactors welded!",
+                                       "Invalid signal",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       "",
+                                       ""};
+    content += "<h4>Contactor weld: " + String(contText[datalayer_extended.bmwi3.ST_WELD]) + "</h4>";
+    static const char* valveText[16] = {"OK",
+                                        "Short circuit to GND",
+                                        "Short circuit to 12V",
+                                        "Line break",
+                                        "",
+                                        "",
+                                        "Driver error",
+                                        "",
+                                        "",
+                                        "",
+                                        "",
+                                        "",
+                                        "Stuck",
+                                        "Stuck",
+                                        "",
+                                        "Invalid Signal"};
+    content += "<h4>Cold shutoff valve: " + String(contText[datalayer_extended.bmwi3.ST_cold_shutoff_valve]) + "</h4>";
+
+#endif  //BMW_I3_BATTERY
+
 #ifdef TESLA_BATTERY
     static const char* contactorText[] = {"UNKNOWN(0)",  "OPEN",        "CLOSING",    "BLOCKED", "OPENING",
                                           "CLOSED",      "UNKNOWN(6)",  "WELDED",     "POS_CL",  "NEG_CL",
@@ -67,7 +151,8 @@ String advanced_battery_processor(const String& var) {
     content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
 #endif
 
-#if !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY)  //Only the listed types have extra info
+#if !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY) && \
+    !defined(BMW_I3_BATTERY)  //Only the listed types have extra info
     content += "No extra information available for this battery type";
 #endif
 


### PR DESCRIPTION
### What
This PR implements an extra battery info page for the BMW i3

### Why
User requested feature, to aid troubleshooting

### How
The following extra info is added to the Webserver page:

![image](https://github.com/user-attachments/assets/ea8d8818-591f-41ba-b3da-2daba658171a)

