### PR TITLE
Nissan LEAF Add event for unavailable value

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -253,6 +253,12 @@ void update_values_battery() { /* This function maps all the values fetched via 
     clear_event(EVENT_BATTERY_EMPTY);
   }
 
+  if (battery_Total_Voltage2 == 0x3FF) {  //Battery reports critical measurement unavailable
+    set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
+  } else {
+    clear_event(EVENT_BATTERY_VALUE_UNAVAILABLE);
+  }
+
   if (battery_Relay_Cut_Request) {  //battery_FAIL, BMS requesting shutdown and contactors to be opened
     //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
     datalayer.battery.status.max_discharge_power_W = 0;
@@ -418,6 +424,12 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
     datalayer.battery2.status.max_discharge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_EMPTY);
+  }
+
+  if (battery2_Total_Voltage2 == 0x3FF) {  //Battery reports critical measurement unavailable
+    set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
+  } else {
+    clear_event(EVENT_BATTERY_VALUE_UNAVAILABLE);
   }
 
   if (battery2_Relay_Cut_Request) {  //battery2_FAIL, BMS requesting shutdown and contactors to be opened

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -167,6 +167,7 @@ void init_events(void) {
   events.entries[EVENT_BATTERY_OVERHEAT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_VALUE_UNAVAILABLE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_ISOLATION].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_VOLTAGE_DIFFERENCE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_SOH_DIFFERENCE].level = EVENT_LEVEL_WARNING;
@@ -318,6 +319,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Warning: Battery exceeding maximum design voltage. Discharge battery to prevent damage!";
     case EVENT_BATTERY_UNDERVOLTAGE:
       return "Warning: Battery under minimum design voltage. Charge battery to prevent damage!";
+    case EVENT_BATTERY_VALUE_UNAVAILABLE:
+      return "Warning: Battery measurement unavailable. Check 12V power supply and battery wiring!";
     case EVENT_BATTERY_ISOLATION:
       return "Warning: Battery reports isolation error. High voltage might be leaking to ground. Check battery!";
     case EVENT_VOLTAGE_DIFFERENCE:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0015  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0016  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -53,6 +53,7 @@
   XX(EVENT_BATTERY_OVERHEAT)            \
   XX(EVENT_BATTERY_OVERVOLTAGE)         \
   XX(EVENT_BATTERY_UNDERVOLTAGE)        \
+  XX(EVENT_BATTERY_VALUE_UNAVAILABLE)   \
   XX(EVENT_BATTERY_ISOLATION)           \
   XX(EVENT_BATTERY_REQUESTS_HEAT)       \
   XX(EVENT_BATTERY_WARMED_UP)           \


### PR DESCRIPTION
### What
This PR implements a new event for Nissan LEAF batteries. Incase a critical value is unavailable, we now inform the user.

### Why
We had an user with a faulty PSU, feeding the BMS with only 9V. Due to this the BMS did not start up properly. Having an event like this would have sped up the troubleshooting

![image](https://github.com/user-attachments/assets/0b31ff84-0385-461f-9b5a-8770c54e54d4)

### How
Incase we see voltage unavailabe (0x3FF), we alert the user to check 12V supply and battery wiring.

`Warning: Battery measurement unavailable. Check 12V power supply and battery wiring!`
