### PR TITLE
Feature: Add more info page for Atto3

### DIFF
--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -46,6 +46,25 @@ typedef struct {
 } DATALAYER_INFO_BMWI3;
 
 typedef struct {
+  /** uint16_t */
+  /** SOC% estimate. Estimated from total pack voltage */
+  uint16_t SOC_estimated = 0;
+  /** uint16_t */
+  /** SOC% raw battery value. Highprecision. Can be locked if pack is crashed */
+  uint16_t SOC_highprec = 0;
+  /** uint16_t */
+  /** SOC% polled OBD2 value. Can be locked if pack is crashed */
+  uint16_t SOC_polled = 0;
+  /** uint16_t */
+  /** Voltage raw battery value */
+  uint16_t voltage_periodic = 0;
+  /** uint16_t */
+  /** Voltage polled OBD2*/
+  uint16_t voltage_polled = 0;
+
+} DATALAYER_INFO_BYDATTO3;
+
+typedef struct {
   /** uint8_t */
   /** Contactor status */
   uint8_t status_contactor = 0;
@@ -119,6 +138,7 @@ typedef struct {
 class DataLayerExtended {
  public:
   DATALAYER_INFO_BMWI3 bmwi3;
+  DATALAYER_INFO_BYDATTO3 bydAtto3;
   DATALAYER_INFO_TESLA tesla;
   DATALAYER_INFO_NISSAN_LEAF nissanleaf;
 };

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -100,6 +100,14 @@ String advanced_battery_processor(const String& var) {
 
 #endif  //BMW_I3_BATTERY
 
+#ifdef BYD_ATTO_3_BATTERY
+    content += "<h4>SOC estimated: " + String(datalayer_extended.bydAtto3.SOC_estimated) + "</h4>";
+    content += "<h4>SOC highprec: " + String(datalayer_extended.bydAtto3.SOC_highprec) + "</h4>";
+    content += "<h4>SOC OBD2: " + String(datalayer_extended.bydAtto3.SOC_polled) + "</h4>";
+    content += "<h4>Voltage periodic: " + String(datalayer_extended.bydAtto3.voltage_periodic) + "</h4>";
+    content += "<h4>Voltage OBD2: " + String(datalayer_extended.bydAtto3.voltage_polled) + "</h4>";
+#endif  //BYD_ATTO_3_BATTERY
+
 #ifdef TESLA_BATTERY
     static const char* contactorText[] = {"UNKNOWN(0)",  "OPEN",        "CLOSING",    "BLOCKED", "OPENING",
                                           "CLOSED",      "UNKNOWN(6)",  "WELDED",     "POS_CL",  "NEG_CL",
@@ -151,8 +159,8 @@ String advanced_battery_processor(const String& var) {
     content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
 #endif
 
-#if !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY) && \
-    !defined(BMW_I3_BATTERY)  //Only the listed types have extra info
+#if !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY) && !defined(BMW_I3_BATTERY) && \
+    !defined(BYD_ATTO_3_BATTERY)  //Only the listed types have extra info
     content += "No extra information available for this battery type";
 #endif
 


### PR DESCRIPTION
### What
This PR implements an extra battery info page for the BYD Atto 3

### Why
More insight for users if battery is locked or not, you can see if SOC% moves

### How
The more battery info webpage now contains the following info:

![image](https://github.com/user-attachments/assets/f1b18a53-3dd1-469d-b3ba-5a2d2de7dedc)

