### PR TITLE
Improvement: Add ifdef to Modbus server error message printing

### DIFF
--- a/Software/src/lib/eModbus-eModbus/ModbusServerRTU.cpp
+++ b/Software/src/lib/eModbus-eModbus/ModbusServerRTU.cpp
@@ -256,7 +256,9 @@ void ModbusServerRTU::serve(ModbusServerRTU *myServer) {
       if (request[0] != TIMEOUT) {
         // Any other error could be important for debugging, so print it
         ModbusError me((Error)request[0]);
+        #ifdef DEBUG_VIA_USB
         LOG_E("RTU receive: %02X - %s\n", (int)me, (const char *)me);
+        #endif //DEBUG_VIA_USB
       }
     }
     // Give scheduler room to breathe


### PR DESCRIPTION
### What
This PR changes to Modbus RTU server only prints error messages incase user has extra USB debugging enabled

### Why
Serial printing is slow and takes CPU resources. We raise an event already if we have RTU missing.

### How
Now we only get Modbus RTU debug info via serial, incase the DEBUG_VIA_USB flag is set.
