### PR TITLE
Feature/can fd crystal frequency setting

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -454,7 +454,7 @@ void init_CAN() {
   Serial.println("CAN FD add-on (ESP32+MCP2517) selected");
 #endif
   SPI.begin(MCP2517_SCK, MCP2517_SDO, MCP2517_SDI);
-  ACAN2517FDSettings settings(ACAN2517FDSettings::OSC_40MHz, 500 * 1000,
+  ACAN2517FDSettings settings(CAN_FD_CRYSTAL_FREQUENCY_MHZ, 500 * 1000,
                               DataBitRateFactor::x4);  // Arbitration bit rate: 500 kbit/s, data bit rate: 2 Mbit/s
 #ifdef USE_CANFD_INTERFACE_AS_CLASSIC_CAN
   settings.mRequestedMode = ACAN2517FDSettings::Normal20B;  // ListenOnly / Normal20B / NormalFD

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -57,6 +57,11 @@
 //#define DUAL_CAN  //Enable this line to activate an isolated secondary CAN Bus using add-on MCP2515 chip (Needed for some inverters / double battery)
 #define CRYSTAL_FREQUENCY_MHZ 8  //DUAL_CAN option, what is your MCP2515 add-on boards crystal frequency?
 //#define CAN_FD  //Enable this line to activate an isolated secondary CAN-FD bus using add-on MCP2518FD chip / Native CANFD on Stark board
+#ifdef CAN_FD  // CAN_FD additional options if enabled
+#define CAN_FD_CRYSTAL_FREQUENCY_MHZ \
+  ACAN2517FDSettings::               \
+      OSC_40MHz  //CAN_FD option, what is your MCP2518 add-on boards crystal frequency? (Default OSC_40MHz)
+#endif
 //#define USE_CANFD_INTERFACE_AS_CLASSIC_CAN // Enable this line if you intend to use the CANFD as normal CAN
 //#define SERIAL_LINK_RECEIVER  //Enable this line to receive battery data over RS485 pins from another Lilygo (This LilyGo interfaces with inverter)
 //#define SERIAL_LINK_TRANSMITTER  //Enable this line to send battery data over RS485 pins to another Lilygo (This LilyGo interfaces with battery)


### PR DESCRIPTION
### What
This PR implements CAN_FD crystal frequency setting in USER_SETTINGS.

### Why
Since there are now MCP2518FD development boards that have 20MHZ crystals.

### How
In USER_SETTINGS.h if CAN_FD is defined it defines CAN_FD_CRYSTAL_FREQUENCY_MHZ which is by default OSC_40MHz. For the 20Mhz board it should be changed to OSC_20MHz.
