### PR TITLE
Speed up value updating

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -56,7 +56,7 @@ Preferences settings;  // Store user settings
 const char* version_number = "7.6.dev";
 
 // Interval settings
-uint16_t intervalUpdateValues = INTERVAL_5_S;  // Interval at which to update inverter values / Modbus registers
+uint16_t intervalUpdateValues = INTERVAL_1_S;  // Interval at which to update inverter values / Modbus registers
 unsigned long previousMillis10ms = 50;
 unsigned long previousMillisUpdateVal = 0;
 
@@ -283,9 +283,8 @@ void core_loop(void* task_time_us) {
     }
     END_TIME_MEASUREMENT_MAX(time_10ms, datalayer.system.status.time_10ms_us);
 
-    START_TIME_MEASUREMENT(time_5s);
-    if (millis() - previousMillisUpdateVal >= intervalUpdateValues)  // Every 5s normally
-    {
+    START_TIME_MEASUREMENT(time_values);
+    if (millis() - previousMillisUpdateVal >= intervalUpdateValues) {
       previousMillisUpdateVal = millis();  // Order matters on the update_loop!
       update_values_battery();             // Fetch battery values
 #ifdef DOUBLE_BATTERY
@@ -300,7 +299,7 @@ void core_loop(void* task_time_us) {
         set_event(EVENT_DUMMY_ERROR, (uint8_t)millis());
       }
     }
-    END_TIME_MEASUREMENT_MAX(time_5s, datalayer.system.status.time_5s_us);
+    END_TIME_MEASUREMENT_MAX(time_values, datalayer.system.status.time_values_us);
 
     START_TIME_MEASUREMENT(cantx);
     // Output
@@ -316,7 +315,7 @@ void core_loop(void* task_time_us) {
       // Record snapshots of task times
       datalayer.system.status.time_snap_comm_us = datalayer.system.status.time_comm_us;
       datalayer.system.status.time_snap_10ms_us = datalayer.system.status.time_10ms_us;
-      datalayer.system.status.time_snap_5s_us = datalayer.system.status.time_5s_us;
+      datalayer.system.status.time_snap_values_us = datalayer.system.status.time_values_us;
       datalayer.system.status.time_snap_cantx_us = datalayer.system.status.time_cantx_us;
       datalayer.system.status.time_snap_ota_us = datalayer.system.status.time_ota_us;
     }
@@ -327,7 +326,7 @@ void core_loop(void* task_time_us) {
       datalayer.system.status.time_ota_us = 0;
       datalayer.system.status.time_comm_us = 0;
       datalayer.system.status.time_10ms_us = 0;
-      datalayer.system.status.time_5s_us = 0;
+      datalayer.system.status.time_values_us = 0;
       datalayer.system.status.time_cantx_us = 0;
       datalayer.system.status.core_task_10s_max_us = 0;
     }

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -145,8 +145,8 @@ typedef struct {
   int64_t time_comm_us = 0;
   /** 10 ms function measurement variable */
   int64_t time_10ms_us = 0;
-  /** 5 s function measurement variable */
-  int64_t time_5s_us = 0;
+  /** Value update function measurement variable */
+  int64_t time_values_us = 0;
   /** CAN TX function measurement variable */
   int64_t time_cantx_us = 0;
 
@@ -163,9 +163,9 @@ typedef struct {
    */
   int64_t time_snap_10ms_us = 0;
   /** Function measurement snapshot variable.
-   * This will show the performance of the 5 s functionality of the core task when the total time reached a new worst case
+   * This will show the performance of the values functionality of the core task when the total time reached a new worst case
    */
-  int64_t time_snap_5s_us = 0;
+  int64_t time_snap_values_us = 0;
   /** Function measurement snapshot variable.
    * This will show the performance of CAN TX when the total time reached a new worst case
    */

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -33,8 +33,8 @@ enum led_color { GREEN, YELLOW, RED, BLUE, RGB };
 #define INTERVAL_200_MS_DELAYED 240
 #define INTERVAL_500_MS_DELAYED 550
 
-#define CAN_STILL_ALIVE 12
-// Set by battery each time we get a CAN message. Decrements every 5seconds. When reaching 0, sets event
+#define CAN_STILL_ALIVE 60
+// Set by battery each time we get a CAN message. Decrements every second. When reaching 0, sets event
 
 /* CAN Frame structure */
 typedef struct {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -459,7 +459,7 @@ String processor(const String& var) {
         "<h4>loop() task max load last 10 s: " + String(datalayer.system.status.loop_task_10s_max_us) + " us</h4>";
     content += "<h4>Max load @ worst case execution of core task:</h4>";
     content += "<h4>10ms function timing: " + String(datalayer.system.status.time_snap_10ms_us) + " us</h4>";
-    content += "<h4>5s function timing: " + String(datalayer.system.status.time_snap_5s_us) + " us</h4>";
+    content += "<h4>Values function timing: " + String(datalayer.system.status.time_snap_values_us) + " us</h4>";
     content += "<h4>CAN/serial RX function timing: " + String(datalayer.system.status.time_snap_comm_us) + " us</h4>";
     content += "<h4>CAN TX function timing: " + String(datalayer.system.status.time_snap_cantx_us) + " us</h4>";
     content += "<h4>OTA function timing: " + String(datalayer.system.status.time_snap_ota_us) + " us</h4>";


### PR DESCRIPTION
### What
This PR speeds up the main loop value update rate from 5seconds -> 1seconds

### Why
It is an industry norm to update values every second. With an 1s update rate we can faster respond to any changing values, and evaluate safety checks more often.

### How
`intervalUpdateValues = INTERVAL_1_S; `
