### PR TITLE
Bug Fix for Precharge Contactor Handling in SHUTDOWN_REQUESTED State and Web Interface Enhancement for Contactor Status Display

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -744,6 +744,7 @@ void handle_contactors() {
   if (timeSpentInFaultedMode > MAX_ALLOWED_FAULT_TICKS ||
       (datalayer.system.settings.equipment_stop_active && contactorStatus != SHUTDOWN_REQUESTED)) {
     contactorStatus = SHUTDOWN_REQUESTED;
+    datalayer.system.settings.equipment_stop_active = true;
   }
   if (contactorStatus == SHUTDOWN_REQUESTED && !datalayer.system.settings.equipment_stop_active) {
     contactorStatus = DISCONNECTED;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -719,6 +719,27 @@ String processor(const String& var) {
       content += "<span style='color: red;'>OFF</span>";
     }
     content += "</h4>";
+
+    content += "<h4>Pre Charge: ";
+    if (digitalRead(PRECHARGE_PIN) == HIGH) {
+      content += "<span style='color: green;'>&#10003;</span>";
+    } else {
+      content += "<span style='color: red;'>&#10005;</span>";
+    }
+    content += " Cont. Neg.: ";
+    if (digitalRead(NEGATIVE_CONTACTOR_PIN) == HIGH) {
+      content += "<span style='color: green;'>&#10003;</span>";
+    } else {
+      content += "<span style='color: red;'>&#10005;</span>";
+    }
+
+    content += " Cont. Pos.: ";
+    if (digitalRead(POSITIVE_CONTACTOR_PIN) == HIGH) {
+      content += "<span style='color: green;'>&#10003;</span>";
+    } else {
+      content += "<span style='color: red;'>&#10005;</span>";
+    }
+    content += "</h4>";
 #endif
 
     // Close the block


### PR DESCRIPTION
### What

This PR addresses a bug fix and introduces a new feature in the Battery Emulator project. The bug affects the handling of precharge contactor in the SHUTDOWN_REQUESTED state, and the feature adds enhanced visibility to contactor states in the web interface.

### Why

When the battery emulator reaches the MAX_ALLOWED_FAULT_TICKS limit, it enters the SHUTDOWN_REQUESTED state. However, an issue in the handle_contactors introduced on equipment stop functionality  code was allowing the system to immediately transition to a DISCONNECTED state. This bypassed the proper shutdown sequence, causing the precharge contactor to remain in a HIGH state. Additionally, providing visibility into the states of all contactors (precharge, negative, and positive) in the web interface allows users to better monitor and diagnose the system status.

### How

The bug fix ensures that, when the system enters the SHUTDOWN_REQUESTED state, equipment_stop_active is also set to true, ensuring the contactors follow the intended shutdown sequence. Furthermore, the web interface has been updated to display the states of all key contactors (precharge, negative, and positive), giving users clear, real-time insight into their statuses directly from the webserver interface.