### PR TITLE
BMW i3: Replace faulty cap check with welded contactor check

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -422,10 +422,10 @@ void update_values_battery2() {  //This function maps all the values fetched via
   } else {
     clear_event(EVENT_HVIL_FAILURE);
   }
-  if (battery2_status_precharge_locked == 2) {  // Capacitor seated?
-    set_event(EVENT_PRECHARGE_FAILURE, 2);
+  if (battery2_status_error_disconnecting_switch > 0) {  // Check if contactors are sticking / welded
+    set_event(EVENT_CONTACTOR_WELDED, 0);
   } else {
-    clear_event(EVENT_PRECHARGE_FAILURE);
+    clear_event(EVENT_CONTACTOR_WELDED);
   }
 }
 
@@ -490,10 +490,10 @@ void update_values_battery() {  //This function maps all the values fetched via 
   } else {
     clear_event(EVENT_HVIL_FAILURE);
   }
-  if (battery_status_precharge_locked == 2) {  // Capacitor seated?
-    set_event(EVENT_PRECHARGE_FAILURE, 0);
+  if (battery_status_error_disconnecting_switch > 0) {  // Check if contactors are sticking / welded
+    set_event(EVENT_CONTACTOR_WELDED, 0);
   } else {
-    clear_event(EVENT_PRECHARGE_FAILURE);
+    clear_event(EVENT_CONTACTOR_WELDED);
   }
 
   // Update webserver datalayer

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -150,6 +150,7 @@ void init_events(void) {
   events.entries[EVENT_CAN_RX_WARNING].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_TX_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CAN_INVERTER_MISSING].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CONTACTOR_WELDED].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_WATER_INGRESS].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DISCHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
@@ -281,6 +282,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "ERROR: CAN messages failed to transmit, or no one on the bus to ACK the message!";
     case EVENT_CAN_INVERTER_MISSING:
       return "Warning: Inverter not sending messages on CAN bus. Check wiring!";
+    case EVENT_CONTACTOR_WELDED:
+      return "Warning: Contactors sticking/welded. Inspect battery with caution!";
     case EVENT_CHARGE_LIMIT_EXCEEDED:
       return "Info: Inverter is charging faster than battery is allowing.";
     case EVENT_DISCHARGE_LIMIT_EXCEEDED:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0016  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0017  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -37,6 +37,7 @@
   XX(EVENT_CAN_TX_FAILURE)              \
   XX(EVENT_CAN_INVERTER_MISSING)        \
   XX(EVENT_CHARGE_LIMIT_EXCEEDED)       \
+  XX(EVENT_CONTACTOR_WELDED)            \
   XX(EVENT_DISCHARGE_LIMIT_EXCEEDED)    \
   XX(EVENT_WATER_INGRESS)               \
   XX(EVENT_12V_LOW)                     \


### PR DESCRIPTION
### What
This PR removes a faulty precharge check, and replaces it with a welded contactor check. 

### Why
It is not possible to use battery_status_precharge_locked to see if capacitor is seated, the parameter cannot be used in this way. Reported by users in https://github.com/dalathegreat/Battery-Emulator/issues/574

### How
Now we check contactor status, if either of the contactors are welded/sticking we report an EVENT_CONTACTOR_WELDED