### PR TITLE
Bugfix: Add remaining capacity writing for Pylon

### DIFF
--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -67,6 +67,9 @@ void update_values_battery() {
 
   datalayer.battery.status.max_discharge_power_W = (-max_discharge_current * (voltage_dV / 10));
 
+  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+
   datalayer.battery.status.cell_max_voltage_mV = cellvoltage_max_mV;
 
   datalayer.battery.status.cell_min_voltage_mV = cellvoltage_min_mV;


### PR DESCRIPTION
### What
This PR fixes a bug, when using `PYLON_BATTERY` the remaining capacity would be 0 all the time

![image](https://github.com/user-attachments/assets/9dc80249-eb2b-49bd-b92e-9f8659d2a91e)

### Why
Fixing this to correct behaviour

### How
We set capacity left according to SOC%, same as other implementations
