### PR TITLE
Bugfix: Update BYD FW to 3.29

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -15,13 +15,13 @@ static uint8_t char5_151 = 0;
 static uint8_t char6_151 = 0;
 static uint8_t char7_151 = 0;
 
-CAN_frame BYD_250 = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x250,
-    .data = {0x03, 0x16, 0x00, 0x66, (uint8_t)((BATTERY_WH_MAX / 100) >> 8), (uint8_t)(BATTERY_WH_MAX / 100), 0x02,
-             0x09}};  //3.16 FW , Capacity kWh byte4&5 (example 24kWh = 240)
+CAN_frame BYD_250 = {.FD = false,
+                     .ext_ID = false,
+                     .DLC = 8,
+                     .ID = 0x250,
+                     .data = {FW_MAJOR_VERSION, FW_MINOR_VERSION, 0x00, 0x66, (uint8_t)((BATTERY_WH_MAX / 100) >> 8),
+                              (uint8_t)(BATTERY_WH_MAX / 100), 0x02,
+                              0x09}};  //0-1 FW version , Capacity kWh byte4&5 (example 24kWh = 240)
 CAN_frame BYD_290 = {.FD = false,
                      .ext_ID = false,
                      .DLC = 8,

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -3,6 +3,8 @@
 #include "../include.h"
 
 #define CAN_INVERTER_SELECTED
+#define FW_MAJOR_VERSION 0x03
+#define FW_MINOR_VERSION 0x29
 
 void send_intial_data();
 void transmit_can(CAN_frame* tx_frame, int interface);


### PR DESCRIPTION
### What
This PR updates the BYD firmware version string we send towards the inverter.

### Why
To make the emulator appear as an up to date BYD battery. This fixes the issue reported in #597

### How
We implement a definable firmware version in .header
