### PR TITLE
Improvement: Centralize active_power_w writing

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -854,6 +854,9 @@ void update_calculated_values() {
   if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
     datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
   }
+  /* Calculate active power based on voltage and current*/
+  datalayer.battery.status.active_power_W =
+      (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
 
   if (datalayer.battery.settings.soc_scaling_active) {
     /** SOC Scaling
@@ -899,6 +902,9 @@ void update_calculated_values() {
     }
 
 #ifdef DOUBLE_BATTERY
+    /* Calculate active power based on voltage and current*/
+    datalayer.battery2.status.active_power_W =
+        (datalayer.battery2.status.current_dA * (datalayer.battery2.status.voltage_dV / 100));
 
     // Calculate the scaled remaining capacity in Wh
     if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery2.status.real_soc > 0) {

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -239,7 +239,6 @@ static int16_t battery_temperature_max = 0;
 static int16_t battery_temperature_min = 0;
 static int16_t battery_max_charge_amperage = 0;
 static int16_t battery_max_discharge_amperage = 0;
-static int16_t battery_power = 0;
 static int16_t battery_current = 0;
 static uint8_t battery_status_error_isolation_external_Bordnetz = 0;
 static uint8_t battery_status_error_isolation_internal_Bordnetz = 0;
@@ -308,7 +307,6 @@ static int16_t battery2_temperature_max = 0;
 static int16_t battery2_temperature_min = 0;
 static int16_t battery2_max_charge_amperage = 0;
 static int16_t battery2_max_discharge_amperage = 0;
-static int16_t battery2_power = 0;
 static int16_t battery2_current = 0;
 static uint8_t battery2_status_error_isolation_external_Bordnetz = 0;
 static uint8_t battery2_status_error_isolation_internal_Bordnetz = 0;
@@ -388,10 +386,6 @@ void update_values_battery2() {  //This function maps all the values fetched via
     datalayer.battery2.status.max_charge_power_W = battery2_BEV_available_power_longterm_charge;
   }
 
-  battery2_power = (datalayer.battery2.status.current_dA * (datalayer.battery2.status.voltage_dV / 100));
-
-  datalayer.battery2.status.active_power_W = battery2_power;
-
   datalayer.battery2.status.temperature_min_dC = battery2_temperature_min * 10;  // Add a decimal
 
   datalayer.battery2.status.temperature_max_dC = battery2_temperature_max * 10;  // Add a decimal
@@ -455,10 +449,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.max_discharge_power_W = battery_BEV_available_power_longterm_discharge;
 
   datalayer.battery.status.max_charge_power_W = battery_BEV_available_power_longterm_charge;
-
-  battery_power = (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
-
-  datalayer.battery.status.active_power_W = battery_power;
 
   datalayer.battery.status.temperature_min_dC = battery_temperature_min * 10;  // Add a decimal
 

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -353,7 +353,6 @@ static unsigned long min_cell_voltage_lastchanged = 0;
 static unsigned long max_cell_voltage_lastchanged = 0;
 static unsigned min_cell_voltage_lastreceived = 0;
 static unsigned max_cell_voltage_lastreceived = 0;
-static int16_t battery_power = 0;
 static uint32_t sme_uptime = 0;               //Uses E4 C0
 static int16_t allowable_charge_amps = 0;     //E5 62
 static int16_t allowable_discharge_amps = 0;  //E5 62
@@ -453,10 +452,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   } else {  // No limits, max charging power allowed
     datalayer.battery.status.max_charge_power_W = MAX_CHARGE_POWER_ALLOWED_W;
   }
-
-  battery_power = (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
-
-  datalayer.battery.status.active_power_W = battery_power;
 
   datalayer.battery.status.temperature_min_dC = min_battery_temperature;
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -122,9 +122,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W = 10000;  //TODO: Map from CAN later on
 
-  datalayer.battery.status.active_power_W =
-      (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
-
   datalayer.battery.status.cell_max_voltage_mV = BMS_highest_cell_voltage_mV;
 
   datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
@@ -444,9 +441,6 @@ void update_values_battery2() {  //This function maps all the values fetched via
   datalayer.battery2.status.max_discharge_power_W = 10000;  //TODO: Map from CAN later on
 
   datalayer.battery2.status.max_charge_power_W = 10000;  //TODO: Map from CAN later on
-
-  datalayer.battery2.status.active_power_W =
-      (datalayer.battery2.status.current_dA * (datalayer.battery2.status.voltage_dV / 100));
 
   datalayer.battery2.status.cell_max_voltage_mV = BMS2_highest_cell_voltage_mV;
 

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -124,9 +124,6 @@ void update_values_battery() {
 
   datalayer.battery.status.current_dA = battery_pack_current_dA;
 
-  datalayer.battery.status.active_power_W =  //Power in watts, Negative = charging batt
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.max_charge_power_W = 5000;  //TODO, is this available via CAN?
 
   datalayer.battery.status.max_discharge_power_W = 5000;  //TODO, is this available via CAN?

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -51,8 +51,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_discharge_power_W = 10000;  // 10kW   //TODO: Fix when CAN is decoded
 
-  datalayer.battery.status.active_power_W = BMU_Power;  //TODO: Scaling?
-
   static int n = sizeof(cell_voltages) / sizeof(cell_voltages[0]);
   max_volt_cel = cell_voltages[0];  // Initialize max with the first element of the array
   for (int i = 1; i < n; i++) {

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -81,10 +81,6 @@ void update_values_battery() {
 
   datalayer.battery.status.cell_min_voltage_mV = HVBattCellVoltageMinMv;
 
-  //Power in watts, Negative = charging batt
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.temperature_min_dC = HVBattCellTempColdest * 10;  // C to dC
 
   datalayer.battery.status.temperature_max_dC = HVBattCellTempHottest * 10;  // C to dC

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -38,7 +38,6 @@ static uint16_t CellVoltMin_mV = 3700;
 static uint16_t batteryVoltage = 6700;
 static int16_t leadAcidBatteryVoltage = 120;
 static int16_t batteryAmps = 0;
-static int16_t powerWatt = 0;
 static int16_t temperatureMax = 0;
 static int16_t temperatureMin = 0;
 static int16_t allowedDischargePower = 0;
@@ -659,10 +658,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //datalayer.battery.status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
   //The allowed discharge power is not available. We hardcode this value for now
   datalayer.battery.status.max_discharge_power_W = MAXDISCHARGEPOWERALLOWED;
-
-  powerWatt = ((batteryVoltage * batteryAmps) / 100);
-
-  datalayer.battery.status.active_power_W = powerWatt;  //Power in watts, Negative = charging batt
 
   datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -124,10 +124,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_discharge_power_W = allowedDischargePower * 10;
 
-  //Power in watts, Negative = charging batt
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 
   datalayer.battery.status.temperature_max_dC = (int8_t)temperatureMax * 10;  //Increase decimals, 18C -> 18.0C

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -68,10 +68,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W = available_charge_power * 10;
 
-  //Power in watts, Negative = charging batt
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.temperature_min_dC = (int16_t)(battery_module_min_temperature * 10);
 
   datalayer.battery.status.temperature_max_dC = (int16_t)(battery_module_max_temperature * 10);

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -39,8 +39,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W;
 
-  datalayer.battery.status.active_power_W;
-
   datalayer.battery.status.temperature_min_dC;
 
   datalayer.battery.status.temperature_max_dC;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -197,9 +197,6 @@ void update_values_battery() { /* This function maps all the values fetched via 
 
   datalayer.battery.status.remaining_capacity_Wh = battery_Wh_Remaining;
 
-  datalayer.battery.status.active_power_W = ((battery_Total_Voltage2 * battery_Current2) /
-                                             4);  //P = U * I (Both values are 0.5 per bit so the math is non-intuitive)
-
   //Update temperature readings. Method depends on which generation LEAF battery is used
   if (LEAF_battery_Type == ZE0_BATTERY) {
     //Since we only have average value, send the minimum as -1.0 degrees below average
@@ -368,10 +365,6 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
   datalayer.battery2.info.total_capacity_Wh = (battery2_Max_GIDS * WH_PER_GID);
 
   datalayer.battery2.status.remaining_capacity_Wh = battery2_Wh_Remaining;
-
-  datalayer.battery2.status.active_power_W =
-      ((battery2_Total_Voltage2 * battery2_Current2) /
-       4);  //P = U * I (Both values are 0.5 per bit so the math is non-intuitive)
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
   if (LEAF_battery2_Type == ZE0_BATTERY) {

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -60,9 +60,6 @@ void update_values_battery() {
 
   datalayer.battery.status.current_dA = current_dA;  //value is *10 (150 = 15.0) , invert the sign
 
-  datalayer.battery.status.active_power_W =  //Power in watts, Negative = charging batt
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.max_charge_power_W = (max_charge_current * (voltage_dV / 10));
 
   datalayer.battery.status.max_discharge_power_W = (-max_discharge_current * (voltage_dV / 10));

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -160,9 +160,6 @@ void update_values_battery() {
 
   datalayer.battery.status.current_dA = (CurrentExt * 0.025) - 209715;
 
-  datalayer.battery.status.active_power_W =  //Power in watts, Negative = charging batt
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.max_charge_power_W = (ChargeContPwrLmt * 10) - 6550;
 
   datalayer.battery.status.max_discharge_power_W = (DischargeContPwrLmt * 10) - 6550;

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -95,9 +95,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //The above value is 0 on some packs. We instead hardcode this now.
   datalayer.battery.status.max_charge_power_W = MAX_CHARGE_POWER_W;
 
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.temperature_min_dC = (LB_MIN_TEMPERATURE * 10);
 
   datalayer.battery.status.temperature_max_dC = (LB_MAX_TEMPERATURE * 10);

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -46,9 +46,6 @@ void update_values_battery() {
   datalayer.battery.status.current_dA = current_dA;  //value is *10 (150 = 15.0)
   datalayer.battery.status.remaining_capacity_Wh = remaining_capacity_Wh;
 
-  datalayer.battery.status.active_power_W =  //Power in watts, Negative = charging batt
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   // The twizy provides two values: one for the maximum charge provided by the on-board charger
   //    and one for the maximum charge during recuperation.
   //    For now we use the lower of the two (usually the charger one)

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -104,10 +104,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.status.max_charge_power_W = 50;
   }
 
-  //Power in watts, Negative = charging batt
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   int16_t temperatures[] = {cell_1_temperature_polled,  cell_2_temperature_polled,  cell_3_temperature_polled,
                             cell_4_temperature_polled,  cell_5_temperature_polled,  cell_6_temperature_polled,
                             cell_7_temperature_polled,  cell_8_temperature_polled,  cell_9_temperature_polled,

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -166,9 +166,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W = battery_max_generated * 10;
 
-  datalayer.battery.status.active_power_W =
-      (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
-
   datalayer.battery.status.temperature_min_dC = ((battery_min_temp - 640) * 0.625);
 
   datalayer.battery.status.temperature_max_dC = ((battery_max_temp - 640) * 0.625);

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -98,9 +98,6 @@ void update_values_battery() {
 
   datalayer.battery.status.current_dA = total_current;
 
-  datalayer.battery.status.active_power_W =  //Power in watts, Negative = charging batt
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   // Charge power is set in .h file
   if (datalayer.battery.status.real_soc > 9900) {
     datalayer.battery.status.max_charge_power_W = MAX_CHARGE_POWER_WHEN_TOPBALANCING_W;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -85,10 +85,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W = allowedChargePower * 10;
 
-  //Power in watts, Negative = charging batt
-  datalayer.battery.status.active_power_W =
-      ((datalayer.battery.status.voltage_dV * datalayer.battery.status.current_dA) / 100);
-
   datalayer.battery.status.cell_max_voltage_mV = CellVoltMax_mV;
 
   datalayer.battery.status.cell_min_voltage_mV = CellVoltMin_mV;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -297,8 +297,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.status.max_charge_power_W = MAXCHARGEPOWERALLOWED;
   }
 
-  datalayer.battery.status.active_power_W = ((battery_volts / 10) * battery_amps);
-
   datalayer.battery.status.temperature_min_dC = battery_min_temp;
 
   datalayer.battery.status.temperature_max_dC = battery_max_temp;
@@ -856,8 +854,6 @@ void update_values_battery2() {  //This function maps all the values fetched via
   } else {  // No limits, max charging power allowed
     datalayer.battery2.status.max_charge_power_W = MAXCHARGEPOWERALLOWED;
   }
-
-  datalayer.battery2.status.active_power_W = ((battery2_volts / 10) * battery2_amps);
 
   datalayer.battery2.status.temperature_min_dC = battery2_min_temp;
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -40,8 +40,6 @@ void update_values_battery() { /* This function puts fake values onto the parame
 
   datalayer.battery.status.cell_min_voltage_mV = 3500;
 
-  datalayer.battery.status.active_power_W = 0;  // 0W
-
   datalayer.battery.status.temperature_min_dC = 50;  // 5.0*C
 
   datalayer.battery.status.temperature_max_dC = 60;  // 6.0*C
@@ -94,8 +92,6 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
   datalayer.battery2.status.cell_max_voltage_mV = 3596;
 
   datalayer.battery2.status.cell_min_voltage_mV = 3500;
-
-  datalayer.battery2.status.active_power_W = 0;  // 0W
 
   datalayer.battery2.status.temperature_min_dC = 50;  // 5.0*C
 

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -83,7 +83,6 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //datalayer.battery.status.max_discharge_power_W = HvBattPwrLimDchaSoft * 1000;	// Use power limit reported from BMS, not trusted ATM
   datalayer.battery.status.max_discharge_power_W = 30000;
   datalayer.battery.status.max_charge_power_W = 30000;
-  datalayer.battery.status.active_power_W = (BATT_U)*BATT_I;
   datalayer.battery.status.temperature_min_dC = BATT_T_MIN;
   datalayer.battery.status.temperature_max_dC = BATT_T_MAX;
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -31,7 +31,7 @@ typedef struct {
 
 typedef struct {
   /** int32_t */
-  /** Instantaneous battery power in Watts */
+  /** Instantaneous battery power in Watts. Calculated based on voltage_dV and current_dA */
   /* Positive value = Battery Charging */
   /* Negative value = Battery Discharging */
   int32_t active_power_W;


### PR DESCRIPTION
### What
This PR implements centralized writing of the active power (W) value

### Why
To make it simpler to maintain and add new battery protocols

### How
Instead of having each battery implementation doing the same calculation to get W from Volt&Amp, we perform this in the `update_calculated_values()` function
