### PR TITLE
Improvements: Webserver / integration simplification

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -34,19 +34,25 @@ jobs:
         # These are the batteries for which the code will be compiled.
         battery:
           - BMW_I3_BATTERY
+          - BMW_IX_BATTERY
           - BYD_ATTO_3_BATTERY
           - CELLPOWER_BMS
           - CHADEMO_BATTERY
           - IMIEV_CZERO_ION_BATTERY
           - JAGUAR_IPACE_BATTERY
           - KIA_HYUNDAI_64_BATTERY
+          - KIA_E_GMP_BATTERY
           - KIA_HYUNDAI_HYBRID_BATTERY
+          - MG_5_BATTERY
           - NISSAN_LEAF_BATTERY
           - PYLON_BATTERY
           - RJXZS_BMS
+          - RANGE_ROVER_PHEV_BATTERY
           - RENAULT_KANGOO_BATTERY
+          - RENAULT_TWIZY_BATTERY
           - RENAULT_ZOE_GEN1_BATTERY
           - RENAULT_ZOE_GEN2_BATTERY
+          - SANTA_FE_PHEV_BATTERY
           - TESLA_MODEL_3Y_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
@@ -54,13 +60,6 @@ jobs:
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - BYD_CAN
-#         - BYD_MODBUS
-#         - PYLON_CAN
-#         - SMA_CAN
-#         - SMA_TRIPOWER_CAN
-#         - SOFAR_CAN
-#         - SOLAX_CAN
-
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest
 

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -42,10 +42,12 @@ jobs:
 #         - TESLA_MODEL_3Y_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
+          - AFORE_CAN
           - BYD_CAN
           - BYD_SMA
           - BYD_MODBUS
           - FOXESS_CAN
+          - PYLON_LV_CAN
           - PYLON_CAN
           - SMA_CAN
           - SMA_TRIPOWER_CAN

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -555,26 +555,13 @@ void init_rs485() {
 }
 
 void init_inverter() {
-#ifdef SOLAX_CAN
-  datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
-  intervalUpdateValues = 800;  // This protocol also requires the values to be updated faster
-#endif
-#ifdef FOXESS_CAN
-  intervalUpdateValues = 950;  // This protocol also requires the values to be updated faster
-#endif
-#ifdef BYD_SMA
-  datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
-  pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
-#endif
+  // Inform user what inverter is used and perform setup
+  setup_inverter();
 }
 
 void init_battery() {
   // Inform user what battery is used and perform setup
   setup_battery();
-
-#ifdef CHADEMO_BATTERY
-  intervalUpdateValues = 800;  // This mode requires the values to be updated faster
-#endif
 }
 
 #ifdef EQUIPMENT_STOP_BUTTON

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -70,13 +70,11 @@ volatile bool send_ok = 0;
 static const uint32_t QUARTZ_FREQUENCY = CRYSTAL_FREQUENCY_MHZ * 1000000UL;  //MHZ configured in USER_SETTINGS.h
 ACAN2515 can(MCP2515_CS, SPI, MCP2515_INT);
 static ACAN2515_Buffer16 gBuffer;
-#endif
+#endif  //DUAL_CAN
 #ifdef CAN_FD
 #include "src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h"
 ACAN2517FD canfd(MCP2517_CS, SPI, MCP2517_INT);
-#else
-typedef char CANFDMessage;
-#endif
+#endif  //CAN_FD
 
 // ModbusRTU parameters
 #ifdef MODBUS_INVERTER_SELECTED
@@ -172,11 +170,10 @@ void setup() {
   init_rs485();
 
   init_serialDataLink();
-
-  init_inverter();
-
-  init_battery();
-
+#if defined(CAN_INVERTER_SELECTED) || defined(MODBUS_INVERTER_SELECTED)
+  setup_inverter();
+#endif
+  setup_battery();
 #ifdef EQUIPMENT_STOP_BUTTON
   init_equipment_stop_button();
 #endif
@@ -552,16 +549,6 @@ void init_rs485() {
   // Start ModbusRTU background task
   MBserver.begin(Serial2, MODBUS_CORE);
 #endif
-}
-
-void init_inverter() {
-  // Inform user what inverter is used and perform setup
-  setup_inverter();
-}
-
-void init_battery() {
-  // Inform user what battery is used and perform setup
-  setup_battery();
 }
 
 #ifdef EQUIPMENT_STOP_BUTTON

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1118,9 +1118,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("BMW i3 battery selected");
-#endif  //DEBUG_VIA_USB
+  strncpy(datalayer.system.info.battery_protocol, "BMW i3", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   //Before we have started up and detected which battery is in use, use 60AH values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
@@ -1129,9 +1129,6 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
 
 #ifdef DOUBLE_BATTERY
-#ifdef DEBUG_VIA_USB
-  Serial.println("Another BMW i3 battery also selected!");
-#endif  //DEBUG_VIA_USB
   datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
   datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1118,8 +1118,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "BMW i3", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "BMW i3", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   //Before we have started up and detected which battery is in use, use 60AH values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1119,8 +1119,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "BMW i3", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   //Before we have started up and detected which battery is in use, use 60AH values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -780,8 +780,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   //Before we have started up and detected which battery is in use, use 108S values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -778,9 +778,10 @@ void send_can_battery() {
 //} //We can always send CAN as the iX BMS will wake up on vehicle comms
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("BMW iX battery selected");
-#endif  //DEBUG_VIA_USB
+  strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   //Before we have started up and detected which battery is in use, use 108S values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -778,9 +778,8 @@ void send_can_battery() {
 //} //We can always send CAN as the iX BMS will wake up on vehicle comms
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   //Before we have started up and detected which battery is in use, use 108S values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -400,8 +400,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "BYD Atto 3", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.number_of_cells = 126;
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -399,9 +399,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("BYD Atto 3 battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "BYD Atto 3", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.number_of_cells = 126;
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -399,8 +399,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "BYD Atto 3", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "BYD Atto 3", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 126;
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -333,8 +333,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Cellpower BMS", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Cellpower BMS", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -334,8 +334,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Cellpower BMS", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -333,9 +333,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Cellpower BMS selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Cellpower BMS", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -1031,9 +1031,11 @@ void handle_chademo_sequence() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Chademo battery selected");
-#endif
+
+  strncpy(datalayer.system.info.battery_protocol, "Chademo V2X mode",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   CHADEMO_Status = CHADEMO_IDLE;
 

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -1034,8 +1034,7 @@ void setup_battery(void) {  // Performs one time setup at startup
 
   strncpy(datalayer.system.info.battery_protocol, "Chademo V2X mode",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   CHADEMO_Status = CHADEMO_IDLE;
 

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -1032,9 +1032,8 @@ void handle_chademo_sequence() {
 
 void setup_battery(void) {  // Performs one time setup at startup
 
-  strncpy(datalayer.system.info.battery_protocol, "Chademo V2X mode",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Chademo V2X mode", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   CHADEMO_Status = CHADEMO_IDLE;
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -224,9 +224,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Mitsubishi i-MiEV / Citroen C-Zero / Peugeot Ion battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "I-Miev / C-Zero / Ion Triplet",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -226,8 +226,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "I-Miev / C-Zero / Ion Triplet",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -224,9 +224,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "I-Miev / C-Zero / Ion Triplet",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "I-Miev / C-Zero / Ion Triplet", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -255,8 +255,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -254,9 +254,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Jaguar iPace 90kWh battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -254,9 +254,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
-
+  strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1037,14 +1037,14 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Hyundai E-GMP (Electric Global Modular Platform) battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai EGMP platform",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   startMillis = millis();  // Record the starting time
 
   datalayer.system.status.battery_allows_contactor_closing = true;
-
   datalayer.battery.info.number_of_cells = 192;  // TODO: will vary depending on battery
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1037,9 +1037,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai EGMP platform",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai EGMP platform", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   startMillis = millis();  // Record the starting time
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1039,8 +1039,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai EGMP platform",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   startMillis = millis();  // Record the starting time
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -534,9 +534,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai 64/40kWh battery",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai 64/40kWh battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -534,9 +534,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Kia Niro / Hyundai Kona 64kWh battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai 64/40kWh battery",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';                                                                // Ensure null termination
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -536,8 +536,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai 64/40kWh battery",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';                                                                // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -257,9 +257,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai Hybrid",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai Hybrid", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.number_of_cells = 56;  // HEV , TODO: Make dynamic according to HEV/PHEV
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -257,9 +257,11 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Kia/Hyundai Hybrid battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai Hybrid",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
+
   datalayer.battery.info.number_of_cells = 56;  // HEV , TODO: Make dynamic according to HEV/PHEV
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -259,8 +259,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai Hybrid",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.number_of_cells = 56;  // HEV , TODO: Make dynamic according to HEV/PHEV
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -135,9 +135,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("MG 5 battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "MG 5 battery", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -135,8 +135,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "MG 5 battery", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "MG 5 battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -136,8 +136,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "MG 5 battery", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1224,9 +1224,8 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1226,8 +1226,7 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1224,9 +1224,10 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Nissan LEAF battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -175,9 +175,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Pylon battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -175,10 +175,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
-
+  strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -177,8 +177,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -313,9 +313,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Range Rover PHEV battery (L494 / L405) selected");
-#endif  //DEBUG_VIA_USB
+  strncpy(datalayer.system.info.battery_protocol, "Range Rover 13kWh PHEV battery (L494/L405)",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -315,8 +315,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Range Rover 13kWh PHEV battery (L494/L405)",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -313,10 +313,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Range Rover 13kWh PHEV battery (L494/L405)",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
-
+  strncpy(datalayer.system.info.battery_protocol, "Range Rover 13kWh PHEV battery (L494/L405)", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -236,8 +236,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
 
   strncpy(datalayer.system.info.battery_protocol, "Renault Kangoo", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -235,8 +235,8 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
 
-  strncpy(datalayer.system.info.battery_protocol, "Renault Kangoo", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Renault Kangoo", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -234,9 +234,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Renault Kangoo battery selected");
-#endif
+
+  strncpy(datalayer.system.info.battery_protocol, "Renault Kangoo", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -132,8 +132,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Renault Twizy", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Renault Twizy", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 14;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -133,8 +133,7 @@ void send_can_battery() {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Renault Twizy", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.number_of_cells = 14;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -132,10 +132,9 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Renault Twizy battery selected");
-#endif
-
+  strncpy(datalayer.system.info.battery_protocol, "Renault Twizy", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.number_of_cells = 14;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -518,9 +518,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Renault Zoe 22/40kWh battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen1 22/40kWh",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -518,9 +518,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen1 22/40kWh",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen1 22/40kWh", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -520,8 +520,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen1 22/40kWh",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -385,9 +385,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen2 50kWh",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen2 50kWh", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -387,8 +387,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen2 50kWh",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -385,9 +385,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Renault Zoe 50kWh battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen2 50kWh",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -570,10 +570,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("RJXZS BMS selected");
-#endif
-
+  strncpy(datalayer.system.info.battery_protocol, "RJXZS BMS, DIY battery",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -572,8 +572,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "RJXZS BMS, DIY battery",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -570,9 +570,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "RJXZS BMS, DIY battery",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "RJXZS BMS, DIY battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -402,9 +402,9 @@ uint8_t CalculateCRC8(CAN_frame rx_frame) {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Hyundai Santa Fe PHEV battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Santa Fe PHEV", sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -402,8 +402,8 @@ uint8_t CalculateCRC8(CAN_frame rx_frame) {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Santa Fe PHEV", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Santa Fe PHEV", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -403,8 +403,7 @@ uint8_t CalculateCRC8(CAN_frame rx_frame) {
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Santa Fe PHEV", sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -221,8 +221,7 @@ void update_values_serial_link() {
 void setup_battery(void) {
   strncpy(datalayer.system.info.battery_protocol, "Serial link to another LilyGo board",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 }
 // Needed to make the compiler happy
 void update_values_battery() {}

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -219,9 +219,8 @@ void update_values_serial_link() {
 }
 
 void setup_battery(void) {
-  strncpy(datalayer.system.info.battery_protocol, "Serial link to another LilyGo board",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Serial link to another LilyGo board", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 }
 // Needed to make the compiler happy
 void update_values_battery() {}

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -219,7 +219,10 @@ void update_values_serial_link() {
 }
 
 void setup_battery(void) {
-  Serial.println("SERIAL_DATA_LINK_RECEIVER selected");
+  strncpy(datalayer.system.info.battery_protocol, "Serial link to another LilyGo board",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 }
 // Needed to make the compiler happy
 void update_values_battery() {}

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1249,13 +1249,13 @@ void printDebugIfActive(uint8_t symbol, const char* message) {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Tesla Model S/3/X/Y battery selected");
-#endif
-
   datalayer.system.status.battery_allows_contactor_closing = true;
 
 #ifdef TESLA_MODEL_SX_BATTERY  // Always use NCM/A mode on S/X packs
+  strncpy(datalayer.system.info.battery_protocol, "Tesla Model S/X",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
@@ -1271,6 +1271,10 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif  // TESLA_MODEL_SX_BATTERY
 
 #ifdef TESLA_MODEL_3Y_BATTERY  // Model 3/Y can be either LFP or NCM/A
+  strncpy(datalayer.system.info.battery_protocol, "Tesla Model 3/Y",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 #ifdef LFP_CHEMISTRY
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1252,9 +1252,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
 
 #ifdef TESLA_MODEL_SX_BATTERY  // Always use NCM/A mode on S/X packs
-  strncpy(datalayer.system.info.battery_protocol, "Tesla Model S/X",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Tesla Model S/X", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
@@ -1270,9 +1269,8 @@ void setup_battery(void) {  // Performs one time setup at startup
 #endif  // TESLA_MODEL_SX_BATTERY
 
 #ifdef TESLA_MODEL_3Y_BATTERY  // Model 3/Y can be either LFP or NCM/A
-  strncpy(datalayer.system.info.battery_protocol, "Tesla Model 3/Y",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Tesla Model 3/Y", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 #ifdef LFP_CHEMISTRY
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1254,8 +1254,7 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef TESLA_MODEL_SX_BATTERY  // Always use NCM/A mode on S/X packs
   strncpy(datalayer.system.info.battery_protocol, "Tesla Model S/X",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
@@ -1273,8 +1272,7 @@ void setup_battery(void) {  // Performs one time setup at startup
 #ifdef TESLA_MODEL_3Y_BATTERY  // Model 3/Y can be either LFP or NCM/A
   strncpy(datalayer.system.info.battery_protocol, "Tesla Model 3/Y",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 #ifdef LFP_CHEMISTRY
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -145,9 +145,8 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   randomSeed(analogRead(0));
 
-  strncpy(datalayer.system.info.battery_protocol, "Fake battery for testing purposes",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Fake battery for testing purposes", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -145,9 +145,10 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   randomSeed(analogRead(0));
 
-#ifdef DEBUG_VIA_USB
-  Serial.println("Test mode with fake battery selected");
-#endif
+  strncpy(datalayer.system.info.battery_protocol, "Fake battery for testing purposes",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
 
   datalayer.battery.info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -147,8 +147,7 @@ void setup_battery(void) {  // Performs one time setup at startup
 
   strncpy(datalayer.system.info.battery_protocol, "Fake battery for testing purposes",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -332,9 +332,8 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Volvo / Polestar 78kWh battery",
-          sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
+  strncpy(datalayer.system.info.battery_protocol, "Volvo / Polestar 78kWh battery", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -334,8 +334,7 @@ void send_can_battery() {
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Volvo / Polestar 78kWh battery",
           sizeof(datalayer.system.info.battery_protocol) - 1);
-  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
-      '\0';  // Ensure null termination
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] = '\0';
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -332,10 +332,10 @@ void send_can_battery() {
 }
 
 void setup_battery(void) {  // Performs one time setup at startup
-#ifdef DEBUG_VIA_USB
-  Serial.println("Volvo SPA XC40 Recharge / Polestar2 78kWh battery selected");
-#endif
-
+  strncpy(datalayer.system.info.battery_protocol, "Volvo / Polestar 78kWh battery",
+          sizeof(datalayer.system.info.battery_protocol) - 1);
+  datalayer.system.info.battery_protocol[sizeof(datalayer.system.info.battery_protocol) - 1] =
+      '\0';  // Ensure null termination
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -127,7 +127,10 @@ typedef struct {
 } DATALAYER_SHUNT_TYPE;
 
 typedef struct {
-  // TODO
+  /** array with type of battery used, for displaying on webserver */
+  char battery_protocol[64] = {0};
+  /** array with type of inverter used, for displaying on webserver */
+  char inverter_protocol[64] = {0};
 } DATALAYER_SYSTEM_INFO_TYPE;
 
 typedef struct {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -492,10 +492,10 @@ String processor(const String& var) {
     content += datalayer.system.info.battery_protocol;
 #ifdef DOUBLE_BATTERY
     content += " (Double battery)";
+#endif  // DOUBLE_BATTERY
     if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
       content += " (LFP)";
     }
-#endif  // DOUBLE_BATTERY
     content += "</h4>";
 
 #if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -487,33 +487,6 @@ String processor(const String& var) {
     // Display which components are used
     content += "<h4 style='color: white;'>Inverter protocol: ";
     content += datalayer.system.info.inverter_protocol;
-#ifdef BYD_CAN
-    content += "BYD Battery-Box Premium HVS over CAN Bus";
-#endif  // BYD_CAN
-#ifdef BYD_MODBUS
-    content += "BYD 11kWh HVM battery over Modbus RTU";
-#endif  // BYD_MODBUS
-#ifdef FOXESS_CAN
-    content += "FoxESS compatible HV2600/ECS4100 battery";
-#endif  // FOXESS_CAN
-#ifdef PYLON_CAN
-    content += "Pylontech battery over CAN bus";
-#endif  // PYLON_CAN
-#ifdef PYLON_LV_CAN
-    content += "Pylontech LV battery over CAN bus";
-#endif  // PYLON_LV_CAN
-#ifdef SERIAL_LINK_TRANSMITTER
-    content += "Serial link to another LilyGo board";
-#endif  // SERIAL_LINK_TRANSMITTER
-#ifdef SMA_CAN
-    content += "BYD Battery-Box H 8.9kWh, 7 mod over CAN bus";
-#endif  // SMA_CAN
-#ifdef SOFAR_CAN
-    content += "Sofar Energy Storage Inverter High Voltage BMS General Protocol (Extended Frame) over CAN bus";
-#endif  // SOFAR_CAN
-#ifdef SOLAX_CAN
-    content += "SolaX Triple Power LFP over CAN bus";
-#endif  // SOLAX_CAN
     content += "</h4>";
     content += "<h4 style='color: white;'>Battery protocol: ";
     content += datalayer.system.info.battery_protocol;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -486,6 +486,7 @@ String processor(const String& var) {
 
     // Display which components are used
     content += "<h4 style='color: white;'>Inverter protocol: ";
+    content += datalayer.system.info.inverter_protocol;
 #ifdef BYD_CAN
     content += "BYD Battery-Box Premium HVS over CAN Bus";
 #endif  // BYD_CAN
@@ -514,83 +515,8 @@ String processor(const String& var) {
     content += "SolaX Triple Power LFP over CAN bus";
 #endif  // SOLAX_CAN
     content += "</h4>";
-
     content += "<h4 style='color: white;'>Battery protocol: ";
-#ifdef BMW_I3_BATTERY
-    content += "BMW i3";
-#endif  // BMW_I3_BATTERY
-#ifdef BMW_IX_BATTERY
-    content += "BMW iX and i4-7 platform";
-#endif  // BMW_IX_BATTERY
-#ifdef BYD_ATTO_3_BATTERY
-    content += "BYD Atto 3";
-#endif  // BYD_ATTO_3_BATTERY
-#ifdef CELLPOWER_BMS
-    content += "Cellpower BMS";
-#endif  // CELLPOWER_BMS
-#ifdef CHADEMO_BATTERY
-    content += "Chademo V2X mode";
-#endif  // CHADEMO_BATTERY
-#ifdef IMIEV_CZERO_ION_BATTERY
-    content += "I-Miev / C-Zero / Ion Triplet";
-#endif  // IMIEV_CZERO_ION_BATTERY
-#ifdef JAGUAR_IPACE_BATTERY
-    content += "Jaguar I-PACE";
-#endif  // JAGUAR_IPACE_BATTERY
-#ifdef KIA_HYUNDAI_64_BATTERY
-    content += "Kia/Hyundai 64kWh";
-#endif  // KIA_HYUNDAI_64_BATTERY
-#ifdef KIA_E_GMP_BATTERY
-    content += "Kia/Hyundai EGMP platform";
-#endif  // KIA_E_GMP_BATTERY
-#ifdef KIA_HYUNDAI_HYBRID_BATTERY
-    content += "Kia/Hyundai Hybrid";
-#endif  // KIA_HYUNDAI_HYBRID_BATTERY
-#ifdef MG_5_BATTERY
-    content += "MG 5";
-#endif  // MG_5_BATTERY
-#ifdef NISSAN_LEAF_BATTERY
-    content += "Nissan LEAF";
-#endif  // NISSAN_LEAF_BATTERY
-#ifdef PYLON_BATTERY
-    content += "Pylon compatible battery";
-#endif  // PYLON_BATTERY
-#ifdef RJXZS_BMS
-    content += "RJXZS BMS, DIY battery";
-#endif  // RJXZS_BMS
-#ifdef RANGE_ROVER_PHEV_BATTERY
-    content += "Range Rover 13kWh PHEV battery (L494/L405)";
-#endif  //RANGE_ROVER_PHEV_BATTERY
-#ifdef RENAULT_KANGOO_BATTERY
-    content += "Renault Kangoo";
-#endif  // RENAULT_KANGOO_BATTERY
-#ifdef RENAULT_TWIZY_BATTERY
-    content += "Renault Twizy";
-#endif  // RENAULT_TWIZY_BATTERY
-#ifdef RENAULT_ZOE_GEN1_BATTERY
-    content += "Renault Zoe Gen1 22/40";
-#endif  // RENAULT_ZOE_GEN1_BATTERY
-#ifdef RENAULT_ZOE_GEN2_BATTERY
-    content += "Renault Zoe Gen2 50";
-#endif  // RENAULT_ZOE_GEN2_BATTERY
-#ifdef SANTA_FE_PHEV_BATTERY
-    content += "Santa Fe PHEV";
-#endif  // SANTA_FE_PHEV_BATTERY
-#ifdef SERIAL_LINK_RECEIVER
-    content += "Serial link to another LilyGo board";
-#endif  // SERIAL_LINK_RECEIVER
-#ifdef TESLA_MODEL_SX_BATTERY
-    content += "Tesla Model S/X";
-#endif  // TESLA_MODEL_SX_BATTERY
-#ifdef TESLA_MODEL_3Y_BATTERY
-    content += "Tesla Model 3/Y";
-#endif  // TESLA_MODEL_3Y_BATTERY
-#ifdef VOLVO_SPA_BATTERY
-    content += "Volvo / Polestar 78kWh battery";
-#endif  // VOLVO_SPA_BATTERY
-#ifdef TEST_FAKE_BATTERY
-    content += "Fake battery for testing purposes";
-#endif  // TEST_FAKE_BATTERY
+    content += datalayer.system.info.battery_protocol;
 #ifdef DOUBLE_BATTERY
     content += " (Double battery)";
     if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -45,10 +45,4 @@
 #error No battery selected! Choose one from the USER_SETTINGS.h file
 #endif
 
-#ifdef KIA_E_GMP_BATTERY
-#ifndef CAN_FD
-#error KIA HYUNDAI EGMP BATTERIES CANNOT BE USED WITHOUT CAN FD
-#endif
-#endif
-
 #endif

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -233,4 +233,8 @@ void send_can_inverter() {
     time_to_send_info = false;
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "Afore battery over CAN", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -4,8 +4,7 @@
 
 #define CAN_INVERTER_SELECTED
 
-void send_system_data();
-void send_setup_info();
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -219,4 +219,8 @@ void send_intial_data() {
   transmit_can(&BYD_3D0_2, can_config.inverter);
   transmit_can(&BYD_3D0_3, can_config.inverter);
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box Premium HVS over CAN Bus", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -8,5 +8,6 @@
 
 void send_intial_data();
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -143,4 +143,8 @@ void verify_inverter_modbus() {
     history_index = (history_index + 1) % HISTORY_LENGTH;
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "BYD 11kWh HVM battery over Modbus RTU", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -14,4 +14,5 @@ void verify_temperature_modbus();
 void verify_inverter_modbus();
 void handle_update_data_modbusp201_byd();
 void handle_update_data_modbusp301_byd();
+void setup_inverter(void);
 #endif

--- a/Software/src/inverter/BYD-SMA.cpp
+++ b/Software/src/inverter/BYD-SMA.cpp
@@ -251,4 +251,10 @@ void send_can_inverter() {
     }
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box HVS over SMA CAN", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+  datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
+  pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
+}
 #endif

--- a/Software/src/inverter/BYD-SMA.h
+++ b/Software/src/inverter/BYD-SMA.h
@@ -8,5 +8,6 @@
 #define STOP_STATE 0x02
 
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -737,4 +737,8 @@ void receive_can_inverter(CAN_frame rx_frame) {
     }
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "FoxESS compatible HV2600/ECS4100 battery", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -5,5 +5,6 @@
 #define CAN_INVERTER_SELECTED
 
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -477,4 +477,8 @@ void send_system_data() {  //System equipment information
   transmit_can(&PYLON_4291, can_config.inverter);
 #endif
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "Pylontech battery over CAN bus", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -7,5 +7,6 @@
 void send_system_data();
 void send_setup_info();
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -133,4 +133,8 @@ void send_can_inverter() {
     transmit_can(&PYLON_35E, can_config.inverter);
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "Pylontech LV battery over CAN bus", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -12,5 +12,6 @@
 void send_system_data();
 void send_setup_info();
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
@@ -159,6 +159,10 @@ void printSendingValues() {
   Serial.print(datalayer.battery.status.soh_pptt);
   Serial.print(" Voltage: ");
   Serial.print(datalayer.battery.status.voltage_dV);
+  void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+    strncpy(datalayer.system.info.inverter_protocol, "Serial link to another LilyGo board", 63);
+    datalayer.system.info.inverter_protocol[63] = '\0';
+  }
   Serial.print(" Current: ");
   Serial.print(datalayer.battery.status.current_dA);
   Serial.print(" Capacity: ");
@@ -189,5 +193,9 @@ void printSendingValues() {
   Serial.print(datalayer.system.status.inverter_allows_contactor_closing);
 
   Serial.println("");
+}
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "Serial link to another LilyGo board", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
 }
 #endif

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.cpp
@@ -128,6 +128,8 @@ void manageSerialLinkTransmitter() {
     static unsigned long updateDataTime = 0;
 
     if (currentTime - updateDataTime > INTERVAL_1_S) {
+      strncpy(datalayer.system.info.inverter_protocol, "Serial link to another LilyGo board", 63);
+      datalayer.system.info.inverter_protocol[63] = '\0';
       updateDataTime = currentTime;
       dataLinkTransmit.updateData(0, datalayer.battery.status.real_soc);
       dataLinkTransmit.updateData(1, datalayer.battery.status.soh_pptt);
@@ -159,10 +161,6 @@ void printSendingValues() {
   Serial.print(datalayer.battery.status.soh_pptt);
   Serial.print(" Voltage: ");
   Serial.print(datalayer.battery.status.voltage_dV);
-  void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-    strncpy(datalayer.system.info.inverter_protocol, "Serial link to another LilyGo board", 63);
-    datalayer.system.info.inverter_protocol[63] = '\0';
-  }
   Serial.print(" Current: ");
   Serial.print(datalayer.battery.status.current_dA);
   Serial.print(" Capacity: ");
@@ -193,9 +191,5 @@ void printSendingValues() {
   Serial.print(datalayer.system.status.inverter_allows_contactor_closing);
 
   Serial.println("");
-}
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Serial link to another LilyGo board", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
 }
 #endif

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
@@ -1,6 +1,8 @@
 #ifndef SERIAL_LINK_TRANSMITTER_INVERTER_H
 #define SERIAL_LINK_TRANSMITTER_INVERTER_H
 
+#define MODBUS_INVERTER_SELECTED
+
 #include <Arduino.h>
 #include "../include.h"
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
@@ -6,5 +6,6 @@
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"
 
 void manageSerialLinkTransmitter();
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
+++ b/Software/src/inverter/SERIAL-LINK-TRANSMITTER-INVERTER.h
@@ -1,8 +1,6 @@
 #ifndef SERIAL_LINK_TRANSMITTER_INVERTER_H
 #define SERIAL_LINK_TRANSMITTER_INVERTER_H
 
-#define MODBUS_INVERTER_SELECTED
-
 #include <Arduino.h>
 #include "../include.h"
 #include "../lib/mackelec-SerialDataLink/SerialDataLink.h"

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -249,4 +249,9 @@ void send_can_inverter() {
     }
   }
 }
+
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "SMA CAN", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -8,5 +8,6 @@
 #define STOP_STATE 0x02
 
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -320,4 +320,9 @@ void send_tripower_init() {
   transmit_can(&SMA_017, can_config.inverter);  // Battery Manufacturer
   transmit_can(&SMA_018, can_config.inverter);  // Battery Name
 }
+
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "SMA Tripower CAN", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -6,5 +6,6 @@
 
 void send_tripower_init();
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -263,4 +263,9 @@ void send_can_inverter() {
     transmit_can(&SOFAR_35A, can_config.inverter);
   }
 }
+
+void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+  strncpy(datalayer.system.info.inverter_protocol, "Sofar BMS (Extended Frame) over CAN bus", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+}
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -5,5 +5,6 @@
 #define CAN_INVERTER_SELECTED
 
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -252,4 +252,9 @@ void receive_can_inverter(CAN_frame rx_frame) {
 #endif
   }
 }
+void setup_inverter(void) {  // Performs one time setup at startup
+  strncpy(datalayer.system.info.inverter_protocol, "SolaX Triple Power LFP over CAN bus", 63);
+  datalayer.system.info.inverter_protocol[63] = '\0';
+  datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
+}
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -15,5 +15,6 @@
 #define UPDATING_FW 4
 
 void transmit_can(CAN_frame* tx_frame, int interface);
+void setup_inverter(void);
 
 #endif


### PR DESCRIPTION
### What
This PR implements simplified webserver & battery/inverter integrations

### Why
To simplify further development and make scaling the software up easier

### How
- Instead of large #ifdef blocks inside Webserver.cpp to signal what battery/inverter is used, we now write a text string to the datalayer on startup. The webpage displays both battery_protocol and inverter_protocol. This simplifies development, no longer needed to add inverter/battery specific text outside of the battery's .cpp file.
- init_inverter() now calls setup_inverter() in each inverter protocol. Code required specifically for inverter protocol is now inside that inverter protocols .cpp file. This simplifies development, with less risk of forgetting inv specific stuff
- All #ifdef intervalUpdateValues removed, since code now updates at 1s rate instead of 5s
- Startup DEBUG_VIA_USB texts removed
- BONUS: Some inverter/batteries were missing from the Github workflow. Added them to build system
