### PR TITLE
BYD Atto3: Fix compilation error

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -118,7 +118,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.real_soc = estimateSOC(datalayer.battery.status.voltage_dV);
   SOC_method = ESTIMATED;
 #else  // Pack is not crashed, we can use periodically transmitted SOC
-  datalayer.battery.status.real_soc = highprecision_SOC * 100;
+  datalayer.battery.status.real_soc = battery_highprecision_SOC * 100;
   SOC_method = MEASURED;
 #endif
 


### PR DESCRIPTION

### What
This PR Fixes compilation error when using SOC sent from battery

### Why
Mistake from branch merge

