### PR TITLE
BMW i3: Swap raw and dash SOC in More Battery Info page

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -487,8 +487,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
   // Update webserver datalayer
-  datalayer_extended.bmwi3.SOC_raw = (battery_display_SOC * 50);
-  datalayer_extended.bmwi3.SOC_dash = (battery_HVBatt_SOC * 10);
+  datalayer_extended.bmwi3.SOC_raw = (battery_HVBatt_SOC * 10);
+  datalayer_extended.bmwi3.SOC_dash = (battery_display_SOC * 50);
   datalayer_extended.bmwi3.SOC_OBD2 = battery_soc;
   datalayer_extended.bmwi3.ST_iso_ext = battery_status_error_isolation_external_Bordnetz;
   datalayer_extended.bmwi3.ST_iso_int = battery_status_error_isolation_internal_Bordnetz;


### PR DESCRIPTION
### What
This PR fixes the swapped SOC% for BMW i3 in advanced webserver page "More Battery Info"

### Why
User reported bug in https://github.com/dalathegreat/Battery-Emulator/issues/633

### How
The two parameters are now mapped correctly