### PR TITLE
Nissan LEAF: Add insulation reading to webserver

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -331,6 +331,7 @@ void update_values_battery() { /* This function maps all the values fetched via 
   datalayer_extended.nissanleaf.ChargePowerLimit = battery_Charge_Power_Limit;
   datalayer_extended.nissanleaf.MaxPowerForCharger = battery_MAX_POWER_FOR_CHARGER;
   datalayer_extended.nissanleaf.Interlock = battery_Interlock;
+  datalayer_extended.nissanleaf.Insulation = battery_insulation;
   datalayer_extended.nissanleaf.RelayCutRequest = battery_Relay_Cut_Request;
   datalayer_extended.nissanleaf.FailsafeStatus = battery_Failsafe_Status;
   datalayer_extended.nissanleaf.Full = battery_Full_CHARGE_flag;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -199,6 +199,9 @@ typedef struct {
   /** bool */
   /** Interlock status */
   bool Interlock = false;
+  /** int16_t */
+  /** Insulation resistance, most likely kOhm */
+  uint16_t Insulation = 0;
   /** uint8_t */
   /** battery_FAIL status */
   uint8_t RelayCutRequest = 0;

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -319,11 +319,13 @@ String advanced_battery_processor(const String& var) {
 #endif
 
 #ifdef NISSAN_LEAF_BATTERY
-    content += "<h4>LEAF generation: " + String(datalayer_extended.nissanleaf.LEAF_gen) + "</h4>";
+    static const char* LEAFgen[] = {"ZE0", "AZE0", "ZE1"};
+    content += "<h4>LEAF generation: " + String(LEAFgen[datalayer_extended.nissanleaf.LEAF_gen]) + "</h4>";
     content += "<h4>GIDS: " + String(datalayer_extended.nissanleaf.GIDS) + "</h4>";
     content += "<h4>Regen kW: " + String(datalayer_extended.nissanleaf.ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(datalayer_extended.nissanleaf.MaxPowerForCharger) + "</h4>";
     content += "<h4>Interlock: " + String(datalayer_extended.nissanleaf.Interlock) + "</h4>";
+    content += "<h4>Insulation: " + String(datalayer_extended.nissanleaf.Insulation) + "</h4>";
     content += "<h4>Relay cut request: " + String(datalayer_extended.nissanleaf.RelayCutRequest) + "</h4>";
     content += "<h4>Failsafe status: " + String(datalayer_extended.nissanleaf.FailsafeStatus) + "</h4>";
     content += "<h4>Fully charged: " + String(datalayer_extended.nissanleaf.Full) + "</h4>";


### PR DESCRIPTION
### What
This PR adds Insulation resistance to Webserver. It also adds enum to LEAF generation.

### Why
One user had low insulation resistance. This enables easier visualization of current insulation resistance. Once we know what is "normal" for LEAF packs, we can add a safety check for low insulation resistance also.

### How
Value is added to Webserver:

![image](https://github.com/user-attachments/assets/1c93c1fd-7e27-4741-b8f0-1dfa1205bb09)
