### PR TITLE
Improvement: Moving secrets from USER_SETTINGS.cpp to platformio config

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -86,6 +86,10 @@ jobs:
       # First we clone the repo using the `checkout` action.
       - name: Checkout
         uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
 
       # We use the `arduino/setup-arduino-cli` action to install and
       # configure the Arduino CLI on the system.

--- a/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
+++ b/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
@@ -92,6 +92,10 @@ jobs:
       # First we clone the repo using the `checkout` action.
       - name: Checkout
         uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
 
       # We use the `arduino/setup-arduino-cli` action to install and
       # configure the Arduino CLI on the system.

--- a/.github/workflows/compile-all-combinations-part2-batteries-N-to-Z.yml
+++ b/.github/workflows/compile-all-combinations-part2-batteries-N-to-Z.yml
@@ -93,6 +93,10 @@ jobs:
       # First we clone the repo using the `checkout` action.
       - name: Checkout
         uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
 
       # We use the `arduino/setup-arduino-cli` action to install and
       # configure the Arduino CLI on the system.

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -78,6 +78,10 @@ jobs:
       # First we clone the repo using the `checkout` action.
       - name: Checkout
         uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
 
       # We use the `arduino/setup-arduino-cli` action to install and
       # configure the Arduino CLI on the system.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ compile.bat
 
 # Ignore binary files
 *.bin
+
+# Ignore secret file
+USER_SECRETS.h

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ For more examples showing wiring, see each battery types own Wiki page. For inst
 5. The Arduino board should be set to `ESP32 Dev Module` (under `Tools` -> `Board` -> `ESP32 Arduino`) with the following settings:
 ![alt text](https://github.com/Xinyuan-LilyGO/T-CAN485/blob/main/img/arduino_setting.png)
 6. Select which battery type you will use, along with other optional settings. This is done in the `USER_SETTINGS.h` file.
-7. Press `Verify` and `Upload` to send the sketch to the board.
+7. Copy the `USER_SECRETS.TEMPLATE.h` file to `USER_SECRETS.h` and update relevant secrets.
+8. Press `Verify` and `Upload` to send the sketch to the board.
 NOTE: In some cases, the LilyGo must be powered through the main power connector instead of USB-C
       when performing the initial firmware upload.
 NOTE: On Mac, the following USB driver may need to be installed: https://github.com/WCHSoftGroup/ch34xser_macos

--- a/Software/USER_SECRETS.TEMPLATE.h
+++ b/Software/USER_SECRETS.TEMPLATE.h
@@ -1,8 +1,13 @@
 #define WIFI_SSID "REPLACE_WITH_YOUR_SSID"          // Maximum of 63 characters
 #define WIFI_PASSWORD "REPLACE_WITH_YOUR_PASSWORD"  // Minimum of 8 characters
-#define AP_PASSWORD "123456789"        // Minimum of 8 characters; set to blank if you want the access point to be open
-#define HTTP_USERNAME "admin"          // username to webserver authentication;
-#define HTTP_PASSWORD "admin"          // password to webserver authentication;
+#define AP_PASSWORD "123456789"  // Minimum of 8 characters; set to blank if you want the access point to be open
+
+#define WEBSERVER_AUTH_REQUIRED \
+  false  //Set this line to true to activate webserver authentication (this line must not be commented).
+#define HTTP_USERNAME "admin"  // username to webserver authentication;
+#define HTTP_PASSWORD "admin"  // password to webserver authentication;
+
 #define MQTT_SERVER "192.168.xxx.yyy"  // mqtt server address
+#define MQTT_PORT 1883                 // mqtt server port
 #define MQTT_USER NULL                 // mqtt username, leave blank for no authentication
 #define MQTT_PASSWORD NULL             // mqtt password, leave blank for no authentication

--- a/Software/USER_SECRETS.TEMPLATE.h
+++ b/Software/USER_SECRETS.TEMPLATE.h
@@ -1,0 +1,8 @@
+#define WIFI_SSID "REPLACE_WITH_YOUR_SSID"          // Maximum of 63 characters
+#define WIFI_PASSWORD "REPLACE_WITH_YOUR_PASSWORD"  // Minimum of 8 characters
+#define AP_PASSWORD "123456789"        // Minimum of 8 characters; set to blank if you want the access point to be open
+#define HTTP_USERNAME "admin"          // username to webserver authentication;
+#define HTTP_PASSWORD "admin"          // password to webserver authentication;
+#define MQTT_SERVER "192.168.xxx.yyy"  // mqtt server address
+#define MQTT_USER NULL                 // mqtt username, leave blank for no authentication
+#define MQTT_PASSWORD NULL             // mqtt password, leave blank for no authentication

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -1,5 +1,6 @@
 #include "USER_SETTINGS.h"
 #include <string>
+#include "USER_SECRETS.h"
 #include "src/devboard/hal/hal.h"
 
 /* This file contains all the battery settings and limits */
@@ -21,12 +22,12 @@ volatile CAN_Configuration can_config = {
 
 #ifdef WIFI
 
-volatile uint8_t AccessPointEnabled = true;           //Set to either true/false to enable direct wifi access point
-std::string ssid = "REPLACE_WITH_YOUR_SSID";          // Maximum of 63 characters
-std::string password = "REPLACE_WITH_YOUR_PASSWORD";  // Minimum of 8 characters
-const char* ssidAP = "Battery Emulator";  // Maximum of 63 characters, also used for device name on web interface
-const char* passwordAP = "123456789";  // Minimum of 8 characters; set to NULL if you want the access point to be open
-const uint8_t wifi_channel = 0;        // Set to 0 for automatic channel selection
+volatile uint8_t AccessPointEnabled = true;  //Set to either true/false to enable direct wifi access point
+std::string ssid = WIFI_SSID;                // Set in USER_SECRETS.h
+std::string password = WIFI_PASSWORD;        // Set in USER_SECRETS.h
+const char* ssidAP = "Battery Emulator";     // Maximum of 63 characters, also used for device name on web interface
+const char* passwordAP = AP_PASSWORD;        // Set in USER_SECRETS.h
+const uint8_t wifi_channel = 0;              // Set to 0 for automatic channel selection
 
 #ifdef WIFICONFIG
 // Set your Static IP address
@@ -37,14 +38,14 @@ IPAddress gateway(192, 168, 10, 1);
 IPAddress subnet(255, 255, 255, 0);
 #endif
 #ifdef WEBSERVER
-const char* http_username = "admin";  // username to webserver authentication;
-const char* http_password = "admin";  // password to webserver authentication;
+const char* http_username = HTTP_USERNAME;  // Set in USER_SECRETS.h
+const char* http_password = HTTP_PASSWORD;  // Set in USER_SECRETS.h
 
 #endif  // WEBSERVER
 // MQTT
 #ifdef MQTT
-const char* mqtt_user = "REDACTED";      // Set NULL for no username
-const char* mqtt_password = "REDACTED";  // Set NULL for no password
+const char* mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
+const char* mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
 const char* mqtt_topic_name =
     "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -82,8 +82,6 @@
 #define WIFI
 //#define WIFICONFIG  //Enable this line to set a static IP address / gateway /subnet mask for the device. see USER_SETTINGS.cpp for the settings
 #define WEBSERVER  //Enable this line to enable WiFi, and to run the webserver. See USER_SETTINGS.cpp for the Wifi settings.
-#define WEBSERVER_AUTH_REQUIRED \
-  false  //Set this line to true to activate webserver authentication (this line must not be commented). Refer to USER_SETTINGS.cpp for setting the credentials.
 #define WIFIAP  //Disable this line to permanently disable WIFI AP mode (make sure to hardcode ssid and password of you home wifi network). When enabled WIFI AP can still be disabled by a setting in the future.
 #define MDNSRESPONDER  //Enable this line to enable MDNS, allows battery monitor te be found by .local address. Requires WEBSERVER to be enabled.
 #define LOAD_SAVED_SETTINGS_ON_BOOT  //Enable this line to read settings stored via the webserver on boot (overrides Wifi/battery settings set below)
@@ -92,7 +90,6 @@
 
 /* MQTT options */
 // #define MQTT  // Enable this line to enable MQTT
-#define MQTT_PORT 1883
 #define MQTT_MANUAL_TOPIC_OBJECT_NAME  // Enable this to use custom MQTT topic, object ID prefix, and device name.    \
                                        // WARNING: If this is not defined, the previous default naming format         \
                                        // 'battery-emulator_esp32-XXXXXX' (based on hardware ID) will be used.        \

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -92,7 +92,6 @@
 
 /* MQTT options */
 // #define MQTT  // Enable this line to enable MQTT
-#define MQTT_SERVER "192.168.xxx.yyy"
 #define MQTT_PORT 1883
 #define MQTT_MANUAL_TOPIC_OBJECT_NAME  // Enable this to use custom MQTT topic, object ID prefix, and device name.    \
                                        // WARNING: If this is not defined, the previous default naming format         \

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <freertos/FreeRTOS.h>
+#include "../../../USER_SECRETS.h"
 #include "../../../USER_SETTINGS.h"
 #include "../../battery/BATTERIES.h"
 #include "../../datalayer/datalayer.h"

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,6 +1,7 @@
 #include "webserver.h"
 #include <Preferences.h>
 #include <ctime>
+#include "../../../USER_SECRETS.h"
 #include "../../datalayer/datalayer.h"
 #include "../../datalayer/datalayer_extended.h"
 #include "../../lib/bblanchon-ArduinoJson/ArduinoJson.h"


### PR DESCRIPTION
### What
This PR moves user secrets from USER_SETTINGS.cpp & USER_SETTINGS.h into a platformio config file USER_SECRETS.ini

### Why
This change makes it less likely that secrets are accidentally exposed by users committing them and makes it easier to maintain these secrets during development

### How
- USER_SECRETS.ini is included as additional platformio configuration in platformio.ini
- A template file USER_SECRETS_TEMPLATE.ini is copied to USER_SECRETS.ini if it does not exist and acts as a base configuration file
- USER_SECRETS.ini has been added to .gitignore to ensure it is not accidentally tracked
