### PR TITLE
Update BMW-I3-BATTERY.cpp

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -785,7 +785,7 @@ void receive_can_battery2(CAN_frame rx_frame) {
         datalayer.battery2.status.cell_voltages_mV[3] = ((rx_frame.data.u8[4] * 10) + 1800);
         datalayer.battery2.status.cell_voltages_mV[4] = ((rx_frame.data.u8[5] * 10) + 1800);
         datalayer.battery2.status.cell_voltages_mV[5] = ((rx_frame.data.u8[6] * 10) + 1800);
-        datalayer.battery2.status.cell_voltages_mV[5] = ((rx_frame.data.u8[7] * 10) + 1800);
+        datalayer.battery2.status.cell_voltages_mV[6] = ((rx_frame.data.u8[7] * 10) + 1800);
       }
       break;
     case 0x430:  //BMS [1s] - Charging status of high-voltage battery - 2


### PR DESCRIPTION
Saw this in the issue tracker, seems easy enough to fix. Looks like a copy + paste error which just results in over-writing some cell data accidentally.

### What
extracting data from a CAN message correctly.

### Why
Why does it do it?

Previous implementation seems to accidentally overwrite an array position.

### How
How does it do it?

Magic bytes.
