### PR TITLE
Atto 3: Update scaling on real SOC

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -118,7 +118,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.real_soc = estimateSOC(datalayer.battery.status.voltage_dV);
   SOC_method = ESTIMATED;
 #else  // Pack is not crashed, we can use periodically transmitted SOC
-  datalayer.battery.status.real_soc = battery_highprecision_SOC * 100;
+  datalayer.battery.status.real_soc = battery_highprecision_SOC * 10;
   SOC_method = MEASURED;
 #endif
 


### PR DESCRIPTION
### What
There was one decimal too much on the real Atto 3 SOC% value sent by battery

### Why
To fix being able to use real soc

### How
*10 instead of *100

Fixes #590