### PR TITLE
Add missing battery and inverter options to GitHub workflows

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -40,8 +40,8 @@ jobs:
           - CHADEMO_BATTERY
           - IMIEV_CZERO_ION_BATTERY
           - JAGUAR_IPACE_BATTERY
-          - KIA_HYUNDAI_64_BATTERY
           - KIA_E_GMP_BATTERY
+          - KIA_HYUNDAI_64_BATTERY
           - KIA_HYUNDAI_HYBRID_BATTERY
           - MEB_BATTERY
           - MG_5_BATTERY
@@ -55,6 +55,7 @@ jobs:
           - RENAULT_ZOE_GEN2_BATTERY
           - SANTA_FE_PHEV_BATTERY
           - TESLA_MODEL_3Y_BATTERY
+          - TESLA_MODEL_SX_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
           - SERIAL_LINK_RECEIVER

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -37,29 +37,43 @@ jobs:
         # These are the batteries for which the code will be compiled.
         battery:
           - BMW_I3_BATTERY
+          - BMW_IX_BATTERY
           - BYD_ATTO_3_BATTERY
+          - CELLPOWER_BMS
           - CHADEMO_BATTERY
           - IMIEV_CZERO_ION_BATTERY
+          - JAGUAR_IPACE_BATTERY
+          - KIA_E_GMP_BATTERY
           - KIA_HYUNDAI_64_BATTERY
           - KIA_HYUNDAI_HYBRID_BATTERY
+          - MEB_BATTERY
+          - MG_5_BATTERY
           - NISSAN_LEAF_BATTERY
           - PYLON_BATTERY
           - RJXZS_BMS
+          - RANGE_ROVER_PHEV_BATTERY
           - RENAULT_KANGOO_BATTERY
+          - RENAULT_TWIZY_BATTERY
           - RENAULT_ZOE_GEN1_BATTERY
           - RENAULT_ZOE_GEN2_BATTERY
+          - SANTA_FE_PHEV_BATTERY
           - TESLA_MODEL_3Y_BATTERY
+          - TESLA_MODEL_SX_BATTERY
           - VOLVO_SPA_BATTERY
           - TEST_FAKE_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
+          - AFORE_CAN
           - BYD_CAN
           - BYD_KOSTAL_RS485
-          - BYD_SMA
           - BYD_MODBUS
+          - BYD_SMA
           - FOXESS_CAN
           - PYLON_CAN
+          - PYLON_LV_CAN
+          - SCHNEIDER_CAN
           - SMA_CAN
+          - SMA_LV_CAN
           - SMA_TRIPOWER_CAN
           - SOFAR_CAN
           - SOLAX_CAN

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -33,30 +33,25 @@ jobs:
           #- esp32:esp32:esp32s3
         # These are the batteries for which the code will be compiled.
         battery:
-#         - BMW_I3_BATTERY
-#         - CHADEMO_BATTERY
-#         - IMIEV_CZERO_ION_BATTERY
-#         - KIA_HYUNDAI_64_BATTERY
           - NISSAN_LEAF_BATTERY
-#         - RENAULT_ZOE_BATTERY
-#         - TESLA_MODEL_3Y_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - AFORE_CAN
           - BYD_CAN
           - BYD_KOSTAL_RS485
-          - BYD_SMA
           - BYD_MODBUS
+          - BYD_SMA
           - FOXESS_CAN
-          - PYLON_LV_CAN
           - PYLON_CAN
+          - PYLON_LV_CAN
           - SCHNEIDER_CAN
           - SMA_CAN
+          - SMA_LV_CAN
           - SMA_TRIPOWER_CAN
           - SOFAR_CAN
           - SOLAX_CAN
           - SERIAL_LINK_TRANSMITTER
-          - NISSANLEAF_CHARGER # Last element is not an inverter, but good to also test if charger compiles
+          - NISSANLEAF_CHARGER # Last element is not an inverter, but good to also test if the charger compiles
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest
 

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -16,8 +16,8 @@
 //#define CHADEMO_BATTERY	//NOTE: inherently enables CONTACTOR_CONTROL below
 //#define IMIEV_CZERO_ION_BATTERY
 //#define JAGUAR_IPACE_BATTERY
-//#define KIA_HYUNDAI_64_BATTERY
 //#define KIA_E_GMP_BATTERY
+//#define KIA_HYUNDAI_64_BATTERY
 //#define KIA_HYUNDAI_HYBRID_BATTERY
 //#define MEB_BATTERY
 //#define MG_5_BATTERY
@@ -30,18 +30,18 @@
 //#define RENAULT_ZOE_GEN1_BATTERY
 //#define RENAULT_ZOE_GEN2_BATTERY
 //#define SANTA_FE_PHEV_BATTERY
-//#define TESLA_MODEL_SX_BATTERY
 //#define TESLA_MODEL_3Y_BATTERY
+//#define TESLA_MODEL_SX_BATTERY
 //#define VOLVO_SPA_BATTERY
 //#define TEST_FAKE_BATTERY
 //#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires DUAL_CAN setup)
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
-//#define AFORE_CAN //Enable this line to emulate an "Afore battery" over CAN bus
-//#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-//#define BYD_SMA //Enable this line to emulate a SMA compatible "BYD Battery-Box HVS 10.2KW battery" over CAN bus
-//#define BYD_MODBUS  //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
-//#define BYD_KOSTAL_RS485  //Enable this line to emulate a "BYD 11kWh HVM battery" over Kostal RS485
+//#define AFORE_CAN        //Enable this line to emulate an "Afore battery" over CAN bus
+//#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+//#define BYD_KOSTAL_RS485 //Enable this line to emulate a "BYD 11kWh HVM battery" over Kostal RS485
+//#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define BYD_SMA          //Enable this line to emulate a SMA compatible "BYD Battery-Box HVS 10.2KW battery" over CAN bus
 //#define FOXESS_CAN       //Enable this line to emulate a "HV2600/ECS4100 battery" over CAN bus
 //#define PYLON_LV_CAN     //Enable this line to emulate a "48V Pylontech battery" over CAN bus
 //#define PYLON_CAN        //Enable this line to emulate a "High Voltage Pylontech battery" over CAN bus


### PR DESCRIPTION
### What
This PR adds missing battery and inverter options to GitHub workflows
It also sorts the options lexicographically, to be able to more easily compare the batteries and inverters listed in different files.

### Why
To ensure that all different battery and inverter combinations get compiled automatically.

### How
By updating the GitHub workflow files