### PR TITLE
Bugfix: Add startup delay for contactors, fix PWM sequence

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -827,6 +827,13 @@ void handle_contactors() {
   }
 
   unsigned long currentTime = millis();
+
+  if (currentTime < INTERVAL_10_S) {
+    // Skip running the state machine before system has started up.
+    // Gives the system some time to detect any faults from battery before blindly just engaging the contactors
+    return;
+  }
+
   // Handle actual state machine. This first turns on Negative, then Precharge, then Positive, and finally turns OFF precharge
   switch (contactorStatus) {
     case START_PRECHARGE:


### PR DESCRIPTION
### What
This PR fixes a bug, where if PWM was used and the board was reset via powercut (Not reproducible via Webserver reboot), the next time it booted it could occasionally engage the startup sequence incorrectly

![image](https://github.com/user-attachments/assets/335d6d83-939f-4fe9-b11b-bd231c94f45a)

### Why
We fix this, since an incorrect startup sequence will skip precharge, and potentially damage components. Phenomenon still unclear why it happens on PWM setups, but this PR fixes it. 

### How
We fix the issue with a very simple fix. Instead of hammering the statemachine 10ms after CPU poweron, we wait 10 seconds until we start the precharge sequence. This has multiple benefits apart from fixing the glitched PWM startup, now incase a critical FAULT is encountered before the system has started (for instance battery sends something via CAN), we can now act on this and not turn on the battery at all, increasing safety.