### PR TITLE
BYD Atto 3: Make startup less prone to throw Events

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -419,6 +419,9 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.status.voltage_dV =
+      MIN_PACK_VOLTAGE_DV +
+      1;  // Init values in datalayer too low, causes safeties to trigger before values are sampled
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.number_of_cells = 126;
   datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -419,9 +419,9 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  datalayer.battery.status.voltage_dV =
-      MIN_PACK_VOLTAGE_DV +
-      1;  // Init values in datalayer too low, causes safeties to trigger before values are sampled
+  //Due to the Datalayer having 370.0V as startup value, which is 10V lower than the Atto 3 min voltage 380.0V
+  //We now init the value to 380.1V to avoid false positive events.
+  datalayer.battery.status.voltage_dV = MIN_PACK_VOLTAGE_DV + 1;
 #ifdef DOUBLE_BATTERY
   datalayer.battery2.info.number_of_cells = 126;
   datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -111,7 +111,8 @@ void update_machineryprotection() {
 #endif  //NISSAN_LEAF_BATTERY
 
   // Check diff between highest and lowest cell
-  cell_deviation_mV = (datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);
+  cell_deviation_mV =
+      std::abs(datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV);
   if (cell_deviation_mV > datalayer.battery.info.max_cell_voltage_deviation_mV) {
     set_event(EVENT_CELL_DEVIATION_HIGH, (cell_deviation_mV / 20));
   } else {


### PR DESCRIPTION
### What
This PR makes the Atto 3 less likely to throw Events the first seconds on startup

![image](https://github.com/user-attachments/assets/03354fb4-59e3-415f-a9d7-035e2150e387)

### Why
Feedback from flying tools video on the Atto 3, which reports CELL DEVIATION and UNDERVOLTAGE as soon as the battery starts.

### How
The issue was split into two parts
- Cell max/min values where updated async during OBD2 polling, causing the min to actually be larger than max for a few seconds. By adding ABS subtraction to compare the diff, we catch this edge case
- Pack undervoltage on startup. Due to the Datalayer having 370.0V as startup value, which is 10V lower than the Atto 3 minimum voltage (380.0V), we now init the value to 380.1V to avoid false positive events.