### PR TITLE
add skip-duplicate-actions to batteries workflow

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -9,12 +9,28 @@ on:
   - pull_request
 
 # This is the list of jobs that will be run concurrently.
-# Since we use a build matrix, the actual number of jobs
-# started depends on how many configurations the matrix
-# will produce.
 jobs:
-  # This is the name of the job
+  # This pre-job is run to skip workflows in case a workflow is already run, i.e. because the workflow is triggered by both push and pull_request
+  pre_job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  # Since we use a build matrix, the actual number of jobs
+  # started depends on how many configurations the matrix
+  # will produce.
   build-batteries:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
 
     # Here we tell GitHub that the jobs must be determined
     # dynamically depending on a matrix configuration.


### PR DESCRIPTION
### What
This PR updates the GitHub Workflow (a.k.a. GitHub Action) that is triggered to build all batteries.

### Why
This change is introduced, because currently 88 checks are performed by GitHub Actions for each pull request, and many of these are duplicates. The duplicates arise as the workflows are triggered both by the `push` as well as by the `pull_request` trigger.

Removing one or the other trigger is not helpful (see this discussion for reference [How to trigger an action on push or pull request but not both? #26276](https://github.com/orgs/community/discussions/26276)).

### How
It does this by means using another GitHub Action in the workflow: [Skip Duplicate Actions](https://github.com/marketplace/actions/skip-duplicate-actions).

I have first added the skip duplicate actions only to the battery workflow, to test if this works correctly by creating this PR. After this is successful, the same content can also be added to the other workflows that dispatch on `push` and `pull_request`.