### PR TITLE
Bugfix: avoid that GitHub Action workflow strategy expansion exceeds 256 results

### DIFF
--- a/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
+++ b/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
@@ -66,19 +66,6 @@ jobs:
           - KIA_HYUNDAI_HYBRID_BATTERY
           - MEB_BATTERY
           - MG_5_BATTERY
-          - NISSAN_LEAF_BATTERY
-          - PYLON_BATTERY
-          - RJXZS_BMS
-          - RANGE_ROVER_PHEV_BATTERY
-          - RENAULT_KANGOO_BATTERY
-          - RENAULT_TWIZY_BATTERY
-          - RENAULT_ZOE_GEN1_BATTERY
-          - RENAULT_ZOE_GEN2_BATTERY
-          - SANTA_FE_PHEV_BATTERY
-          - TESLA_MODEL_3Y_BATTERY
-          - TESLA_MODEL_SX_BATTERY
-          - VOLVO_SPA_BATTERY
-          - TEST_FAKE_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - AFORE_CAN

--- a/.github/workflows/compile-all-combinations-part2-batteries-N-to-Z.yml
+++ b/.github/workflows/compile-all-combinations-part2-batteries-N-to-Z.yml
@@ -1,0 +1,112 @@
+# This is the name of the workflow, visible on GitHub UI.
+name: Compile All Combinations
+
+# Here we tell GitHub when to run the workflow.
+on:
+  # This allows you to run this workflow manually from the
+  # GitHub Actions tab.
+  workflow_dispatch:
+  # The workflow is run upon creating, editing,
+  # pre-releasing, releasing and publishing a release
+  release:
+    types: [created, edited, prereleased, released, published]
+
+# This is the list of jobs that will be run concurrently.
+jobs:
+  # This pre-job is run to skip workflows in case a workflow is already run, i.e. because the workflow is triggered by both push and pull_request
+  skip-duplicate-actions:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  # Since we use a build matrix, the actual number of jobs
+  # started depends on how many configurations the matrix
+  # will produce.
+
+  # This is the name of the job.
+  build-matrix:
+    needs: skip-duplicate-actions
+    if: needs.skip-duplicate-actions.outputs.should_skip != 'true'
+
+    # Here we tell GitHub that the jobs must be determined
+    # dynamically depending on a matrix configuration.
+    strategy:
+      # The matrix will produce one job for each combination of parameters.
+      matrix:
+        # This is the development board hardware for which the code will be compiled.
+        # FBQN stands for "fully qualified board name", and is used by Arduino to define the hardware to compile for.
+        fqbn:
+          - esp32:esp32:esp32
+          # further ESP32 chips
+          #- esp32:esp32:esp32c3
+          #- esp32:esp32:esp32c2
+          #- esp32:esp32:esp32c6
+          #- esp32:esp32:esp32h2
+          #- esp32:esp32:esp32s3
+        # These are the batteries for which the code will be compiled.
+        battery:
+          - NISSAN_LEAF_BATTERY
+          - PYLON_BATTERY
+          - RJXZS_BMS
+          - RANGE_ROVER_PHEV_BATTERY
+          - RENAULT_KANGOO_BATTERY
+          - RENAULT_TWIZY_BATTERY
+          - RENAULT_ZOE_GEN1_BATTERY
+          - RENAULT_ZOE_GEN2_BATTERY
+          - SANTA_FE_PHEV_BATTERY
+          - TESLA_MODEL_3Y_BATTERY
+          - TESLA_MODEL_SX_BATTERY
+          - VOLVO_SPA_BATTERY
+          - TEST_FAKE_BATTERY
+        # These are the emulated inverter communication protocols for which the code will be compiled.
+        inverter:
+          - AFORE_CAN
+          - BYD_CAN
+          - BYD_KOSTAL_RS485
+          - BYD_MODBUS
+          - BYD_SMA
+          - FOXESS_CAN
+          - PYLON_CAN
+          - PYLON_LV_CAN
+          - SCHNEIDER_CAN
+          - SMA_CAN
+          - SMA_LV_CAN
+          - SMA_TRIPOWER_CAN
+          - SOFAR_CAN
+          - SOLAX_CAN
+          - SERIAL_LINK_TRANSMITTER
+
+    # This is the platform GitHub will use to run our workflow.
+    runs-on: ubuntu-latest
+
+    # This is the list of steps this job will run.
+    steps:
+      # First we clone the repo using the `checkout` action.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # We use the `arduino/setup-arduino-cli` action to install and
+      # configure the Arduino CLI on the system.
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      # We then install the platform.
+      - name: Install platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32
+
+      # Finally, we compile the sketch, using the FQBN that was set
+      # in the build matrix, and using build flags to define the
+      # battery and inverter set in the build matrix.
+      - name: Compile Sketch
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}}" ./Software


### PR DESCRIPTION
### What
This PR updates the GitHub Action workflow that compiles all battery and inverter combinations.

### Why
Currently the "Compile all combinations" workflow fails, with the error `Strategy expansion exceeded 256 results for job 'build-matrix'`. See [Compile All Combinations | v7.9.2 #159](https://github.com/dalathegreat/Battery-Emulator/actions/runs/12339753775) as an example.

This PR avoids that GitHub Action workflow strategy expansion exceeds 256 results for job build-matrix

### How
It does this by splitting the workflow into two parts:
- Part 1: batteries starting with A-N
- Part 2: batteries starting with M-Z