### PR TITLE
Zoe Gen1: Change to use regen allowed value

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -90,7 +90,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.max_discharge_power_W = LB_Discharge_allowed_W;
 
-  datalayer.battery.status.max_charge_power_W = LB_Charging_Power_W;
+  datalayer.battery.status.max_charge_power_W = LB_Regen_allowed_W;
 
   int16_t temperatures[] = {cell_1_temperature_polled,  cell_2_temperature_polled,  cell_3_temperature_polled,
                             cell_4_temperature_polled,  cell_5_temperature_polled,  cell_6_temperature_polled,


### PR DESCRIPTION
### What
This PR changes to that Zoe Gen1 uses regen allowed instead of charger allowed value. This allows battery to charge full faster

### Why
The charger allowed value started to limit operation (dropping below 4kW) already at 60% SOC. The regen allowed value is still 40kW at this stage

### How
We switch out:
  datalayer.battery.status.max_charge_power_W = LB_Charging_Power_W;

To:

 datalayer.battery.status.max_charge_power_W = LB_Regen_allowed_W;
