### PR TITLE
Reword functions names used for CAN communication

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -214,13 +214,7 @@ void core_loop(void* task_time_us) {
 #endif
 
     // Input, Runs as fast as possible
-    receive_can_native();  // Receive CAN messages from native CAN port
-#ifdef CANFD_ADDON
-    receive_canfd_addon();  // Receive CAN-FD messages.
-#endif                      // CANFD_ADDON
-#ifdef CAN_ADDON
-    receive_can_addon();  // Receive CAN messages on add-on MCP2515 chip
-#endif                    // CAN_ADDON
+    receive_can();  // Receive CAN messages
 #ifdef RS485_INVERTER_SELECTED
     receive_RS485();  // Process serial2 RS485 interface
 #endif                // RS485_INVERTER_SELECTED
@@ -261,7 +255,7 @@ void core_loop(void* task_time_us) {
 
     START_TIME_MEASUREMENT(cantx);
     // Output
-    send_can();  // Send CAN messages to all components
+    transmit_can();  // Send CAN messages to all components
 
     END_TIME_MEASUREMENT_MAX(cantx, datalayer.system.status.time_cantx_us);
     END_TIME_MEASUREMENT_MAX(all, datalayer.system.status.core_task_10s_max_us);
@@ -289,7 +283,7 @@ void core_loop(void* task_time_us) {
     }
 #endif  // FUNCTION_TIME_MEASUREMENT
     if (check_pause_2s.elapsed()) {
-      emulator_pause_state_send_CAN_battery();
+      emulator_pause_state_transmit_can_battery();
     }
 
     vTaskDelayUntil(&xLastWakeTime, xFrequency);

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -112,14 +112,14 @@
 #include "SERIAL-LINK-RECEIVER-FROM-BATTERY.h"
 #endif
 
-void receive_can_battery(CAN_frame rx_frame);
+void map_can_frame_to_variable_battery(CAN_frame rx_frame);
 void update_values_battery();
-void send_can_battery();
+void transmit_can_battery();
 void setup_battery(void);
 
 #ifdef DOUBLE_BATTERY
 void update_values_battery2();
-void receive_can_battery2(CAN_frame rx_frame);
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame);
 #endif
 
 #endif

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -112,7 +112,7 @@
 #include "SERIAL-LINK-RECEIVER-FROM-BATTERY.h"
 #endif
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame);
+void handle_incoming_can_frame_battery(CAN_frame rx_frame);
 void update_values_battery();
 void transmit_can_battery();
 void setup_battery(void);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -502,7 +502,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bmwi3.ST_cold_shutoff_valve = battery_status_cold_shutoff_valve;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery_awake = true;
@@ -632,7 +632,7 @@ void receive_can_battery(CAN_frame rx_frame) {
     case 0x607:  //BMS - responses to message requests on 0x615
       if ((cmdState == CELL_VOLTAGE_CELLNO || cmdState == CELL_VOLTAGE_CELLNO_LAST) && (rx_frame.data.u8[0] == 0xF4)) {
         if (rx_frame.DLC == 6) {
-          transmit_can(&BMW_6F4_CELL_CONTINUE, can_config.battery);  // tell battery to send the cellvoltage
+          transmit_can_frame(&BMW_6F4_CELL_CONTINUE, can_config.battery);  // tell battery to send the cellvoltage
         }
         if (rx_frame.DLC == 8) {  // We have the full value, map it
           datalayer.battery.status.cell_voltages_mV[current_cell_polled - 1] =
@@ -645,7 +645,7 @@ void receive_can_battery(CAN_frame rx_frame) {
         while (count < rx_frame.DLC && next_data < 49) {
           message_data[next_data++] = rx_frame.data.u8[count++];
         }
-        transmit_can(&BMW_6F1_CONTINUE, can_config.battery);  // tell battery to send additional messages
+        transmit_can_frame(&BMW_6F1_CONTINUE, can_config.battery);  // tell battery to send additional messages
 
       } else if (rx_frame.DLC > 3 && next_data > 0 && rx_frame.data.u8[0] == 0xf1 &&
                  ((rx_frame.data.u8[1] & 0xF0) == 0x20)) {
@@ -681,7 +681,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery2_awake = true;
@@ -820,7 +820,7 @@ void receive_can_battery2(CAN_frame rx_frame) {
         while (count2 < rx_frame.DLC && next_data < 49) {
           message_data[next_data++] = rx_frame.data.u8[count2++];
         }
-        transmit_can(&BMW_6F1_CONTINUE, can_config.battery_double);
+        transmit_can_frame(&BMW_6F1_CONTINUE, can_config.battery_double);
 
       } else if (rx_frame.DLC > 3 && next_data > 0 && rx_frame.data.u8[0] == 0xf1 &&
                  ((rx_frame.data.u8[1] & 0xF0) == 0x20)) {
@@ -856,7 +856,7 @@ void receive_can_battery2(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   if (battery_awake) {
@@ -887,12 +887,12 @@ void send_can_battery() {
       if (datalayer.battery.status.bms_status == FAULT) {
       }  //If battery is not in Fault mode, allow contactor to close by sending 10B
       else {
-        transmit_can(&BMW_10B, can_config.battery);
+        transmit_can_frame(&BMW_10B, can_config.battery);
       }
 
 #ifdef DOUBLE_BATTERY  //If second battery is allowed to join in, also send 10B
       if (datalayer.system.status.battery2_allows_contactor_closing == true) {
-        transmit_can(&BMW_10B, can_config.battery_double);
+        transmit_can_frame(&BMW_10B, can_config.battery_double);
       }
 #endif
     }
@@ -905,9 +905,9 @@ void send_can_battery() {
 
       alive_counter_100ms = increment_alive_counter(alive_counter_100ms);
 
-      transmit_can(&BMW_12F, can_config.battery);
+      transmit_can_frame(&BMW_12F, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_12F, can_config.battery_double);
+      transmit_can_frame(&BMW_12F, can_config.battery_double);
 #endif
     }
     // Send 200ms CAN Message
@@ -919,9 +919,9 @@ void send_can_battery() {
 
       alive_counter_200ms = increment_alive_counter(alive_counter_200ms);
 
-      transmit_can(&BMW_19B, can_config.battery);
+      transmit_can_frame(&BMW_19B, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_19B, can_config.battery_double);
+      transmit_can_frame(&BMW_19B, can_config.battery_double);
 #endif
     }
     // Send 500ms CAN Message
@@ -933,20 +933,20 @@ void send_can_battery() {
 
       alive_counter_500ms = increment_alive_counter(alive_counter_500ms);
 
-      transmit_can(&BMW_30B, can_config.battery);
+      transmit_can_frame(&BMW_30B, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_30B, can_config.battery_double);
+      transmit_can_frame(&BMW_30B, can_config.battery_double);
 #endif
     }
     // Send 640ms CAN Message
     if (currentMillis - previousMillis640 >= INTERVAL_640_MS) {
       previousMillis640 = currentMillis;
 
-      transmit_can(&BMW_512, can_config.battery);  // Keep BMS alive
-      transmit_can(&BMW_5F8, can_config.battery);
+      transmit_can_frame(&BMW_512, can_config.battery);  // Keep BMS alive
+      transmit_can_frame(&BMW_5F8, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_512, can_config.battery_double);
-      transmit_can(&BMW_5F8, can_config.battery_double);
+      transmit_can_frame(&BMW_512, can_config.battery_double);
+      transmit_can_frame(&BMW_5F8, can_config.battery_double);
 #endif
     }
     // Send 1000ms CAN Message
@@ -973,39 +973,39 @@ void send_can_battery() {
 
       alive_counter_1000ms = increment_alive_counter(alive_counter_1000ms);
 
-      transmit_can(&BMW_3E8, can_config.battery);  //Order comes from CAN logs
-      transmit_can(&BMW_328, can_config.battery);
-      transmit_can(&BMW_3F9, can_config.battery);
-      transmit_can(&BMW_2E2, can_config.battery);
-      transmit_can(&BMW_41D, can_config.battery);
-      transmit_can(&BMW_3D0, can_config.battery);
-      transmit_can(&BMW_3CA, can_config.battery);
-      transmit_can(&BMW_3A7, can_config.battery);
-      transmit_can(&BMW_2CA, can_config.battery);
-      transmit_can(&BMW_3FB, can_config.battery);
-      transmit_can(&BMW_418, can_config.battery);
-      transmit_can(&BMW_1D0, can_config.battery);
-      transmit_can(&BMW_3EC, can_config.battery);
-      transmit_can(&BMW_192, can_config.battery);
-      transmit_can(&BMW_13E, can_config.battery);
-      transmit_can(&BMW_433, can_config.battery);
+      transmit_can_frame(&BMW_3E8, can_config.battery);  //Order comes from CAN logs
+      transmit_can_frame(&BMW_328, can_config.battery);
+      transmit_can_frame(&BMW_3F9, can_config.battery);
+      transmit_can_frame(&BMW_2E2, can_config.battery);
+      transmit_can_frame(&BMW_41D, can_config.battery);
+      transmit_can_frame(&BMW_3D0, can_config.battery);
+      transmit_can_frame(&BMW_3CA, can_config.battery);
+      transmit_can_frame(&BMW_3A7, can_config.battery);
+      transmit_can_frame(&BMW_2CA, can_config.battery);
+      transmit_can_frame(&BMW_3FB, can_config.battery);
+      transmit_can_frame(&BMW_418, can_config.battery);
+      transmit_can_frame(&BMW_1D0, can_config.battery);
+      transmit_can_frame(&BMW_3EC, can_config.battery);
+      transmit_can_frame(&BMW_192, can_config.battery);
+      transmit_can_frame(&BMW_13E, can_config.battery);
+      transmit_can_frame(&BMW_433, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_3E8, can_config.battery_double);
-      transmit_can(&BMW_328, can_config.battery_double);
-      transmit_can(&BMW_3F9, can_config.battery_double);
-      transmit_can(&BMW_2E2, can_config.battery_double);
-      transmit_can(&BMW_41D, can_config.battery_double);
-      transmit_can(&BMW_3D0, can_config.battery_double);
-      transmit_can(&BMW_3CA, can_config.battery_double);
-      transmit_can(&BMW_3A7, can_config.battery_double);
-      transmit_can(&BMW_2CA, can_config.battery_double);
-      transmit_can(&BMW_3FB, can_config.battery_double);
-      transmit_can(&BMW_418, can_config.battery_double);
-      transmit_can(&BMW_1D0, can_config.battery_double);
-      transmit_can(&BMW_3EC, can_config.battery_double);
-      transmit_can(&BMW_192, can_config.battery_double);
-      transmit_can(&BMW_13E, can_config.battery_double);
-      transmit_can(&BMW_433, can_config.battery_double);
+      transmit_can_frame(&BMW_3E8, can_config.battery_double);
+      transmit_can_frame(&BMW_328, can_config.battery_double);
+      transmit_can_frame(&BMW_3F9, can_config.battery_double);
+      transmit_can_frame(&BMW_2E2, can_config.battery_double);
+      transmit_can_frame(&BMW_41D, can_config.battery_double);
+      transmit_can_frame(&BMW_3D0, can_config.battery_double);
+      transmit_can_frame(&BMW_3CA, can_config.battery_double);
+      transmit_can_frame(&BMW_3A7, can_config.battery_double);
+      transmit_can_frame(&BMW_2CA, can_config.battery_double);
+      transmit_can_frame(&BMW_3FB, can_config.battery_double);
+      transmit_can_frame(&BMW_418, can_config.battery_double);
+      transmit_can_frame(&BMW_1D0, can_config.battery_double);
+      transmit_can_frame(&BMW_3EC, can_config.battery_double);
+      transmit_can_frame(&BMW_192, can_config.battery_double);
+      transmit_can_frame(&BMW_13E, can_config.battery_double);
+      transmit_can_frame(&BMW_433, can_config.battery_double);
 #endif
 
       BMW_433.data.u8[1] = 0x01;  // First 433 message byte1 we send is unique, once we sent initial value send this
@@ -1014,23 +1014,23 @@ void send_can_battery() {
       next_data = 0;
       switch (cmdState) {
         case SOC:
-          transmit_can(&BMW_6F1_CELL, can_config.battery);
+          transmit_can_frame(&BMW_6F1_CELL, can_config.battery);
 #ifdef DOUBLE_BATTERY
-          transmit_can(&BMW_6F1_CELL, can_config.battery_double);
+          transmit_can_frame(&BMW_6F1_CELL, can_config.battery_double);
 #endif
           cmdState = CELL_VOLTAGE_MINMAX;
           break;
         case CELL_VOLTAGE_MINMAX:
-          transmit_can(&BMW_6F1_SOH, can_config.battery);
+          transmit_can_frame(&BMW_6F1_SOH, can_config.battery);
 #ifdef DOUBLE_BATTERY
-          transmit_can(&BMW_6F1_SOH, can_config.battery_double);
+          transmit_can_frame(&BMW_6F1_SOH, can_config.battery_double);
 #endif
           cmdState = SOH;
           break;
         case SOH:
-          transmit_can(&BMW_6F1_CELL_VOLTAGE_AVG, can_config.battery);
+          transmit_can_frame(&BMW_6F1_CELL_VOLTAGE_AVG, can_config.battery);
 #ifdef DOUBLE_BATTERY
-          transmit_can(&BMW_6F1_CELL_VOLTAGE_AVG, can_config.battery_double);
+          transmit_can_frame(&BMW_6F1_CELL_VOLTAGE_AVG, can_config.battery_double);
 #endif
           cmdState = CELL_VOLTAGE_CELLNO;
           current_cell_polled = 0;
@@ -1045,16 +1045,16 @@ void send_can_battery() {
             cmdState = CELL_VOLTAGE_CELLNO;
 
             BMW_6F4_CELL_VOLTAGE_CELLNO.data.u8[6] = current_cell_polled;
-            transmit_can(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery);
+            transmit_can_frame(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery);
 #ifdef DOUBLE_BATTERY
-            transmit_can(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery_double);
+            transmit_can_frame(&BMW_6F4_CELL_VOLTAGE_CELLNO, can_config.battery_double);
 #endif
           }
           break;
         case CELL_VOLTAGE_CELLNO_LAST:
-          transmit_can(&BMW_6F1_SOC, can_config.battery);
+          transmit_can_frame(&BMW_6F1_SOC, can_config.battery);
 #ifdef DOUBLE_BATTERY
-          transmit_can(&BMW_6F1_SOC, can_config.battery_double);
+          transmit_can_frame(&BMW_6F1_SOC, can_config.battery_double);
 #endif
           cmdState = SOC;
           break;
@@ -1067,25 +1067,25 @@ void send_can_battery() {
       BMW_3FC.data.u8[1] = ((BMW_3FC.data.u8[1] & 0xF0) + alive_counter_5000ms);
       BMW_3C5.data.u8[0] = ((BMW_3C5.data.u8[0] & 0xF0) + alive_counter_5000ms);
 
-      transmit_can(&BMW_3FC, can_config.battery);  //Order comes from CAN logs
-      transmit_can(&BMW_3C5, can_config.battery);
-      transmit_can(&BMW_3A0, can_config.battery);
-      transmit_can(&BMW_592_0, can_config.battery);
-      transmit_can(&BMW_592_1, can_config.battery);
+      transmit_can_frame(&BMW_3FC, can_config.battery);  //Order comes from CAN logs
+      transmit_can_frame(&BMW_3C5, can_config.battery);
+      transmit_can_frame(&BMW_3A0, can_config.battery);
+      transmit_can_frame(&BMW_592_0, can_config.battery);
+      transmit_can_frame(&BMW_592_1, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_3FC, can_config.battery_double);
-      transmit_can(&BMW_3C5, can_config.battery_double);
-      transmit_can(&BMW_3A0, can_config.battery_double);
-      transmit_can(&BMW_592_0, can_config.battery_double);
-      transmit_can(&BMW_592_1, can_config.battery_double);
+      transmit_can_frame(&BMW_3FC, can_config.battery_double);
+      transmit_can_frame(&BMW_3C5, can_config.battery_double);
+      transmit_can_frame(&BMW_3A0, can_config.battery_double);
+      transmit_can_frame(&BMW_592_0, can_config.battery_double);
+      transmit_can_frame(&BMW_592_1, can_config.battery_double);
 #endif
 
       alive_counter_5000ms = increment_alive_counter(alive_counter_5000ms);
 
       if (BMW_380_counter < 3) {
-        transmit_can(&BMW_380, can_config.battery);  // This message stops after 3 times on startup
+        transmit_can_frame(&BMW_380, can_config.battery);  // This message stops after 3 times on startup
 #ifdef DOUBLE_BATTERY
-        transmit_can(&BMW_380, can_config.battery_double);
+        transmit_can_frame(&BMW_380, can_config.battery_double);
 #endif
         BMW_380_counter++;
       }
@@ -1094,13 +1094,13 @@ void send_can_battery() {
     if (currentMillis - previousMillis10000 >= INTERVAL_10_S) {
       previousMillis10000 = currentMillis;
 
-      transmit_can(&BMW_3E5, can_config.battery);  //Order comes from CAN logs
-      transmit_can(&BMW_3E4, can_config.battery);
-      transmit_can(&BMW_37B, can_config.battery);
+      transmit_can_frame(&BMW_3E5, can_config.battery);  //Order comes from CAN logs
+      transmit_can_frame(&BMW_3E4, can_config.battery);
+      transmit_can_frame(&BMW_37B, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&BMW_3E5, can_config.battery_double);
-      transmit_can(&BMW_3E4, can_config.battery_double);
-      transmit_can(&BMW_37B, can_config.battery_double);
+      transmit_can_frame(&BMW_3E5, can_config.battery_double);
+      transmit_can_frame(&BMW_3E4, can_config.battery_double);
+      transmit_can_frame(&BMW_37B, can_config.battery_double);
 #endif
 
       BMW_3E5.data.u8[0] = 0xFD;  // First 3E5 message byte0 we send is unique, once we sent initial value send this

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -502,7 +502,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bmwi3.ST_cold_shutoff_valve = battery_status_cold_shutoff_valve;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery_awake = true;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -20,6 +20,6 @@
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
 #define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -516,7 +516,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   }
 }
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   battery_awake = true;
   switch (rx_frame.ID) {
     case 0x112:

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -516,7 +516,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   }
 }
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   battery_awake = true;
   switch (rx_frame.ID) {
     case 0x112:
@@ -540,7 +540,7 @@ void receive_can_battery(CAN_frame rx_frame) {
         }
 
         //Frame has continued data  - so request it
-        transmit_can(&BMWiX_6F4_CONTINUE_DATA, can_config.battery);
+        transmit_can_frame(&BMWiX_6F4_CONTINUE_DATA, can_config.battery);
       }
 
       if (rx_frame.DLC = 64 && rx_frame.data.u8[0] == 0xF4 &&
@@ -674,7 +674,7 @@ void receive_can_battery(CAN_frame rx_frame) {
           logging.println("Cell MinMax Qualifier Invalid - Requesting BMS Reset");
 #endif
           //set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, (millis())); //Eventually need new Info level event type
-          transmit_can(&BMWiX_6F4_REQUEST_HARD_RESET, can_config.battery);
+          transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET, can_config.battery);
         } else {  //Only ingest values if they are not the 10V Error state
           min_cell_voltage = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);
           max_cell_voltage = (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]);
@@ -724,7 +724,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   //if (battery_awake) { //We can always send CAN as the iX BMS will wake up on vehicle comms
@@ -734,10 +734,10 @@ void send_can_battery() {
 
     //Loop through and send a different UDS request each cycle
     uds_req_id_counter = increment_uds_req_id_counter(uds_req_id_counter);
-    transmit_can(UDS_REQUESTS100MS[uds_req_id_counter], can_config.battery);
+    transmit_can_frame(UDS_REQUESTS100MS[uds_req_id_counter], can_config.battery);
 
     //Send SME Keep alive values 100ms
-    transmit_can(&BMWiX_510, can_config.battery);
+    transmit_can_frame(&BMWiX_510, can_config.battery);
   }
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
@@ -745,16 +745,16 @@ void send_can_battery() {
 
     //Send SME Keep alive values 200ms
     BMWiX_0C0.data.u8[0] = increment_0C0_counter(BMWiX_0C0.data.u8[0]);  //Keep Alive 1
-    transmit_can(&BMWiX_0C0, can_config.battery);
+    transmit_can_frame(&BMWiX_0C0, can_config.battery);
   }
   // Send 1000ms CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
     previousMillis1000 = currentMillis;
 
     //Send SME Keep alive values 1000ms
-    //Don't believe this is needed: transmit_can(&BMWiX_06D, can_config.battery);
-    //Don't believe this is needed: transmit_can(&BMWiX_2F1, can_config.battery);
-    //Don't believe this is needed: transmit_can(&BMWiX_439, can_config.battery);
+    //Don't believe this is needed: transmit_can_frame(&BMWiX_06D, can_config.battery);
+    //Don't believe this is needed: transmit_can_frame(&BMWiX_2F1, can_config.battery);
+    //Don't believe this is needed: transmit_can_frame(&BMWiX_439, can_config.battery);
   }
   // Send 5000ms CAN Message
   if (currentMillis - previousMillis5000 >= INTERVAL_5_S) {

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -18,6 +18,6 @@
 #define STALE_PERIOD_CONFIG \
   300000;  //Number of milliseconds before critical values are classed as stale/stuck 300000 = 300 seconds
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -254,7 +254,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.boltampera.battery_current_7E4 = battery_current_7E4;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x200:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -254,7 +254,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.boltampera.battery_current_7E4 = battery_current_7E4;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x200:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -319,7 +319,7 @@ void receive_can_battery(CAN_frame rx_frame) {
     case 0x7EC:  //When polling 7E4 BMS replies with 7EC ??
 
       if (rx_frame.data.u8[0] == 0x10) {  //"PID Header"
-        transmit_can(&BOLT_ACK_7E4, can_config.battery);
+        transmit_can_frame(&BOLT_ACK_7E4, can_config.battery);
       }
 
       //Frame 2 & 3 contains reply
@@ -391,7 +391,7 @@ void receive_can_battery(CAN_frame rx_frame) {
     case 0x7EF:  //When polling 7E7 BMS replies with 7EF
 
       if (rx_frame.data.u8[0] == 0x10) {  //"PID Header"
-        transmit_can(&BOLT_ACK_7E7, can_config.battery);
+        transmit_can_frame(&BOLT_ACK_7E7, can_config.battery);
       }
 
       //Frame 2 & 3 contains reply
@@ -730,7 +730,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   //Send 20ms message
@@ -742,7 +742,7 @@ void send_can_battery() {
       clear_event(EVENT_CAN_OVERRUN);
     }
     previousMillis20ms = currentMillis;
-    transmit_can(&BOLT_778, can_config.battery);
+    transmit_can_frame(&BOLT_778, can_config.battery);
   }
 
   //Send 100ms message
@@ -756,7 +756,7 @@ void send_can_battery() {
     BOLT_POLL_7E7.data.u8[2] = (uint8_t)((currentpoll_7E7 & 0xFF00) >> 8);
     BOLT_POLL_7E7.data.u8[3] = (uint8_t)(currentpoll_7E7 & 0x00FF);
 
-    transmit_can(&BOLT_POLL_7E7, can_config.battery);
+    transmit_can_frame(&BOLT_POLL_7E7, can_config.battery);
   }
 
   //Send 120ms message
@@ -770,7 +770,7 @@ void send_can_battery() {
     BOLT_POLL_7E4.data.u8[2] = (uint8_t)((currentpoll_7E4 & 0xFF00) >> 8);
     BOLT_POLL_7E4.data.u8[3] = (uint8_t)(currentpoll_7E4 & 0x00FF);
 
-    transmit_can(&BOLT_POLL_7E4, can_config.battery);
+    transmit_can_frame(&BOLT_POLL_7E4, can_config.battery);
   }
 }
 

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -141,6 +141,6 @@
 #define POLL_7E7_CELL_96 0x4240
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -162,7 +162,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bydAtto3.voltage_polled = BMS_voltage;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //Log values taken with 422V from battery
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;
@@ -292,7 +292,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   //Send 50ms message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
@@ -334,9 +334,9 @@ void send_can_battery() {
     ATTO_3_12D.data.u8[6] = (0x0F | (frame6_counter << 4));
     ATTO_3_12D.data.u8[7] = (0x09 | (frame7_counter << 4));
 
-    transmit_can(&ATTO_3_12D, can_config.battery);
+    transmit_can_frame(&ATTO_3_12D, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&ATTO_3_12D, can_config.battery_double);
+    transmit_can_frame(&ATTO_3_12D, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
   }
   // Send 100ms CAN Message
@@ -355,9 +355,9 @@ void send_can_battery() {
       ATTO_3_441.data.u8[7] = 0xF5;
     }
 
-    transmit_can(&ATTO_3_441, can_config.battery);
+    transmit_can_frame(&ATTO_3_441, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&ATTO_3_441, can_config.battery_double);
+    transmit_can_frame(&ATTO_3_441, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
   }
   // Send 500ms CAN Message
@@ -402,9 +402,9 @@ void send_can_battery() {
         break;
     }
 
-    transmit_can(&ATTO_3_7E7_POLL, can_config.battery);
+    transmit_can_frame(&ATTO_3_7E7_POLL, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&ATTO_3_7E7_POLL, can_config.battery_double);
+    transmit_can_frame(&ATTO_3_7E7_POLL, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
   }
 }
@@ -477,7 +477,7 @@ void update_values_battery2() {  //This function maps all the values fetched via
   datalayer.battery2.status.temperature_max_dC = battery2_calc_max_temperature * 10;
 }
 
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //Log values taken with 422V from battery2
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -162,7 +162,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bydAtto3.voltage_polled = BMS_voltage;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //Log values taken with 422V from battery
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -17,6 +17,6 @@
 #define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -213,7 +213,7 @@ void update_values_battery() {
     //TODO, shall we react on this?
   }
 }
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x1A4:  //PDO1_TX - 200ms
@@ -316,7 +316,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 1s CAN Message
   if (currentMillis - previousMillis1s >= INTERVAL_1_S) {
@@ -324,10 +324,10 @@ void send_can_battery() {
     previousMillis1s = currentMillis;
 
     /*
-    transmit_can(&CELLPOWER_18FF50E9, can_config.battery);
-    transmit_can(&CELLPOWER_18FF50E8, can_config.battery);
-    transmit_can(&CELLPOWER_18FF50E7, can_config.battery);
-    transmit_can(&CELLPOWER_18FF50E5, can_config.battery);
+    transmit_can_frame(&CELLPOWER_18FF50E9, can_config.battery);
+    transmit_can_frame(&CELLPOWER_18FF50E8, can_config.battery);
+    transmit_can_frame(&CELLPOWER_18FF50E7, can_config.battery);
+    transmit_can_frame(&CELLPOWER_18FF50E5, can_config.battery);
     */
   }
 }

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -213,7 +213,7 @@ void update_values_battery() {
     //TODO, shall we react on this?
   }
 }
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x1A4:  //PDO1_TX - 200ms

--- a/Software/src/battery/CELLPOWER-BMS.h
+++ b/Software/src/battery/CELLPOWER-BMS.h
@@ -14,6 +14,6 @@
 #define NATIVECAN_250KBPS
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -367,7 +367,7 @@ inline void process_vehicle_vendor_ID(CAN_frame rx_frame) {
       ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[1]);  //Actually more bytes, but not needed for our purpose
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
 #ifdef CH_CAN_DEBUG
   logging.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   logging.print("  ");
@@ -657,7 +657,7 @@ void update_evse_discharge_capabilities(CAN_frame& f) {
   CHADEMO_208.data.u8[7] = highByte(x208_evse_dischg_cap.lower_threshold_voltage);
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
 
   unsigned long currentMillis = millis();
 
@@ -693,8 +693,8 @@ void send_can_battery() {
      * that is the limiting factor. Therefore, we
      * can generally send as is without tweaks here.
      */
-    transmit_can(&CHADEMO_108, can_config.battery);
-    transmit_can(&CHADEMO_109, can_config.battery);
+    transmit_can_frame(&CHADEMO_108, can_config.battery);
+    transmit_can_frame(&CHADEMO_109, can_config.battery);
 
     /* TODO for dynamic control: can send x118 with byte 6 bit 0 set to 0 for 1s (before flipping back to 1) as a way of giving vehicle a chance to update 101.1 and 101.2
      * 	within 6 seconds of x118 toggle.
@@ -703,9 +703,9 @@ void send_can_battery() {
      */
 
     if (EVSE_mode == CHADEMO_DISCHARGE || EVSE_mode == CHADEMO_BIDIRECTIONAL) {
-      transmit_can(&CHADEMO_208, can_config.battery);
+      transmit_can_frame(&CHADEMO_208, can_config.battery);
       if (x201_received) {
-        transmit_can(&CHADEMO_209, can_config.battery);
+        transmit_can_frame(&CHADEMO_209, can_config.battery);
         x209_sent = true;
       }
     }
@@ -717,7 +717,7 @@ void send_can_battery() {
       //FIXME REMOVE
       logging.println("REMOVE: proto 2.0");
 #endif
-      transmit_can(&CHADEMO_118, can_config.battery);
+      transmit_can_frame(&CHADEMO_118, can_config.battery);
     }
   }
 }
@@ -819,7 +819,7 @@ void handle_chademo_sequence() {
     case CHADEMO_INIT:
       /* Transient state while awaiting CAN from Vehicle.
        * Used for triggers/error handling elsewhere;
-       * State change to CHADEMO_NEGOTIATE occurs in receive_can_battery(..)
+       * State change to CHADEMO_NEGOTIATE occurs in map_can_frame_to_variable_battery(..)
        */
 #ifdef DEBUG_LOG
 //      logging.println("Awaiting initial vehicle CAN to trigger negotiation");

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -367,7 +367,7 @@ inline void process_vehicle_vendor_ID(CAN_frame rx_frame) {
       ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[1]);  //Actually more bytes, but not needed for our purpose
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 #ifdef CH_CAN_DEBUG
   logging.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   logging.print("  ");
@@ -819,7 +819,7 @@ void handle_chademo_sequence() {
     case CHADEMO_INIT:
       /* Transient state while awaiting CAN from Vehicle.
        * Used for triggers/error handling elsewhere;
-       * State change to CHADEMO_NEGOTIATE occurs in map_can_frame_to_variable_battery(..)
+       * State change to CHADEMO_NEGOTIATE occurs in handle_incoming_can_frame_battery(..)
        */
 #ifdef DEBUG_LOG
 //      logging.println("Awaiting initial vehicle CAN to trigger negotiation");

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -13,6 +13,6 @@
 #define ISA_SHUNT
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -257,7 +257,7 @@ void ISA_initialize() {
     outframe.data.u8[6] = 0x00;
     outframe.data.u8[7] = 0x00;
 
-    transmit_can(&outframe, can_config.battery);
+    transmit_can_frame(&outframe, can_config.battery);
     delay(500);
   }
 
@@ -282,7 +282,7 @@ void ISA_STOP() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_sendSTORE() {
@@ -297,7 +297,7 @@ void ISA_sendSTORE() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_START() {
@@ -312,7 +312,7 @@ void ISA_START() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_RESTART() {
@@ -328,7 +328,7 @@ void ISA_RESTART() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_deFAULT() {
@@ -347,7 +347,7 @@ void ISA_deFAULT() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
   delay(500);
 
   ISA_START();
@@ -369,7 +369,7 @@ void ISA_initCurrent() {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
   delay(500);
 
   ISA_sendSTORE();
@@ -394,7 +394,7 @@ void ISA_getCONFIG(uint8_t i) {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_getCAN_ID(uint8_t i) {
@@ -414,7 +414,7 @@ void ISA_getCAN_ID(uint8_t i) {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 
 void ISA_getINFO(uint8_t i) {
@@ -430,6 +430,6 @@ void ISA_getINFO(uint8_t i) {
   outframe.data.u8[6] = 0x00;
   outframe.data.u8[7] = 0x00;
 
-  transmit_can(&outframe, can_config.battery);
+  transmit_can_frame(&outframe, can_config.battery);
 }
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -25,6 +25,6 @@ void ISA_getCONFIG(uint8_t i);
 void ISA_getCAN_ID(uint8_t i);
 void ISA_getINFO(uint8_t i);
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -72,7 +72,7 @@ void update_values_battery() {
   datalayer.battery.status.cell_max_voltage_mV = max_cell_mv_value;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x125:
@@ -288,7 +288,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -72,7 +72,7 @@ void update_values_battery() {
   datalayer.battery.status.cell_max_voltage_mV = max_cell_mv_value;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x125:

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -7,6 +7,6 @@
 #define MAX_CELL_DEVIATION_MV 250
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -129,7 +129,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x374:  //BMU message, 10ms - SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -129,7 +129,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x374:  //BMU message, 10ms - SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -207,7 +207,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -11,6 +11,6 @@
 #define MIN_CELL_VOLTAGE_MV 2750  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -119,7 +119,7 @@ void update_values_battery() {
 #endif
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
@@ -242,13 +242,13 @@ void receive_can_battery(CAN_frame rx_frame) {
   logging.println("");
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   /* Send keep-alive every 200ms */
   if (currentMillis - previousMillisKeepAlive >= INTERVAL_200_MS) {
     previousMillisKeepAlive = currentMillis;
-    transmit_can(&ipace_keep_alive, can_config.battery);
+    transmit_can_frame(&ipace_keep_alive, can_config.battery);
     return;
   }
 }

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -119,7 +119,7 @@ void update_values_battery() {
 #endif
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -10,6 +10,6 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -750,7 +750,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   startedUp = true;
   switch (rx_frame.ID) {
     case 0x055:

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -750,7 +750,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   startedUp = true;
   switch (rx_frame.ID) {
     case 0x055:
@@ -811,7 +811,7 @@ void receive_can_battery(CAN_frame rx_frame) {
           // logging.println ("Send ack");
           poll_data_pid = rx_frame.data.u8[4];
           // if (rx_frame.data.u8[4] == poll_data_pid) {
-          transmit_can(&EGMP_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+          transmit_can_frame(&EGMP_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           // }
           break;
         case 0x21:  //First frame in PID group
@@ -982,7 +982,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   if (startedUp) {
     //Send Contactor closing message loop
@@ -993,7 +993,7 @@ void send_can_battery() {
       if (currentMillis - startMillis >= messageDelays[messageIndex]) {
 
         // Transmit the current message
-        transmit_can(messages[messageIndex], can_config.battery);
+        transmit_can_frame(messages[messageIndex], can_config.battery);
 
         // Move to the next message
         messageIndex++;
@@ -1019,7 +1019,7 @@ void send_can_battery() {
       EGMP_7E4.data.u8[3] = KIA_7E4_COUNTER;
 
       if (ok_start_polling_battery) {
-        transmit_can(&EGMP_7E4, can_config.battery);
+        transmit_can_frame(&EGMP_7E4, can_config.battery);
       }
 
       KIA_7E4_COUNTER++;

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -18,6 +18,6 @@ extern ACAN2517FD canfd;
 #define RAMPDOWNPOWERALLOWED 10000  // What power we ramp down from towards top balancing
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -220,7 +220,7 @@ void update_number_of_cells() {
   }
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4DE:
       startedUp = true;
@@ -268,17 +268,17 @@ void receive_can_battery(CAN_frame rx_frame) {
       }
       poll_data_pid++;
       if (poll_data_pid == 1) {
-        transmit_can(&KIA64_7E4_id1, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id1, can_config.battery);
       } else if (poll_data_pid == 2) {
-        transmit_can(&KIA64_7E4_id2, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id2, can_config.battery);
       } else if (poll_data_pid == 3) {
-        transmit_can(&KIA64_7E4_id3, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id3, can_config.battery);
       } else if (poll_data_pid == 4) {
-        transmit_can(&KIA64_7E4_id4, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id4, can_config.battery);
       } else if (poll_data_pid == 5) {
-        transmit_can(&KIA64_7E4_id5, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id5, can_config.battery);
       } else if (poll_data_pid == 6) {
-        transmit_can(&KIA64_7E4_id6, can_config.battery);
+        transmit_can_frame(&KIA64_7E4_id6, can_config.battery);
       } else if (poll_data_pid == 7) {
       } else if (poll_data_pid == 8) {
       } else if (poll_data_pid == 9) {
@@ -289,7 +289,8 @@ void receive_can_battery(CAN_frame rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
-            transmit_can(&KIA64_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can_frame(&KIA64_7E4_ack,
+                               can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -460,7 +461,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   if (!startedUp) {
@@ -471,9 +472,9 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    transmit_can(&KIA64_553, can_config.battery);
-    transmit_can(&KIA64_57F, can_config.battery);
-    transmit_can(&KIA64_2A1, can_config.battery);
+    transmit_can_frame(&KIA64_553, can_config.battery);
+    transmit_can_frame(&KIA64_57F, can_config.battery);
+    transmit_can_frame(&KIA64_2A1, can_config.battery);
   }
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
@@ -525,11 +526,11 @@ void send_can_battery() {
         break;
     }
 
-    transmit_can(&KIA_HYUNDAI_200, can_config.battery);
+    transmit_can_frame(&KIA_HYUNDAI_200, can_config.battery);
 
-    transmit_can(&KIA_HYUNDAI_523, can_config.battery);
+    transmit_can_frame(&KIA_HYUNDAI_523, can_config.battery);
 
-    transmit_can(&KIA_HYUNDAI_524, can_config.battery);
+    transmit_can_frame(&KIA_HYUNDAI_524, can_config.battery);
   }
 }
 

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -220,7 +220,7 @@ void update_number_of_cells() {
   }
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4DE:
       startedUp = true;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -14,6 +14,6 @@
 
 void setup_battery(void);
 void update_number_of_cells();
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -86,7 +86,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x5F1:
@@ -108,7 +108,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[3] == poll_data_pid) {
-            transmit_can(&KIA_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can_frame(&KIA_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:                      //First frame in PID group
@@ -230,7 +230,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   // Send 1000ms CAN Message
@@ -243,15 +243,15 @@ void send_can_battery() {
     }
     poll_data_pid++;
     if (poll_data_pid == 1) {
-      transmit_can(&KIA_7E4_id1, can_config.battery);
+      transmit_can_frame(&KIA_7E4_id1, can_config.battery);
     } else if (poll_data_pid == 2) {
-      transmit_can(&KIA_7E4_id2, can_config.battery);
+      transmit_can_frame(&KIA_7E4_id2, can_config.battery);
     } else if (poll_data_pid == 3) {
-      transmit_can(&KIA_7E4_id3, can_config.battery);
+      transmit_can_frame(&KIA_7E4_id3, can_config.battery);
     } else if (poll_data_pid == 4) {
 
     } else if (poll_data_pid == 5) {
-      transmit_can(&KIA_7E4_id5, can_config.battery);
+      transmit_can_frame(&KIA_7E4_id5, can_config.battery);
     }
   }
 }

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -86,7 +86,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x5F1:

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -11,6 +11,6 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -618,7 +618,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.meb.rt_battery_unathorized = realtime_warning_battery_unathorized;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   last_can_msg_timestamp = millis();
   if (first_can_msg == 0)
     first_can_msg = last_can_msg_timestamp;

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -618,7 +618,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.meb.rt_battery_unathorized = realtime_warning_battery_unathorized;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   last_can_msg_timestamp = millis();
   if (first_can_msg == 0)
     first_can_msg = last_can_msg_timestamp;
@@ -994,7 +994,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
     case 0x1C42007B:                      // Reply from battery
       if (rx_frame.data.u8[0] == 0x10) {  //PID header
-        transmit_can(&MEB_ACK_FRAME, can_config.battery);
+        transmit_can_frame(&MEB_ACK_FRAME, can_config.battery);
       }
       if (rx_frame.DLC == 8) {
         pid_reply = (rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3];
@@ -1453,7 +1453,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 10ms CAN Message
   if (currentMillis > last_can_msg_timestamp + 500) {
@@ -1474,7 +1474,7 @@ void send_can_battery() {
 
     counter_10ms = (counter_10ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
-    transmit_can(&MEB_0FC, can_config.battery);  // Required for contactor closing
+    transmit_can_frame(&MEB_0FC, can_config.battery);  // Required for contactor closing
   }
   // Send 20ms CAN Message
   if (currentMillis - previousMillis20ms >= INTERVAL_20_MS) {
@@ -1485,7 +1485,7 @@ void send_can_battery() {
 
     counter_20ms = (counter_20ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
-    transmit_can(&MEB_0FD, can_config.battery);  // Required for contactor closing
+    transmit_can_frame(&MEB_0FD, can_config.battery);  // Required for contactor closing
   }
   // Send 40ms CAN Message
   if (currentMillis - previousMillis40ms >= INTERVAL_40_MS) {
@@ -1502,7 +1502,7 @@ void send_can_battery() {
     }
     toggle = !toggle;  // Flip the toggle each time the code block is executed
 
-    transmit_can(&MEB_040, can_config.battery);  // Airbag message - Needed for contactor closing
+    transmit_can_frame(&MEB_040, can_config.battery);  // Airbag message - Needed for contactor closing
   }
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50ms >= INTERVAL_50_MS) {
@@ -1518,7 +1518,7 @@ void send_can_battery() {
     MEB_0C0.data.u8[0] = vw_crc_calc(MEB_0C0.data.u8, MEB_0C0.DLC, MEB_0C0.ID);
     counter_50ms = (counter_50ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
-    transmit_can(&MEB_0C0, can_config.battery);  //  Needed for contactor closing
+    transmit_can_frame(&MEB_0C0, can_config.battery);  //  Needed for contactor closing
   }
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100ms >= INTERVAL_100_MS) {
@@ -1560,11 +1560,11 @@ void send_can_battery() {
     MEB_14C.data.u8[0] = vw_crc_calc(MEB_14C.data.u8, MEB_14C.DLC, MEB_14C.ID);
 
     counter_100ms = (counter_100ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
-    transmit_can(&MEB_503, can_config.battery);
-    transmit_can(&MEB_272, can_config.battery);
-    transmit_can(&MEB_3C0, can_config.battery);
-    transmit_can(&MEB_3BE, can_config.battery);
-    transmit_can(&MEB_14C, can_config.battery);
+    transmit_can_frame(&MEB_503, can_config.battery);
+    transmit_can_frame(&MEB_272, can_config.battery);
+    transmit_can_frame(&MEB_3C0, can_config.battery);
+    transmit_can_frame(&MEB_3BE, can_config.battery);
+    transmit_can_frame(&MEB_14C, can_config.battery);
   }
   //Send 200ms message
   if (currentMillis - previousMillis200ms >= INTERVAL_200_MS) {
@@ -1574,11 +1574,11 @@ void send_can_battery() {
 
     //TODO: MEB_1B0000B9 & MEB_1B000010 & MEB_1B000046 has CAN sleep commands, static OK?
 
-    transmit_can(&MEB_5E1, can_config.battery);
-    transmit_can(&MEB_153, can_config.battery);
-    transmit_can(&MEB_1B0000B9, can_config.battery);
-    transmit_can(&MEB_1B000010, can_config.battery);
-    transmit_can(&MEB_1B000046, can_config.battery);
+    transmit_can_frame(&MEB_5E1, can_config.battery);
+    transmit_can_frame(&MEB_153, can_config.battery);
+    transmit_can_frame(&MEB_1B0000B9, can_config.battery);
+    transmit_can_frame(&MEB_1B000010, can_config.battery);
+    transmit_can_frame(&MEB_1B000046, can_config.battery);
 
     switch (poll_pid) {
       case PID_SOC:
@@ -2076,7 +2076,7 @@ void send_can_battery() {
         break;
     }
     if (first_can_msg > 0 && currentMillis > first_can_msg + 2000) {
-      transmit_can(&MEB_POLLING_FRAME, can_config.battery);
+      transmit_can_frame(&MEB_POLLING_FRAME, can_config.battery);
     }
   }
 
@@ -2084,11 +2084,11 @@ void send_can_battery() {
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
 
-    transmit_can(&MEB_16A954B4, can_config.battery);  //eTM, Cooling valves and pumps for BMS
-    transmit_can(&MEB_569, can_config.battery);       // Battery heating requests
-    transmit_can(&MEB_1A55552B, can_config.battery);  //Climate, heatpump and priorities
-    transmit_can(&MEB_1A555548, can_config.battery);  //ORU, OTA update message for reserving battery
-    transmit_can(&MEB_16A954FB, can_config.battery);  //Climate, request to BMS for starting preconditioning
+    transmit_can_frame(&MEB_16A954B4, can_config.battery);  //eTM, Cooling valves and pumps for BMS
+    transmit_can_frame(&MEB_569, can_config.battery);       // Battery heating requests
+    transmit_can_frame(&MEB_1A55552B, can_config.battery);  //Climate, heatpump and priorities
+    transmit_can_frame(&MEB_1A555548, can_config.battery);  //ORU, OTA update message for reserving battery
+    transmit_can_frame(&MEB_16A954FB, can_config.battery);  //Climate, request to BMS for starting preconditioning
   }
 
   //Send 1s CANFD message
@@ -2109,12 +2109,12 @@ void send_can_battery() {
     MEB_6B2.data.u8[7] = (uint8_t)((seconds & 0x3E) >> 1);
     seconds = (seconds + 1) % 60;
 
-    counter_1000ms = (counter_1000ms + 1) % 16;       //Goes from 0-1-2-3...15-0-1-2-3..
-    transmit_can(&MEB_6B2, can_config.battery);       // Diagnostics - Needed for contactor closing
-    transmit_can(&MEB_641, can_config.battery);       // Motor - OBD
-    transmit_can(&MEB_5F5, can_config.battery);       // Loading profile
-    transmit_can(&MEB_585, can_config.battery);       // Systeminfo
-    transmit_can(&MEB_1A5555A6, can_config.battery);  // Temperature QBit
+    counter_1000ms = (counter_1000ms + 1) % 16;             //Goes from 0-1-2-3...15-0-1-2-3..
+    transmit_can_frame(&MEB_6B2, can_config.battery);       // Diagnostics - Needed for contactor closing
+    transmit_can_frame(&MEB_641, can_config.battery);       // Motor - OBD
+    transmit_can_frame(&MEB_5F5, can_config.battery);       // Loading profile
+    transmit_can_frame(&MEB_585, can_config.battery);       // Systeminfo
+    transmit_can_frame(&MEB_1A5555A6, can_config.battery);  // Temperature QBit
   }
 }
 

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -133,6 +133,6 @@
 #define PID_CELLVOLTAGE_CELL_108 0x1EAB
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -44,7 +44,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.temperature_max_dC;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x171:  //Following messages were detected on a MG5 battery BMS

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -44,7 +44,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.temperature_max_dC;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x171:  //Following messages were detected on a MG5 battery BMS
@@ -108,7 +108,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   //Send 10ms message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
@@ -120,13 +120,13 @@ void send_can_battery() {
     }
     previousMillis10 = currentMillis;
 
-    transmit_can(&MG_5_100, can_config.battery);
+    transmit_can_frame(&MG_5_100, can_config.battery);
   }
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    //transmit_can(&MG_5_100, can_config.battery);
+    //transmit_can_frame(&MG_5_100, can_config.battery);
   }
 }
 

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -11,6 +11,6 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -740,7 +740,7 @@ void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
 }
 #endif  // DOUBLE_BATTERY
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -502,7 +502,7 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
     }
   }
 }
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
@@ -612,7 +612,7 @@ void receive_can_battery2(CAN_frame rx_frame) {
       //First check which group data we are getting
       if (rx_frame.data.u8[0] == 0x10) {  //First message of a group
         battery2_group_7bb = rx_frame.data.u8[3];
-        transmit_can(&LEAF_NEXT_LINE_REQUEST, can_config.battery_double);
+        transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery_double);
       }
 
       if (battery2_group_7bb == 1)  //High precision SOC, Current, voltages etc.
@@ -740,7 +740,7 @@ void receive_can_battery2(CAN_frame rx_frame) {
 }
 #endif  // DOUBLE_BATTERY
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
@@ -870,7 +870,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       if (rx_frame.data.u8[0] == 0x10) {  //First message of a group
         group_7bb = rx_frame.data.u8[3];
 
-        transmit_can(&LEAF_NEXT_LINE_REQUEST, can_config.battery);  //Request the next frame for the group
+        transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery);  //Request the next frame for the group
       }
 
       if (group_7bb == 1)  //High precision SOC, Current, voltages etc.
@@ -1056,7 +1056,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   if (battery_can_alive) {
 
     unsigned long currentMillis = millis();
@@ -1089,9 +1089,9 @@ void send_can_battery() {
           LEAF_1D4.data.u8[7] = 0xDE;
           break;
       }
-      transmit_can(&LEAF_1D4, can_config.battery);
+      transmit_can_frame(&LEAF_1D4, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&LEAF_1D4, can_config.battery_double);
+      transmit_can_frame(&LEAF_1D4, can_config.battery_double);
 #endif  // DOUBLE_BATTERY
 
       switch (mprun10r) {
@@ -1185,9 +1185,9 @@ void send_can_battery() {
 
 //Only send this message when NISSANLEAF_CHARGER is not defined (otherwise it will collide!)
 #ifndef NISSANLEAF_CHARGER
-      transmit_can(&LEAF_1F2, can_config.battery);
+      transmit_can_frame(&LEAF_1F2, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&LEAF_1F2, can_config.battery_double);
+      transmit_can_frame(&LEAF_1F2, can_config.battery_double);
 #endif  // DOUBLE_BATTERY
 #endif
 
@@ -1212,9 +1212,9 @@ void send_can_battery() {
       }
 
       // VCM message, containing info if battery should sleep or stay awake
-      transmit_can(&LEAF_50B, can_config.battery);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
+      transmit_can_frame(&LEAF_50B, can_config.battery);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 #ifdef DOUBLE_BATTERY
-      transmit_can(&LEAF_50B, can_config.battery_double);
+      transmit_can_frame(&LEAF_50B, can_config.battery_double);
 #endif  // DOUBLE_BATTERY
 
       LEAF_50C.data.u8[3] = mprun100;
@@ -1236,9 +1236,9 @@ void send_can_battery() {
           LEAF_50C.data.u8[5] = 0x9A;
           break;
       }
-      transmit_can(&LEAF_50C, can_config.battery);
+      transmit_can_frame(&LEAF_50C, can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&LEAF_50C, can_config.battery_double);
+      transmit_can_frame(&LEAF_50C, can_config.battery_double);
 #endif  // DOUBLE_BATTERY
 
       mprun100 = (mprun100 + 1) % 4;  // mprun100 cycles between 0-1-2-3-0-1...
@@ -1255,9 +1255,9 @@ void send_can_battery() {
         PIDindex = (PIDindex + 1) % 6;  // 6 = amount of elements in the PIDgroups[]
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
-        transmit_can(&LEAF_GROUP_REQUEST, can_config.battery);
+        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery);
 #ifdef DOUBLE_BATTERY
-        transmit_can(&LEAF_GROUP_REQUEST, can_config.battery_double);
+        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery_double);
 #endif  // DOUBLE_BATTERY
       }
 
@@ -1320,19 +1320,19 @@ void clearSOH(void) {
       break;
     case 1:  // Set CAN_PROCESS_FLAG to 0xC0
       LEAF_CLEAR_SOH.data = {0x02, 0x10, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // BMS should reply 02 50 C0 FF FF FF FF FF
       stateMachineClearSOH = 2;
       break;
     case 2:  // Set something ?
       LEAF_CLEAR_SOH.data = {0x02, 0x3E, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // BMS should reply 7E FF FF FF FF FF FF
       stateMachineClearSOH = 3;
       break;
     case 3:  // Request challenge to solve
       LEAF_CLEAR_SOH.data = {0x02, 0x27, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // BMS should reply with (challenge) 06 67 65 (02 DD 86 43) FF
       stateMachineClearSOH = 4;
       break;
@@ -1340,34 +1340,34 @@ void clearSOH(void) {
       decodeChallengeData(incomingChallenge, solvedChallenge);
       LEAF_CLEAR_SOH.data = {
           0x10, 0x0A, 0x27, 0x66, solvedChallenge[0], solvedChallenge[1], solvedChallenge[2], solvedChallenge[3]};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // BMS should reply 7BB 8 30 01 00 FF FF FF FF FF // Proceed with more data (PID ACK)
       stateMachineClearSOH = 5;
       break;
     case 5:  // Reply with even more decoded challenge data
       LEAF_CLEAR_SOH.data = {
           0x21, solvedChallenge[4], solvedChallenge[5], solvedChallenge[6], solvedChallenge[7], 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // BMS should reply 02 67 66 FF FF FF FF FF // Thank you for the data
       stateMachineClearSOH = 6;
       break;
     case 6:  // Check if solved data was OK
       LEAF_CLEAR_SOH.data = {0x03, 0x31, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       //7BB 8 03 71 03 01 FF FF FF FF // If all is well, BMS replies with 03 71 03 01.
       //Incase you sent wrong challenge, you get 03 7f 31 12
       stateMachineClearSOH = 7;
       break;
     case 7:  // Reset SOH% request
       LEAF_CLEAR_SOH.data = {0x03, 0x31, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       //7BB 8 03 71 03 02 FF FF FF FF // 03 71 03 02 means that BMS accepted command.
       //7BB 03 7f 31 12 means your challenge was wrong, so command ignored
       stateMachineClearSOH = 8;
       break;
     case 8:  // Please proceed with resetting SOH
       LEAF_CLEAR_SOH.data = {0x02, 0x10, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
       // 7BB 8 02 50 81 FF FF FF FF FF // SOH reset OK
       stateMachineClearSOH = 255;
       break;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -13,7 +13,7 @@
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame rx_frame);
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void clearSOH(void);
 //Cryptographic functions
 void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -80,7 +80,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = discharge_cutoff_voltage;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x7310:
@@ -156,17 +156,17 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
 
     previousMillis1000 = currentMillis;
 
-    transmit_can(&PYLON_3010, can_config.battery);  // Heartbeat
-    transmit_can(&PYLON_4200, can_config.battery);  // Ensemble OR System equipment info, depends on frame0
-    transmit_can(&PYLON_8200, can_config.battery);  // Control device quit sleep status
-    transmit_can(&PYLON_8210, can_config.battery);  // Charge command
+    transmit_can_frame(&PYLON_3010, can_config.battery);  // Heartbeat
+    transmit_can_frame(&PYLON_4200, can_config.battery);  // Ensemble OR System equipment info, depends on frame0
+    transmit_can_frame(&PYLON_8200, can_config.battery);  // Control device quit sleep status
+    transmit_can_frame(&PYLON_8210, can_config.battery);  // Charge command
 
     if (ensemble_info_ack) {
       PYLON_4200.data.u8[0] = 0x00;  //Request system equipment info

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -80,7 +80,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = discharge_cutoff_voltage;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x7310:

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -13,6 +13,6 @@
 #define MAX_CELL_DEVIATION_MV 500
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -180,7 +180,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = DischargeVoltageLimit * 10;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x080:  // 15ms
@@ -301,14 +301,14 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50ms >= INTERVAL_50_MS) {
 
     previousMillis50ms = currentMillis;
 
-    transmit_can(&RANGE_ROVER_18B, can_config.battery);
+    transmit_can_frame(&RANGE_ROVER_18B, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -180,7 +180,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = DischargeVoltageLimit * 10;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x080:  // 15ms

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -13,6 +13,6 @@
 #define MAX_CELL_DEVIATION_MV 500  //TODO: Configure
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -137,7 +137,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x155:  //BMS1
@@ -210,12 +210,12 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message (for 2.4s, then pause 10s)
   if ((currentMillis - previousMillis100) >= (INTERVAL_100_MS + GVL_pause)) {
     previousMillis100 = currentMillis;
-    transmit_can(&KANGOO_423, can_config.battery);
+    transmit_can_frame(&KANGOO_423, can_config.battery);
     GVI_Pollcounter++;
     GVL_pause = 0;
     if (GVI_Pollcounter >= 24) {
@@ -227,9 +227,9 @@ void send_can_battery() {
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
     previousMillis1000 = currentMillis;
     if (GVB_79B_Continue)
-      transmit_can(&KANGOO_79B_Continue, can_config.battery);
+      transmit_can_frame(&KANGOO_79B_Continue, can_config.battery);
   } else {
-    transmit_can(&KANGOO_79B, can_config.battery);
+    transmit_can_frame(&KANGOO_79B, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -137,7 +137,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x155:  //BMS1

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -12,6 +12,6 @@
 #define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -65,7 +65,7 @@ void update_values_battery() {
       max_value(cell_temperatures_dC, sizeof(cell_temperatures_dC) / sizeof(*cell_temperatures_dC));
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x155:
@@ -127,7 +127,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   // we do not need to send anything to the battery for now
 }
 

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -65,7 +65,7 @@ void update_values_battery() {
       max_value(cell_temperatures_dC, sizeof(cell_temperatures_dC) / sizeof(*cell_temperatures_dC));
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x155:

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -135,7 +135,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.voltage_dV = static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // mV to dV
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x155:  //10ms - Charging power, current and SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -195,7 +195,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       switch (frame0) {
         case 0x10:  //PID HEADER, datarow 0
           requested_poll = rx_frame.data.u8[3];
-          transmit_can(&ZOE_ACK_79B, can_config.battery);
+          transmit_can_frame(&ZOE_ACK_79B, can_config.battery);
 
           if (requested_poll == GROUP1_CELLVOLTAGES_1_POLL) {
             cellvoltages[0] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
@@ -486,7 +486,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -495,7 +495,7 @@ void send_can_battery() {
       set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
     }
     previousMillis100 = currentMillis;
-    transmit_can(&ZOE_423, can_config.battery);
+    transmit_can_frame(&ZOE_423, can_config.battery);
 
     if ((counter_423 / 5) % 2 == 0) {  // Alternate every 5 messages between these two
       ZOE_423.data.u8[4] = 0xB2;
@@ -534,7 +534,7 @@ void send_can_battery() {
 
     ZOE_POLL_79B.data.u8[2] = current_poll;
 
-    transmit_can(&ZOE_POLL_79B, can_config.battery);
+    transmit_can_frame(&ZOE_POLL_79B, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -135,7 +135,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.voltage_dV = static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // mV to dV
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x155:  //10ms - Charging power, current and SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -11,6 +11,6 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -218,7 +218,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.zoePH2.battery_soc_max = battery_soc_max;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18DAF1DB:  // LBC Reply from active polling

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -218,7 +218,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.zoePH2.battery_soc_max = battery_soc_max;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18DAF1DB:  // LBC Reply from active polling
@@ -358,7 +358,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
@@ -375,8 +375,8 @@ void send_can_battery() {
     ZOE_POLL_18DADBF1.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
     ZOE_POLL_18DADBF1.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);
 
-    transmit_can(&ZOE_POLL_18DADBF1, can_config.battery);
-    transmit_can(&ZOE_373, can_config.battery);
+    transmit_can_frame(&ZOE_POLL_18DADBF1, can_config.battery);
+    transmit_can_frame(&ZOE_373, can_config.battery);
   }
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -10,7 +10,7 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #define POLL_SOC 0x9001
 #define POLL_USABLE_SOC 0x9002

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -158,7 +158,7 @@ void update_values_battery() {
   datalayer.battery.status.cell_min_voltage_mV = minimum_cell_voltage;
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
 
   /*
   // All CAN messages recieved will be logged via serial
@@ -550,7 +550,7 @@ void receive_can_battery(CAN_frame rx_frame) {
   }
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
@@ -563,8 +563,8 @@ void send_can_battery() {
     }
 
     if (!setup_completed) {
-      transmit_can(&RJXZS_10, can_config.battery);  // Communication connected flag
-      transmit_can(&RJXZS_1C, can_config.battery);  // CAN OK
+      transmit_can_frame(&RJXZS_10, can_config.battery);  // Communication connected flag
+      transmit_can_frame(&RJXZS_1C, can_config.battery);  // CAN OK
     }
   }
 }

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -158,7 +158,7 @@ void update_values_battery() {
   datalayer.battery.status.cell_min_voltage_mV = minimum_cell_voltage;
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   /*
   // All CAN messages recieved will be logged via serial

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -19,6 +19,6 @@
 #define NATIVECAN_250KBPS
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -116,7 +116,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -116,7 +116,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -171,7 +171,8 @@ void receive_can_battery(CAN_frame rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
-            transmit_can(&SANTAFE_7E4_ack, can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can_frame(&SANTAFE_7E4_ack,
+                               can_config.battery);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -332,7 +333,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   //Send 10ms message
@@ -351,13 +352,13 @@ void send_can_battery() {
 
     SANTAFE_200.data.u8[7] = checksum_200;
 
-    transmit_can(&SANTAFE_200, can_config.battery);
-    transmit_can(&SANTAFE_2A1, can_config.battery);
-    transmit_can(&SANTAFE_2F0, can_config.battery);
+    transmit_can_frame(&SANTAFE_200, can_config.battery);
+    transmit_can_frame(&SANTAFE_2A1, can_config.battery);
+    transmit_can_frame(&SANTAFE_2F0, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&SANTAFE_200, can_config.battery_double);
-    transmit_can(&SANTAFE_2A1, can_config.battery_double);
-    transmit_can(&SANTAFE_2F0, can_config.battery_double);
+    transmit_can_frame(&SANTAFE_200, can_config.battery_double);
+    transmit_can_frame(&SANTAFE_2A1, can_config.battery_double);
+    transmit_can_frame(&SANTAFE_2F0, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
 
     counter_200++;
@@ -370,9 +371,9 @@ void send_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    transmit_can(&SANTAFE_523, can_config.battery);
+    transmit_can_frame(&SANTAFE_523, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&SANTAFE_523, can_config.battery_double);
+    transmit_can_frame(&SANTAFE_523, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
   }
 
@@ -383,9 +384,9 @@ void send_can_battery() {
     // PID data is polled after last message sent from battery:
     poll_data_pid = (poll_data_pid % 5) + 1;
     SANTAFE_7E4_poll.data.u8[3] = (uint8_t)poll_data_pid;
-    transmit_can(&SANTAFE_7E4_poll, can_config.battery);
+    transmit_can_frame(&SANTAFE_7E4_poll, can_config.battery);
 #ifdef DOUBLE_BATTERY
-    transmit_can(&SANTAFE_7E4_poll, can_config.battery_double);
+    transmit_can_frame(&SANTAFE_7E4_poll, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
   }
 }
@@ -425,7 +426,7 @@ void update_values_battery2() {  //This function maps all the values fetched via
   }
 }
 
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -480,8 +481,8 @@ void receive_can_battery2(CAN_frame rx_frame) {
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
-            transmit_can(&SANTAFE_7E4_ack,
-                         can_config.battery_double);  //Send ack to BMS if the same frame is sent as polled
+            transmit_can_frame(&SANTAFE_7E4_ack,
+                               can_config.battery_double);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -12,6 +12,6 @@
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -224,7 +224,7 @@ void setup_battery(void) {
 }
 // Needed to make the compiler happy
 void update_values_battery() {}
-void send_can_battery() {}
-void receive_can_battery(CAN_frame rx_frame) {}
+void transmit_can_battery() {}
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {}
 
 #endif

--- a/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
+++ b/Software/src/battery/SERIAL-LINK-RECEIVER-FROM-BATTERY.cpp
@@ -225,6 +225,6 @@ void setup_battery(void) {
 // Needed to make the compiler happy
 void update_values_battery() {}
 void transmit_can_battery() {}
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {}
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {}
 
 #endif

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1149,7 +1149,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif  //DEBUG_LOG
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 
@@ -1808,7 +1808,7 @@ void receive_can_battery(CAN_frame rx_frame) {
 
 #ifdef DOUBLE_BATTERY  //Need to update battery2
 
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 
@@ -2621,7 +2621,7 @@ int index_1CF = 0;
 int index_118 = 0;
 #endif  //defined(TESLA_MODEL_SX_BATTERY) || defined(EXP_TESLA_BMS_DIGITAL_HVIL)
 
-void send_can_battery() {
+void transmit_can_battery() {
   /*From bielec: My fist 221 message, to close the contactors is 0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96 and then, 
 to cause "hv_up_for_drive" I send an additional 221 message 0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA  so 
 two 221 messages are being continuously transmitted.   When I want to shut down, I stop the second message and only send 
@@ -2632,10 +2632,10 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
 #if defined(TESLA_MODEL_SX_BATTERY) || defined(EXP_TESLA_BMS_DIGITAL_HVIL)
   if ((datalayer.system.status.inverter_allows_contactor_closing) && (datalayer.battery.status.bms_status != FAULT)) {
     if (currentMillis - lastSend1CF >= 10) {
-      transmit_can(&can_msg_1CF[index_1CF], can_config.battery);
+      transmit_can_frame(&can_msg_1CF[index_1CF], can_config.battery);
 
 #ifdef DOUBLE_BATTERY
-      transmit_can(&can_msg_1CF[index_1CF], can_config.battery_double);
+      transmit_can_frame(&can_msg_1CF[index_1CF], can_config.battery_double);
 #endif  // DOUBLE_BATTERY
 
       index_1CF = (index_1CF + 1) % 8;
@@ -2643,9 +2643,9 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
     }
 
     if (currentMillis - lastSend118 >= 10) {
-      transmit_can(&can_msg_118[index_118], can_config.battery);
+      transmit_can_frame(&can_msg_118[index_118], can_config.battery);
 #ifdef DOUBLE_BATTERY
-      transmit_can(&can_msg_1CF[index_1CF], can_config.battery_double);
+      transmit_can_frame(&can_msg_1CF[index_1CF], can_config.battery_double);
 #endif  //DOUBLE_BATTERY
 
       index_118 = (index_118 + 1) % 16;
@@ -2670,21 +2670,21 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
     if ((datalayer.system.status.inverter_allows_contactor_closing == true) &&
         (datalayer.battery.status.bms_status != FAULT)) {
       sendContactorClosingMessagesStill = 300;
-      transmit_can(&TESLA_221_1, can_config.battery);
-      transmit_can(&TESLA_221_2, can_config.battery);
+      transmit_can_frame(&TESLA_221_1, can_config.battery);
+      transmit_can_frame(&TESLA_221_2, can_config.battery);
 #ifdef DOUBLE_BATTERY
       if (datalayer.system.status.battery2_allows_contactor_closing) {
-        transmit_can(&TESLA_221_1, can_config.battery_double);
-        transmit_can(&TESLA_221_2, can_config.battery_double);
+        transmit_can_frame(&TESLA_221_1, can_config.battery_double);
+        transmit_can_frame(&TESLA_221_2, can_config.battery_double);
       }
 #endif        //DOUBLE_BATTERY
     } else {  // Faulted state, or inverter blocks contactor closing
       if (sendContactorClosingMessagesStill > 0) {
-        transmit_can(&TESLA_221_1, can_config.battery);
+        transmit_can_frame(&TESLA_221_1, can_config.battery);
         sendContactorClosingMessagesStill--;
 
 #ifdef DOUBLE_BATTERY
-        transmit_can(&TESLA_221_1, can_config.battery_double);
+        transmit_can_frame(&TESLA_221_1, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
       }
     }

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1149,7 +1149,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif  //DEBUG_LOG
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -35,7 +35,7 @@ void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);
 void print_SOC(char* header, int SOC);
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 #ifdef DOUBLE_BATTERY
 void printFaultCodesIfActive_battery2();
 #endif  //DOUBLE_BATTERY

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -127,7 +127,7 @@ void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
 }
 #endif  // DOUBLE_BATTERY
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
 void transmit_can_battery() {

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -122,21 +122,21 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
 #endif
 }
 
-void receive_can_battery2(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
   datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
 #endif  // DOUBLE_BATTERY
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     // Put fake messages here incase you want to test sending CAN
-    //transmit_can(&TEST, can_config.battery);
+    //transmit_can_frame(&TEST, can_config.battery);
   }
 }
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -6,6 +6,6 @@
 #define MAX_CELL_DEVIATION_MV 9999
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -140,7 +140,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void receive_can_battery(CAN_frame rx_frame) {
+void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
@@ -263,7 +263,7 @@ void receive_can_battery(CAN_frame rx_frame) {
       {
         cell_voltages[battery_request_idx++] = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
         cell_voltages[battery_request_idx] = (rx_frame.data.u8[7] << 8);
-        transmit_can(&VOLVO_FlowControl, can_config.battery);  // Send flow control
+        transmit_can_frame(&VOLVO_FlowControl, can_config.battery);  // Send flow control
         rxConsecutiveFrames = 1;
       } else if ((rx_frame.data.u8[0] == 0x21) && (rxConsecutiveFrames == 1)) {
         cell_voltages[battery_request_idx++] = cell_voltages[battery_request_idx] | rx_frame.data.u8[1];
@@ -273,7 +273,7 @@ void receive_can_battery(CAN_frame rx_frame) {
         if (batteryModuleNumber <= 0x2A)  // Run until last pack is read
         {
           VOLVO_CELL_U_Req.data.u8[3] = batteryModuleNumber++;
-          transmit_can(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for next module
+          transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for next module
         } else {
           min_max_voltage[0] = 9999;
           min_max_voltage[1] = 0;
@@ -284,7 +284,7 @@ void receive_can_battery(CAN_frame rx_frame) {
               min_max_voltage[1] = cell_voltages[cellcounter];
           }
 
-          transmit_can(&VOLVO_SOH_Req, can_config.battery);  //Send SOH read request
+          transmit_can_frame(&VOLVO_SOH_Req, can_config.battery);  //Send SOH read request
         }
         rxConsecutiveFrames = 0;
       }
@@ -299,10 +299,10 @@ void readCellVoltages() {
   batteryModuleNumber = 0x10;
   rxConsecutiveFrames = 0;
   VOLVO_CELL_U_Req.data.u8[3] = batteryModuleNumber++;
-  transmit_can(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
+  transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-void send_can_battery() {
+void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -314,8 +314,8 @@ void send_can_battery() {
     }
     previousMillis100 = currentMillis;
 
-    transmit_can(&VOLVO_536, can_config.battery);  //Send 0x536 Network managing frame to keep BMS alive
-    transmit_can(&VOLVO_372, can_config.battery);  //Send 0x372 ECMAmbientTempCalculated
+    transmit_can_frame(&VOLVO_536, can_config.battery);  //Send 0x536 Network managing frame to keep BMS alive
+    transmit_can_frame(&VOLVO_372, can_config.battery);  //Send 0x372 ECMAmbientTempCalculated
 
     if (datalayer.battery.status.bms_status == ACTIVE) {
       datalayer.system.status.battery_allows_contactor_closing = true;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -140,7 +140,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void map_can_frame_to_variable_battery(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -11,6 +11,6 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 void setup_battery(void);
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #endif

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -10,7 +10,7 @@
 #include "NISSAN-LEAF-CHARGER.h"
 #endif
 
-void receive_can_charger(CAN_frame rx_frame);
-void send_can_charger();
+void map_can_frame_to_variable_charger(CAN_frame rx_frame);
+void transmit_can_charger();
 
 #endif

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -56,7 +56,7 @@ static CAN_frame charger_set_targets = {
     .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a static value, meaning unknown
 
 /* We are mostly sending out not receiving */
-void receive_can_charger(CAN_frame rx_frame) {
+void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   uint16_t charger_stat_HVcur_temp = 0;
   uint16_t charger_stat_HVvol_temp = 0;
   uint16_t charger_stat_LVcur_temp = 0;
@@ -108,7 +108,7 @@ void receive_can_charger(CAN_frame rx_frame) {
   }
 }
 
-void send_can_charger() {
+void transmit_can_charger() {
   unsigned long currentMillis = millis();
   uint16_t Vol_temp = 0;
 
@@ -137,7 +137,7 @@ void send_can_charger() {
 
     charger_keepalive_frame.data.u8[0] = charger_mode;
 
-    transmit_can(&charger_keepalive_frame, can_config.charger);
+    transmit_can_frame(&charger_keepalive_frame, can_config.charger);
   }
 
   /* Send current targets every 200ms */
@@ -174,7 +174,7 @@ void send_can_charger() {
     /* LSB of the voltage command. Then MSB LSB is divided by 2 */
     charger_set_targets.data.u8[3] = lowByte(Vol_temp);
 
-    transmit_can(&charger_set_targets, can_config.charger);
+    transmit_can_frame(&charger_set_targets, can_config.charger);
   }
 
 #ifdef DEBUG_LOG

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -129,7 +129,7 @@ static uint8_t calculate_checksum_nibble(CAN_frame* frame) {
   return sum;
 }
 
-void receive_can_charger(CAN_frame rx_frame) {
+void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x679:  // This message fires once when charging cable is plugged in
@@ -166,7 +166,7 @@ void receive_can_charger(CAN_frame rx_frame) {
   }
 }
 
-void send_can_charger() {
+void transmit_can_charger() {
   unsigned long currentMillis = millis();
 
   /* Send keepalive with mode every 10ms */
@@ -182,13 +182,13 @@ void send_can_charger() {
 #ifndef NISSAN_LEAF_BATTERY
 
     // VCM message, containing info if battery should sleep or stay awake
-    transmit_can(&LEAF_50B, can_config.charger);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
+    transmit_can_frame(&LEAF_50B, can_config.charger);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 
     LEAF_1DB.data.u8[7] = calculate_CRC_Nissan(&LEAF_1DB);
-    transmit_can(&LEAF_1DB, can_config.charger);
+    transmit_can_frame(&LEAF_1DB, can_config.charger);
 
     LEAF_1DC.data.u8[7] = calculate_CRC_Nissan(&LEAF_1DC);
-    transmit_can(&LEAF_1DC, can_config.charger);
+    transmit_can_frame(&LEAF_1DC, can_config.charger);
 #endif
 
     OBCpowerSetpoint = ((charger_setpoint_HV_IDC * 4) + 0x64);
@@ -233,8 +233,9 @@ void send_can_charger() {
     LEAF_1F2.data.u8[6] = mprun10;
     LEAF_1F2.data.u8[7] = calculate_checksum_nibble(&LEAF_1F2);
 
-    transmit_can(&LEAF_1F2,
-                 can_config.charger);  // Sending of 1F2 message is halted in LEAF-BATTERY function incase used here
+    transmit_can_frame(
+        &LEAF_1F2,
+        can_config.charger);  // Sending of 1F2 message is halted in LEAF-BATTERY function incase used here
   }
 
   /* Send messages every 100ms here */
@@ -252,11 +253,11 @@ void send_can_charger() {
     LEAF_55B.data.u8[6] = ((0x1 << 4) | (mprun100));
 
     LEAF_55B.data.u8[7] = calculate_CRC_Nissan(&LEAF_55B);
-    transmit_can(&LEAF_55B, can_config.charger);
+    transmit_can_frame(&LEAF_55B, can_config.charger);
 
-    transmit_can(&LEAF_59E, can_config.charger);
+    transmit_can_frame(&LEAF_59E, can_config.charger);
 
-    transmit_can(&LEAF_5BC, can_config.charger);
+    transmit_can_frame(&LEAF_5BC, can_config.charger);
 #endif
   }
 }

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -321,7 +321,7 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
 #endif
 
   if (interface == can_config.battery) {
-    map_can_frame_to_variable_battery(*rx_frame);
+    handle_incoming_can_frame_battery(*rx_frame);
 #ifdef CHADEMO_BATTERY
     ISA_handleFrame(rx_frame);
 #endif

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -103,8 +103,22 @@ void init_CAN() {
 }
 
 // Transmit functions
+void transmit_can() {
+  if (!allowed_to_send_CAN) {
+    return;
+  }
+  transmit_can_battery();
 
-void transmit_can(CAN_frame* tx_frame, int interface) {
+#ifdef CAN_INVERTER_SELECTED
+  transmit_can_inverter();
+#endif  // CAN_INVERTER_SELECTED
+
+#ifdef CHARGER_SELECTED
+  transmit_can_charger();
+#endif  // CHARGER_SELECTED
+}
+
+void transmit_can_frame(CAN_frame* tx_frame, int interface) {
   if (!allowed_to_send_CAN) {
     return;
   }
@@ -173,54 +187,18 @@ void transmit_can(CAN_frame* tx_frame, int interface) {
   }
 }
 
-void send_can() {
-  if (!allowed_to_send_CAN) {
-    return;
-  }
-  send_can_battery();
-
-#ifdef CAN_INVERTER_SELECTED
-  send_can_inverter();
-#endif  // CAN_INVERTER_SELECTED
-
-#ifdef CHARGER_SELECTED
-  send_can_charger();
-#endif  // CHARGER_SELECTED
-}
-
 // Receive functions
-
-void receive_can(CAN_frame* rx_frame, int interface) {
-  print_can_frame(*rx_frame, frameDirection(MSG_RX));
-
-#ifdef LOG_CAN_TO_SD
-  add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
-#endif
-
-  if (interface == can_config.battery) {
-    receive_can_battery(*rx_frame);
-#ifdef CHADEMO_BATTERY
-    ISA_handleFrame(rx_frame);
-#endif
-  }
-  if (interface == can_config.inverter) {
-#ifdef CAN_INVERTER_SELECTED
-    receive_can_inverter(*rx_frame);
-#endif
-  }
-  if (interface == can_config.battery_double) {
-#ifdef DOUBLE_BATTERY
-    receive_can_battery2(*rx_frame);
-#endif
-  }
-  if (interface == can_config.charger) {
-#ifdef CHARGER_SELECTED
-    receive_can_charger(*rx_frame);
-#endif
-  }
+void receive_can() {
+  receive_frame_can_native();  // Receive CAN messages from native CAN port
+#ifdef CAN_ADDON
+  receive_frame_can_addon();  // Receive CAN messages on add-on MCP2515 chip
+#endif                        // CAN_ADDON
+#ifdef CANFD_ADDON
+  receive_frame_canfd_addon();  // Receive CAN-FD messages.
+#endif                          // CANFD_ADDON
 }
 
-void receive_can_native() {  // This section checks if we have a complete CAN message incoming on native CAN port
+void receive_frame_can_native() {  // This section checks if we have a complete CAN message incoming on native CAN port
   CAN_frame_t rx_frame_native;
   if (xQueueReceive(CAN_cfg.rx_queue, &rx_frame_native, 0) == pdTRUE) {
     CAN_frame rx_frame;
@@ -235,47 +213,46 @@ void receive_can_native() {  // This section checks if we have a complete CAN me
       rx_frame.data.u8[i] = rx_frame_native.data.u8[i];
     }
     //message incoming, pass it on to the handler
-    receive_can(&rx_frame, CAN_NATIVE);
+    map_can_frame_to_variable(&rx_frame, CAN_NATIVE);
   }
 }
 
 #ifdef CAN_ADDON
-void receive_can_addon() {  // This section checks if we have a complete CAN message incoming on add-on CAN port
-  CAN_frame rx_frame;       // Struct with our CAN format
-  CANMessage MCP2515Frame;  // Struct with ACAN2515 library format, needed to use the MCP2515 library
+void receive_frame_can_addon() {  // This section checks if we have a complete CAN message incoming on add-on CAN port
+  CAN_frame rx_frame;             // Struct with our CAN format
+  CANMessage MCP2515frame;        // Struct with ACAN2515 library format, needed to use the MCP2515 library
 
   if (can.available()) {
-    can.receive(MCP2515Frame);
+    can.receive(MCP2515frame);
 
-    rx_frame.ID = MCP2515Frame.id;
-    rx_frame.ext_ID = MCP2515Frame.ext ? CAN_frame_ext : CAN_frame_std;
-    rx_frame.DLC = MCP2515Frame.len;
-    for (uint8_t i = 0; i < MCP2515Frame.len && i < 8; i++) {
-      rx_frame.data.u8[i] = MCP2515Frame.data[i];
+    rx_frame.ID = MCP2515frame.id;
+    rx_frame.ext_ID = MCP2515frame.ext ? CAN_frame_ext : CAN_frame_std;
+    rx_frame.DLC = MCP2515frame.len;
+    for (uint8_t i = 0; i < MCP2515frame.len && i < 8; i++) {
+      rx_frame.data.u8[i] = MCP2515frame.data[i];
     }
 
     //message incoming, pass it on to the handler
-    receive_can(&rx_frame, CAN_ADDON_MCP2515);
+    map_can_frame_to_variable(&rx_frame, CAN_ADDON_MCP2515);
   }
 }
 #endif  // CAN_ADDON
 
 #ifdef CANFD_ADDON
-// Functions
-void receive_canfd_addon() {  // This section checks if we have a complete CAN-FD message incoming
-  CANFDMessage frame;
+void receive_frame_canfd_addon() {  // This section checks if we have a complete CAN-FD message incoming
+  CANFDMessage MCP2518frame;
   int count = 0;
   while (canfd.available() && count++ < 16) {
-    canfd.receive(frame);
+    canfd.receive(MCP2518frame);
 
     CAN_frame rx_frame;
-    rx_frame.ID = frame.id;
-    rx_frame.ext_ID = frame.ext;
-    rx_frame.DLC = frame.len;
-    memcpy(rx_frame.data.u8, frame.data, MIN(rx_frame.DLC, 64));
+    rx_frame.ID = MCP2518frame.id;
+    rx_frame.ext_ID = MCP2518frame.ext;
+    rx_frame.DLC = MCP2518frame.len;
+    memcpy(rx_frame.data.u8, MCP2518frame.data, MIN(rx_frame.DLC, 64));
     //message incoming, pass it on to the handler
-    receive_can(&rx_frame, CANFD_ADDON_MCP2518);
-    receive_can(&rx_frame, CANFD_NATIVE);
+    map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518);
+    map_can_frame_to_variable(&rx_frame, CANFD_NATIVE);
   }
 }
 #endif  // CANFD_ADDON
@@ -333,5 +310,35 @@ void print_can_frame(CAN_frame frame, frameDirection msgDir) {
     offset += snprintf(message_string + offset, message_string_size - offset, "\n");
 
     datalayer.system.info.logged_can_messages_offset = offset;  // Update offset in buffer
+  }
+}
+
+void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
+  print_can_frame(*rx_frame, frameDirection(MSG_RX));
+
+#ifdef LOG_CAN_TO_SD
+  add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
+#endif
+
+  if (interface == can_config.battery) {
+    map_can_frame_to_variable_battery(*rx_frame);
+#ifdef CHADEMO_BATTERY
+    ISA_handleFrame(rx_frame);
+#endif
+  }
+  if (interface == can_config.inverter) {
+#ifdef CAN_INVERTER_SELECTED
+    map_can_frame_to_variable_inverter(*rx_frame);
+#endif
+  }
+  if (interface == can_config.battery_double) {
+#ifdef DOUBLE_BATTERY
+    map_can_frame_to_variable_battery2(*rx_frame);
+#endif
+  }
+  if (interface == can_config.charger) {
+#ifdef CHARGER_SELECTED
+    map_can_frame_to_variable_charger(*rx_frame);
+#endif
   }
 }

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -32,7 +32,7 @@ void init_CAN();
  *
  * @return void
  */
-void transmit_can();
+void transmit_can_frame();
 
 /**
  * @brief Send CAN messages to all components 
@@ -41,7 +41,7 @@ void transmit_can();
  *
  * @return void
  */
-void send_can();
+void transmit_can();
 
 /**
  * @brief Receive CAN messages from all interfaces 
@@ -59,7 +59,7 @@ void receive_can();
  *
  * @return void
  */
-void receive_can_native();
+void receive_frame_can_native();
 
 /**
  * @brief Receive CAN messages from CAN addon chip
@@ -68,7 +68,7 @@ void receive_can_native();
  *
  * @return void
  */
-void receive_can_addon();
+void receive_frame_can_addon();
 
 /**
  * @brief Receive CAN messages from CANFD addon chip
@@ -77,7 +77,7 @@ void receive_can_addon();
  *
  * @return void
  */
-void receive_canfd_addon();
+void receive_frame_canfd_addon();
 
 /**
  * @brief print CAN frames via USB
@@ -87,5 +87,15 @@ void receive_canfd_addon();
  * @return void
  */
 void print_can_frame(CAN_frame frame, frameDirection msgDir);
+
+/**
+ * @brief Map CAN frame from specified interface to variable
+ *
+ * @param[in] CAN_frame* rx_frame
+ * @param[in] int interface
+ *
+ * @return void
+ */
+void map_can_frame_to_variable(CAN_frame* rx_frame, int interface);
 
 #endif

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -283,12 +283,12 @@ void setBatteryPause(bool pause_battery, bool pause_CAN, bool equipment_stop, bo
   }
 
   //immediate check if we can send CAN messages
-  emulator_pause_state_send_CAN_battery();
+  emulator_pause_state_transmit_can_battery();
 }
 
 /// @brief handle emulator pause status
 /// @return true if CAN messages should be sent to battery, false if not
-void emulator_pause_state_send_CAN_battery() {
+void emulator_pause_state_transmit_can_battery() {
   bool previous_allowed_to_send_CAN = allowed_to_send_CAN;
 
   if (emulator_pause_status == NORMAL) {

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -22,7 +22,7 @@ void update_machineryprotection();
 
 //battery pause status begin
 void setBatteryPause(bool pause_battery, bool pause_CAN, bool equipment_stop = false, bool store_settings = true);
-void emulator_pause_state_send_CAN_battery();
+void emulator_pause_state_transmit_can_battery();
 std::string get_emulator_pause_status();
 //battery pause status end
 

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -200,7 +200,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   */
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  // Every 1s from inverter
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -217,19 +217,19 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   if (time_to_send_info) {  // Set every 1s if we get message from inverter
-    transmit_can(&AFORE_350, can_config.inverter);
-    transmit_can(&AFORE_351, can_config.inverter);
-    transmit_can(&AFORE_352, can_config.inverter);
-    transmit_can(&AFORE_353, can_config.inverter);
-    transmit_can(&AFORE_354, can_config.inverter);
-    transmit_can(&AFORE_355, can_config.inverter);
-    transmit_can(&AFORE_356, can_config.inverter);
-    transmit_can(&AFORE_357, can_config.inverter);
-    transmit_can(&AFORE_358, can_config.inverter);
-    transmit_can(&AFORE_359, can_config.inverter);
-    transmit_can(&AFORE_35A, can_config.inverter);
+    transmit_can_frame(&AFORE_350, can_config.inverter);
+    transmit_can_frame(&AFORE_351, can_config.inverter);
+    transmit_can_frame(&AFORE_352, can_config.inverter);
+    transmit_can_frame(&AFORE_353, can_config.inverter);
+    transmit_can_frame(&AFORE_354, can_config.inverter);
+    transmit_can_frame(&AFORE_355, can_config.inverter);
+    transmit_can_frame(&AFORE_356, can_config.inverter);
+    transmit_can_frame(&AFORE_357, can_config.inverter);
+    transmit_can_frame(&AFORE_358, can_config.inverter);
+    transmit_can_frame(&AFORE_359, can_config.inverter);
+    transmit_can_frame(&AFORE_35A, can_config.inverter);
     time_to_send_info = false;
   }
 }

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -4,7 +4,7 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -164,7 +164,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 #endif
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x151:  //Message originating from BYD HVS compatible inverter. Reply with CAN identifier!
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -196,7 +196,7 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
   // Send initial CAN data once on bootup
   if (!initialDataSent) {
@@ -208,32 +208,32 @@ void send_can_inverter() {
   if (currentMillis - previousMillis2s >= INTERVAL_2_S) {
     previousMillis2s = currentMillis;
 
-    transmit_can(&BYD_110, can_config.inverter);
+    transmit_can_frame(&BYD_110, can_config.inverter);
   }
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
     previousMillis10s = currentMillis;
 
-    transmit_can(&BYD_150, can_config.inverter);
-    transmit_can(&BYD_1D0, can_config.inverter);
-    transmit_can(&BYD_210, can_config.inverter);
+    transmit_can_frame(&BYD_150, can_config.inverter);
+    transmit_can_frame(&BYD_1D0, can_config.inverter);
+    transmit_can_frame(&BYD_210, can_config.inverter);
   }
   //Send 60s message
   if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
     previousMillis60s = currentMillis;
 
-    transmit_can(&BYD_190, can_config.inverter);
+    transmit_can_frame(&BYD_190, can_config.inverter);
   }
 }
 
 void send_intial_data() {
-  transmit_can(&BYD_250, can_config.inverter);
-  transmit_can(&BYD_290, can_config.inverter);
-  transmit_can(&BYD_2D0, can_config.inverter);
-  transmit_can(&BYD_3D0_0, can_config.inverter);
-  transmit_can(&BYD_3D0_1, can_config.inverter);
-  transmit_can(&BYD_3D0_2, can_config.inverter);
-  transmit_can(&BYD_3D0_3, can_config.inverter);
+  transmit_can_frame(&BYD_250, can_config.inverter);
+  transmit_can_frame(&BYD_290, can_config.inverter);
+  transmit_can_frame(&BYD_2D0, can_config.inverter);
+  transmit_can_frame(&BYD_3D0_0, can_config.inverter);
+  transmit_can_frame(&BYD_3D0_1, can_config.inverter);
+  transmit_can_frame(&BYD_3D0_2, can_config.inverter);
+  transmit_can_frame(&BYD_3D0_3, can_config.inverter);
 }
 void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box Premium HVS over CAN Bus", 63);

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -7,7 +7,7 @@
 #define FW_MINOR_VERSION 0x29
 
 void send_intial_data();
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/BYD-SMA.cpp
+++ b/Software/src/inverter/BYD-SMA.cpp
@@ -195,7 +195,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -209,12 +209,12 @@ void receive_can_inverter(CAN_frame rx_frame) {
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Frame0-3 Timestamp
       /*
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
       */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
@@ -225,37 +225,37 @@ void receive_can_inverter(CAN_frame rx_frame) {
       break;
     case 0x5E7:  //Pairing request
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
-      transmit_can(&SMA_558, can_config.inverter);
-      transmit_can(&SMA_598, can_config.inverter);
-      transmit_can(&SMA_5D8, can_config.inverter);
-      transmit_can(&SMA_618_1, can_config.inverter);
-      transmit_can(&SMA_618_2, can_config.inverter);
-      transmit_can(&SMA_618_3, can_config.inverter);
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_558, can_config.inverter);
+      transmit_can_frame(&SMA_598, can_config.inverter);
+      transmit_can_frame(&SMA_5D8, can_config.inverter);
+      transmit_can_frame(&SMA_618_1, can_config.inverter);
+      transmit_can_frame(&SMA_618_2, can_config.inverter);
+      transmit_can_frame(&SMA_618_3, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
       break;
     default:
       break;
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message every 100ms if we're enabled
   if (datalayer.system.status.inverter_allows_contactor_closing) {
     if (currentMillis - previousMillis100ms >= 100) {
       previousMillis100ms = currentMillis;
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
     }
   }
 }

--- a/Software/src/inverter/BYD-SMA.h
+++ b/Software/src/inverter/BYD-SMA.h
@@ -7,7 +7,7 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -583,7 +583,7 @@ void update_values_can_inverter() {  //This function maps all the CAN values fet
   // So do we really need to map the same two values over and over to 32 places?
 }
 
-void send_can_inverter() {  // This function loops as fast as possible
+void transmit_can_inverter() {  // This function loops as fast as possible
 
   if (send_cellvoltages) {
     unsigned long currentMillis = millis();  // Get the current time
@@ -598,63 +598,63 @@ void send_can_inverter() {  // This function loops as fast as possible
 #ifdef DEBUG_LOG
           logging.println("Sending large batch");
 #endif
-          transmit_can(&FOXESS_0C1D, can_config.inverter);
-          transmit_can(&FOXESS_0C21, can_config.inverter);
-          transmit_can(&FOXESS_0C29, can_config.inverter);
-          transmit_can(&FOXESS_0C2D, can_config.inverter);
-          transmit_can(&FOXESS_0C31, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C1D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C21, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C29, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C2D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C31, can_config.inverter);
           break;
         case 1:
-          transmit_can(&FOXESS_0C35, can_config.inverter);
-          transmit_can(&FOXESS_0C39, can_config.inverter);
-          transmit_can(&FOXESS_0C3D, can_config.inverter);
-          transmit_can(&FOXESS_0C41, can_config.inverter);
-          transmit_can(&FOXESS_0C45, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C35, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C39, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C3D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C41, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C45, can_config.inverter);
           break;
         case 2:
-          transmit_can(&FOXESS_0C49, can_config.inverter);
-          transmit_can(&FOXESS_0C4D, can_config.inverter);
-          transmit_can(&FOXESS_0C51, can_config.inverter);
-          transmit_can(&FOXESS_0C55, can_config.inverter);
-          transmit_can(&FOXESS_0C59, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C49, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C4D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C51, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C55, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C59, can_config.inverter);
           break;
         case 3:
-          transmit_can(&FOXESS_0C5D, can_config.inverter);
-          transmit_can(&FOXESS_0C61, can_config.inverter);
-          transmit_can(&FOXESS_0C65, can_config.inverter);
-          transmit_can(&FOXESS_0C69, can_config.inverter);
-          transmit_can(&FOXESS_0C6D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C5D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C61, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C65, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C69, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C6D, can_config.inverter);
           break;
         case 4:
-          transmit_can(&FOXESS_0C71, can_config.inverter);
-          transmit_can(&FOXESS_0C75, can_config.inverter);
-          transmit_can(&FOXESS_0C79, can_config.inverter);
-          transmit_can(&FOXESS_0C7D, can_config.inverter);
-          transmit_can(&FOXESS_0C81, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C71, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C75, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C79, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C7D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C81, can_config.inverter);
           break;
         case 5:
-          transmit_can(&FOXESS_0C85, can_config.inverter);
-          transmit_can(&FOXESS_0C89, can_config.inverter);
-          transmit_can(&FOXESS_0C8D, can_config.inverter);
-          transmit_can(&FOXESS_0C91, can_config.inverter);
-          transmit_can(&FOXESS_0C95, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C85, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C89, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C8D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C91, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C95, can_config.inverter);
           break;
         case 6:
-          transmit_can(&FOXESS_0C99, can_config.inverter);
-          transmit_can(&FOXESS_0C9D, can_config.inverter);
-          transmit_can(&FOXESS_0CA1, can_config.inverter);
-          transmit_can(&FOXESS_0CA5, can_config.inverter);
-          transmit_can(&FOXESS_0CA9, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C99, can_config.inverter);
+          transmit_can_frame(&FOXESS_0C9D, can_config.inverter);
+          transmit_can_frame(&FOXESS_0CA1, can_config.inverter);
+          transmit_can_frame(&FOXESS_0CA5, can_config.inverter);
+          transmit_can_frame(&FOXESS_0CA9, can_config.inverter);
           break;
         case 7:  //Celltemperatures
-          transmit_can(&FOXESS_0D21, can_config.inverter);
-          transmit_can(&FOXESS_0D29, can_config.inverter);
-          transmit_can(&FOXESS_0D31, can_config.inverter);
-          transmit_can(&FOXESS_0D39, can_config.inverter);
-          transmit_can(&FOXESS_0D41, can_config.inverter);
-          transmit_can(&FOXESS_0D49, can_config.inverter);
-          transmit_can(&FOXESS_0D51, can_config.inverter);
-          transmit_can(&FOXESS_0D59, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D21, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D29, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D31, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D39, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D41, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D49, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D51, can_config.inverter);
+          transmit_can_frame(&FOXESS_0D59, can_config.inverter);
 #ifdef DEBUG_LOG
           logging.println("Sending completed");
 #endif
@@ -672,7 +672,7 @@ void send_can_inverter() {  // This function loops as fast as possible
   }
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -688,27 +688,28 @@ void receive_can_inverter(CAN_frame rx_frame) {
 #ifdef DEBUG_LOG
         logging.println("Inverter requests 1s BMS info, we reply");
 #endif
-        transmit_can(&FOXESS_1872, can_config.inverter);
-        transmit_can(&FOXESS_1873, can_config.inverter);
-        transmit_can(&FOXESS_1874, can_config.inverter);
-        transmit_can(&FOXESS_1875, can_config.inverter);
-        transmit_can(&FOXESS_1876, can_config.inverter);
-        transmit_can(&FOXESS_1877, can_config.inverter);
-        transmit_can(&FOXESS_1878, can_config.inverter);
-        transmit_can(&FOXESS_1879, can_config.inverter);
+        transmit_can_frame(&FOXESS_1872, can_config.inverter);
+        transmit_can_frame(&FOXESS_1873, can_config.inverter);
+        transmit_can_frame(&FOXESS_1874, can_config.inverter);
+        transmit_can_frame(&FOXESS_1875, can_config.inverter);
+        transmit_can_frame(&FOXESS_1876, can_config.inverter);
+        transmit_can_frame(&FOXESS_1877, can_config.inverter);
+        transmit_can_frame(&FOXESS_1878, can_config.inverter);
+        transmit_can_frame(&FOXESS_1879, can_config.inverter);
       } else if (rx_frame.data.u8[4] == 0x01) {  // b4 0x01 , 0x1871 [0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00]
         //Inverter wants to know all individual cellvoltages (occurs 6 seconds after valid BMS reply)
 #ifdef DEBUG_LOG
         logging.println("Inverter requests individual battery pack status, we reply");
 #endif
-        transmit_can(&FOXESS_0C05, can_config.inverter);  //TODO, should we limit this incase NUMBER_OF_PACKS =! 8?
-        transmit_can(&FOXESS_0C06, can_config.inverter);
-        transmit_can(&FOXESS_0C07, can_config.inverter);
-        transmit_can(&FOXESS_0C08, can_config.inverter);
-        transmit_can(&FOXESS_0C09, can_config.inverter);
-        transmit_can(&FOXESS_0C0A, can_config.inverter);
-        transmit_can(&FOXESS_0C0B, can_config.inverter);
-        transmit_can(&FOXESS_0C0C, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C05,
+                           can_config.inverter);  //TODO, should we limit this incase NUMBER_OF_PACKS =! 8?
+        transmit_can_frame(&FOXESS_0C06, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C07, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C08, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C09, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C0A, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C0B, can_config.inverter);
+        transmit_can_frame(&FOXESS_0C0C, can_config.inverter);
       } else if (rx_frame.data.u8[4] == 0x04) {  // b4 0x01 , 0x1871 [0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00]
         //Inverter wants to know all individual cellvoltages (occurs 6 seconds after valid BMS reply)
 #ifdef DEBUG_LOG
@@ -730,9 +731,9 @@ void receive_can_inverter(CAN_frame rx_frame) {
         FOXESS_1882.data.u8[0] = (uint8_t)i;
         FOXESS_1883.data.u8[0] = (uint8_t)i;
         //TODO, should we add something to serial number field?
-        transmit_can(&FOXESS_1881, can_config.inverter);
-        transmit_can(&FOXESS_1882, can_config.inverter);
-        transmit_can(&FOXESS_1883, can_config.inverter);
+        transmit_can_frame(&FOXESS_1881, can_config.inverter);
+        transmit_can_frame(&FOXESS_1882, can_config.inverter);
+        transmit_can_frame(&FOXESS_1883, can_config.inverter);
       }
     }
   }

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -4,7 +4,7 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -65,8 +65,8 @@
 
 #ifdef CAN_INVERTER_SELECTED
 void update_values_can_inverter();
-void receive_can_inverter(CAN_frame rx_frame);
-void send_can_inverter();
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
+void transmit_can_inverter();
 #endif
 
 #ifdef MODBUS_INVERTER_SELECTED

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -422,7 +422,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -438,43 +438,43 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   // No periodic sending, we only react on received can messages
 }
 
 void send_setup_info() {  //Ensemble information
 #ifdef SEND_0
-  transmit_can(&PYLON_7310, can_config.inverter);
-  transmit_can(&PYLON_7320, can_config.inverter);
+  transmit_can_frame(&PYLON_7310, can_config.inverter);
+  transmit_can_frame(&PYLON_7320, can_config.inverter);
 #endif
 #ifdef SEND_1
-  transmit_can(&PYLON_7311, can_config.inverter);
-  transmit_can(&PYLON_7321, can_config.inverter);
+  transmit_can_frame(&PYLON_7311, can_config.inverter);
+  transmit_can_frame(&PYLON_7321, can_config.inverter);
 #endif
 }
 
 void send_system_data() {  //System equipment information
 #ifdef SEND_0
-  transmit_can(&PYLON_4210, can_config.inverter);
-  transmit_can(&PYLON_4220, can_config.inverter);
-  transmit_can(&PYLON_4230, can_config.inverter);
-  transmit_can(&PYLON_4240, can_config.inverter);
-  transmit_can(&PYLON_4250, can_config.inverter);
-  transmit_can(&PYLON_4260, can_config.inverter);
-  transmit_can(&PYLON_4270, can_config.inverter);
-  transmit_can(&PYLON_4280, can_config.inverter);
-  transmit_can(&PYLON_4290, can_config.inverter);
+  transmit_can_frame(&PYLON_4210, can_config.inverter);
+  transmit_can_frame(&PYLON_4220, can_config.inverter);
+  transmit_can_frame(&PYLON_4230, can_config.inverter);
+  transmit_can_frame(&PYLON_4240, can_config.inverter);
+  transmit_can_frame(&PYLON_4250, can_config.inverter);
+  transmit_can_frame(&PYLON_4260, can_config.inverter);
+  transmit_can_frame(&PYLON_4270, can_config.inverter);
+  transmit_can_frame(&PYLON_4280, can_config.inverter);
+  transmit_can_frame(&PYLON_4290, can_config.inverter);
 #endif
 #ifdef SEND_1
-  transmit_can(&PYLON_4211, can_config.inverter);
-  transmit_can(&PYLON_4221, can_config.inverter);
-  transmit_can(&PYLON_4231, can_config.inverter);
-  transmit_can(&PYLON_4241, can_config.inverter);
-  transmit_can(&PYLON_4251, can_config.inverter);
-  transmit_can(&PYLON_4261, can_config.inverter);
-  transmit_can(&PYLON_4271, can_config.inverter);
-  transmit_can(&PYLON_4281, can_config.inverter);
-  transmit_can(&PYLON_4291, can_config.inverter);
+  transmit_can_frame(&PYLON_4211, can_config.inverter);
+  transmit_can_frame(&PYLON_4221, can_config.inverter);
+  transmit_can_frame(&PYLON_4231, can_config.inverter);
+  transmit_can_frame(&PYLON_4241, can_config.inverter);
+  transmit_can_frame(&PYLON_4251, can_config.inverter);
+  transmit_can_frame(&PYLON_4261, can_config.inverter);
+  transmit_can_frame(&PYLON_4271, can_config.inverter);
+  transmit_can_frame(&PYLON_4281, can_config.inverter);
+  transmit_can_frame(&PYLON_4291, can_config.inverter);
 #endif
 }
 void setup_inverter(void) {  // Performs one time setup at startup over CAN bus

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -6,7 +6,7 @@
 
 void send_system_data();
 void send_setup_info();
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -108,7 +108,7 @@ void update_values_can_inverter() {
   // PYLON_35E is pre-filled with the manufacturer name
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  //Message originating from inverter.
       // according to the spec, this message includes only 0-bytes
@@ -119,18 +119,18 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   if (currentMillis - previousMillis1000ms >= 1000) {
     previousMillis1000ms = currentMillis;
 
-    transmit_can(&PYLON_351, can_config.inverter);
-    transmit_can(&PYLON_355, can_config.inverter);
-    transmit_can(&PYLON_356, can_config.inverter);
-    transmit_can(&PYLON_359, can_config.inverter);
-    transmit_can(&PYLON_35C, can_config.inverter);
-    transmit_can(&PYLON_35E, can_config.inverter);
+    transmit_can_frame(&PYLON_351, can_config.inverter);
+    transmit_can_frame(&PYLON_355, can_config.inverter);
+    transmit_can_frame(&PYLON_356, can_config.inverter);
+    transmit_can_frame(&PYLON_359, can_config.inverter);
+    transmit_can_frame(&PYLON_35C, can_config.inverter);
+    transmit_can_frame(&PYLON_35E, can_config.inverter);
   }
 }
 void setup_inverter(void) {  // Performs one time setup at startup over CAN bus

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -11,7 +11,7 @@
 
 void send_system_data();
 void send_setup_info();
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -255,7 +255,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SE_320.data.u8[1] = 0x02;
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x310:  // Still alive message from inverter, every 1s
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -265,35 +265,35 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
 
-    transmit_can(&SE_321, can_config.inverter);
-    transmit_can(&SE_322, can_config.inverter);
-    transmit_can(&SE_323, can_config.inverter);
-    transmit_can(&SE_324, can_config.inverter);
-    transmit_can(&SE_325, can_config.inverter);
+    transmit_can_frame(&SE_321, can_config.inverter);
+    transmit_can_frame(&SE_322, can_config.inverter);
+    transmit_can_frame(&SE_323, can_config.inverter);
+    transmit_can_frame(&SE_324, can_config.inverter);
+    transmit_can_frame(&SE_325, can_config.inverter);
   }
   // Send 2s CAN Message
   if (currentMillis - previousMillis2s >= INTERVAL_2_S) {
     previousMillis2s = currentMillis;
 
-    transmit_can(&SE_320, can_config.inverter);
-    transmit_can(&SE_326, can_config.inverter);
-    transmit_can(&SE_327, can_config.inverter);
+    transmit_can_frame(&SE_320, can_config.inverter);
+    transmit_can_frame(&SE_326, can_config.inverter);
+    transmit_can_frame(&SE_327, can_config.inverter);
   }
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
     previousMillis10s = currentMillis;
-    transmit_can(&SE_328, can_config.inverter);
-    transmit_can(&SE_330, can_config.inverter);
-    transmit_can(&SE_331, can_config.inverter);
-    transmit_can(&SE_332, can_config.inverter);
-    transmit_can(&SE_333, can_config.inverter);
+    transmit_can_frame(&SE_328, can_config.inverter);
+    transmit_can_frame(&SE_330, can_config.inverter);
+    transmit_can_frame(&SE_331, can_config.inverter);
+    transmit_can_frame(&SE_332, can_config.inverter);
+    transmit_can_frame(&SE_333, can_config.inverter);
   }
 }
 

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -27,7 +27,7 @@
 #define COMMAND_CHARGE_AND_DISCHARGE_ALLOWED 0x06
 #define COMMAND_STOP 0x08
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SMA-CAN.cpp
+++ b/Software/src/inverter/SMA-CAN.cpp
@@ -192,7 +192,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -206,12 +206,12 @@ void receive_can_inverter(CAN_frame rx_frame) {
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Frame0-3 Timestamp
       /*
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
       */
       break;
     case 0x5E0:  //Message originating from SMA inverter - String
@@ -222,25 +222,25 @@ void receive_can_inverter(CAN_frame rx_frame) {
       break;
     case 0x5E7:  //Pairing request
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
-      transmit_can(&SMA_558, can_config.inverter);
-      transmit_can(&SMA_598, can_config.inverter);
-      transmit_can(&SMA_5D8, can_config.inverter);
-      transmit_can(&SMA_618_1, can_config.inverter);
-      transmit_can(&SMA_618_2, can_config.inverter);
-      transmit_can(&SMA_618_3, can_config.inverter);
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_558, can_config.inverter);
+      transmit_can_frame(&SMA_598, can_config.inverter);
+      transmit_can_frame(&SMA_5D8, can_config.inverter);
+      transmit_can_frame(&SMA_618_1, can_config.inverter);
+      transmit_can_frame(&SMA_618_2, can_config.inverter);
+      transmit_can_frame(&SMA_618_3, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
       break;
     default:
       break;
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message every 100ms if Enable line is HIGH
@@ -248,12 +248,12 @@ void send_can_inverter() {
     if (currentMillis - previousMillis100ms >= 100) {
       previousMillis100ms = currentMillis;
 
-      transmit_can(&SMA_158, can_config.inverter);
-      transmit_can(&SMA_358, can_config.inverter);
-      transmit_can(&SMA_3D8, can_config.inverter);
-      transmit_can(&SMA_458, can_config.inverter);
-      transmit_can(&SMA_518, can_config.inverter);
-      transmit_can(&SMA_4D8, can_config.inverter);
+      transmit_can_frame(&SMA_158, can_config.inverter);
+      transmit_can_frame(&SMA_358, can_config.inverter);
+      transmit_can_frame(&SMA_3D8, can_config.inverter);
+      transmit_can_frame(&SMA_458, can_config.inverter);
+      transmit_can_frame(&SMA_518, can_config.inverter);
+      transmit_can_frame(&SMA_4D8, can_config.inverter);
     }
   }
 }

--- a/Software/src/inverter/SMA-CAN.h
+++ b/Software/src/inverter/SMA-CAN.h
@@ -7,7 +7,7 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -114,7 +114,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //TODO: Map error/warnings in 0x35A
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -136,23 +136,23 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   if (currentMillis - previousMillis100ms >= INTERVAL_100_MS) {
     previousMillis100ms = currentMillis;
 
-    transmit_can(&SMA_351, can_config.inverter);
-    transmit_can(&SMA_355, can_config.inverter);
-    transmit_can(&SMA_356, can_config.inverter);
-    transmit_can(&SMA_35A, can_config.inverter);
-    transmit_can(&SMA_35B, can_config.inverter);
-    transmit_can(&SMA_35E, can_config.inverter);
-    transmit_can(&SMA_35F, can_config.inverter);
+    transmit_can_frame(&SMA_351, can_config.inverter);
+    transmit_can_frame(&SMA_355, can_config.inverter);
+    transmit_can_frame(&SMA_356, can_config.inverter);
+    transmit_can_frame(&SMA_35A, can_config.inverter);
+    transmit_can_frame(&SMA_35B, can_config.inverter);
+    transmit_can_frame(&SMA_35E, can_config.inverter);
+    transmit_can_frame(&SMA_35F, can_config.inverter);
 
     //Remote quick stop (optional)
     if (datalayer.battery.status.bms_status == FAULT) {
-      transmit_can(&SMA_00F, can_config.inverter);
+      transmit_can_frame(&SMA_00F, can_config.inverter);
       //After receiving this message, Sunny Island will immediately go into standby.
       //Please send start command, to start again. Manual start is also possible.
     }

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -7,7 +7,7 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -4,10 +4,10 @@
 #include "SMA-TRIPOWER-CAN.h"
 
 /* TODO:
-- Figure out the manufacturer info needed in send_tripower_init() CAN messages
+- Figure out the manufacturer info needed in transmit_tripower_init() CAN messages
   - CAN logs from real system might be needed
 - Figure out how cellvoltages need to be displayed
-- Figure out if sending send_tripower_init() like we do now is OK
+- Figure out if sending transmit_tripower_init() like we do now is OK
 - Figure out how to send the non-cyclic messages when needed
 */
 
@@ -147,7 +147,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -171,7 +171,7 @@ void receive_can_inverter(CAN_frame rx_frame) {
       break;
     case 0x660:  //Message originating from SMA inverter - Pairing request
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
-      send_tripower_init();
+      transmit_tripower_init();
       break;
     default:
       break;
@@ -189,7 +189,7 @@ void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
   listLength++;
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message only if we're enabled by inverter
@@ -201,7 +201,7 @@ void send_can_inverter() {
     previousMillis250ms = currentMillis;
     // Send next frame.
     Frame frame = framesToSend[0];
-    transmit_can(frame.frame, can_config.inverter);
+    transmit_can_frame(frame.frame, can_config.inverter);
     if (frame.callback != NULL) {
       frame.callback();
     }
@@ -233,7 +233,7 @@ void completePairing() {
   pairing_completed = true;
 }
 
-void send_tripower_init() {
+void transmit_tripower_init() {
   listLength = 0;  // clear all frames
 
   pushFrame(&SMA_558);    //Pairing start - Vendor
@@ -256,4 +256,5 @@ void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
   pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
 }
+
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -7,8 +7,8 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void send_tripower_init();
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_tripower_init();
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -230,7 +230,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOFAR_356.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -247,20 +247,20 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     //Frames actively reported by BMS
-    transmit_can(&SOFAR_351, can_config.inverter);
-    transmit_can(&SOFAR_355, can_config.inverter);
-    transmit_can(&SOFAR_356, can_config.inverter);
-    transmit_can(&SOFAR_30F, can_config.inverter);
-    transmit_can(&SOFAR_359, can_config.inverter);
-    transmit_can(&SOFAR_35E, can_config.inverter);
-    transmit_can(&SOFAR_35F, can_config.inverter);
-    transmit_can(&SOFAR_35A, can_config.inverter);
+    transmit_can_frame(&SOFAR_351, can_config.inverter);
+    transmit_can_frame(&SOFAR_355, can_config.inverter);
+    transmit_can_frame(&SOFAR_356, can_config.inverter);
+    transmit_can_frame(&SOFAR_30F, can_config.inverter);
+    transmit_can_frame(&SOFAR_359, can_config.inverter);
+    transmit_can_frame(&SOFAR_35E, can_config.inverter);
+    transmit_can_frame(&SOFAR_35F, can_config.inverter);
+    transmit_can_frame(&SOFAR_35A, can_config.inverter);
   }
 }
 

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -4,7 +4,7 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -199,11 +199,11 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 
-void send_can_inverter() {
+void transmit_can_inverter() {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
-void receive_can_inverter(CAN_frame rx_frame) {
+void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -220,17 +220,17 @@ void receive_can_inverter(CAN_frame rx_frame) {
         datalayer.system.status.inverter_allows_contactor_closing = false;
         SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
         for (uint8_t i = 0; i <= number_of_batteries; i++) {
-          transmit_can(&SOLAX_187E, can_config.inverter);
-          transmit_can(&SOLAX_187A, can_config.inverter);
-          transmit_can(&SOLAX_1872, can_config.inverter);
-          transmit_can(&SOLAX_1873, can_config.inverter);
-          transmit_can(&SOLAX_1874, can_config.inverter);
-          transmit_can(&SOLAX_1875, can_config.inverter);
-          transmit_can(&SOLAX_1876, can_config.inverter);
-          transmit_can(&SOLAX_1877, can_config.inverter);
-          transmit_can(&SOLAX_1878, can_config.inverter);
+          transmit_can_frame(&SOLAX_187E, can_config.inverter);
+          transmit_can_frame(&SOLAX_187A, can_config.inverter);
+          transmit_can_frame(&SOLAX_1872, can_config.inverter);
+          transmit_can_frame(&SOLAX_1873, can_config.inverter);
+          transmit_can_frame(&SOLAX_1874, can_config.inverter);
+          transmit_can_frame(&SOLAX_1875, can_config.inverter);
+          transmit_can_frame(&SOLAX_1876, can_config.inverter);
+          transmit_can_frame(&SOLAX_1877, can_config.inverter);
+          transmit_can_frame(&SOLAX_1878, can_config.inverter);
         }
-        transmit_can(&SOLAX_100A001, can_config.inverter);  //BMS Announce
+        transmit_can_frame(&SOLAX_100A001, can_config.inverter);  //BMS Announce
         // Message from the inverter to proceed to contactor closing
         // Byte 4 changes from 0 to 1
         if (rx_frame.data.u64 == Contactor_Close_Payload)
@@ -239,17 +239,17 @@ void receive_can_inverter(CAN_frame rx_frame) {
 
       case (WAITING_FOR_CONTACTOR):
         SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
-        transmit_can(&SOLAX_187E, can_config.inverter);
-        transmit_can(&SOLAX_187A, can_config.inverter);
-        transmit_can(&SOLAX_1872, can_config.inverter);
-        transmit_can(&SOLAX_1873, can_config.inverter);
-        transmit_can(&SOLAX_1874, can_config.inverter);
-        transmit_can(&SOLAX_1875, can_config.inverter);
-        transmit_can(&SOLAX_1876, can_config.inverter);
-        transmit_can(&SOLAX_1877, can_config.inverter);
-        transmit_can(&SOLAX_1878, can_config.inverter);
-        transmit_can(&SOLAX_1801, can_config.inverter);  // Announce that the battery will be connected
-        STATE = CONTACTOR_CLOSED;                        // Jump to Contactor Closed State
+        transmit_can_frame(&SOLAX_187E, can_config.inverter);
+        transmit_can_frame(&SOLAX_187A, can_config.inverter);
+        transmit_can_frame(&SOLAX_1872, can_config.inverter);
+        transmit_can_frame(&SOLAX_1873, can_config.inverter);
+        transmit_can_frame(&SOLAX_1874, can_config.inverter);
+        transmit_can_frame(&SOLAX_1875, can_config.inverter);
+        transmit_can_frame(&SOLAX_1876, can_config.inverter);
+        transmit_can_frame(&SOLAX_1877, can_config.inverter);
+        transmit_can_frame(&SOLAX_1878, can_config.inverter);
+        transmit_can_frame(&SOLAX_1801, can_config.inverter);  // Announce that the battery will be connected
+        STATE = CONTACTOR_CLOSED;                              // Jump to Contactor Closed State
 #ifdef DEBUG_LOG
         logging.println("Solax Battery State: Contactor Closed");
 #endif
@@ -258,15 +258,15 @@ void receive_can_inverter(CAN_frame rx_frame) {
       case (CONTACTOR_CLOSED):
         datalayer.system.status.inverter_allows_contactor_closing = true;
         SOLAX_1875.data.u8[4] = (0x01);  // Inform Inverter: Contactor 0=off, 1=on.
-        transmit_can(&SOLAX_187E, can_config.inverter);
-        transmit_can(&SOLAX_187A, can_config.inverter);
-        transmit_can(&SOLAX_1872, can_config.inverter);
-        transmit_can(&SOLAX_1873, can_config.inverter);
-        transmit_can(&SOLAX_1874, can_config.inverter);
-        transmit_can(&SOLAX_1875, can_config.inverter);
-        transmit_can(&SOLAX_1876, can_config.inverter);
-        transmit_can(&SOLAX_1877, can_config.inverter);
-        transmit_can(&SOLAX_1878, can_config.inverter);
+        transmit_can_frame(&SOLAX_187E, can_config.inverter);
+        transmit_can_frame(&SOLAX_187A, can_config.inverter);
+        transmit_can_frame(&SOLAX_1872, can_config.inverter);
+        transmit_can_frame(&SOLAX_1873, can_config.inverter);
+        transmit_can_frame(&SOLAX_1874, can_config.inverter);
+        transmit_can_frame(&SOLAX_1875, can_config.inverter);
+        transmit_can_frame(&SOLAX_1876, can_config.inverter);
+        transmit_can_frame(&SOLAX_1877, can_config.inverter);
+        transmit_can_frame(&SOLAX_1878, can_config.inverter);
         // Message from the inverter to open contactor
         // Byte 4 changes from 1 to 0
         if (rx_frame.data.u64 == Contactor_Open_Payload) {
@@ -278,8 +278,8 @@ void receive_can_inverter(CAN_frame rx_frame) {
   }
 
   if (rx_frame.ID == 0x1871 && rx_frame.data.u64 == __builtin_bswap64(0x0500010000000000)) {
-    transmit_can(&SOLAX_1881, can_config.inverter);
-    transmit_can(&SOLAX_1882, can_config.inverter);
+    transmit_can_frame(&SOLAX_1881, can_config.inverter);
+    transmit_can_frame(&SOLAX_1882, can_config.inverter);
 #ifdef DEBUG_LOG
     logging.println("1871 05-frame received from inverter");
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,7 +14,7 @@
 #define FAULT_SOLAX 3
 #define UPDATING_FW 4
 
-void transmit_can(CAN_frame* tx_frame, int interface);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void setup_inverter(void);
 
 #endif


### PR DESCRIPTION
### What
This PR updates the function names used for CAN communication, as it was confusing what each function was used for. For instance the difference between `send_can` and `transmit_can` was not clear.

It also adds a new function `receive_can`, to simplify the code used in `Software.ino`.

### Why
This change should make the code easier to read and easier to maintain.

### How
It changes the function names used for CAN communication, for instance:
- `receive_can` becomes `map_can_frame_to_variable`
- `receive_can_addon` becomes `receive_frame_can_addon`
- `transmit_can` becomes `transmit_can_frame`
- `send_can` becomes `transmit_can`