### PR TITLE
Adding feature to log to SD Card

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -104,7 +104,7 @@ void setup() {
                           TASK_CONNECTIVITY_PRIO, &connectivity_loop_task, WIFI_CORE);
 #endif
 
-#ifdef LOG_CAN_TO_SD
+#if defined(LOG_CAN_TO_SD) || defined(LOG_TO_SD)
   xTaskCreatePinnedToCore((TaskFunction_t)&logging_loop, "logging_loop", 4096, &logging_task_time_us,
                           TASK_CONNECTIVITY_PRIO, &logging_loop_task, WIFI_CORE);
 #endif
@@ -151,14 +151,19 @@ void loop() {
 #endif
 }
 
-#ifdef LOG_CAN_TO_SD
+#if defined(LOG_CAN_TO_SD) || defined(LOG_TO_SD)
 void logging_loop(void* task_time_us) {
 
-  init_logging_buffer();
+  init_logging_buffers();
   init_sdcard();
 
   while (true) {
+#ifdef LOG_TO_SD
+    write_log_to_sdcard();
+#endif
+#ifdef LOG_CAN_TO_SD
     write_can_frame_to_sdcard();
+#endif
   }
 }
 #endif

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -71,9 +71,10 @@
 //#define BMW_SBOX  // SBOX relay control & battery current/voltage measurement
 
 /* Other options */
+//#define LOG_TO_SD              //Enable this line to log diagnostic data to SD card
 //#define DEBUG_VIA_USB          //Enable this line to have the USB port output serial diagnostic data while program runs (WARNING, raises CPU load, do not use for production)
 //#define DEBUG_VIA_WEB          //Enable this line to log diagnostic data while program runs, which can be viewed via webpage (WARNING, slightly raises CPU load, do not use for production)
-#if defined(DEBUG_VIA_USB) || defined(DEBUG_VIA_WEB)
+#if defined(DEBUG_VIA_USB) || defined(DEBUG_VIA_WEB) || defined(LOG_TO_SD)
 #define DEBUG_LOG
 #endif
 

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -117,12 +117,12 @@ void write_can_frame_to_sdcard() {
   }
 }
 
-void add_log_to_buffer(uint8_t buffer) {
+void add_log_to_buffer(const uint8_t* buffer, size_t size) {
 
   if (!sd_card_active)
     return;
 
-  if (xRingbufferSend(log_bufferHandle, &buffer, sizeof(buffer), 0) != pdTRUE) {
+  if (xRingbufferSend(log_bufferHandle, buffer, size, 0) != pdTRUE) {
     Serial.println("Failed to send log to ring buffer!");
     return;
   }
@@ -155,17 +155,21 @@ void write_log_to_sdcard() {
 }
 
 void init_logging_buffers() {
+#if defined(LOG_CAN_TO_SD)
   can_bufferHandle = xRingbufferCreate(32 * 1024, RINGBUF_TYPE_BYTEBUF);
   if (can_bufferHandle == NULL) {
     Serial.println("Failed to create CAN ring buffer!");
     return;
   }
+#endif  // defined(LOG_CAN_TO_SD)
 
-  log_bufferHandle = xRingbufferCreate(32 * 1024, RINGBUF_TYPE_BYTEBUF);
+#if defined(LOG_TO_SD)
+  log_bufferHandle = xRingbufferCreate(1024, RINGBUF_TYPE_BYTEBUF);
   if (log_bufferHandle == NULL) {
     Serial.println("Failed to create log ring buffer!");
     return;
   }
+#endif  // defined(LOG_TO_SD)
 }
 
 void init_sdcard() {

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -9,8 +9,9 @@
 #if defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && \
     defined(SD_MISO_PIN)  // ensure code is only compiled if all SD card pins are defined
 #define CAN_LOG_FILE "/canlog.txt"
+#define LOG_FILE "/log.txt"
 
-void init_logging_buffer();
+void init_logging_buffers();
 
 void init_sdcard();
 void print_sdcard_details();
@@ -21,6 +22,12 @@ void write_can_frame_to_sdcard();
 void pause_can_writing();
 void resume_can_writing();
 void delete_can_log();
-#endif  // defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && defined(SD_MISO_PIN)
+void delete_log();
+void resume_log_writing();
+void pause_log_writing();
 
+void add_log_to_buffer(uint8_t buffer);
+void write_log_to_sdcard();
+
+#endif  // defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && defined(SD_MISO_PIN)
 #endif  // SDCARD_H

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -26,7 +26,7 @@ void delete_log();
 void resume_log_writing();
 void pause_log_writing();
 
-void add_log_to_buffer(uint8_t buffer);
+void add_log_to_buffer(const uint8_t* buffer, size_t size);
 void write_log_to_sdcard();
 
 #endif  // defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && defined(SD_MISO_PIN)

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -31,7 +31,7 @@ void Logging::add_timestamp(size_t size) {
   timestr = timestr_buffer;
 #endif  // DEBUG_VIA_WEB
 
-  offset += min(MAX_LENGTH_TIME_STR - 1, 
+  offset += min(MAX_LENGTH_TIME_STR - 1,
                 snprintf(timestr, MAX_LENGTH_TIME_STR, "%8lu.%03lu ", currentTime / 1000, currentTime % 1000));
 
 #ifdef DEBUG_VIA_WEB

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -31,7 +31,8 @@ void Logging::add_timestamp(size_t size) {
   timestr = timestr_buffer;
 #endif  // DEBUG_VIA_WEB
 
-  offset += min(MAX_LENGTH_TIME_STR - 1, snprintf(timestr, MAX_LENGTH_TIME_STR, "%8lu.%03lu ", currentTime / 1000, currentTime % 1000));
+  offset += min(MAX_LENGTH_TIME_STR - 1, 
+                snprintf(timestr, MAX_LENGTH_TIME_STR, "%8lu.%03lu ", currentTime / 1000, currentTime % 1000));
 
 #ifdef DEBUG_VIA_WEB
   if (!datalayer.system.info.can_logging_active) {
@@ -112,7 +113,7 @@ void Logging::printf(const char* fmt, ...) {
 
   va_list(args);
   va_start(args, fmt);
-  int size = min(MAX_LINE_LENGTH_PRINTF-1, vsnprintf(message_buffer, MAX_LINE_LENGTH_PRINTF, fmt, args));
+  int size = min(MAX_LINE_LENGTH_PRINTF - 1, vsnprintf(message_buffer, MAX_LINE_LENGTH_PRINTF, fmt, args));
   va_end(args);
 
 #ifdef LOG_TO_SD

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -99,7 +99,7 @@ void Logging::printf(const char* fmt, ...) {
   message_string = datalayer.system.info.logged_can_messages;
   offset = datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
   message_string_size = sizeof(datalayer.system.info.logged_can_messages);
-#endif
+
   if (offset + 128 > sizeof(datalayer.system.info.logged_can_messages)) {
     // Not enough space, reset and start from the beginning
     offset = 0;
@@ -113,4 +113,5 @@ void Logging::printf(const char* fmt, ...) {
   datalayer.system.info.logged_can_messages_offset = offset + size;  // Update offset in buffer
 
   previous_message_was_newline = true;
+#endif
 }

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -6,13 +6,13 @@
 
 bool previous_message_was_newline = true;
 
-void Logging::add_timestamp(size_t size){
+void Logging::add_timestamp(size_t size) {
 #ifdef DEBUG_LOG
   char* message_string = datalayer.system.info.logged_can_messages;
   int offset = datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
   size_t message_string_size = sizeof(datalayer.system.info.logged_can_messages);
   unsigned long currentTime = millis();
-  char *timestr;
+  char* timestr;
   static char timestr_buffer[14];
 
 #ifdef DEBUG_VIA_WEB
@@ -39,11 +39,11 @@ void Logging::add_timestamp(size_t size){
 #endif  // DEBUG_VIA_WEB
 
 #ifdef LOG_TO_SD
-    add_log_to_buffer((uint8_t*)timestr, 13);
+  add_log_to_buffer((uint8_t*)timestr, 13);
 #endif  // LOG_TO_SD
 
 #ifdef DEBUG_VIA_USB
-    Serial.write(timestr);
+  Serial.write(timestr);
 #endif  // DEBUG_VIA_USB
 
 #endif  // DEBUG_LOG
@@ -92,7 +92,7 @@ void Logging::printf(const char* fmt, ...) {
   }
 
   static char buffer[MAX_LINE_LENGTH_PRINTF];
-  char *message_buffer;
+  char* message_buffer;
 #ifdef DEBUG_VIA_WEB
   if (!datalayer.system.info.can_logging_active) {
     /* If web debug is active and can logging is inactive, 
@@ -125,10 +125,11 @@ void Logging::printf(const char* fmt, ...) {
 #ifdef DEBUG_VIA_WEB
   if (!datalayer.system.info.can_logging_active) {
     // Data was already added to buffer, just move offset
-    datalayer.system.info.logged_can_messages_offset = offset + size;  // Keeps track of the current position in the buffer
+    datalayer.system.info.logged_can_messages_offset =
+        offset + size;  // Keeps track of the current position in the buffer
   }
 #endif  // DEBUG_VIA_WEB
 
   previous_message_was_newline = buffer[size - 1] == '\n';
-#endif // DEBUG_LOG
+#endif  // DEBUG_LOG
 }

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -31,7 +31,7 @@ void Logging::add_timestamp(size_t size) {
   timestr = timestr_buffer;
 #endif  // DEBUG_VIA_WEB
 
-  offset += min(MAX_LENGTH_TIME_STR-1, snprintf(timestr, MAX_LENGTH_TIME_STR, "%8lu.%03lu ", currentTime / 1000, currentTime % 1000));
+  offset += min(MAX_LENGTH_TIME_STR - 1, snprintf(timestr, MAX_LENGTH_TIME_STR, "%8lu.%03lu ", currentTime / 1000, currentTime % 1000));
 
 #ifdef DEBUG_VIA_WEB
   if (!datalayer.system.info.can_logging_active) {

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -5,6 +5,7 @@
 #include "Print.h"
 
 class Logging : public Print {
+  void add_timestamp(size_t size);
  public:
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -6,6 +6,7 @@
 
 class Logging : public Print {
   void add_timestamp(size_t size);
+  
  public:
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -6,7 +6,7 @@
 
 class Logging : public Print {
   void add_timestamp(size_t size);
-  
+
  public:
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }

--- a/Software/src/devboard/webserver/debug_logging_html.cpp
+++ b/Software/src/devboard/webserver/debug_logging_html.cpp
@@ -3,7 +3,7 @@
 #include "../../datalayer/datalayer.h"
 #include "index_html.h"
 
-#ifdef DEBUG_VIA_WEB
+#if defined(DEBUG_VIA_WEB) || defined(LOG_TO_SD)
 String debug_logger_processor(void) {
   String content = String(index_html_header);
   // Page format
@@ -17,8 +17,13 @@ String debug_logger_processor(void) {
       ".can-message { background-color: #404E57; margin-bottom: 5px; padding: 10px; border-radius: 5px; font-family: "
       "monospace; }";
   content += "</style>";
+#ifdef DEBUG_VIA_WEB
   content += "<button onclick='refreshPage()'>Refresh data</button> ";
+#endif
   content += "<button onclick='exportLog()'>Export to .txt</button> ";
+#ifdef LOG_TO_SD
+  content += "<button onclick='deleteLog()'>Delete log file</button> ";
+#endif
   content += "<button onclick='goToMainPage()'>Back to main page</button>";
 
   // Start a new block for the debug log messages
@@ -30,9 +35,12 @@ String debug_logger_processor(void) {
   content += "<script>";
   content += "function refreshPage(){ location.reload(true); }";
   content += "function exportLog() { window.location.href = '/export_log'; }";
+#ifdef LOG_TO_SD
+  content += "function deleteLog() { window.location.href = '/delete_log'; }";
+#endif
   content += "function goToMainPage() { window.location.href = '/'; }";
   content += "</script>";
   content += index_html_footer;
   return content;
 }
-#endif  // DEBUG_VIA_WEB
+#endif

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -65,7 +65,7 @@ void init_webserver() {
     request->send(response);
   });
 
-#ifdef DEBUG_VIA_WEB
+#if defined(DEBUG_VIA_WEB) || defined(LOG_TO_SD)
   // Route for going to debug logging web page
   server.on("/log", HTTP_GET, [](AsyncWebServerRequest* request) {
     AsyncWebServerResponse* response = request->beginResponse(200, "text/html", debug_logger_processor());
@@ -123,6 +123,22 @@ void init_webserver() {
   });
 #endif
 
+#ifdef LOG_TO_SD
+  // Define the handler to delete log file
+  server.on("/delete_log", HTTP_GET, [](AsyncWebServerRequest* request) {
+    delete_log();
+    request->send_P(200, "text/plain", "Log file deleted");
+  });
+
+  // Define the handler to export debug log
+  server.on("/export_log", HTTP_GET, [](AsyncWebServerRequest* request) {
+    pause_log_writing();
+    request->send(SD, LOG_FILE, String(), true);
+    resume_log_writing();
+  });
+#endif
+
+#ifndef LOG_TO_SD
   // Define the handler to export debug log
   server.on("/export_log", HTTP_GET, [](AsyncWebServerRequest* request) {
     String logs = String(datalayer.system.info.logged_can_messages);
@@ -149,6 +165,7 @@ void init_webserver() {
     response->addHeader("Content-Disposition", String("attachment; filename=\"") + String(filename) + "\"");
     request->send(response);
   });
+#endif
 
   // Route for going to cellmonitor web page
   server.on("/cellmonitor", HTTP_GET, [](AsyncWebServerRequest* request) {
@@ -1061,7 +1078,7 @@ String processor(const String& var) {
     content += "<button onclick='Settings()'>Change Settings</button> ";
     content += "<button onclick='Advanced()'>More Battery Info</button> ";
     content += "<button onclick='CANlog()'>CAN logger</button> ";
-#ifdef DEBUG_VIA_WEB
+#if defined(DEBUG_VIA_WEB) || defined(LOG_TO_SD)
     content += "<button onclick='Log()'>Log</button> ";
 #endif  // DEBUG_VIA_WEB
     content += "<button onclick='Cellmon()'>Cellmonitor</button> ";

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -206,7 +206,7 @@ void init_WiFi_AP() {
 #ifdef DEBUG_LOG
   logging.println("Access Point created.");
   logging.print("IP address: ");
-  logging.println(IP);
+  logging.println(IP.toString());
 #endif
 }
 #endif  // WIFIAP

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -48,7 +48,7 @@
 #error No battery selected! Choose one from the USER_SETTINGS.h file
 #endif
 
-#ifdef LOG_CAN_TO_SD
+#if defined(LOG_CAN_TO_SD) || defined(LOG_TO_SD)
 #if !defined(HW_LILYGO)
 #error The SD card logging feature is only available on LilyGo hardware
 #endif


### PR DESCRIPTION
### What
This PR implements logging messages to an SD Card where available

### Why
This will help to diagnose issues when an emulator reboots as the log is persisted

### How
This is an extension to the sdcard methods to add a second buffer for logs which are sent from the logger and written to the SD Card on the second CPU core
