### PR TITLE
Bugfix: ensure code builds for DOUBLE_BATTERY

### DIFF
--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -119,7 +119,7 @@ void setup_battery(void);
 
 #ifdef DOUBLE_BATTERY
 void update_values_battery2();
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame);
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame);
 #endif
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -681,7 +681,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x112:  //BMS [10ms] Status Of High-Voltage Battery - 2
       battery2_awake = true;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -477,7 +477,7 @@ void update_values_battery2() {  //This function maps all the values fetched via
   datalayer.battery2.status.temperature_max_dC = battery2_calc_max_temperature * 10;
 }
 
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //Log values taken with 422V from battery2
     case 0x244:           //00,00,00,04,41,0F,20,8B - Static, values never changes between logs
       break;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -502,7 +502,7 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
     }
   }
 }
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -426,7 +426,7 @@ void update_values_battery2() {  //This function maps all the values fetched via
   }
 }
 
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1808,7 +1808,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
 #ifdef DOUBLE_BATTERY  //Need to update battery2
 
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   static uint8_t mux = 0;
   static uint16_t temp = 0;
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -122,7 +122,7 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
 #endif
 }
 
-void map_can_frame_to_variable_battery2(CAN_frame rx_frame) {
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
   datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
 #endif  // DOUBLE_BATTERY

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -333,7 +333,7 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
   }
   if (interface == can_config.battery_double) {
 #ifdef DOUBLE_BATTERY
-    map_can_frame_to_variable_battery2(*rx_frame);
+    handle_incoming_can_frame_battery2(*rx_frame);
 #endif
   }
   if (interface == can_config.charger) {


### PR DESCRIPTION
### What
Update function name `map_can_frame_to_variable_battery2()` to `handle_incoming_can_frame_battery2()`

### Why
This follows as the change done in #699 (eb4e5bc) was not fully carried out.

### How
By carrying out the change done in eb4e5bc, also for battery2.
