### PR TITLE
Add wake up pin for second BMW I3 battery

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -425,9 +425,15 @@ void update_values_battery2() {  //This function maps all the values fetched via
 
 void update_values_battery() {  //This function maps all the values fetched via CAN to the battery datalayer
   if (datalayer.system.settings.equipment_stop_active == true) {
-    digitalWrite(WUP_PIN, LOW);  // Turn off WUP_PIN
+    digitalWrite(WUP_PIN1, LOW);  // Turn off WUP_PIN1
+#if defined(WUP_PIN2) && defined(DOUBLE_BATTERY)
+    digitalWrite(WUP_PIN2, LOW);  // Turn off WUP_PIN2
+#endif                            // defined(WUP_PIN2) &&  defined (DOUBLE_BATTERY)
   } else {
-    digitalWrite(WUP_PIN, HIGH);  // Wake up the battery
+    digitalWrite(WUP_PIN1, HIGH);  // Wake up the battery
+#if defined(WUP_PIN2) && defined(DOUBLE_BATTERY)
+    digitalWrite(WUP_PIN2, HIGH);  // Wake up the battery2
+#endif                             // defined(WUP_PIN2) &&  defined (DOUBLE_BATTERY)
   }
 
   if (!battery_awake) {
@@ -1134,8 +1140,12 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery2.status.voltage_dV =
       0;  //Init voltage to 0 to allow contactor check to operate without fear of default values colliding
 #endif
-  pinMode(WUP_PIN, OUTPUT);
-  digitalWrite(WUP_PIN, HIGH);  // Wake up the battery
+  pinMode(WUP_PIN1, OUTPUT);
+  digitalWrite(WUP_PIN1, HIGH);  // Wake up the battery
+#if defined(DOUBLE_BATTERY) && defined(WUP_PIN2)
+  pinMode(WUP_PIN2, OUTPUT);
+  digitalWrite(WUP_PIN2, HIGH);  // Wake up the battery
+#endif                           // defined(WUP_PIN2) &&  defined (DOUBLE_BATTERY)
 }
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -5,7 +5,6 @@
 
 #define BATTERY_SELECTED
 
-#define WUP_PIN 25
 #define MAX_CELL_VOLTAGE_60AH 4110   // Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_60AH 2700   // Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_VOLTAGE_94AH 4140   // Battery is put into emergency stop if one cell goes over this value

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -5,7 +5,6 @@
 
 #define BATTERY_SELECTED
 
-//#define WUP_PIN 25 //Not used
 #define MAX_PACK_VOLTAGE_DV 4650  //4650 = 465.0V
 #define MIN_PACK_VOLTAGE_DV 3000
 #define MAX_CELL_DEVIATION_MV 250

--- a/Software/src/devboard/hal/hw_3LB.h
+++ b/Software/src/devboard/hal/hw_3LB.h
@@ -72,6 +72,14 @@
 // Equipment stop pin
 #define EQUIPMENT_STOP_PIN 35
 
+// BMW_I3_BATTERY wake up pin
+#ifdef BMW_I3_BATTERY
+#define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
+#ifdef DOUBLE_BATTERY
+#define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
+#endif                        // DOUBLE_BATTERY
+#endif                        // BMW_I3_BATTERY
+
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED
 #define HW_CONFIGURED
@@ -98,8 +106,11 @@
 #endif
 
 #ifdef BMW_I3_BATTERY
-#ifdef CONTACTOR_CONTROL
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
 #error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
+#endif
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN2)
+#error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
 #endif
 

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -68,6 +68,14 @@
 // Equipment stop pin
 #define EQUIPMENT_STOP_PIN 35
 
+// BMW_I3_BATTERY wake up pin
+#ifdef BMW_I3_BATTERY
+#define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
+#ifdef DOUBLE_BATTERY
+#define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
+#endif                        // DOUBLE_BATTERY
+#endif                        // BMW_I3_BATTERY
+
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED
 #define HW_CONFIGURED
@@ -94,8 +102,11 @@
 #endif
 
 #ifdef BMW_I3_BATTERY
-#ifdef CONTACTOR_CONTROL
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
 #error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
+#endif
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN2)
+#error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
 #endif
 

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -61,11 +61,27 @@ GPIOs on extra header
 // Equipment stop pin
 #define EQUIPMENT_STOP_PIN 2
 
+// BMW_I3_BATTERY wake up pin
+#ifdef BMW_I3_BATTERY
+#define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
+#ifdef DOUBLE_BATTERY
+#define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
+#endif                        // DOUBLE_BATTERY
+#endif                        // BMW_I3_BATTERY
+
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED
 #define HW_CONFIGURED
 #else
 #error Multiple HW defined! Please select a single HW
+#endif
+
+#ifdef BMW_I3_BATTERY
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
+#error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
+#endif
+#if defined(CONTACTOR_CONTROL) && defined(WUP_PIN2)
+#error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
 
 #endif


### PR DESCRIPTION
### What
This PR implements a Wake up pin for a second battery (`DOUBLE_BATTERY`) for BMW I3 (`BMW_I3_BATTERY`).

### Why
This PR fixes #626. This feature was requested by [pmajor021](https://github.com/pmajor021).

### How
- The `WUP_PIN` is updated to `WUP_PIN1` and `WUP_PIN2`.
- The pin definition is moved from the battery file to the hardware abstraction layer of each supported hardware.
- Error handling is implemented, in case the pins defined as wake up pin, are also used for contactor control.