### PR TITLE
Make BMS_POWER hardware agnostic

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -82,10 +82,10 @@ void init_contactors() {
   set(SECOND_NEGATIVE_CONTACTOR_PIN, OFF);
 #endif  // CONTACTOR_CONTROL_DOUBLE_BATTERY
 // Init BMS contactor
-#ifdef HW_STARK  // TODO: Rewrite this so LilyGo can also handle this BMS contactor
+#ifdef BMS_POWER
   pinMode(BMS_POWER, OUTPUT);
   digitalWrite(BMS_POWER, HIGH);
-#endif  // HW_STARK
+#endif  // BMS_POWER
 }
 
 // Main functions

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -563,7 +563,7 @@ String get_firmware_info_processor(const String& var) {
 #endif  // HW_STARK
 #ifdef HW_3LB
     doc["hardware"] = "3LB board";
-#endif  // HW_STARK
+#endif  // HW_3LB
 
     doc["firmware"] = String(version_number);
     serializeJson(doc, content);


### PR DESCRIPTION
### What
This PR ensures that `BMS_POWER` can be used by all hardware variants.

While we are at it, this PR also updates a mistake in a comment from `HW_STARK` to `HW_3LB`.

### Why
To ensure that functions are available for all types of hardware.

### How
By updating a define from `#ifdef HW_STARK` to `#ifdef BMS_POWER`.
