### PR TITLE
Bugfix: ensure code compiles for hardware that does not have SD card pins

### DIFF
--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -1,6 +1,9 @@
 #include "sdcard.h"
 #include "freertos/ringbuf.h"
 
+#if defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && \
+    defined(SD_MISO_PIN)  // ensure code is only compiled if all SD card pins are defined
+
 File can_log_file;
 RingbufHandle_t can_bufferHandle;
 
@@ -149,3 +152,4 @@ void print_sdcard_details() {
     Serial.println(" MB");
   }
 }
+#endif  // defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && defined(SD_MISO_PIN)

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -6,6 +6,8 @@
 #include "../../communication/can/comm_can.h"
 #include "../hal/hal.h"
 
+#if defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && \
+    defined(SD_MISO_PIN)  // ensure code is only compiled if all SD card pins are defined
 #define CAN_LOG_FILE "/canlog.txt"
 
 void init_logging_buffer();
@@ -19,5 +21,6 @@ void write_can_frame_to_sdcard();
 void pause_can_writing();
 void resume_can_writing();
 void delete_can_log();
+#endif  // defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && defined(SD_MISO_PIN)
 
-#endif
+#endif  // SDCARD_H


### PR DESCRIPTION
### What
This PR fixes the issue that the code does not compile anymore for hardware that does not have SD card pins defined, since the SD functions were introduced in #707.

### Why
To ensure the code compiles for all hardware types.

### How
By adding `#if defined()` statements around the code that requires the hardware pins to be defined.