### PR TITLE
Add hardware to GitHub Actions workflows

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -79,6 +79,10 @@ jobs:
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
           - BYD_CAN
+        # These are the supported hardware platforms for which the code will be compiled.
+        hardware:
+          - HW_LILYGO
+
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest
 
@@ -107,4 +111,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
+++ b/.github/workflows/compile-all-combinations-part1-batteries-A-to-M.yml
@@ -83,6 +83,9 @@ jobs:
           - SOFAR_CAN
           - SOLAX_CAN
           - SERIAL_LINK_TRANSMITTER
+        # These are the supported hardware platforms for which the code will be compiled.
+        hardware:
+          - HW_LILYGO
 
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest
@@ -112,4 +115,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/.github/workflows/compile-all-hardware.yml
+++ b/.github/workflows/compile-all-hardware.yml
@@ -1,15 +1,12 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Combinations
+name: Compile All Hardware
 
 # Here we tell GitHub when to run the workflow.
 on:
-  # This allows you to run this workflow manually from the
-  # GitHub Actions tab.
-  workflow_dispatch:
-  # The workflow is run upon creating, editing,
-  # pre-releasing, releasing and publishing a release
-  release:
-    types: [created, edited, prereleased, released, published]
+  # The workflow is run when a commit is pushed or for a
+  # Pull Request.
+  - push
+  - pull_request
 
 # This is the list of jobs that will be run concurrently.
 jobs:
@@ -33,7 +30,7 @@ jobs:
   # will produce.
 
   # This is the name of the job.
-  build-matrix:
+  build-hardware:
     needs: skip-duplicate-actions
     if: needs.skip-duplicate-actions.outputs.should_skip != 'true'
 
@@ -55,39 +52,14 @@ jobs:
         # These are the batteries for which the code will be compiled.
         battery:
           - NISSAN_LEAF_BATTERY
-          - PYLON_BATTERY
-          - RJXZS_BMS
-          - RANGE_ROVER_PHEV_BATTERY
-          - RENAULT_KANGOO_BATTERY
-          - RENAULT_TWIZY_BATTERY
-          - RENAULT_ZOE_GEN1_BATTERY
-          - RENAULT_ZOE_GEN2_BATTERY
-          - SANTA_FE_PHEV_BATTERY
-          - STELLANTIS_ECMP_BATTERY
-          - TESLA_MODEL_3Y_BATTERY
-          - TESLA_MODEL_SX_BATTERY
-          - VOLVO_SPA_BATTERY
-          - TEST_FAKE_BATTERY
         # These are the emulated inverter communication protocols for which the code will be compiled.
         inverter:
-          - AFORE_CAN
           - BYD_CAN
-          - BYD_KOSTAL_RS485
-          - BYD_MODBUS
-          - BYD_SMA
-          - FOXESS_CAN
-          - PYLON_CAN
-          - PYLON_LV_CAN
-          - SCHNEIDER_CAN
-          - SMA_CAN
-          - SMA_LV_CAN
-          - SMA_TRIPOWER_CAN
-          - SOFAR_CAN
-          - SOLAX_CAN
-          - SERIAL_LINK_TRANSMITTER
         # These are the supported hardware platforms for which the code will be compiled.
         hardware:
           - HW_LILYGO
+          - HW_STARK
+          - HW_3LB
 
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -70,6 +70,10 @@ jobs:
           - SOLAX_CAN
           - SERIAL_LINK_TRANSMITTER
           - NISSANLEAF_CHARGER # Last element is not an inverter, but good to also test if the charger compiles
+        # These are the supported hardware platforms for which the code will be compiled.
+        hardware:
+          - HW_LILYGO
+
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest
 
@@ -98,4 +102,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -55,7 +55,7 @@
 //#define SOLAX_CAN        //Enable this line to emulate a "SolaX Triple Power LFP" over CAN bus
 
 /* Select hardware used for Battery-Emulator */
-#define HW_LILYGO
+//#define HW_LILYGO
 //#define HW_STARK
 //#define HW_3LB
 

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -74,7 +74,7 @@ GPIOs on extra header
 #define HW_CONFIGURED
 #else
 #error Multiple HW defined! Please select a single HW
-#endif
+#endif  // HW_CONFIGURED
 
 #ifdef BMW_I3_BATTERY
 #if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
@@ -83,5 +83,6 @@ GPIOs on extra header
 #if defined(CONTACTOR_CONTROL) && defined(WUP_PIN2)
 #error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
+#endif  // BMW_I3_BATTERY
 
-#endif
+#endif  // __HW_STARK_H__

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -20,7 +20,7 @@
 /* - ERROR CHECKS BELOW, DON'T TOUCH - */
 
 #if !defined(HW_CONFIGURED)
-#error You must select a HW to run on!
+#error You must select a target hardware in the USER_SERTTINGS.h file!
 #endif
 
 #if defined(CAN_ADDON) && defined(CANFD_ADDON)


### PR DESCRIPTION
### What
This PR implements automatic builds for the different supported hardware platforms, using GitHub Actions.

### Why
It does this, to ensure that the code compiles for all different types of hardware. This prevents the need for bug fixes such as #714.

### How
A GitHub Action workflow is added to compile the code for different hardware setups. This check is done on each push and each pull request.