### PR TITLE
Add support for ESP32 DevKit V1 hardware

### DIFF
--- a/.github/workflows/compile-all-hardware.yml
+++ b/.github/workflows/compile-all-hardware.yml
@@ -60,6 +60,7 @@ jobs:
           - HW_LILYGO
           - HW_STARK
           - HW_3LB
+          - HW_DEVKIT
 
     # This is the platform GitHub will use to run our workflow.
     runs-on: ubuntu-latest

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -58,6 +58,7 @@
 //#define HW_LILYGO
 //#define HW_STARK
 //#define HW_3LB
+//#define HW_DEVKIT
 
 /* Contactor settings. If you have a battery that does not activate contactors via CAN, configure this section */
 #define PRECHARGE_TIME_MS 500  //Precharge time in milliseconds. Modify to suit your inverter (See wiki for more info)

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -9,6 +9,8 @@
 #include "hw_stark.h"
 #elif defined(HW_3LB)
 #include "hw_3LB.h"
+#elif defined(HW_DEVKIT)
+#include "hw_devkit.h"
 #endif
 
 #endif

--- a/Software/src/devboard/hal/hw_devkit.h
+++ b/Software/src/devboard/hal/hw_devkit.h
@@ -1,0 +1,93 @@
+#ifndef __HW_DEVKIT_H__
+#define __HW_DEVKIT_H__
+
+/*
+ESP32 DevKit V1 development board with 30 pins.
+For more information, see: https://lastminuteengineers.com/esp32-pinout-reference/.
+
+The pin layout below supports the following:
+- 1x RS485
+- 2x CAN (1x via SN65HVD230 (UART), 1x via MCP2515 (SPI))
+- 1x CANFD (via MCP2518FD (SPI))
+*/
+
+// Board boot-up time
+#define BOOTUP_TIME 1000  // Time in ms it takes before system is considered fully started up
+
+// Core assignment
+#define CORE_FUNCTION_CORE 1
+#define MODBUS_CORE 0
+#define WIFI_CORE 0
+
+// RS485
+#define RS485_TX_PIN GPIO_NUM_1
+#define RS485_RX_PIN GPIO_NUM_3
+
+// CAN settings
+#define CAN_1_TYPE ESP32CAN
+//#define CAN_2_TYPE MCP2515
+//#define CAN_3_TYPE MCP2518FD
+
+// CAN1 PIN mappings, do not change these unless you are adding on extra hardware to the PCB
+#define CAN_TX_PIN GPIO_NUM_27
+#define CAN_RX_PIN GPIO_NUM_26
+
+// CAN_ADDON defines
+#define MCP2515_SCK GPIO_NUM_22   // SCK input of MCP2515
+#define MCP2515_MOSI GPIO_NUM_21  // SDI input of MCP2515
+#define MCP2515_MISO GPIO_NUM_19  // SDO output of MCP2515
+#define MCP2515_CS GPIO_NUM_18    // CS input of MCP2515
+#define MCP2515_INT GPIO_NUM_23   // INT output of MCP2515
+
+// CANFD_ADDON defines
+#define MCP2517_SCK GPIO_NUM_33  // SCK input of MCP2517
+#define MCP2517_SDI GPIO_NUM_32  // SDI input of MCP2517
+#define MCP2517_SDO GPIO_NUM_35  // SDO output of MCP2517 | Pin 35 is input only, without pullup/down resistors
+#define MCP2517_CS GPIO_NUM_25   // CS input of MCP2517
+#define MCP2517_INT GPIO_NUM_34  // INT output of MCP2517 | Pin 34 is input only, without pullup/down resistors
+
+// Contactor handling
+#define POSITIVE_CONTACTOR_PIN GPIO_NUM_5
+#define NEGATIVE_CONTACTOR_PIN GPIO_NUM_16
+#define PRECHARGE_PIN GPIO_NUM_17
+
+// SMA CAN contactor pins
+#define INVERTER_CONTACTOR_ENABLE_PIN GPIO_NUM_14
+
+// LED
+#define LED_PIN GPIO_NUM_4
+#define LED_MAX_BRIGHTNESS 40
+#define INVERTER_CONTACTOR_ENABLE_LED_PIN GPIO_NUM_2
+
+// Equipment stop pin
+#define EQUIPMENT_STOP_PIN GPIO_NUM_12
+
+// BMW_I3_BATTERY wake up pin
+#ifdef BMW_I3_BATTERY
+#define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
+#ifdef DOUBLE_BATTERY
+#define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
+#endif                        // DOUBLE_BATTERY
+#endif                        // BMW_I3_BATTERY
+
+/* ----- Error checks below, don't change (can't be moved to separate file) ----- */
+#ifndef HW_CONFIGURED
+#define HW_CONFIGURED
+#else
+#error Multiple HW defined! Please select a single HW
+#endif  // HW_CONFIGURED
+
+#ifdef CHADEMO_BATTERY
+#error CHADEMO pins are not defined for this hardware.
+#endif  // CHADEMO_BATTERY
+
+#ifdef BMW_I3_BATTERY
+#if defined(WUP_PIN1) && defined(CANFD_ADDON)
+#error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and a CANFD addon board using these pins. Choose between BMW_I3_BATTERY and CANFD_ADDON
+#endif  // defined(WUP_PIN1) && defined(CANFD_ADDON)
+#if defined(WUP_PIN2) && defined(CANFD_ADDON)
+#error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and a CANFD addon board using these pins. Choose between BMW_I3_BATTERY and CANFD_ADDON
+#endif  // defined(WUP_PIN2) && defined(CANFD_ADDON)
+#endif  // BMW_I3_BATTERY
+
+#endif  // __HW_DEVKIT_H__

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -563,7 +563,10 @@ String get_firmware_info_processor(const String& var) {
 #endif  // HW_STARK
 #ifdef HW_3LB
     doc["hardware"] = "3LB board";
-#endif  // HW_STARK
+#endif  // HW_3LB
+#ifdef HW_DEVKIT
+    doc["hardware"] = "ESP32 DevKit V1";
+#endif  // HW_DEVKIT
 
     doc["firmware"] = String(version_number);
     serializeJson(doc, content);


### PR DESCRIPTION
### What
This PR adds support of ESP32 DevKit V1 hardware with 30 pins. The hardware is, for instance, documented on [lastminuteengineers.com](https://lastminuteengineers.com/esp32-pinout-reference/).

The hardware is available with micro USB, or USB C connector.

To make the hardware work with the battery emulator, the relevant breakout boards must be connected to the ESP32 DevKit V1, for instance:
- SN65HVD230 for `CAN_NATIVE`
- MCP2515 for `CAN_ADDON`
- MCP2518FD for `CANFD_ADDON`
- MAX485 for RS485

To connect these breakout boards, it is handy to use an ESP32 DevKit V1 breakout board, which includes GND, 3V3, 5V rails, and can be powered with 12V.

### Why
This hardware is added, as the LilyGo only has relatively little pins available to connect additional hardware. The ESP32 DevKit V1 has 30 pins, and is even more affordable than the LilyGo.

### How
A new hardware abstraction layer (hal) file is created.