### PR TITLE
Move check if CAN_ADDON AND CANFD_ADDON are defined simultaneously, to respective hardware

### DIFF
--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -83,6 +83,11 @@
 #error Multiple HW defined! Please select a single HW
 #endif
 
+#if defined(CAN_ADDON) && defined(CANFD_ADDON)
+// Check that user did not try to use dual can and fd-can on same hardware pins
+#error CAN_ADDON AND CANFD_ADDON CANNOT BE USED SIMULTANEOUSLY
+#endif
+
 #ifdef CHADEMO_BATTERY
 #ifdef CAN_ADDON
 #error CHADEMO and CAN_ADDON cannot coexist due to overlapping GPIO pin usage

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -23,11 +23,6 @@
 #error You must select a target hardware in the USER_SERTTINGS.h file!
 #endif
 
-#if defined(CAN_ADDON) && defined(CANFD_ADDON)
-// Check that user did not try to use dual can and fd-can on same hardware pins
-#error CAN_ADDON AND CANFD_ADDON CANNOT BE USED SIMULTANEOUSLY
-#endif
-
 #ifdef USE_CANFD_INTERFACE_AS_CLASSIC_CAN
 #if !defined(CANFD_ADDON)
 // Check that user did not try to use classic CAN over FD, without FD component


### PR DESCRIPTION
### What
This PR moves the check if `CAN_ADDON` and `CANFD_ADDON` are defined simultaneously, to throw an error if these functions use the same hardware pins, only to the hardware where these pins overlap (i.e. LilyGo).

### Why
To ensure that the respective error message is only triggered for the hardware that it needs to trigger for.

### How
By moving the check from `include.h` to `hw_liligo.h`, as this check is only relevant for LilyGo hardware.