### PR TITLE
Bugfix: Tesla, fix broken references in logging

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1122,11 +1122,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
   logging.print("Cellstats, Max: ");
   logging.print(battery_cell_max_v);
   logging.print("mV (cell ");
-  logging.print(battery_max_vno);
+  logging.print(battery_BrickVoltageMaxNum);
   logging.print("), Min: ");
   logging.print(battery_cell_min_v);
   logging.print("mV (cell ");
-  logging.print(battery_min_vno);
+  logging.print(battery_BrickVoltageMinNum);
   logging.print("), Imbalance: ");
   logging.print(battery_cell_deviation_mV);
   logging.println("mV.");


### PR DESCRIPTION
### What
The names where recently changed by @josiahhiggs , causing compilation error

### Why
When #ifdef DEBUG_LOG was turned on, the build would not pass. Main tests does not test with this turned on. Maybe it should?

### How
Quickfix, rename variables
