### PR TITLE
Improvement: Remove Tesla watchdog spamming 

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2732,7 +2732,7 @@ void printFaultCodesIfActive() {
   }
   // Check each symbol and print debug information if its value is 1
   // 0X3AA: 938 HVP_alertMatrix1
-  printDebugIfActive(battery_WatchdogReset, "ERROR: The processor has experienced a reset due to watchdog reset");
+  //printDebugIfActive(battery_WatchdogReset, "ERROR: The processor has experienced a reset due to watchdog reset"); //Uncommented due to not affecting usage
   printDebugIfActive(battery_PowerLossReset, "ERROR: The processor has experienced a reset due to power loss");
   printDebugIfActive(battery_SwAssertion, "ERROR: An internal software assertion has failed");
   printDebugIfActive(battery_CrashEvent, "ERROR: crash signal is detected by HVP");
@@ -2900,7 +2900,7 @@ void printFaultCodesIfActive_battery2() {
         "disable the inverter protocol to proceed with contactor closing");
   }
   // Check each symbol and print debug information if its value is 1
-  printDebugIfActive(battery2_WatchdogReset, "ERROR: The processor has experienced a reset due to watchdog reset");
+  //printDebugIfActive(battery2_WatchdogReset, "ERROR: The processor has experienced a reset due to watchdog reset"); //Uncommented due to not affecting usage
   printDebugIfActive(battery2_PowerLossReset, "ERROR: The processor has experienced a reset due to power loss");
   printDebugIfActive(battery2_SwAssertion, "ERROR: An internal software assertion has failed");
   printDebugIfActive(battery2_CrashEvent, "ERROR: crash signal is detected by HVP");


### PR DESCRIPTION
### What
This PR makes the Tesla debug messages a bit more manageable

### Why
During normal operation of the battery, the Tesla code spams the following error codes every second:

```
       1.000 ERROR: The processor has experienced a reset due to watchdog reset
       1.000 ERROR: BMS_a035_SW_Isolation
       1.000 ERROR: BMS_a036_SW_HvpHvilFault
       1.000 ERROR: BMS_a088_SW_VcFront_MIA_InDrive
       1.000 ERROR: BMS_a090_SW_Gateway_MIA
       1.000 ERROR: BMS_a091_SW_ChargePort_MIA
       1.000 ERROR: BMS_a092_SW_ChargePort_Mia_On_Hv
       1.000 ERROR: BMS_a094_SW_Drive_Inverter_MIA
       1.000 ERROR: BMS_a170_SW_Limp_Mode
```

The MIA messages are good info for further development, hinting towards CAN messages from these units are missing. We should improve the software by sending more CAN towards the battery.

However, the first message about the Watchdog is quite unnecessary, and causes users to incorrectly report this as a severe issue. The Tesla battery operates perfectly OK, so spamming about this watchdog every seconds really does not help the debug log at all.

### How
We uncomment the watchdog message for now. Further development should focus on sending more messages towards the battery to make it happier.
