### PR TITLE
Bugfix: Fix Panic Reset caused by percentage char

### DIFF
--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -106,8 +106,8 @@ void update_values_battery() {
 /*Finally print out values to serial if configured to do so*/
 #ifdef DEBUG_LOG
   logging.println("Values going to inverter");
-  print_units("SOH%: ", (datalayer.battery.status.soh_pptt * 0.01), "% ");
-  print_units(", SOC%: ", (datalayer.battery.status.reported_soc * 0.01), "% ");
+  print_units("SOH: ", (datalayer.battery.status.soh_pptt * 0.01), "pct ");
+  print_units(", SOC: ", (datalayer.battery.status.reported_soc * 0.01), "pct ");
   print_units(", Voltage: ", (datalayer.battery.status.voltage_dV * 0.1), "V ");
   print_units(", Max discharge power: ", datalayer.battery.status.max_discharge_power_W, "W ");
   print_units(", Max charge power: ", datalayer.battery.status.max_charge_power_W, "W ");

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -695,11 +695,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
   logging.println("Values from battery: ");
   logging.print("SOC BMS: ");
   logging.print((uint16_t)SOC_BMS / 10.0, 1);
-  logging.print("%  |  SOC Display: ");
+  logging.print("pct  |  SOC Display: ");
   logging.print((uint16_t)SOC_Display / 10.0, 1);
-  logging.print("%  |  SOH ");
+  logging.print("pct  |  SOH ");
   logging.print((uint16_t)batterySOH / 10.0, 1);
-  logging.println("%");
+  logging.println("pct");
   logging.print((int16_t)batteryAmps / 10.0, 1);
   logging.print(" Amps  |  ");
   logging.print((uint16_t)batteryVoltage / 10.0, 1);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -147,11 +147,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
   logging.println("Values from battery: ");
   logging.print("SOC BMS: ");
   logging.print((uint16_t)SOC_BMS / 10.0, 1);
-  logging.print("%  |  SOC Display: ");
+  logging.print("pct  |  SOC Display: ");
   logging.print((uint16_t)SOC_Display / 10.0, 1);
-  logging.print("%  |  SOH ");
+  logging.print("pct  |  SOH ");
   logging.print((uint16_t)batterySOH / 10.0, 1);
-  logging.println("%");
+  logging.println("pct");
   logging.print((int16_t)batteryAmps / 10.0, 1);
   logging.print(" Amps  |  ");
   logging.print((uint16_t)batteryVoltage / 10.0, 1);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -105,9 +105,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
 #ifdef DEBUG_LOG
   logging.println("Values going to inverter:");
-  logging.print("SOH%: ");
+  logging.print("SOH: ");
   logging.print(datalayer.battery.status.soh_pptt);
-  logging.print(", SOC% scaled: ");
+  logging.print(", SOC scaled: ");
   logging.print(datalayer.battery.status.reported_soc);
   logging.print(", Voltage: ");
   logging.print(datalayer.battery.status.voltage_dV);

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2713,7 +2713,7 @@ void print_SOC(char* header, int SOC) {
   if (hundredth < 10)
     logging.print(0);
   logging.print(hundredth);
-  logging.println("%");
+  logging.println("pct");
 }
 
 void printFaultCodesIfActive() {

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -56,8 +56,8 @@ void update_values_battery() { /* This function puts fake values onto the parame
 /*Finally print out values to serial if configured to do so*/
 #ifdef DEBUG_LOG
   logging.println("FAKE Values going to inverter");
-  print_units("SOH%: ", (datalayer.battery.status.soh_pptt * 0.01), "% ");
-  print_units(", SOC%: ", (datalayer.battery.status.reported_soc * 0.01), "% ");
+  print_units("SOH: ", (datalayer.battery.status.soh_pptt * 0.01), "pct ");
+  print_units(", SOC: ", (datalayer.battery.status.reported_soc * 0.01), "pct ");
   print_units(", Voltage: ", (datalayer.battery.status.voltage_dV * 0.1), "V ");
   print_units(", Max discharge power: ", datalayer.battery.status.max_discharge_power_W, "W ");
   print_units(", Max charge power: ", datalayer.battery.status.max_charge_power_W, "W ");
@@ -109,8 +109,8 @@ void update_values_battery2() {  // Handle the values coming in from battery #2
 /*Finally print out values to serial if configured to do so*/
 #ifdef DEBUG_LOG
   logging.println("FAKE Values  battery 2 going to inverter");
-  print_units("SOH 2 %: ", (datalayer.battery2.status.soh_pptt * 0.01), "% ");
-  print_units(", SOC 2 %: ", (datalayer.battery2.status.reported_soc * 0.01), "% ");
+  print_units("SOH 2: ", (datalayer.battery2.status.soh_pptt * 0.01), "pct ");
+  print_units(", SOC 2: ", (datalayer.battery2.status.reported_soc * 0.01), "pct ");
   print_units(", Voltage 2: ", (datalayer.battery2.status.voltage_dV * 0.1), "V ");
   print_units(", Max discharge power 2: ", datalayer.battery2.status.max_discharge_power_W, "W ");
   print_units(", Max charge power 2: ", datalayer.battery2.status.max_charge_power_W, "W ");

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -95,11 +95,11 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 
 #ifdef DEBUG_LOG
-  logging.print("BMS reported SOC%: ");
+  logging.print("BMS reported SOC: ");
   logging.println(SOC_BMS);
-  logging.print("Calculated SOC%: ");
+  logging.print("Calculated SOC: ");
   logging.println(SOC_CALC);
-  logging.print("Rescaled SOC%: ");
+  logging.print("Rescaled SOC: ");
   logging.println(datalayer.battery.status.reported_soc / 100);
   logging.print("Battery current: ");
   logging.println(BATT_I);

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -101,9 +101,6 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
     case 0x308:
       break;
     default:
-#ifdef DEBUG_LOG
-      logging.printf("CAN Rcv unknown frame MsgID=%x\n", rx_frame.MsgID);
-#endif
       break;
   }
 }

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -90,7 +90,7 @@ void init_CAN() {
     logging.println(settings2517.exactArbitrationBitRate() ? "yes)" : "no)");
     logging.print("Arbitration Sample point: ");
     logging.print(settings2517.arbitrationSamplePointFromBitStart());
-    logging.println("%");
+    logging.println("pct");
 #endif  // DEBUG_LOG
   } else {
 #ifdef DEBUG_LOG


### PR DESCRIPTION
### What
This PR fixes the panic reset caused by using Weblogging with the Tesla battery, as reported in #723 

### How
Serial printing % signs are a bad idea in C++