### PR TITLE
Assert failure: Add task priority setting for CAN addons

### DIFF
--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
@@ -6,6 +6,7 @@
 //----------------------------------------------------------------------------------------------------------------------
 
 #include "ACAN2517FD.h"
+#include "../../system_settings.h" //Contains task priority
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -506,7 +507,7 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
       }
     }
     #ifdef ARDUINO_ARCH_ESP32
-      xTaskCreate (myESP32Task, "ACAN2517Handler", 1024, this, 256, &mESP32TaskHandle) ;
+      xTaskCreate (myESP32Task, "ACAN2517Handler", 1024, this, TASK_ACAN2517FD_PRIORITY, &mESP32TaskHandle) ;
     #endif
     if (mINT != 255) { // 255 means interrupt is not used
       #ifdef ARDUINO_ARCH_ESP32

--- a/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
+++ b/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
@@ -5,6 +5,7 @@
 //··································································································
 
 #include "ACAN2515.h"
+#include "../../system_settings.h" //Contains task priority
 
 //··································································································
 //   MCP2515 COMMANDS
@@ -225,7 +226,7 @@ uint16_t ACAN2515::beginWithoutFilterCheck (const ACAN2515Settings & inSettings,
       #endif
     }
     #ifdef ARDUINO_ARCH_ESP32
-      xTaskCreate (myESP32Task, "ACAN2515Handler", 1024, this, 256, NULL) ;
+      xTaskCreate (myESP32Task, "ACAN2515Handler", 1024, this, TASK_ACAN2515_PRIORITY, NULL) ;
     #endif
   }
 //----------------------------------- Return

--- a/Software/src/system_settings.h
+++ b/Software/src/system_settings.h
@@ -1,6 +1,7 @@
 #ifndef SYSTEM_SETTINGS_H_
 #define SYSTEM_SETTINGS_H_
 /** TASKS
+ * Higher number equals higher priority. Max 25 per core
  * 
  * Parameter: TASK_CORE_PRIO
  * Description:
@@ -13,10 +14,20 @@
  * Parameter: TASK_MODBUS_PRIO
  * Description:
  * Defines the priority of MODBUS handling
+ *
+ * Parameter: TASK_ACAN2515_PRIORITY
+ * Description:
+ * Defines the priority of ACAN2515 CAN handling
+ *  
+ * Parameter: TASK_ACAN2515_PRIORITY
+ * Description:
+ * Defines the priority of ACAN2517FD CAN-FD handling
 */
 #define TASK_CORE_PRIO 4
 #define TASK_CONNECTIVITY_PRIO 3
 #define TASK_MODBUS_PRIO 8
+#define TASK_ACAN2515_PRIORITY 10
+#define TASK_ACAN2517FD_PRIORITY 10
 
 /** MAX AMOUNT OF CELLS
  * 


### PR DESCRIPTION
### What
This PR fixes the crashing at boot reported in #729 when using ESP32 v3.1.0

### Why
To be able to use the application with ESP32 v3.1.0

### How
Both CAN libraries are creating tasks with a priority of 256, which is far beyond the maximum allowed value for the ESP32's FreeRTOS. We now set this manually instead, base value of 10 added.
