### PR TITLE
Fix bugs in printf logging code & add version to log

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -97,6 +97,10 @@ Logging logging;
 void setup() {
   init_serial();
 
+  // We print this after setting up serial, such that is also printed to serial with DEBUG_VIA_USB set.
+  logging.printf("Battery emulator %s build " __DATE__
+                 " " __TIME__ "\n", version_number);
+
   init_stored_settings();
 
 #ifdef WIFI

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -98,8 +98,7 @@ void setup() {
   init_serial();
 
   // We print this after setting up serial, such that is also printed to serial with DEBUG_VIA_USB set.
-  logging.printf("Battery emulator %s build " __DATE__
-                 " " __TIME__ "\n", version_number);
+  logging.printf("Battery emulator %s build " __DATE__ " " __TIME__ "\n", version_number);
 
   init_stored_settings();
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -85,14 +85,13 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
 
 void Logging::printf(const char* fmt, ...) {
 #ifdef DEBUG_LOG
-  char* message_string = datalayer.system.info.logged_can_messages;
-  int offset = datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
-  size_t message_string_size = sizeof(datalayer.system.info.logged_can_messages);
-
   if (previous_message_was_newline) {
     add_timestamp(MAX_LINE_LENGTH_PRINTF);
   }
 
+  char* message_string = datalayer.system.info.logged_can_messages;
+  size_t message_string_size = sizeof(datalayer.system.info.logged_can_messages);
+  int offset = datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
   static char buffer[MAX_LINE_LENGTH_PRINTF];
   char* message_buffer;
 #ifdef DEBUG_VIA_WEB
@@ -132,6 +131,6 @@ void Logging::printf(const char* fmt, ...) {
   }
 #endif  // DEBUG_VIA_WEB
 
-  previous_message_was_newline = buffer[size - 1] == '\n';
+  previous_message_was_newline = message_buffer[size - 1] == '\n';
 #endif  // DEBUG_LOG
 }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -14,9 +14,10 @@ class Logging : public Print {
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
   Logging() {
-    printf("Battery emulator %s build "__DATE__
-      " " __TIME__ "\n",
-      version_number);
+    printf(
+        "Battery emulator %s build "__DATE__
+        " " __TIME__ "\n",
+        version_number);
   }
 };
 

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -4,6 +4,8 @@
 #include <inttypes.h>
 #include "Print.h"
 
+extern const char* version_number;  // The current software version, shown on webserver
+
 class Logging : public Print {
   void add_timestamp(size_t size);
 
@@ -11,7 +13,7 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
-  Logging() {}
+  Logging() {printf("Battery emulator %s build "__DATE__ " " __TIME__ "\n", version_number);}
 };
 
 extern Logging logging;

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -4,8 +4,6 @@
 #include <inttypes.h>
 #include "Print.h"
 
-extern const char* version_number;  // The current software version, shown on webserver
-
 class Logging : public Print {
   void add_timestamp(size_t size);
 
@@ -13,12 +11,7 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
-  Logging() {
-    printf(
-        "Battery emulator %s build "__DATE__
-        " " __TIME__ "\n",
-        version_number);
-  }
+  Logging() {}
 };
 
 extern Logging logging;

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -13,7 +13,11 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
-  Logging() {printf("Battery emulator %s build "__DATE__ " " __TIME__ "\n", version_number);}
+  Logging() {
+    printf("Battery emulator %s build "__DATE__
+      " " __TIME__ "\n",
+      version_number);
+  }
 };
 
 extern Logging logging;


### PR DESCRIPTION
### What
Fix bugs in printf logging code & add Battery Emulator version and build date/time to log

### Why
Fix the bug and being able to see the exact build version that is running

### How
Fixed the code. Added printf containing version and date/time.
