### PR TITLE
Bugfix: Kia64 cellvoltages + More Battery Info

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -1,6 +1,7 @@
 #include "../include.h"
 #ifdef KIA_HYUNDAI_64_BATTERY
 #include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/events.h"
 #include "KIA-HYUNDAI-64-BATTERY.h"
 
@@ -141,8 +142,17 @@ void update_values_battery() {  //This function maps all the values fetched via 
     set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
   }
 
-  /* Safeties verified. Perform USB serial printout if configured to do so */
+  // Update webserver datalayer
+  datalayer_extended.KiaHyundai64.total_cell_count = datalayer.battery.info.number_of_cells;
+  datalayer_extended.KiaHyundai64.battery_12V = leadAcidBatteryVoltage;
+  datalayer_extended.KiaHyundai64.waterleakageSensor = waterleakageSensor;
+  datalayer_extended.KiaHyundai64.temperature_water_inlet = temperature_water_inlet;
+  datalayer_extended.KiaHyundai64.powerRelayTemperature = powerRelayTemperature * 2;
+  datalayer_extended.KiaHyundai64.batteryManagementMode = batteryManagementMode;
+  datalayer_extended.KiaHyundai64.BMS_ign = BMS_ign;
+  datalayer_extended.KiaHyundai64.batteryRelay = batteryRelay;
 
+  //Perform logging if configured to do so
 #ifdef DEBUG_LOG
   logging.println();  //sepatator
   logging.println("Values from battery: ");

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -420,7 +420,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
             cellvoltages_mv[87] = (rx_frame.data.u8[4] * 20);
             cellvoltages_mv[88] = (rx_frame.data.u8[5] * 20);
             cellvoltages_mv[89] = (rx_frame.data.u8[6] * 20);
-            cellvoltages_mv[90] = (rx_frame.data.u8[7] * 20);
+            if (rx_frame.data.u8[7] > 4) {                       // Data only valid on 98S
+              cellvoltages_mv[90] = (rx_frame.data.u8[7] * 20);  // Perform extra checks
+            }
           } else if (poll_data_pid == 5) {
             batterySOH = ((rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3]);
           }
@@ -438,15 +440,29 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
             cellvoltages_mv[61] = (rx_frame.data.u8[3] * 20);
             cellvoltages_mv[62] = (rx_frame.data.u8[4] * 20);
             cellvoltages_mv[63] = (rx_frame.data.u8[5] * 20);
-          } else if (poll_data_pid == 4) {
-            cellvoltages_mv[91] = (rx_frame.data.u8[1] * 20);
-            cellvoltages_mv[92] = (rx_frame.data.u8[2] * 20);
-            cellvoltages_mv[93] = (rx_frame.data.u8[3] * 20);
-            cellvoltages_mv[94] = (rx_frame.data.u8[4] * 20);
-            cellvoltages_mv[95] = (rx_frame.data.u8[5] * 20);
-          } else if (poll_data_pid == 5) {
-            cellvoltages_mv[96] = (rx_frame.data.u8[4] * 20);
-            cellvoltages_mv[97] = (rx_frame.data.u8[5] * 20);
+          } else if (poll_data_pid == 4) {  // Data only valid on 98S
+            if (rx_frame.data.u8[1] > 4) {  // Perform extra checks
+              cellvoltages_mv[91] = (rx_frame.data.u8[1] * 20);
+            }
+            if (rx_frame.data.u8[2] > 4) {  // Perform extra checks
+              cellvoltages_mv[92] = (rx_frame.data.u8[2] * 20);
+            }
+            if (rx_frame.data.u8[3] > 4) {  // Perform extra checks
+              cellvoltages_mv[93] = (rx_frame.data.u8[3] * 20);
+            }
+            if (rx_frame.data.u8[4] > 4) {  // Perform extra checks
+              cellvoltages_mv[94] = (rx_frame.data.u8[4] * 20);
+            }
+            if (rx_frame.data.u8[5] > 4) {  // Perform extra checks
+              cellvoltages_mv[95] = (rx_frame.data.u8[5] * 20);
+            }
+          } else if (poll_data_pid == 5) {  // Data only valid on 98S
+            if (rx_frame.data.u8[4] > 4) {  // Perform extra checks
+              cellvoltages_mv[96] = (rx_frame.data.u8[4] * 20);
+            }
+            if (rx_frame.data.u8[5] > 4) {  // Perform extra checks
+              cellvoltages_mv[97] = (rx_frame.data.u8[5] * 20);
+            }
           }
           break;
         case 0x26:  //Sixth datarow in PID group

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -195,6 +195,17 @@ typedef struct {
 } DATALAYER_INFO_CELLPOWER;
 
 typedef struct {
+  uint8_t total_cell_count = 0;
+  int16_t battery_12V = 0;
+  uint8_t waterleakageSensor = 0;
+  int8_t temperature_water_inlet = 0;
+  int8_t powerRelayTemperature = 0;
+  uint8_t batteryManagementMode = 0;
+  uint8_t BMS_ign = 0;
+  uint8_t batteryRelay = 0;
+} DATALAYER_INFO_KIAHYUNDAI64;
+
+typedef struct {
   /** uint8_t */
   /** Contactor status */
   uint8_t status_contactor = 0;
@@ -606,6 +617,7 @@ class DataLayerExtended {
   DATALAYER_INFO_BMWI3 bmwi3;
   DATALAYER_INFO_BYDATTO3 bydAtto3;
   DATALAYER_INFO_CELLPOWER cellpower;
+  DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64;
   DATALAYER_INFO_TESLA tesla;
   DATALAYER_INFO_NISSAN_LEAF nissanleaf;
   DATALAYER_INFO_MEB meb;

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -317,16 +317,16 @@ String advanced_battery_processor(const String& var) {
 #endif  //CELLPOWER_BMS
 
 #ifdef KIA_HYUNDAI_64_BATTERY
-    /*
-   content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.total_cell_count) + "S</h4>";
-   content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery_12V) + "</h4>";
-   content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.waterleakageSensor) + "</h4>";
-   content += "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.temperature_water_inlet) + "</h4>";
-   content += "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.powerRelayTemperature) + "</h4>";
-   content += "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
-   content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
-   content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
-   */
+    content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.total_cell_count) + "S</h4>";
+    content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery_12V / 10.0, 1) + "</h4>";
+    content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.waterleakageSensor) + "</h4>";
+    content +=
+        "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.temperature_water_inlet) + "</h4>";
+    content +=
+        "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.powerRelayTemperature) + "</h4>";
+    content += "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
+    content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
+    content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
 #endif  //KIA_HYUNDAI_64_BATTERY
 
 #ifdef BYD_ATTO_3_BATTERY
@@ -1148,7 +1148,6 @@ String advanced_battery_processor(const String& var) {
 #endif
 
     content += "</div>";
-#ifdef NISSAN_LEAF_BATTERY
     content += "<script>";
     content +=
         "function askResetSOH() { if (window.confirm('Are you sure you want to reset degradation data? "
@@ -1161,8 +1160,6 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
-#endif  //NISSAN_LEAF_BATTERY
-#ifdef VOLVO_SPA_BATTERY
     content += "<script>";
     content +=
         "function Volvo_askEraseDTC() { if (window.confirm('Are you sure you want to erase DTCs?')) { "
@@ -1196,7 +1193,8 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
-#endif  //VOLVO_SPA_BATTERY
+
+    return content;
   }
   return String();
 }

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -316,6 +316,19 @@ String advanced_battery_processor(const String& var) {
                String(falseTrue[datalayer_extended.cellpower.warning_Charger_not_responding]) + "</h4>";
 #endif  //CELLPOWER_BMS
 
+#ifdef KIA_HYUNDAI_64_BATTERY
+    /*
+   content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.total_cell_count) + "S</h4>";
+   content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery_12V) + "</h4>";
+   content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.waterleakageSensor) + "</h4>";
+   content += "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.temperature_water_inlet) + "</h4>";
+   content += "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.powerRelayTemperature) + "</h4>";
+   content += "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
+   content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
+   content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
+   */
+#endif  //KIA_HYUNDAI_64_BATTERY
+
 #ifdef BYD_ATTO_3_BATTERY
     static const char* SOCmethod[2] = {"Estimated from voltage", "Measured by BMS"};
     content += "<h4>SOC method used: " + String(SOCmethod[datalayer_extended.bydAtto3.SOC_method]) + "</h4>";
@@ -1130,12 +1143,12 @@ String advanced_battery_processor(const String& var) {
 #if !defined(BMW_IX_BATTERY) && !defined(BOLT_AMPERA_BATTERY) && !defined(TESLA_BATTERY) &&      \
     !defined(NISSAN_LEAF_BATTERY) && !defined(BMW_I3_BATTERY) && !defined(BYD_ATTO_3_BATTERY) && \
     !defined(RENAULT_ZOE_GEN2_BATTERY) && !defined(CELLPOWER_BMS) && !defined(MEB_BATTERY) &&    \
-    !defined(VOLVO_SPA_BATTERY)  //Only the listed types have extra info
+    !defined(VOLVO_SPA_BATTERY) && !defined(KIA_HYUNDAI_64_BATTERY)  //Only the listed types have extra info
     content += "No extra information available for this battery type";
 #endif
 
     content += "</div>";
-
+#ifdef NISSAN_LEAF_BATTERY
     content += "<script>";
     content +=
         "function askResetSOH() { if (window.confirm('Are you sure you want to reset degradation data? "
@@ -1148,7 +1161,8 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
-
+#endif  //NISSAN_LEAF_BATTERY
+#ifdef VOLVO_SPA_BATTERY
     content += "<script>";
     content +=
         "function Volvo_askEraseDTC() { if (window.confirm('Are you sure you want to erase DTCs?')) { "
@@ -1182,6 +1196,7 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+#endif  //VOLVO_SPA_BATTERY
   }
   return String();
 }


### PR DESCRIPTION
### What
This PR implements a more battery info page for Kia64, along with cellvoltage sanity checking

### Why
To make 90S batteries work better with cellmonitor page

### How
This PR also fixes the More Battery Info page from breaking, bug introduced in PR 744
More Battery Info page added:

![image](https://github.com/user-attachments/assets/cd36905d-29e6-457c-8ef6-9ea1c6d03dd1)

