### PR TITLE
Bugfix: Make Volvo/Polestar use BMS allowed charge/discharge values

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -150,9 +150,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.current_dA = BATT_I * 10;
   datalayer.battery.status.remaining_capacity_Wh = remaining_capacity;
 
-  //datalayer.battery.status.max_discharge_power_W = HvBattPwrLimDchaSoft * 1000;	// Use power limit reported from BMS, not trusted ATM
-  datalayer.battery.status.max_discharge_power_W = 30000;
-  datalayer.battery.status.max_charge_power_W = 30000;
+  datalayer.battery.status.max_discharge_power_W = HvBattPwrLimDchaSlowAgi * 1000;  //kW to W
+  datalayer.battery.status.max_charge_power_W = HvBattPwrLimChrgSlowAgi * 1000;     //kW to W
   datalayer.battery.status.temperature_min_dC = BATT_T_MIN;
   datalayer.battery.status.temperature_max_dC = BATT_T_MAX;
 


### PR DESCRIPTION
### What
This PR allows for safer operation of Volvo/Polestar SPA batteries

### Why
To not damage the battery while charging. Before this PR, allowed charge/discharge was locked at 30kW, even at 99%!

### How
We now use the Charge/Discharge power limit values that the BMS sends. Example of values at 95.53%SOC

![image](https://github.com/user-attachments/assets/a317e6f9-c690-46a6-887d-215b45848223)
