### PR TITLE
Improvements to CAN logging to SD to significantly improve performance

### DIFF
--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -1,8 +1,7 @@
 #ifndef SDCARD_H
 #define SDCARD_H
 
-#include <SD.h>
-#include <SPI.h>
+#include <SD_MMC.h>
 #include "../../communication/can/comm_can.h"
 #include "../hal/hal.h"
 
@@ -14,7 +13,7 @@
 void init_logging_buffers();
 
 void init_sdcard();
-void print_sdcard_details();
+void log_sdcard_details();
 
 void add_can_frame_to_buffer(CAN_frame frame, frameDirection msgDir);
 void write_can_frame_to_sdcard();

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -112,7 +112,7 @@ void init_webserver() {
   // Define the handler to export can log
   server.on("/export_can_log", HTTP_GET, [](AsyncWebServerRequest* request) {
     pause_can_writing();
-    request->send(SD, CAN_LOG_FILE, String(), true);
+    request->send(SD_MMC, CAN_LOG_FILE, String(), true);
     resume_can_writing();
   });
 
@@ -133,7 +133,7 @@ void init_webserver() {
   // Define the handler to export debug log
   server.on("/export_log", HTTP_GET, [](AsyncWebServerRequest* request) {
     pause_log_writing();
-    request->send(SD, LOG_FILE, String(), true);
+    request->send(SD_MMC, LOG_FILE, String(), true);
     resume_log_writing();
   });
 #endif


### PR DESCRIPTION
This is an update to the CAN logging to SD feature to significantly improve performance for busy CAN networks

- Migrate from SPI SD library to SD_MMC
- Minimise the number of individual file writes by batching writes where possible
- Write a binary stream to the buffer to stop corruption