### PR TITLE
Improvement: Update CANFD library with 2517 compat toggle

### DIFF
--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
@@ -175,6 +175,30 @@ static uint16_t u16FromBufferAtIndex (uint8_t ioBuffer [], const uint8_t inIndex
 
 //----------------------------------------------------------------------------------------------------------------------
 
+static inline void turnOffInterrupts () {
+  #ifndef DISABLEMCP2517FDCOMPAT
+    #ifdef ARDUINO_ARCH_ESP32
+      taskDISABLE_INTERRUPTS () ;
+    #else
+      noInterrupts () ;
+    #endif
+  #endif
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+static inline void turnOnInterrupts() {
+  #ifndef DISABLEMCP2517FDCOMPAT
+    #ifdef ARDUINO_ARCH_ESP32
+      taskENABLE_INTERRUPTS () ;
+    #else
+      interrupts () ;
+    #endif
+  #endif
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
 ACAN2517FD::ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                         SPIClass & inSPI, // Hardware SPI object
                         const uint8_t inINT) : // INT output of MCP2517FD
@@ -532,11 +556,7 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
 
 bool ACAN2517FD::end (void) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
   //--- Detach interrupt pin
     if (mINT != 255) { // 255 means interrupt is not used
       const int8_t itPin = digitalPinToInterrupt (mINT) ;
@@ -571,11 +591,7 @@ bool ACAN2517FD::end (void) {
     mDriverReceiveBuffer.initWithSize (0) ;
     mDriverTransmitBuffer.initWithSize (0) ;
   //---
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+  turnOnInterrupts () ;
   mSPI.endTransaction () ;
 //---
   return ok ;
@@ -589,11 +605,7 @@ bool ACAN2517FD::tryToSend (const CANFDMessage & inMessage) {
   bool ok = inMessage.isValid () ;
   if (ok) {
     mSPI.beginTransaction (mSPISettings) ;
-      #ifdef ARDUINO_ARCH_ESP32
-        taskDISABLE_INTERRUPTS () ;
-      #else
-        noInterrupts () ;
-      #endif
+        turnOffInterrupts () ;
         if (inMessage.idx == 0) {
           ok = inMessage.len <= mTransmitFIFOPayload ;
           if (ok) {
@@ -605,11 +617,7 @@ bool ACAN2517FD::tryToSend (const CANFDMessage & inMessage) {
             ok = sendViaTXQ (inMessage) ;
           }
         }
-      #ifdef ARDUINO_ARCH_ESP32
-        taskENABLE_INTERRUPTS () ;
-      #else
-        interrupts () ;
-      #endif
+    turnOnInterrupts();
     mSPI.endTransaction () ;
   }
   return ok ;
@@ -780,17 +788,9 @@ bool ACAN2517FD::sendViaTXQ (const CANFDMessage & inMessage) {
 
 bool ACAN2517FD::available (void) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+      turnOffInterrupts () ;
       const bool hasReceivedMessage = mDriverReceiveBuffer.count () > 0 ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+      turnOnInterrupts();
   mSPI.endTransaction () ;
   return hasReceivedMessage ;
 }
@@ -799,11 +799,7 @@ bool ACAN2517FD::available (void) {
 
 bool ACAN2517FD::receive (CANFDMessage & outMessage) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+      turnOffInterrupts () ;
       const bool hasReceivedMessage = mDriverReceiveBuffer.remove (outMessage) ;
     //--- If receive interrupt is disabled, enable it (added in release 2.17)
       if (mINT == 255) { // No interrupt pin
@@ -815,11 +811,7 @@ bool ACAN2517FD::receive (CANFDMessage & outMessage) {
         data8 |= (1 << 1) ; // Receive FIFO Interrupt Enable
         writeRegister8Assume_SPI_transaction (INT_REGISTER + 2, data8) ;
       }
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+  turnOnInterrupts();
   mSPI.endTransaction () ;
   return hasReceivedMessage ;
 }
@@ -860,9 +852,9 @@ bool ACAN2517FD::dispatchReceivedMessage (const tFilterMatchCallBack inFilterMat
 
 #ifndef ARDUINO_ARCH_ESP32
   void ACAN2517FD::poll (void) {
-    noInterrupts () ;
+    turnOffInterrupts () ;
       isr_poll_core () ;
-    interrupts () ;
+    turnOnInterrupts () ;
   }
 #endif
 
@@ -1108,17 +1100,9 @@ uint8_t ACAN2517FD::readRegister8Assume_SPI_transaction (const uint16_t inRegist
 
 void ACAN2517FD::writeRegister8 (const uint16_t inRegisterAddress, const uint8_t inValue) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       writeRegister8Assume_SPI_transaction (inRegisterAddress, inValue) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 
@@ -1126,17 +1110,9 @@ void ACAN2517FD::writeRegister8 (const uint16_t inRegisterAddress, const uint8_t
 
 uint8_t ACAN2517FD::readRegister8 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint8_t result = readRegister8Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1145,17 +1121,9 @@ uint8_t ACAN2517FD::readRegister8 (const uint16_t inRegisterAddress) {
 
 uint16_t ACAN2517FD::readRegister16 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint16_t result = readRegister16Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1164,17 +1132,9 @@ uint16_t ACAN2517FD::readRegister16 (const uint16_t inRegisterAddress) {
 
 void ACAN2517FD::writeRegister32 (const uint16_t inRegisterAddress, const uint32_t inValue) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       writeRegister32Assume_SPI_transaction (inRegisterAddress, inValue) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 
@@ -1182,17 +1142,9 @@ void ACAN2517FD::writeRegister32 (const uint16_t inRegisterAddress, const uint32
 
 uint32_t ACAN2517FD::readRegister32 (const uint16_t inRegisterAddress) {
   mSPI.beginTransaction (mSPISettings) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       const uint32_t result = readRegister32Assume_SPI_transaction (inRegisterAddress) ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
   return result ;
 }
@@ -1244,19 +1196,11 @@ void ACAN2517FD::setOperationMode (const ACAN2517FDSettings::OperationMode inOpe
 
 void ACAN2517FD::reset2517FD (void) {
   mSPI.beginTransaction (mSPISettings) ; // Check RESET is performed with 800 kHz clock
-    #ifdef ARDUINO_ARCH_ESP32
-      taskDISABLE_INTERRUPTS () ;
-    #else
-      noInterrupts () ;
-    #endif
+    turnOffInterrupts () ;
       assertCS () ;
         mSPI.transfer16 (0x00) ; // Reset instruction: 0x0000
       deassertCS () ;
-    #ifdef ARDUINO_ARCH_ESP32
-      taskENABLE_INTERRUPTS () ;
-    #else
-      interrupts () ;
-    #endif
+    turnOnInterrupts () ;
   mSPI.endTransaction () ;
 }
 

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
@@ -16,6 +16,16 @@
 #include <SPI.h>
 
 //----------------------------------------------------------------------------------------------------------------------
+//   Settings
+//----------------------------------------------------------------------------------------------------------------------
+//
+// Enable this if you want to disable the MCP2517FD compatability mode. This can slightly increase performance when
+// running on the MCP2518FD but you risk hitting issues mentioned in the MCP2517FD errata-sheet when using this option
+// on the MCP2517FD.
+//
+//#define DISABLEMCP2517FDCOMPAT 
+
+//----------------------------------------------------------------------------------------------------------------------
 //   ACAN2517FD class
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### What
This PR adds the suggested changes to the pierremolinaro/acan2517FD library as suggested [in this PR](https://github.com/pierremolinaro/acan2517FD/pull/34)

### Why
There is a performance gain, disabling 2517FD compat mode, it no longer disables interrupts during SPI transactions which slightly increases performance and avoids delaying interrupts. There should be no downside to enabling this, since [our Wiki](https://github.com/dalathegreat/Battery-Emulator/wiki/CAN%E2%80%90FD-add%E2%80%90on-(MCP2518FD)#hardware) suggests using the 251**8**FD chip instead.

### How
Disabling the MCP2517 compatibility mode can be done in ACAN2517FD.h by uncommenting the `#define DISABLEMCP2517FDCOMPAT` line. By default we keep this disabled until someone has had time to test it properly on a heavy bus load CAN-FD setup.
