### PR TITLE
Improvement: Remove MCP2517 support for code speedup

### DIFF
--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
@@ -23,7 +23,7 @@
 // running on the MCP2518FD but you risk hitting issues mentioned in the MCP2517FD errata-sheet when using this option
 // on the MCP2517FD.
 //
-//#define DISABLEMCP2517FDCOMPAT 
+#define DISABLEMCP2517FDCOMPAT 
 
 //----------------------------------------------------------------------------------------------------------------------
 //   ACAN2517FD class


### PR DESCRIPTION
### What
This PR enabled the optimization developed in PR https://github.com/dalathegreat/Battery-Emulator/pull/753

### Why
We drop MCP2517 support in favour of the newer MCP2518. By dropping the support we get improved CAN performance

### How
See PR https://github.com/dalathegreat/Battery-Emulator/pull/753 for more info. This PR just enabled the speedup
