### PR TITLE
Tesla: Add overdischarge prevention

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2715,13 +2715,17 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
         transmit_can_frame(&TESLA_221_1, can_config.battery_double);
         transmit_can_frame(&TESLA_221_2, can_config.battery_double);
       }
-#endif        //DOUBLE_BATTERY
-    } else {  // Faulted state, or inverter blocks contactor closing
+#endif                                                     //DOUBLE_BATTERY
+    } else {                                               // Faulted state, or inverter blocks contactor closing
+      datalayer.battery.status.max_charge_power_W = 0;     //Prepare for contactor opening
+      datalayer.battery.status.max_discharge_power_W = 0;  //Signal to inverter no power in/out
       if (sendContactorClosingMessagesStill > 0) {
         transmit_can_frame(&TESLA_221_1, can_config.battery);
         sendContactorClosingMessagesStill--;
 
 #ifdef DOUBLE_BATTERY
+        datalayer.battery2.status.max_charge_power_W = 0;     //Prepare for contactor opening
+        datalayer.battery2.status.max_discharge_power_W = 0;  //Signal to inverter no power in/out
         transmit_can_frame(&TESLA_221_1, can_config.battery_double);
 #endif  //DOUBLE_BATTERY
       }

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -848,6 +848,10 @@ void update_values_battery() {  //This function maps all the values fetched via 
   if (datalayer.battery.status.max_discharge_power_W > MAXDISCHARGEPOWERALLOWED) {
     datalayer.battery.status.max_discharge_power_W = MAXDISCHARGEPOWERALLOWED;
   }
+  // Extra safety check to prevent battery from overdischarging. Zero if we are 50mV from the contactor opening limit
+  if (datalayer.battery.status.cell_min_voltage_mV < (datalayer.battery.info.min_cell_voltage_mV + 50)) {
+    datalayer.battery.status.max_discharge_power_W = 0;
+  }
 
   //The allowed charge power behaves strangely. We instead estimate this value
   if (battery_soc_ui > 990) {


### PR DESCRIPTION
### What
This PR implements an attempt at overdischarge prevention for Tesla

### Why
One user reported an overdischarge event which led to contactor opening. This should not happen, battery should just stop discharge

### How
We now check if we are approaching cellvoltage limit, and if we do, we zero out the allowed discharge power.
