### PR TITLE
Update VOLVO-SPA-BATTERY.cpp

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -49,13 +49,13 @@ CAN_frame VOLVO_140_CLOSE = {.FD = false,
                              .ext_ID = false,
                              .DLC = 8,
                              .ID = 0x140,
-                             .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x83}};  //Close contactors message
+                             .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
 
 CAN_frame VOLVO_140_OPEN = {.FD = false,
                             .ext_ID = false,
                             .DLC = 8,
                             .ID = 0x140,
-                            .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x83}};  //Open contactor message
+                            .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
 
 CAN_frame VOLVO_372 = {
     .FD = false,


### PR DESCRIPTION
Correct command for opening and closing contactors

0x140 Byte 8 Bit 0 is DcDcActivationRequest
0x140 Byte 8 Bit 1 is DcDcActivationRequest_Valid (should be 1 to have DcDcActivationRequest bit valid)

So 0x83 on that bytes means that the ECM requests to activate the DC-DC.

But we don’t want to do it , so we should send 0x82