### PR TITLE
Bugfix: Move Battery2 power calculation outside SOC scaling function

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -355,6 +355,12 @@ void update_calculated_values() {
   datalayer.battery.status.active_power_W =
       (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
 
+#ifdef DOUBLE_BATTERY
+  /* Calculate active power based on voltage and current for battery 2*/
+  datalayer.battery2.status.active_power_W =
+      (datalayer.battery2.status.current_dA * (datalayer.battery2.status.voltage_dV / 100));
+#endif  // DOUBLE_BATTERY
+
   if (datalayer.battery.settings.soc_scaling_active) {
     /** SOC Scaling
      * 
@@ -404,10 +410,6 @@ void update_calculated_values() {
     }
 
 #ifdef DOUBLE_BATTERY
-    /* Calculate active power based on voltage and current*/
-    datalayer.battery2.status.active_power_W =
-        (datalayer.battery2.status.current_dA * (datalayer.battery2.status.voltage_dV / 100));
-
     // Calculate the scaled remaining capacity in Wh
     if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery2.status.real_soc > 0) {
       calc_max_capacity =


### PR DESCRIPTION
### What
This PR fixes a bug related to using 2x batteries without SOC scaling

### Why
Old software only calculated power for battery2 when "SOC scaling" option was turned on

### How
Massive thanks to @pmajor021 for finding and reporting this bug!
