### PR TITLE
Bugfix: i3, Add cellvoltage amount for battery2

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1051,6 +1051,9 @@ void transmit_can_battery() {
           current_cell_polled++;
           if (current_cell_polled > 96) {
             datalayer.battery.info.number_of_cells = 97;
+#ifdef DOUBLE_BATTERY
+            datalayer.battery2.info.number_of_cells = 97;
+#endif
             cmdState = CELL_VOLTAGE_CELLNO_LAST;
           } else {
             cmdState = CELL_VOLTAGE_CELLNO;


### PR DESCRIPTION
### What
This PR writes cellvoltage amount for battery 2 also on i3

### Why
To make the cellmonitor page able to see and display the second battery

### How
datalayer.battery2.info.number_of_cells = 97;
