### PR TITLE
Bugfix: Make all 96 cells work on Zoe Gen1

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -8,7 +8,6 @@
 https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
 The Zoe BMS apparently does not send total pack voltage, so we use the polled 96x cellvoltages summed up as total voltage
 Still TODO:
-- Fix the missing cell96 issue (Only cells 1-95 is shown on cellmonitor page)
 - Automatically detect if we are on 22 or 41kWh battery (Nice to have, requires log file from 22kWh battery)
 /*
 
@@ -397,7 +396,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
         case 0x29:
           if (requested_poll == GROUP1_CELLVOLTAGES_1_POLL) {
             cellvoltages[30] = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2];
-            cellvoltages[21] = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
+            cellvoltages[31] = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
             cellvoltages[32] = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6];
             highbyte_cell_next_frame = rx_frame.data.u8[7];
           }


### PR DESCRIPTION
### What
This PR fixes the missing cell voltage 32. This has plauged the Zoe Gen1 for a while, 95 out of 96 cells have been visible.

### Why
Safer operation of the battery

### How
We fix a mistake, where I typed [21] instead of [31]
