### PR TITLE
Bugfix: Make PERIODIC_BMS_RESET not cause events after reset

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -515,7 +515,10 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
         battery2_Current2 |= 0xf800;
       }  //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
 
-      battery2_Total_Voltage2 = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
+      battery2_TEMP = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
+      if (battery2_TEMP != 0x3ff) {  //3FF is unavailable value. Can happen directly on reboot.
+        battery2_Total_Voltage2 = battery2_TEMP;
+      }
 
       //Collect various data from the BMS
       battery2_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);
@@ -754,7 +757,10 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
         battery_Current2 |= 0xf800;
       }  //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
 
-      battery_Total_Voltage2 = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
+      battery_TEMP = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
+      if (battery_TEMP != 0x3ff) {  //3FF is unavailable value. Can happen directly on reboot.
+        battery_Total_Voltage2 = battery_TEMP;
+      }
 
       //Collect various data from the BMS
       battery_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);


### PR DESCRIPTION
### What
This PR attempts to fix the bug reported in #792

### Why
PERIODIC_BMS_RESET was a newly introduced feature in 8.x.x , it periodically reboots the battery BMS to prevent memory leaks. However, the LEAF battery sends some garbage data upon poweron, which we incorrectly interpreted as sane values. This caused many events to trigger once we resumed using the battery.

### How
We now sanity check voltage measurements, if they are 0x3FF we skip using it. This is the default value when you boot