### PR TITLE
Feature: Add event for blown fuse in Zoe battery

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -454,6 +454,11 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
         case 0x2E:
           if (requested_poll == GROUP1_CELLVOLTAGES_1_POLL) {
             cellvoltages[47] = (highbyte_cell_next_frame << 8) | rx_frame.data.u8[1];
+            if (cellvoltages[47] < 100) {  //This cell measurement is inbetween pack halves. If low, fuse blown
+              set_event(EVENT_BATTERY_FUSE, cellvoltages[47]);
+            } else {
+              clear_event(EVENT_BATTERY_FUSE);
+            }
             cellvoltages[48] = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
             cellvoltages[49] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
             cellvoltages[50] = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -153,6 +153,7 @@ void init_events(void) {
   events.entries[EVENT_BALANCING_END].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY_EMPTY].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY_FULL].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_FUSE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY_FROZEN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY_CAUTION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
@@ -304,6 +305,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Battery is completely discharged";
     case EVENT_BATTERY_FULL:
       return "Battery is fully charged";
+    case EVENT_BATTERY_FUSE:
+      return "Battery internal fuse blown. Inspect battery";
     case EVENT_BATTERY_FROZEN:
       return "Battery is too cold to operate optimally. Consider warming it up!";
     case EVENT_BATTERY_CAUTION:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0020  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0021  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -49,6 +49,7 @@
   XX(EVENT_BALANCING_END)               \
   XX(EVENT_BATTERY_EMPTY)               \
   XX(EVENT_BATTERY_FULL)                \
+  XX(EVENT_BATTERY_FUSE)                \
   XX(EVENT_BATTERY_FROZEN)              \
   XX(EVENT_BATTERY_CAUTION)             \
   XX(EVENT_BATTERY_CHG_STOP_REQ)        \


### PR DESCRIPTION
### What
This PR adds a new event, EVENT_BATTERY_FUSE

### Why
On the Zoe, it is possible to detect that the internal fuse connecting the two battery halves have been blown. This is good info to relay back to the user, to let them know that the battery needs service

### How
If the cell number 48 is low (<100mV), we trigger this event.

Example of battery with blown fuse:

![image](https://github.com/user-attachments/assets/2e96e91a-93a8-4f48-9705-e868750fe3f0)
