### PR TITLE
Bugfix: Pylon CAN, add status bit writing to 0x4250

### DIFF
--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -196,12 +196,16 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 
   // Status=Bit 0,1,2= 0:Sleep, 1:Charge, 2:Discharge 3:Idle. Bit3 ForceChargeReq. Bit4 Balance charge Request
   if (datalayer.battery.status.bms_status == FAULT) {
+    PYLON_4250.data.u8[0] = (0x00);  // Sleep
     PYLON_4251.data.u8[0] = (0x00);  // Sleep
   } else if (datalayer.battery.status.current_dA < 0) {
+    PYLON_4250.data.u8[0] = (0x01);  // Charge
     PYLON_4251.data.u8[0] = (0x01);  // Charge
   } else if (datalayer.battery.status.current_dA > 0) {
+    PYLON_4250.data.u8[0] = (0x02);  // Discharge
     PYLON_4251.data.u8[0] = (0x02);  // Discharge
   } else if (datalayer.battery.status.current_dA == 0) {
+    PYLON_4250.data.u8[0] = (0x03);  // Idle
     PYLON_4251.data.u8[0] = (0x03);  // Idle
   }
 


### PR DESCRIPTION
### What
This PR fixes a small bug, we have only been writing status bits to the message 0x4251 , but not to the 0x4250 message

### Why
We fix this, to be able to better relay status when using the SEND_0 option

### How
Thanks to Stefan for noticing this on the Discord :raised_hands: 
