### PR TITLE
Improvement: Tesla blown pyro event

### DIFF
--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -2,8 +2,6 @@
 #ifdef CHADEMO_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "CHADEMO-BATTERY-INTERNAL.h"
 #include "CHADEMO-BATTERY.h"
 #include "CHADEMO-SHUNTS.h"

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -22,8 +22,6 @@
 #ifdef CHADEMO_BATTERY
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/CAN_config.h"
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 #include "CHADEMO-BATTERY-INTERNAL.h"
 #include "CHADEMO-BATTERY.h"
 #include "CHADEMO-SHUNTS.h"

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -1,8 +1,6 @@
 #ifndef CHADEMO_SHUNTS_H
 #define CHADEMO_SHUNTS_H
 
-#include "../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
-
 uint16_t get_measured_voltage();
 uint16_t get_measured_current();
 void ISA_handleFrame(CAN_frame* frame);

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -887,11 +887,17 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   /* Value mapping is completed. Start to check all safeties */
 
-  if (battery_hvil_status ==
-      3) {  //INTERNAL_OPEN_FAULT - Someone disconnected a high voltage cable while battery was in use
+  //INTERNAL_OPEN_FAULT - Someone disconnected a high voltage cable while battery was in use
+  if (battery_hvil_status == 3) {
     set_event(EVENT_INTERNAL_OPEN_FAULT, 0);
   } else {
     clear_event(EVENT_INTERNAL_OPEN_FAULT);
+  }
+  //Voltage missing, pyrofuse most likely blown
+  if (datalayer.battery.status.voltage_dV == 10) {
+    set_event(EVENT_BATTERY_FUSE, 0);
+  } else {
+    clear_event(EVENT_BATTERY_FUSE);
   }
 
 #ifdef TESLA_MODEL_3Y_BATTERY
@@ -2585,12 +2591,17 @@ void update_values_battery2() {  //This function maps all the values fetched via
   battery2_cell_deviation_mV = (battery2_cell_max_v - battery2_cell_min_v);
 
   /* Value mapping is completed. Start to check all safeties */
-
-  if (battery2_hvil_status ==
-      3) {  //INTERNAL_OPEN_FAULT - Someone disconnected a high voltage cable while battery was in use
+  //INTERNAL_OPEN_FAULT - Someone disconnected a high voltage cable while battery was in use
+  if (battery2_hvil_status == 3) {
     set_event(EVENT_INTERNAL_OPEN_FAULT, 2);
   } else {
     clear_event(EVENT_INTERNAL_OPEN_FAULT);
+  }
+  //Voltage missing, pyrofuse most likely blown
+  if (datalayer.battery2.status.voltage_dV == 10) {
+    set_event(EVENT_BATTERY_FUSE, 0);
+  } else {
+    clear_event(EVENT_BATTERY_FUSE);
   }
 
 #ifdef TESLA_MODEL_3Y_BATTERY

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -8,7 +8,6 @@
 #include "../../lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h"
 #include "../../lib/mathieucarbou-AsyncTCPSock/src/AsyncTCP.h"
 #include "../../lib/mathieucarbou-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
-#include "../../lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
 
 extern const char* version_number;  // The current software version, shown on webserver
 


### PR DESCRIPTION
### What
This PR introduces an event for detecting blown pyro fuse on Tesla batteries

### Why
To aid troubleshooting Tesla batteries

### How
We now fire an event about fuse being blown if the voltage is 1.0V

Bonus, removed some unnecessary header include files for quicker compilation time
