### PR TITLE
Bugfix: Nissan LEAF, move battery-allows-closing writing

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -766,11 +766,6 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       battery_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);
       battery_Failsafe_Status = (rx_frame.data.u8[1] & 0x07);
       battery_MainRelayOn_flag = (bool)((rx_frame.data.u8[3] & 0x20) >> 5);
-      if (battery_MainRelayOn_flag) {
-        datalayer.system.status.battery_allows_contactor_closing = true;
-      } else {
-        datalayer.system.status.battery_allows_contactor_closing = false;
-      }
       battery_Full_CHARGE_flag = (bool)((rx_frame.data.u8[3] & 0x10) >> 4);
       battery_Interlock = (bool)((rx_frame.data.u8[3] & 0x08) >> 3);
       break;
@@ -1499,7 +1494,7 @@ void decodeChallengeData(unsigned int incomingChallenge, unsigned char* solvedCh
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-
+  datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -237,6 +237,11 @@ void update_values_battery() { /* This function maps all the values fetched via 
 
   datalayer.battery.status.max_charge_power_W = (battery_Charge_Power_Limit * 1000);  //kW to W
 
+  //Allow contactors to close
+  if (battery_can_alive) {
+    datalayer.system.status.battery_allows_contactor_closing = true;
+  }
+
   /*Extra safety functions below*/
   if (battery_GIDS < 10)  //700Wh left in battery!
   {                       //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
@@ -1494,7 +1499,6 @@ void decodeChallengeData(unsigned int incomingChallenge, unsigned char* solvedCh
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;


### PR DESCRIPTION
### What
This PR moves the `battery_allows_contactor_closing` writing for Nissan LEAF

### Why
Periodic BMS reset would always cause this red X on the webserver, confusing users

![image](https://github.com/user-attachments/assets/0956ee6b-3eab-4041-9b59-413172984b27)

It also confused users, some packs never set this bit as stated in the LEAF wiki

_NOTE: with some Leaf BMS (so far only noticed on the 30kWh 2016) the line batteryAllowsContactorClosing = true is never set: https://github.com/dalathegreat/Battery-Emulator/blob/d759946cc41882576b6c27be095fffe0f47ba191/Software/src/battery/NISSAN-LEAF-BATTERY.cpp#L745 . This prevents the automatic contactor sequence. A workaround is to force the value to always true. So if you are having problems with the contactor sequence, change the above line to datalayer.system.status.battery_allows_contactor_closing = true;_

### How
Instead of dynamically writing it based on CAN, always allow contactor closing on boot

This also makes the workaround no longer required
