### PR TITLE
Bugfix: Make Webserver show correct contactor status when Solax opens them

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -153,6 +153,7 @@ void handle_contactors() {
     set(PRECHARGE_PIN, OFF);
     set(NEGATIVE_CONTACTOR_PIN, OFF, PWM_OFF_DUTY);
     set(POSITIVE_CONTACTOR_PIN, OFF, PWM_OFF_DUTY);
+    datalayer.system.status.contactors_engaged = false;
 
     if (datalayer.system.status.battery_allows_contactor_closing &&
         datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.settings.equipment_stop_active) {


### PR DESCRIPTION
### What
This PR fixes the bug reported in #679 

### Why
To make it easier for users to see actual contactor state

### How
Currently datalayer.system.status.contactors_engaged only gets set to false if contractor opening is requested from the web page, not if it is requested by the inverter or estop.
