### PR TITLE
Bugfix: Halt only CAN sending towards battery while BMS resetting

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1064,9 +1064,19 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 void transmit_can_battery() {
-  if (battery_can_alive) {
 
-    unsigned long currentMillis = millis();
+  unsigned long currentMillis = millis();
+
+  if (datalayer.system.status.BMS_reset_in_progress) {
+    // Transmitting towards battery is halted while BMS is being reset
+    // Reset sending counters to avoid overrun messages when reset is over
+    previousMillis10 = currentMillis;
+    previousMillis100 = currentMillis;
+    previousMillis10s = currentMillis;
+    return;
+  }
+
+  if (battery_can_alive) {
 
     //Send 10ms message
     if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -108,10 +108,7 @@ void transmit_can() {
     return;  //Global block of CAN messages
   }
 
-  if (!datalayer.system.status.BMS_reset_in_progress) {
-    //Transmitting towards battery is halted while BMS is being reset
-    transmit_can_battery();
-  }
+  transmit_can_battery();
 
 #ifdef CAN_INVERTER_SELECTED
   transmit_can_inverter();

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -105,9 +105,13 @@ void init_CAN() {
 // Transmit functions
 void transmit_can() {
   if (!allowed_to_send_CAN) {
-    return;
+    return;  //Global block of CAN messages
   }
-  transmit_can_battery();
+
+  if (!datalayer.system.status.BMS_reset_in_progress) {
+    //Transmitting towards battery is halted while BMS is being reset
+    transmit_can_battery();
+  }
 
 #ifdef CAN_INVERTER_SELECTED
   transmit_can_inverter();

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -43,7 +43,6 @@ unsigned long currentTime = 0;
 unsigned long lastPowerRemovalTime = 0;
 const unsigned long powerRemovalInterval = 24 * 60 * 60 * 1000;  // 24 hours in milliseconds
 const unsigned long powerRemovalDuration = 30000;                // 30 seconds in milliseconds
-bool isBMSResetActive = false;
 
 void set(uint8_t pin, bool direction, uint32_t pwm_freq = 0xFFFF) {
 #ifdef PWM_CONTACTOR_CONTROL
@@ -256,48 +255,38 @@ void handle_BMSpower() {
 #endif  //PERIODIC_BMS_RESET
 
   // If power has been removed for 30 seconds, restore the power and resume the emulator
-  if (isBMSResetActive && currentTime - lastPowerRemovalTime >= powerRemovalDuration) {
-    // Reapply power to the BMS
-    digitalWrite(BMS_POWER, HIGH);
-
-    //Resume the battery pause and CAN communication
-    setBatteryPause(false, false, false, false);
-
-    isBMSResetActive = false;  // Reset the power removal flag
-  }
-#endif  //defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
-}
-
-void start_bms_reset() {
-#if defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
-  if (!isBMSResetActive) {
-    lastPowerRemovalTime = currentTime;  // Record the time when BMS reset was started
-
-    // Set emulator state to paused (Max Charge/Discharge = 0 & CAN = stop)
-    // TODO: We try to keep contactors engaged during this pause, and just ramp power down to 0.
-    // If this turns out to not work properly, set also the third option to true to open contactors
-    setBatteryPause(true, true, false, false);
-
-    digitalWrite(BMS_POWER, LOW);  // Remove power by setting the BMS power pin to LOW
-#ifdef BMS_2_POWER
-    digitalWrite(BMS_2_POWER, LOW);  // Same for battery 2
-#endif
-
-    isBMSResetActive = true;  // Set a flag to indicate power removal is active
-  }
-
-  // If power has been removed for 30 seconds, restore the power and resume the emulator
-  if (isBMSResetActive && currentTime - lastPowerRemovalTime >= powerRemovalDuration) {
+  if (datalayer.system.status.BMS_reset_in_progress && currentTime - lastPowerRemovalTime >= powerRemovalDuration) {
     // Reapply power to the BMS
     digitalWrite(BMS_POWER, HIGH);
 #ifdef BMS_2_POWER
     digitalWrite(BMS_2_POWER, HIGH);  // Same for battery 2
 #endif
 
-    //Resume the battery pause and CAN communication
+    //Resume from the power pause
     setBatteryPause(false, false, false, false);
 
-    isBMSResetActive = false;  // Reset the power removal flag
+    datalayer.system.status.BMS_reset_in_progress = false;  // Reset the power removal flag
   }
-#endif  //PERIODIC_BMS_RESET
+#endif  //defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
+}
+
+void start_bms_reset() {
+#if defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
+  if (!datalayer.system.status.BMS_reset_in_progress) {
+    lastPowerRemovalTime = currentTime;  // Record the time when BMS reset was started
+
+    // Set a flag to let the rest of the system know we are cutting power to the BMS.
+    // The battery CAN sending routine will then know not to try to send anything towards battery while active
+    datalayer.system.status.BMS_reset_in_progress = true;
+
+    // Set emulator state to paused (Max Charge/Discharge = 0 & CAN = stop)
+    // We try to keep contactors engaged during this pause, and just ramp power down to 0.
+    setBatteryPause(true, false, false, false);
+
+    digitalWrite(BMS_POWER, LOW);  // Remove power by setting the BMS power pin to LOW
+#ifdef BMS_2_POWER
+    digitalWrite(BMS_2_POWER, LOW);  // Same for battery 2
+#endif
+  }
+#endif  //defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
 }

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -272,6 +272,8 @@ typedef struct {
   /** True if the contactor controlled by battery-emulator is closed. Determined by check_interconnect_available(); if voltage is OK */
   bool contactors_battery2_engaged = false;
 #endif
+  /** True if the BMS is being reset, by cutting power towards it */
+  bool BMS_reset_in_progress = false;
 } DATALAYER_SYSTEM_STATUS_TYPE;
 
 typedef struct {


### PR DESCRIPTION
### What
This PR makes the BMS Reset only halt CAN message sending towards battery

### Why
The current implementation pauses CAN sending globally. That means that if you use a CAN based inverter + Period BMS reset, the inverter will also get starved of CAN messages while the reset is active. This is not desired, since it risks using power from battery while it is off. This new fix makes it pause only sending CAN towards battery while it is down.

Another issue was also that the original implementation only stopped ESP32.CAN , which was the first CAN interface. So it was impossible to use the feature right on setups where battery was not connected to fist CAN port

### How
Moved the `isBMSResetActive` into the datalayer `datalayer.system.status.BMS_reset_in_progress`. Also simplified the code a bit.
