### PR TITLE
Improvemen/solax

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -147,16 +147,16 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1873.data.u8[3] = (datalayer.battery.status.current_dA >> 8);
   SOLAX_1873.data.u8[4] = (uint8_t)(datalayer.battery.status.reported_soc / 100);  //SOC (100.00%)
   //SOLAX_1873.data.u8[5] = //Seems like this is not required? Or shall we put SOC decimals here?
-  SOLAX_1873.data.u8[6] = (uint8_t)(capped_remaining_capacity_Wh / 10);
-  SOLAX_1873.data.u8[7] = ((capped_remaining_capacity_Wh / 10) >> 8);
+  SOLAX_1873.data.u8[6] = (uint8_t)(capped_capacity_Wh / 10);
+  SOLAX_1873.data.u8[7] = ((capped_capacity_Wh / 10) >> 8);
 
   //BMS_CellData
   SOLAX_1874.data.u8[0] = (int8_t)datalayer.battery.status.temperature_max_dC;
   SOLAX_1874.data.u8[1] = (datalayer.battery.status.temperature_max_dC >> 8);
   SOLAX_1874.data.u8[2] = (int8_t)datalayer.battery.status.temperature_min_dC;
   SOLAX_1874.data.u8[3] = (datalayer.battery.status.temperature_min_dC >> 8);
-  SOLAX_1874.data.u8[4] = (uint8_t)(datalayer.battery.status.cell_max_voltage_mV);
-  SOLAX_1874.data.u8[5] = (datalayer.battery.status.cell_max_voltage_mV >> 8);
+  SOLAX_1874.data.u8[4] = (uint8_t)(datalayer.battery.info.max_cell_voltage_mV);
+  SOLAX_1874.data.u8[5] = (datalayer.battery.info.max_cell_voltage_mV >> 8);
   SOLAX_1874.data.u8[6] = (uint8_t)(datalayer.battery.status.cell_min_voltage_mV);
   SOLAX_1874.data.u8[7] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
 
@@ -167,9 +167,13 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1875.data.u8[4] = (uint8_t)0;                  // Contactor Status 0=off, 1=on.
 
   //BMS_PackTemps (strange name, since it has voltages?)
+  SOLAX_1876.data.u8[0] = (int8_t)datalayer.battery.status.temperature_max_dC;
+  SOLAX_1876.data.u8[1] = (datalayer.battery.status.temperature_max_dC >> 8);
   SOLAX_1876.data.u8[2] = (uint8_t)datalayer.battery.status.cell_max_voltage_mV;
   SOLAX_1876.data.u8[3] = (datalayer.battery.status.cell_max_voltage_mV >> 8);
 
+  SOLAX_1876.data.u8[4] = (int8_t)datalayer.battery.status.temperature_min_dC;
+  SOLAX_1876.data.u8[5] = (datalayer.battery.status.temperature_min_dC >> 8);
   SOLAX_1876.data.u8[6] = (uint8_t)datalayer.battery.status.cell_min_voltage_mV;
   SOLAX_1876.data.u8[7] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
 
@@ -183,8 +187,10 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1878.data.u8[0] = (uint8_t)(datalayer.battery.status.voltage_dV);
   SOLAX_1878.data.u8[1] = ((datalayer.battery.status.voltage_dV) >> 8);
 
-  SOLAX_1878.data.u8[4] = (uint8_t)capped_capacity_Wh;
-  SOLAX_1878.data.u8[5] = (capped_capacity_Wh >> 8);
+  SOLAX_1878.data.u8[4] = (uint8_t)datalayer.battery.info.total_capacity_Wh;
+  SOLAX_1878.data.u8[5] = (datalayer.battery.info.total_capacity_Wh >> 8);
+  SOLAX_1878.data.u8[6] = (datalayer.battery.info.total_capacity_Wh >> 16);
+  SOLAX_1878.data.u8[7] = (datalayer.battery.info.total_capacity_Wh >> 24);
 
   // BMS_Answer
   SOLAX_1801.data.u8[0] = 2;
@@ -192,10 +198,10 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1801.data.u8[4] = 1;
 
   //Ultra messages
-  SOLAX_187E.data.u8[0] = (uint8_t)capped_remaining_capacity_Wh;
-  SOLAX_187E.data.u8[1] = (capped_remaining_capacity_Wh >> 8);
-  SOLAX_187E.data.u8[2] = 0;
-  SOLAX_187E.data.u8[3] = 0;
+  SOLAX_187E.data.u8[0] = (uint8_t)datalayer.battery.info.total_capacity_Wh;
+  SOLAX_187E.data.u8[1] = (datalayer.battery.info.total_capacity_Wh >> 8);
+  SOLAX_187E.data.u8[2] = (datalayer.battery.info.total_capacity_Wh >> 16);
+  SOLAX_187E.data.u8[3] = (datalayer.battery.info.total_capacity_Wh >> 24);
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 


### PR DESCRIPTION
### What
Fix Solax CAN message contents
- Fix 1874 msg where remaining kwh was included instead of total kwh.
- Fix 1874 msg where actual min/max cell voltages were included instead of design min/max cell voltages
- Fix 1876 msg where actual min/max temperature were missing
- Fix 1878 msg where more bytes are available for total capacit3
- Fix 187E msg where remaining kwh was included instead of total kwh.

Values where confirmed with Home assistant modbus integration reading a G4 X1 inverter.

### Why
I encountered issues while charging with 7.5kW with my Solax G4 X1 inverter.
Some of the information retrieved with Home assistant modbus integration was not correct, the implementation of the modbus protocol however seems to conform to the spec from Solax.

### How
Fix message contents, see above.
