### PR TITLE
Bugfix for mqtt crash & platformio update

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -114,7 +114,8 @@
 //#define FUNCTION_TIME_MEASUREMENT  // Enable this to record execution times and present them in the web UI (WARNING, raises CPU load, do not use for production)
 
 /* MQTT options */
-// #define MQTT  // Enable this line to enable MQTT
+// #define MQTT     // Enable this line to enable MQTT
+#define MQTT_QOS 0  // MQTT Quality of Service (0, 1, or 2)
 #define MQTT_MANUAL_TOPIC_OBJECT_NAME
 // Enable MQTT_MANUAL_TOPIC_OBJECT_NAME to use custom MQTT topic, object ID prefix, and device name.
 // WARNING: If this is not defined, the previous default naming format 'battery-emulator_esp32-XXXXXX' (based on hardware ID) will be used.

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -538,6 +538,6 @@ void mqtt_loop(void) {
 }
 
 bool mqtt_publish(const char* topic, const char* mqtt_msg, bool retain) {
-  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), 1, retain);
+  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), MQTT_QOS, retain);
   return msg_id > -1;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,7 @@
 src_dir = ./Software
 
 [env:esp32dev]
-platform = espressif32
-platform_packages=
-  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.4
-  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.4/esp32-arduino-libs-3.0.4.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.11/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file


### PR DESCRIPTION
This PR adds a new setting MQTT_QOS with a default value of 0 to stop crashes when the mqtt server is unavailable but still allow higher QoS when desired

It also updates the platformio config to use ESP 3.1.1 as it was using an out of date version

Fix for #824 