### PR TITLE
Fix for compilation errors when HA_AUTODISCOVERY is commented out

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -38,7 +38,6 @@ static void publish_values(void) {
 }
 
 #ifdef HA_AUTODISCOVERY
-
 static bool ha_common_info_published = false;
 static bool ha_cell_voltages_published = false;
 static bool ha_events_published = false;
@@ -132,6 +131,7 @@ void set_common_discovery_attributes(JsonDocument& doc) {
   doc["payload_not_available"] = "offline";
   doc["enabled_by_default"] = true;
 }
+#endif  // HA_AUTODISCOVERY
 
 void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& battery, const String& suffix) {
   doc["SOC" + suffix] = ((float)battery.status.reported_soc) / 100.0;
@@ -155,6 +155,7 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   doc["max_charge_power" + suffix] = ((float)battery.status.max_charge_power_W);
 }
 
+#ifdef HA_AUTODISCOVERY
 void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, const String& state_topic,
                                     const String& object_id_prefix, const String& battery_name_suffix) {
   doc["name"] = "Battery" + battery_name_suffix + " Cell Voltage " + String(cellNumber);
@@ -166,7 +167,6 @@ void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, co
   doc["unit_of_measurement"] = "V";
   doc["value_template"] = "{{ value_json.cell_voltages[" + String(i) + "] }}";
 }
-
 #endif  // HA_AUTODISCOVERY
 
 static std::vector<EventData> order_events;
@@ -425,6 +425,7 @@ void mqtt_message_received(char* topic, int topic_len, char* data, int data_len)
   }
 #endif  // REMOTE_BMS_RESET
 
+#ifdef HA_AUTODISCOVERY
   if (strncmp(topic, generateButtonTopic("PAUSE").c_str(), topic_len) == 0) {
     setBatteryPause(true, false);
   }
@@ -442,6 +443,7 @@ void mqtt_message_received(char* topic, int topic_len, char* data, int data_len)
   if (strncmp(topic, generateButtonTopic("STOP").c_str(), topic_len) == 0) {
     setBatteryPause(true, false, true);
   }
+#endif  // HA_AUTODISCOVERY
 }
 
 static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_t event_id, void* event_data) {
@@ -538,6 +540,6 @@ void mqtt_loop(void) {
 }
 
 bool mqtt_publish(const char* topic, const char* mqtt_msg, bool retain) {
-  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), MQTT_QOS, retain);
+  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), 1, retain);
   return msg_id > -1;
 }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -113,10 +113,6 @@ static String generateEventsAutoConfigTopic(const char* object_id) {
   return "homeassistant/sensor/" + topic_name + "/" + String(object_id) + "/config";
 }
 
-static String generateButtonTopic(const char* subtype) {
-  return topic_name + "/command/" + String(subtype);
-}
-
 static String generateButtonAutoConfigTopic(const char* subtype) {
   return "homeassistant/button/" + topic_name + "/" + String(subtype) + "/config";
 }
@@ -131,7 +127,23 @@ void set_common_discovery_attributes(JsonDocument& doc) {
   doc["payload_not_available"] = "offline";
   doc["enabled_by_default"] = true;
 }
+
+void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, const String& state_topic,
+                                    const String& object_id_prefix, const String& battery_name_suffix) {
+  doc["name"] = "Battery" + battery_name_suffix + " Cell Voltage " + String(cellNumber);
+  doc["object_id"] = object_id_prefix + "battery_voltage_cell" + String(cellNumber);
+  doc["unique_id"] = topic_name + object_id_prefix + "_battery_voltage_cell" + String(cellNumber);
+  doc["device_class"] = "voltage";
+  doc["state_class"] = "measurement";
+  doc["state_topic"] = state_topic;
+  doc["unit_of_measurement"] = "V";
+  doc["value_template"] = "{{ value_json.cell_voltages[" + String(i) + "] }}";
+}
 #endif  // HA_AUTODISCOVERY
+
+static String generateButtonTopic(const char* subtype) {
+  return topic_name + "/command/" + String(subtype);
+}
 
 void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& battery, const String& suffix) {
   doc["SOC" + suffix] = ((float)battery.status.reported_soc) / 100.0;
@@ -154,20 +166,6 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   doc["max_discharge_power" + suffix] = ((float)battery.status.max_discharge_power_W);
   doc["max_charge_power" + suffix] = ((float)battery.status.max_charge_power_W);
 }
-
-#ifdef HA_AUTODISCOVERY
-void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, const String& state_topic,
-                                    const String& object_id_prefix, const String& battery_name_suffix) {
-  doc["name"] = "Battery" + battery_name_suffix + " Cell Voltage " + String(cellNumber);
-  doc["object_id"] = object_id_prefix + "battery_voltage_cell" + String(cellNumber);
-  doc["unique_id"] = topic_name + object_id_prefix + "_battery_voltage_cell" + String(cellNumber);
-  doc["device_class"] = "voltage";
-  doc["state_class"] = "measurement";
-  doc["state_topic"] = state_topic;
-  doc["unit_of_measurement"] = "V";
-  doc["value_template"] = "{{ value_json.cell_voltages[" + String(i) + "] }}";
-}
-#endif  // HA_AUTODISCOVERY
 
 static std::vector<EventData> order_events;
 
@@ -425,7 +423,6 @@ void mqtt_message_received(char* topic, int topic_len, char* data, int data_len)
   }
 #endif  // REMOTE_BMS_RESET
 
-#ifdef HA_AUTODISCOVERY
   if (strncmp(topic, generateButtonTopic("PAUSE").c_str(), topic_len) == 0) {
     setBatteryPause(true, false);
   }
@@ -443,7 +440,6 @@ void mqtt_message_received(char* topic, int topic_len, char* data, int data_len)
   if (strncmp(topic, generateButtonTopic("STOP").c_str(), topic_len) == 0) {
     setBatteryPause(true, false, true);
   }
-#endif  // HA_AUTODISCOVERY
 }
 
 static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_t event_id, void* event_data) {
@@ -484,8 +480,9 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_
 
 void init_mqtt(void) {
 
-#ifdef MQTT
+#ifdef HA_AUTODISCOVERY
   create_sensor_configs();
+#endif  // HA_AUTODISCOVERY
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
   // Use custom topic name, object ID prefix, and device name from user settings
   topic_name = mqtt_topic_name;
@@ -498,7 +495,6 @@ void init_mqtt(void) {
   object_id_prefix = String(WiFi.getHostname()) + String("_");
   device_name = "BatteryEmulator_" + String(WiFi.getHostname());
   device_id = "battery-emulator";
-#endif
 #endif
 
   char clientId[64];  // Adjust the size as needed
@@ -540,6 +536,6 @@ void mqtt_loop(void) {
 }
 
 bool mqtt_publish(const char* topic, const char* mqtt_msg, bool retain) {
-  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), 1, retain);
+  int msg_id = esp_mqtt_client_publish(client, topic, mqtt_msg, strlen(mqtt_msg), MQTT_QOS, retain);
   return msg_id > -1;
 }

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -20,7 +20,7 @@
 /* - ERROR CHECKS BELOW, DON'T TOUCH - */
 
 #if !defined(HW_CONFIGURED)
-#error You must select a target hardware in the USER_SERTTINGS.h file!
+#error You must select a target hardware in the USER_SETTINGS.h file!
 #endif
 
 #ifdef USE_CANFD_INTERFACE_AS_CLASSIC_CAN


### PR DESCRIPTION
What

This PR fixes MQTT build errors when autodiscovery is disabled and mqtt is enabled as per issue #831 - pre-commit now run/checked :-)

Why

Build fails when #define HA_AUTODISCOVERY is commented out (disabled) in USER_SETTINGS.h

How

ifdefs changed to incorporate missing function definitions
