### PR TITLE
Add warning event if SD card fails to initialize

### DIFF
--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -191,12 +191,14 @@ void init_sdcard() {
 
   SD_MMC.setPins(SD_SCLK_PIN, SD_MOSI_PIN, SD_MISO_PIN);
   if (!SD_MMC.begin("/root", true, true, SDMMC_FREQ_HIGHSPEED)) {
+    set_event_latched(EVENT_SD_INIT_FAILED, 0);
 #ifdef DEBUG_LOG
     logging.println("SD Card initialization failed!");
 #endif  // DEBUG_LOG
     return;
   }
 
+  clear_event(EVENT_SD_INIT_FAILED);
 #ifdef DEBUG_LOG
   logging.println("SD Card initialization successful.");
 #endif  // DEBUG_LOG

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -4,6 +4,7 @@
 #include <SD_MMC.h>
 #include "../../communication/can/comm_can.h"
 #include "../hal/hal.h"
+#include "../utils/events.h"
 
 #if defined(SD_CS_PIN) && defined(SD_SCLK_PIN) && defined(SD_MOSI_PIN) && \
     defined(SD_MISO_PIN)  // ensure code is only compiled if all SD card pins are defined

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -217,6 +217,7 @@ void init_events(void) {
   events.entries[EVENT_MQTT_CONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MQTT_DISCONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_EQUIPMENT_STOP].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_SD_INIT_FAILED].level = EVENT_LEVEL_WARNING;
 
   events.entries[EVENT_EEPROM_WRITE].log = false;  // Don't log the logger...
 
@@ -443,6 +444,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "MQTT disconnected.";
     case EVENT_EQUIPMENT_STOP:
       return "EQUIPMENT STOP ACTIVATED!!!";
+    case EVENT_SD_INIT_FAILED:
+      return "SD card initialization failed, check hardware. Power must be removed to reset the SD card.";
     default:
       return "";
   }

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0022  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0023  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -115,6 +115,7 @@
   XX(EVENT_MQTT_DISCONNECT)             \
   XX(EVENT_EQUIPMENT_STOP)              \
   XX(EVENT_AUTOMATIC_PRECHARGE_FAILURE) \
+  XX(EVENT_SD_INIT_FAILED)              \
   XX(EVENT_NOF_EVENTS)
 
 typedef enum { EVENTS_ENUM_TYPE(GENERATE_ENUM) } EVENTS_ENUM_TYPE;


### PR DESCRIPTION
### What
This PR adds a warning event on SD initialization failure to make it more visible when a failure occurs. It includes the messages that a power reset is required if you end up in this state.