### PR TITLE
BYD Atto3: Add 10 temperature sensors to datalayer

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -135,6 +135,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
 
+#ifdef SKIP_TEMPERATURE_SENSOR_NUMBER
   // Initialize min and max variables for temperature calculation
   battery_calc_min_temperature = battery_daughterboard_temperatures[0];
   battery_calc_max_temperature = battery_daughterboard_temperatures[0];
@@ -146,7 +147,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
     battery_calc_max_temperature = battery_daughterboard_temperatures[1];
   }
   for (int i = 1; i < 10; i++) {
-    if (i == SKIP_TEMPERATURE_SENSOR_NUMBER) {
+    if (i == (SKIP_TEMPERATURE_SENSOR_NUMBER - 1)) {
       i++;
     }
     if (battery_daughterboard_temperatures[i] < battery_calc_min_temperature) {
@@ -159,6 +160,10 @@ void update_values_battery() {  //This function maps all the values fetched via 
   //Write the result to datalayer
   datalayer.battery.status.temperature_min_dC = battery_calc_min_temperature * 10;
   datalayer.battery.status.temperature_max_dC = battery_calc_max_temperature * 10;
+#else   //User does not need filtering out a broken sensor, just use the min-max the BMS sends
+  datalayer.battery.status.temperature_min_dC = BMS_lowest_cell_temperature * 10;
+  datalayer.battery.status.temperature_max_dC = BMS_highest_cell_temperature * 10;
+#endif  //!SKIP_TEMPERATURE_SENSOR_NUMBER
 
   // Update webserver datalayer
   datalayer_extended.bydAtto3.SOC_method = SOC_method;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -147,6 +147,16 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bydAtto3.SOC_polled = BMS_SOC;
   datalayer_extended.bydAtto3.voltage_periodic = battery_voltage;
   datalayer_extended.bydAtto3.voltage_polled = BMS_voltage;
+  datalayer_extended.bydAtto3.battery_temperatures[0] = battery_daughterboard_temperatures[0];
+  datalayer_extended.bydAtto3.battery_temperatures[1] = battery_daughterboard_temperatures[1];
+  datalayer_extended.bydAtto3.battery_temperatures[2] = battery_daughterboard_temperatures[2];
+  datalayer_extended.bydAtto3.battery_temperatures[3] = battery_daughterboard_temperatures[3];
+  datalayer_extended.bydAtto3.battery_temperatures[4] = battery_daughterboard_temperatures[4];
+  datalayer_extended.bydAtto3.battery_temperatures[5] = battery_daughterboard_temperatures[5];
+  datalayer_extended.bydAtto3.battery_temperatures[6] = battery_daughterboard_temperatures[6];
+  datalayer_extended.bydAtto3.battery_temperatures[7] = battery_daughterboard_temperatures[7];
+  datalayer_extended.bydAtto3.battery_temperatures[8] = battery_daughterboard_temperatures[8];
+  datalayer_extended.bydAtto3.battery_temperatures[9] = battery_daughterboard_temperatures[9];
 }
 
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -135,9 +135,30 @@ void update_values_battery() {  //This function maps all the values fetched via 
 
   datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
 
-  datalayer.battery.status.temperature_min_dC = BMS_lowest_cell_temperature * 10;  // Add decimals
+  // Initialize min and max variables for temperature calculation
+  battery_calc_min_temperature = battery_daughterboard_temperatures[0];
+  battery_calc_max_temperature = battery_daughterboard_temperatures[0];
 
-  datalayer.battery.status.temperature_max_dC = BMS_highest_cell_temperature * 10;
+  // Loop through the array of 10x daughterboard temps to find the smallest and largest values
+  // Note, it is possible for user to skip using a faulty sensor in the .h file
+  if (SKIP_TEMPERATURE_SENSOR_NUMBER == 1) {  //If sensor 1 is skipped, init minmax to sensor 2
+    battery_calc_min_temperature = battery_daughterboard_temperatures[1];
+    battery_calc_max_temperature = battery_daughterboard_temperatures[1];
+  }
+  for (int i = 1; i < 10; i++) {
+    if (i == SKIP_TEMPERATURE_SENSOR_NUMBER) {
+      i++;
+    }
+    if (battery_daughterboard_temperatures[i] < battery_calc_min_temperature) {
+      battery_calc_min_temperature = battery_daughterboard_temperatures[i];
+    }
+    if (battery_daughterboard_temperatures[i] > battery_calc_max_temperature) {
+      battery_calc_max_temperature = battery_daughterboard_temperatures[i];
+    }
+  }
+  //Write the result to datalayer
+  datalayer.battery.status.temperature_min_dC = battery_calc_min_temperature * 10;
+  datalayer.battery.status.temperature_max_dC = battery_calc_max_temperature * 10;
 
   // Update webserver datalayer
   datalayer_extended.bydAtto3.SOC_method = SOC_method;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -8,7 +8,9 @@
 #define MAXPOWER_CHARGE_W 10000
 #define MAXPOWER_DISCHARGE_W 10000
 
-#define SKIP_TEMPERATURE_SENSOR_NUMBER 0  // Enter incase one of your temperature sensors are broken (1-10)
+//Uncomment and configure this line, if you want to filter out a broken temperature sensor (1-10)
+//Make sure you understand risks associated with disabling. Values can be read via "More Battery info"
+//#define SKIP_TEMPERATURE_SENSOR_NUMBER 1
 
 /* Do not modify the rows below */
 #define BATTERY_SELECTED

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -8,6 +8,8 @@
 #define MAXPOWER_CHARGE_W 10000
 #define MAXPOWER_DISCHARGE_W 10000
 
+#define SKIP_TEMPERATURE_SENSOR_NUMBER 0  // Enter incase one of your temperature sensors are broken (1-10)
+
 /* Do not modify the rows below */
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4410  //5000 = 500.0V

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -181,7 +181,9 @@ typedef struct {
   /** uint16_t */
   /** Voltage polled OBD2*/
   uint16_t voltage_polled = 0;
-
+  /** int16_t */
+  /** All the temperature sensors inside the battery pack*/
+  int16_t battery_temperatures[10];
 } DATALAYER_INFO_BYDATTO3;
 
 typedef struct {

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -469,6 +469,16 @@ String advanced_battery_processor(const String& var) {
     content += "<h4>SOC OBD2: " + String(datalayer_extended.bydAtto3.SOC_polled) + "</h4>";
     content += "<h4>Voltage periodic: " + String(datalayer_extended.bydAtto3.voltage_periodic) + "</h4>";
     content += "<h4>Voltage OBD2: " + String(datalayer_extended.bydAtto3.voltage_polled) + "</h4>";
+    content += "<h4>Temperature sensor 1: " + String(datalayer_extended.bydAtto3.battery_temperatures[0]) + "</h4>";
+    content += "<h4>Temperature sensor 2: " + String(datalayer_extended.bydAtto3.battery_temperatures[1]) + "</h4>";
+    content += "<h4>Temperature sensor 3: " + String(datalayer_extended.bydAtto3.battery_temperatures[2]) + "</h4>";
+    content += "<h4>Temperature sensor 4: " + String(datalayer_extended.bydAtto3.battery_temperatures[3]) + "</h4>";
+    content += "<h4>Temperature sensor 5: " + String(datalayer_extended.bydAtto3.battery_temperatures[4]) + "</h4>";
+    content += "<h4>Temperature sensor 6: " + String(datalayer_extended.bydAtto3.battery_temperatures[5]) + "</h4>";
+    content += "<h4>Temperature sensor 7: " + String(datalayer_extended.bydAtto3.battery_temperatures[6]) + "</h4>";
+    content += "<h4>Temperature sensor 8: " + String(datalayer_extended.bydAtto3.battery_temperatures[7]) + "</h4>";
+    content += "<h4>Temperature sensor 9: " + String(datalayer_extended.bydAtto3.battery_temperatures[8]) + "</h4>";
+    content += "<h4>Temperature sensor 10: " + String(datalayer_extended.bydAtto3.battery_temperatures[9]) + "</h4>";
 #endif  //BYD_ATTO_3_BATTERY
 
 #ifdef TESLA_BATTERY


### PR DESCRIPTION
### What
This PR makes it so you can track all 10 temperature sensors inside the battery

It also adds a method to skip using a specific temperature sensor, if you know it is broken.

Example, Sensor number 4 broken

![image](https://github.com/user-attachments/assets/60df2743-7418-4f20-bfd1-2b27423f827b)

![image](https://github.com/user-attachments/assets/2d6ed734-79f7-40cf-bd55-48bfc9554243)


### Why
Better way to monitor the battery.

Also adds a way to use a battery without needing to replace a daughterboard with broken temp sensor (Note, requires deep knowledge of actual battery status)

### How
All 10x measurements added to extended datalayer

Configurable option in .h file, SKIP_TEMPERATURE_SENSOR_NUMBER that can be tuned between 1-10 if needed
