### PR TITLE
Tesla S/3/X/Y: Update rampdown power

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -10,8 +10,7 @@
 
 /* Do not change the defines below */
 #define RAMPDOWN_SOC 900  // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
-#define RAMPDOWNPOWERALLOWED \
-  15000  // What power we ramp down from towards top balancing (usually same as MAXCHARGEPOWERALLOWED)
+#define RAMPDOWNPOWERALLOWED 10000  // What power we ramp down from towards top balancing
 #define FLOAT_MAX_POWER_W 200  // W, what power to allow for top balancing battery
 #define FLOAT_START_MV 20      // mV, how many mV under overvoltage to start float charging
 

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -9,10 +9,10 @@
 #define MAXDISCHARGEPOWERALLOWED 60000  // 60000W we use a define since the value supplied by Tesla is always 0
 
 /* Do not change the defines below */
-#define RAMPDOWN_SOC 900  // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
+#define RAMPDOWN_SOC 900            // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define RAMPDOWNPOWERALLOWED 10000  // What power we ramp down from towards top balancing
-#define FLOAT_MAX_POWER_W 200  // W, what power to allow for top balancing battery
-#define FLOAT_START_MV 20      // mV, how many mV under overvoltage to start float charging
+#define FLOAT_MAX_POWER_W 200       // W, what power to allow for top balancing battery
+#define FLOAT_START_MV 20           // mV, how many mV under overvoltage to start float charging
 
 #define MAX_PACK_VOLTAGE_SX_NCMA 4600   // V+1, if pack voltage goes over this, charge stops
 #define MIN_PACK_VOLTAGE_SX_NCMA 3100   // V+1, if pack voltage goes over this, charge stops


### PR DESCRIPTION
### What
This PR updates the default rampdown powervalue for Tesla batteries

### Why
We had an user that overcharged their Tesla LFP pack, since the current values still allow for almost 7kW charging at 97%SOC.

![image](https://github.com/user-attachments/assets/9fcb80dd-3b5f-4b1d-8391-cd6b173bb01a)
![image](https://github.com/user-attachments/assets/5adae04c-be5b-4c4c-b82a-ac17b6f5994f)

### How
Instead of starting the rampdown from 15kW at 90%, we now start at 10kW. This change will hopefully allow for the cellvoltage safeties to have more time to react, and write allowed power to 0W incase it starts to get out of hand
