### PR TITLE
iX Battery Type - Send BMS Reset at startup

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -790,6 +790,9 @@ void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
 
+  //Reset Battery at bootup
+  transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET, can_config.battery);
+
   //Before we have started up and detected which battery is in use, use 108S values
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -15,7 +15,7 @@
 #define MAX_CHARGE_POWER_WHEN_TOPBALANCING_W 500
 #define RAMPDOWN_SOC 9000  // (90.00) SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define STALE_PERIOD_CONFIG \
-  300000;  //Number of milliseconds before critical values are classed as stale/stuck 300000 = 300 seconds
+  400000;  //Number of milliseconds before critical values are classed as stale/stuck 300000 = 400 seconds
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);
 


### PR DESCRIPTION

### What
A fix to reset battery at BatEmu startup

### Why
Previously if BMS was already in error state at battery emulator it will fail to auto reset.

### How
Sends a BMS reset can frame at boot. Also extends stale timeout as it's possible to trigger it in solar/use equilibrium.
