### PR TITLE
Pylon: Fix compilation error when using SET_30K_OFFSET

### DIFF
--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -310,7 +310,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   PYLON_4271.data.u8[3] = (datalayer.battery.status.temperature_min_dC >> 8);
 #else  // Not INVERT_LOW_HIGH_BYTES
   //Voltage (370.0)
-  PYLON_4210.data.u8[0] = (datalayer.battery.status.voltage_dV >> 8;
+  PYLON_4210.data.u8[0] = (datalayer.battery.status.voltage_dV >> 8);
   PYLON_4210.data.u8[1] = (datalayer.battery.status.voltage_dV & 0x00FF);
   PYLON_4211.data.u8[0] = (datalayer.battery.status.voltage_dV >> 8);
   PYLON_4211.data.u8[1] = (datalayer.battery.status.voltage_dV & 0x00FF);
@@ -348,28 +348,28 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 
 #ifdef SET_30K_OFFSET
   //Max ChargeCurrent
-  PYLON_4220.data.u8[4] = ((max_charge_current + 30000) >> 8);
-  PYLON_4220.data.u8[5] = ((max_charge_current + 30000) & 0x00FF);
-  PYLON_4221.data.u8[4] = ((max_charge_current + 30000) >> 8);
-  PYLON_4221.data.u8[5] = ((max_charge_current + 30000) & 0x00FF);
+  PYLON_4220.data.u8[4] = ((datalayer.battery.status.max_charge_current_dA + 30000) >> 8);
+  PYLON_4220.data.u8[5] = ((datalayer.battery.status.max_charge_current_dA + 30000) & 0x00FF);
+  PYLON_4221.data.u8[4] = ((datalayer.battery.status.max_charge_current_dA + 30000) >> 8);
+  PYLON_4221.data.u8[5] = ((datalayer.battery.status.max_charge_current_dA + 30000) & 0x00FF);
 
   //Max DischargeCurrent
-  PYLON_4220.data.u8[6] = ((30000 - max_discharge_current) >> 8);
-  PYLON_4220.data.u8[7] = ((30000 - max_discharge_current) & 0x00FF);
-  PYLON_4221.data.u8[6] = ((30000 - max_discharge_current) >> 8);
-  PYLON_4221.data.u8[7] = ((30000 - max_discharge_current) & 0x00FF);
+  PYLON_4220.data.u8[6] = ((30000 - datalayer.battery.status.max_discharge_current_dA) >> 8);
+  PYLON_4220.data.u8[7] = ((30000 - datalayer.battery.status.max_discharge_current_dA) & 0x00FF);
+  PYLON_4221.data.u8[6] = ((30000 - datalayer.battery.status.max_discharge_current_dA) >> 8);
+  PYLON_4221.data.u8[7] = ((30000 - datalayer.battery.status.max_discharge_current_dA) & 0x00FF);
 #else   // Not SET_30K_OFFSET
   //Max ChargeCurrent
-  PYLON_4220.data.u8[4] = (max_charge_current >> 8);
-  PYLON_4220.data.u8[5] = (max_charge_current & 0x00FF);
-  PYLON_4221.data.u8[4] = (max_charge_current >> 8);
-  PYLON_4221.data.u8[5] = (max_charge_current & 0x00FF);
+  PYLON_4220.data.u8[4] = (datalayer.battery.status.max_charge_current_dA >> 8);
+  PYLON_4220.data.u8[5] = (datalayer.battery.status.max_charge_current_dA & 0x00FF);
+  PYLON_4221.data.u8[4] = (datalayer.battery.status.max_charge_current_dA >> 8);
+  PYLON_4221.data.u8[5] = (datalayer.battery.status.max_charge_current_dA & 0x00FF);
 
   //Max DishargeCurrent
-  PYLON_4220.data.u8[6] = (max_discharge_current >> 8);
-  PYLON_4220.data.u8[7] = (max_discharge_current & 0x00FF);
-  PYLON_4221.data.u8[6] = (max_discharge_current >> 8);
-  PYLON_4221.data.u8[7] = (max_discharge_current & 0x00FF);
+  PYLON_4220.data.u8[6] = (datalayer.battery.status.max_discharge_current_dA >> 8);
+  PYLON_4220.data.u8[7] = (datalayer.battery.status.max_discharge_current_dA & 0x00FF);
+  PYLON_4221.data.u8[6] = (datalayer.battery.status.max_discharge_current >> 8);
+  PYLON_4221.data.u8[7] = (datalayer.battery.status.max_discharge_current_dA & 0x00FF);
 #endif  //SET_30K_OFFSET
 
   //Max cell voltage


### PR DESCRIPTION
### What
This PR fixes a compilation error, when using SET_30K_OFFSET

![image](https://github.com/user-attachments/assets/e619efe6-9570-4aff-8aa2-a55d9b156a47)


### Why
We fix is to users can use Pylon CAN with all inverters

### How
Fix the compilation errors