### PR TITLE
Improvement: Tigthen cellvoltage warnings on most batteries

### DIFF
--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -7,7 +7,7 @@
 
 #define MAX_PACK_VOLTAGE_DV 4150  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 2500
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -6,7 +6,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 3696  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3160
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 250
 #define MAX_CELL_VOLTAGE_MV 4150  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2750  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -5,7 +5,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4546  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3370
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 250
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -6,7 +6,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 2600
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -10,7 +10,7 @@
 #define MIN_PACK_VOLTAGE_DV 1500
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -6,11 +6,11 @@
 #define BATTERY_SELECTED
 
 /* Change the following to suit your battery */
-#define MAX_PACK_VOLTAGE_DV 5000   //TODO: Configure
-#define MIN_PACK_VOLTAGE_DV 0      //TODO: Configure
-#define MAX_CELL_VOLTAGE_MV 4250   //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700   //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 500  //TODO: Configure
+#define MAX_PACK_VOLTAGE_DV 5000  //TODO: Configure
+#define MIN_PACK_VOLTAGE_DV 0     //TODO: Configure
+#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_DEVIATION_MV 150
 
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -6,7 +6,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4150  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 2500
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -5,7 +5,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 579  // 57.9V at 100% SOC (with 70% SOH, new one might be higher)
 #define MIN_PACK_VOLTAGE_DV 480  // 48.4V at 13.76% SOC
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 3400  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -3,10 +3,9 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CELL_DEVIATION_MV 500
 #define MAX_PACK_VOLTAGE_DV 4200  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -5,7 +5,7 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4100  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 500
+#define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 


### PR DESCRIPTION
### What
This PR lowers the threshold needed to trigger a cellvoltage warning on most battery implementations

### Why
Many batteries were left at the default 500mV diff value, before raising an event. The idea was that feedback should be gathered from each integration, and these limits refined over time. They have now been set to the same value for a long time, so this change is long overdue. 

### How
We now tighten the limits significantly for those batteries left with essentially un-set limits
