### PR TITLE
SOLAX-CAN: message 187E should contain total_capacity.

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -198,10 +198,10 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1801.data.u8[4] = 1;
 
   //Ultra messages
-  SOLAX_187E.data.u8[0] = (uint8_t)datalayer.battery.status.reported_remaining_capacity_Wh;
-  SOLAX_187E.data.u8[1] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 8);
-  SOLAX_187E.data.u8[2] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 16);
-  SOLAX_187E.data.u8[3] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 24);
+  SOLAX_187E.data.u8[0] = (uint8_t)datalayer.battery.info.total_capacity_Wh;
+  SOLAX_187E.data.u8[1] = (datalayer.battery.info.total_capacity_Wh >> 8);
+  SOLAX_187E.data.u8[2] = (datalayer.battery.info.total_capacity_Wh >> 16);
+  SOLAX_187E.data.u8[3] = (datalayer.battery.info.total_capacity_Wh >> 24);
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 


### PR DESCRIPTION
### What
On Solax CAN message 187E should contain the total capacity of the battery.
### Why
To make solax modbus report the bms capacity value correct.

### How
Report the correct value.
