### PR TITLE
Feature: Add limiting factor to Webserver

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -335,13 +335,48 @@ void update_calculated_values() {
   /* Restrict values from user settings if needed*/
   if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
     datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
+    datalayer.battery.settings.user_settings_limit_charge = true;
+  } else {
+    datalayer.battery.settings.user_settings_limit_charge = false;
   }
   if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
     datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
+    datalayer.battery.settings.user_settings_limit_discharge = true;
+  } else {
+    datalayer.battery.settings.user_settings_limit_discharge = false;
   }
   /* Calculate active power based on voltage and current*/
   datalayer.battery.status.active_power_W =
       (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));
+  /* Calculate if battery or inverter is limiting factor*/
+
+  if (datalayer.battery.status.current_dA == 0) {  //Battery idle
+    if (datalayer.battery.status.max_discharge_current_dA > 0) {
+      //We allow discharge, but inverter does nothing. Inverter is limiting
+      datalayer.battery.settings.inverter_limits_discharge = true;
+    } else {
+      datalayer.battery.settings.inverter_limits_discharge = false;
+    }
+    if (datalayer.battery.status.max_charge_current_dA > 0) {
+      //We allow charge, but inverter does nothing. Inverter is limiting
+      datalayer.battery.settings.inverter_limits_charge = true;
+    } else {
+      datalayer.battery.settings.inverter_limits_charge = false;
+    }
+  } else if (datalayer.battery.status.current_dA < 0) {  //Battery discharging
+    if (-datalayer.battery.status.current_dA < datalayer.battery.status.max_discharge_current_dA) {
+      datalayer.battery.settings.inverter_limits_discharge = true;
+    } else {
+      datalayer.battery.settings.inverter_limits_discharge = false;
+    }
+  } else {  // > 0 Battery charging
+    //If actual current is smaller than max we allow, inverter is limiting factor
+    if (datalayer.battery.status.current_dA < datalayer.battery.status.max_charge_current_dA) {
+      datalayer.battery.settings.inverter_limits_charge = true;
+    } else {
+      datalayer.battery.settings.inverter_limits_charge = false;
+    }
+  }
 
 #ifdef DOUBLE_BATTERY
   /* Calculate active power based on voltage and current for battery 2*/

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -124,6 +124,12 @@ typedef struct {
   /** The user specified maximum allowed discharge voltage, in deciVolt. 3000 = 300.0 V */
   uint16_t max_user_set_discharge_voltage_dV = BATTERY_MAX_DISCHARGE_VOLTAGE;
 
+  /** Parameters for keeping track of the limiting factor in the system */
+  bool user_settings_limit_discharge = false;
+  bool user_settings_limit_charge = false;
+  bool inverter_limits_discharge = false;
+  bool inverter_limits_charge = false;
+
   /** Tesla specific settings that are edited on the fly when manually forcing a balance charge for LFP chemistry */
   /* Bool for specifying if user has requested manual function */
   bool user_requests_balancing = false;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -885,8 +885,18 @@ String processor(const String& var) {
     } else {
       content += formatPowerValue("Max discharge power", datalayer.battery.status.max_discharge_power_W, "", 1);
       content += formatPowerValue("Max charge power", datalayer.battery.status.max_charge_power_W, "", 1);
-      content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A</h4>";
-      content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
+      content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A";
+      if (datalayer.battery.settings.user_settings_limit_discharge) {
+        content += " (Manual)</h4>";
+      } else {
+        content += " (BMS)</h4>";
+      }
+      content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A";
+      if (datalayer.battery.settings.user_settings_limit_charge) {
+        content += " (Manual)</h4>";
+      } else {
+        content += " (BMS)</h4>";
+      }
     }
 
     content += "<h4>Cell max: " + String(datalayer.battery.status.cell_max_voltage_mV) + " mV</h4>";
@@ -947,9 +957,22 @@ String processor(const String& var) {
     if (datalayer.battery.status.current_dA == 0) {
       content += "<h4>Battery idle</h4>";
     } else if (datalayer.battery.status.current_dA < 0) {
-      content += "<h4>Battery discharging!</h4>";
-    } else {  // > 0
-      content += "<h4>Battery charging!</h4>";
+      content += "<h4>Battery discharging!";
+      if (datalayer.battery.settings.inverter_limits_discharge) {
+        content += " (Inverter limiting)</h4>";
+      } else {
+        //Note, this can also be settings limiting
+        content += " (Battery limiting)</h4>";
+      }
+      content += "</h4>";
+    } else {  // > 0 , positive current
+      content += "<h4>Battery charging!";
+      if (datalayer.battery.settings.inverter_limits_charge) {
+        content += " (Inverter limiting)</h4>";
+      } else {
+        //Note, this can also be settings limiting
+        content += " (Battery limiting)</h4>";
+      }
     }
 
     content += "<h4>Automatic contactor closing allowed:</h4>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -961,8 +961,11 @@ String processor(const String& var) {
       if (datalayer.battery.settings.inverter_limits_discharge) {
         content += " (Inverter limiting)</h4>";
       } else {
-        //Note, this can also be settings limiting
-        content += " (Battery limiting)</h4>";
+        if (datalayer.battery.settings.user_settings_limit_discharge) {
+          content += " (Settings limiting)</h4>";
+        } else {
+          content += " (Battery limiting)</h4>";
+        }
       }
       content += "</h4>";
     } else {  // > 0 , positive current
@@ -970,8 +973,11 @@ String processor(const String& var) {
       if (datalayer.battery.settings.inverter_limits_charge) {
         content += " (Inverter limiting)</h4>";
       } else {
-        //Note, this can also be settings limiting
-        content += " (Battery limiting)</h4>";
+        if (datalayer.battery.settings.user_settings_limit_charge) {
+          content += " (Settings limiting)</h4>";
+        } else {
+          content += " (Battery limiting)</h4>";
+        }
       }
     }
 


### PR DESCRIPTION
### What
This PR implements an user requested feature, Webserver to show what is limiting power in/out of the battery.

### Why
Feature requested by Discord users

### How
We implement a few new variables to the datalayer

- user_settings_limit_charge
- user_settings_limit_discharge

Based on these, we show in the Webserver when the charge/discharge amperage values are limited by the battery itself (BMS), or by the user configurable settings (Manual)

![image](https://github.com/user-attachments/assets/17505198-e9e3-4c02-9270-40f393b14ebc)

We also show if the Inverter or the Battery is the limiting factor, at the Battery Charging/Discharging text, using the following variables

- inverter_limits_discharge
- inverter_limits_charge

![image](https://github.com/user-attachments/assets/264ced38-13a8-49b7-a5a9-b7622376ea06)

![image](https://github.com/user-attachments/assets/acaa7804-feeb-4b27-bf0e-d2fc4217920d)
