### PR TITLE
BYD CAN: Safety, add overriding SOC incase of 0W allowed

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -126,6 +126,16 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //SOC (100.00%)
   BYD_150.data.u8[0] = (datalayer.battery.status.reported_soc >> 8);
   BYD_150.data.u8[1] = (datalayer.battery.status.reported_soc & 0x00FF);
+  if (datalayer.battery.status.max_charge_current_dA == 0) {
+    //Force to 100.00% incase battery no longer wants to charge
+    BYD_150.data.u8[0] = (10000 >> 8);
+    BYD_150.data.u8[1] = (10000 & 0x00FF);
+  }
+  if (datalayer.battery.status.max_discharge_current_dA == 0) {
+    //Force to 0% incase battery no longer wants to discharge
+    BYD_150.data.u8[0] = 0;
+    BYD_150.data.u8[1] = 0;
+  }
   //StateOfHealth (100.00%)
   BYD_150.data.u8[2] = (datalayer.battery.status.soh_pptt >> 8);
   BYD_150.data.u8[3] = (datalayer.battery.status.soh_pptt & 0x00FF);


### PR DESCRIPTION
### What
This PR implements a safety check to the BYD CAN protocol. Incase the battery no longer wants to charge, we send 100% SOC, and incase it no longer wants to discharge, we send 0% SOC

### Why
To avoid offgrid Deye inverters overdischarging batteries, as reported in https://github.com/dalathegreat/Battery-Emulator/issues/873

### How
If checks