### PR TITLE
Init event handling before any use of events

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -80,6 +80,8 @@ void setup() {
   // We print this after setting up serial, such that is also printed to serial with DEBUG_VIA_USB set.
   logging.printf("Battery emulator %s build " __DATE__ " " __TIME__ "\n", version_number);
 
+  init_events();
+
   init_stored_settings();
 
 #ifdef WIFI
@@ -91,8 +93,6 @@ void setup() {
   xTaskCreatePinnedToCore((TaskFunction_t)&logging_loop, "logging_loop", 4096, &logging_task_time_us,
                           TASK_CONNECTIVITY_PRIO, &logging_loop_task, WIFI_CORE);
 #endif
-
-  init_events();
 
   init_CAN();
 

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -198,10 +198,10 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_1801.data.u8[4] = 1;
 
   //Ultra messages
-  SOLAX_187E.data.u8[0] = (uint8_t)datalayer.battery.status.reported_remaining_capacity_Wh;
-  SOLAX_187E.data.u8[1] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 8);
-  SOLAX_187E.data.u8[2] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 16);
-  SOLAX_187E.data.u8[3] = (datalayer.battery.status.reported_remaining_capacity_Wh >> 24);
+  SOLAX_187E.data.u8[0] = (uint8_t)datalayer.battery.info.total_capacity_Wh;
+  SOLAX_187E.data.u8[1] = (datalayer.battery.info.total_capacity_Wh >> 8);
+  SOLAX_187E.data.u8[2] = (datalayer.battery.info.total_capacity_Wh >> 16);
+  SOLAX_187E.data.u8[3] = (datalayer.battery.info.total_capacity_Wh >> 24);
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 


### PR DESCRIPTION
### What
Move init of events to earlier in initialisation, to prevent and event being generated before the event system is initialised.

### Why
Prevent crashes due to uninitialized values/pointers.

### How
Move the init_events function call to earlier in the setup routine.