### PR TITLE
Bugfix: Growatt HV, Add user customizable charge/discharge voltage

### DIFF
--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -164,11 +164,16 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 
   //Map values to CAN messages
-
   //Battery operating parameters and status information
-  //Recommended charge voltage (eg 400.0V = 4000 , 16bits long) (MIN 0, MAX 1000V)
-  GROWATT_3110.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV >> 8);
-  GROWATT_3110.data.u8[1] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
+  if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
+    //User specified charge voltage (eg 400.0V = 4000 , 16bits long) (MIN 0, MAX 1000V)
+    GROWATT_3110.data.u8[0] = (datalayer.battery.settings.max_user_set_charge_voltage_dV >> 8);
+    GROWATT_3110.data.u8[1] = (datalayer.battery.settings.max_user_set_charge_voltage_dV & 0x00FF);
+  } else {
+    //Battery max voltage used as charge voltage (eg 400.0V = 4000 , 16bits long) (MIN 0, MAX 1000V)
+    GROWATT_3110.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV >> 8);
+    GROWATT_3110.data.u8[1] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
+  }
   //Charge limited current, 125 =12.5A (0.1, A) (Min 0, Max 300A)
   GROWATT_3110.data.u8[2] = (datalayer.battery.status.max_charge_current_dA >> 8);
   GROWATT_3110.data.u8[3] = (datalayer.battery.status.max_charge_current_dA & 0x00FF);
@@ -239,9 +244,15 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   GROWATT_3140.data.u8[7] = 0;
 
   //Battery working parameters and module number information
-  //Discharge cutoff voltage (0.1V) [0-1000V]
-  GROWATT_3150.data.u8[0] = (datalayer.battery.info.min_design_voltage_dV >> 8);
-  GROWATT_3150.data.u8[1] = (datalayer.battery.info.min_design_voltage_dV & 0x00FF);
+  if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
+    //Use user specified voltage as Discharge cutoff voltage (0.1V) [0-1000V]
+    GROWATT_3150.data.u8[0] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV >> 8);
+    GROWATT_3150.data.u8[1] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV & 0x00FF);
+  } else {
+    //Use battery min design voltage as Discharge cutoff voltage (0.1V) [0-1000V]
+    GROWATT_3150.data.u8[0] = (datalayer.battery.info.min_design_voltage_dV >> 8);
+    GROWATT_3150.data.u8[1] = (datalayer.battery.info.min_design_voltage_dV & 0x00FF);
+  }
   //Main control unit temperature (0.1C) [-40 to 120*C]
   GROWATT_3150.data.u8[2] = (datalayer.battery.status.temperature_max_dC >> 8);
   GROWATT_3150.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);


### PR DESCRIPTION
### What
This PR implements user customizable charge/discharge voltage limits

### Why
Fixes #880 

### How
The configurable settings are in the Webserver (and in USER_SETTINGS.h). These are now utilized by the Growatt HV protocol. Incase user does not enable this feature, the hardcoded min/max design limits are used instead.

![image](https://github.com/user-attachments/assets/c24ebc67-d126-43b2-985e-bbcc8f7d8adb)