### PR TITLE
Feature: Add event for RJXZS BMS error and guide user how to clear

### DIFF
--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -507,6 +507,12 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
         low_temperature_protection_setting_value = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6];
         protecting_historical_logs = rx_frame.data.u8[7];
 
+        if ((protecting_historical_logs & 0x0F) > 0) {
+          set_event(EVENT_RJXZS_LOG, 0);
+        } else {
+          clear_event(EVENT_RJXZS_LOG);
+        }
+
         if (protecting_historical_logs == 0x01) {
           // Overcurrent protection
           set_event(EVENT_DISCHARGE_LIMIT_EXCEEDED, 0);  // could also be EVENT_CHARGE_LIMIT_EXCEEDED

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -210,6 +210,7 @@ void init_events(void) {
   events.entries[EVENT_RESET_EFUSE].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_RESET_PWR_GLITCH].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_RESET_CPU_LOCKUP].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_RJXZS_LOG].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_PAUSE_BEGIN].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_PAUSE_END].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_CONNECT].level = EVENT_LEVEL_INFO;
@@ -434,6 +435,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "The board was reset due to a detected power glitch";
     case EVENT_RESET_CPU_LOCKUP:
       return "The board was reset due to CPU lockup. Inform developers!";
+    case EVENT_RJXZS_LOG:
+      return "Error code active in RJXZS BMS. Clear via their smartphone app!";
     case EVENT_PAUSE_BEGIN:
       return "The emulator is trying to pause the battery.";
     case EVENT_PAUSE_END:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -6,7 +6,7 @@
 
 // #define INCLUDE_EVENTS_TEST  // Enable to run an event test loop, see events_test_on_target.cpp
 
-#define EE_MAGIC_HEADER_VALUE 0x0023  // 0x0000 to 0xFFFF
+#define EE_MAGIC_HEADER_VALUE 0x0024  // 0x0000 to 0xFFFF
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -107,6 +107,7 @@
   XX(EVENT_RESET_EFUSE)                 \
   XX(EVENT_RESET_PWR_GLITCH)            \
   XX(EVENT_RESET_CPU_LOCKUP)            \
+  XX(EVENT_RJXZS_LOG)                   \
   XX(EVENT_PAUSE_BEGIN)                 \
   XX(EVENT_PAUSE_END)                   \
   XX(EVENT_WIFI_CONNECT)                \


### PR DESCRIPTION
### What
This PR adds a generic event for when the RJXZS BMS has errors active

### Why
Easier for end users to understand the system. As reported in https://github.com/dalathegreat/Battery-Emulator/issues/886

### How
Incase the fault code bits are high, we fire an info event that tells the user:

"Error code active in RJXZS BMS. Clear via their smartphone app!"