### PR TITLE
Feature: Add cellvoltage reading for BYD Atto 3

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -37,7 +37,8 @@ static int16_t BMS_average_cell_temperature = 0;
 static uint16_t BMS_lowest_cell_voltage_mV = 3300;
 static uint16_t BMS_highest_cell_voltage_mV = 3300;
 static uint8_t battery_frame_index = 0;
-static uint16_t battery_cellvoltages[126] = {0};
+#define NOF_CELLS 126
+static uint16_t battery_cellvoltages[NOF_CELLS] = {0};
 #ifdef DOUBLE_BATTERY
 static int16_t battery2_temperature_ambient = 0;
 static int16_t battery2_daughterboard_temperatures[10];
@@ -55,7 +56,7 @@ static int16_t BMS2_average_cell_temperature = 0;
 static uint16_t BMS2_lowest_cell_voltage_mV = 3300;
 static uint16_t BMS2_highest_cell_voltage_mV = 3300;
 static uint8_t battery2_frame_index = 0;
-static uint16_t battery2_cellvoltages[126] = {0};
+static uint16_t battery2_cellvoltages[NOF_CELLS] = {0};
 #endif  //DOUBLE_BATTERY
 #define POLL_FOR_BATTERY_SOC 0x05
 #define POLL_FOR_BATTERY_VOLTAGE 0x08
@@ -262,7 +263,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_frame_index = rx_frame.data.u8[0];
 
-      if (battery_frame_index <= 0x29) {
+      if (battery_frame_index < (NOF_CELLS / 3)) {
         uint8_t base_index = battery_frame_index * 3;
         for (uint8_t i = 0; i < 3; i++) {
           battery_cellvoltages[base_index + i] =
@@ -567,7 +568,7 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
     case 0x43D:
       datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery2_frame_index = rx_frame.data.u8[0];
-      if (battery2_frame_index <= 0x29) {
+      if (battery2_frame_index < (NOF_CELLS / 3)) {
         uint8_t base2_index = battery2_frame_index * 3;
         for (uint8_t i = 0; i < 3; i++) {
           battery2_cellvoltages[base2_index + i] =

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -36,6 +36,8 @@ static int16_t BMS_highest_cell_temperature = 0;
 static int16_t BMS_average_cell_temperature = 0;
 static uint16_t BMS_lowest_cell_voltage_mV = 3300;
 static uint16_t BMS_highest_cell_voltage_mV = 3300;
+static uint8_t battery_frame_index = 0;
+static uint16_t battery_cellvoltages[126] = {0};
 #ifdef DOUBLE_BATTERY
 static int16_t battery2_temperature_ambient = 0;
 static int16_t battery2_daughterboard_temperatures[10];
@@ -52,6 +54,8 @@ static int16_t BMS2_highest_cell_temperature = 0;
 static int16_t BMS2_average_cell_temperature = 0;
 static uint16_t BMS2_lowest_cell_voltage_mV = 3300;
 static uint16_t BMS2_highest_cell_voltage_mV = 3300;
+static uint8_t battery2_frame_index = 0;
+static uint16_t battery2_cellvoltages[126] = {0};
 #endif  //DOUBLE_BATTERY
 #define POLL_FOR_BATTERY_SOC 0x05
 #define POLL_FOR_BATTERY_VOLTAGE 0x08
@@ -134,6 +138,9 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.cell_max_voltage_mV = BMS_highest_cell_voltage_mV;
 
   datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
+
+  //Map all cell voltages to the global array
+  memcpy(datalayer.battery.status.cell_voltages_mV, battery_cellvoltages, 126 * sizeof(uint16_t));
 
 #ifdef SKIP_TEMPERATURE_SENSOR_NUMBER
   // Initialize min and max variables for temperature calculation
@@ -253,6 +260,15 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
     case 0x43D:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      battery_frame_index = rx_frame.data.u8[0];
+
+      if (battery_frame_index <= 0x29) {
+        uint8_t base_index = battery_frame_index * 3;
+        for (uint8_t i = 0; i < 3; i++) {
+          battery_cellvoltages[base_index + i] =
+              (((rx_frame.data.u8[2 * (i + 1)] & 0x0F) << 8) | rx_frame.data.u8[2 * i + 1]);
+        }
+      }
       break;
     case 0x444:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -479,6 +495,9 @@ void update_values_battery2() {  //This function maps all the values fetched via
   datalayer.battery2.status.temperature_min_dC = BMS2_lowest_cell_temperature * 10;  // Add decimals
 
   datalayer.battery2.status.temperature_max_dC = BMS2_highest_cell_temperature * 10;
+
+  //Map all cell voltages to the global array
+  memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages, 126 * sizeof(uint16_t));
 }
 
 void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
@@ -547,6 +566,14 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
       break;
     case 0x43D:
       datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      battery2_frame_index = rx_frame.data.u8[0];
+      if (battery2_frame_index <= 0x29) {
+        uint8_t base2_index = battery2_frame_index * 3;
+        for (uint8_t i = 0; i < 3; i++) {
+          battery2_cellvoltages[base2_index + i] =
+              (((rx_frame.data.u8[2 * (i + 1)] & 0x0F) << 8) | rx_frame.data.u8[2 * i + 1]);
+        }
+      }
       break;
     case 0x444:
       datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -141,7 +141,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
 
   //Map all cell voltages to the global array
-  memcpy(datalayer.battery.status.cell_voltages_mV, battery_cellvoltages, 126 * sizeof(uint16_t));
+  memcpy(datalayer.battery.status.cell_voltages_mV, battery_cellvoltages, NOF_CELLS * sizeof(uint16_t));
 
 #ifdef SKIP_TEMPERATURE_SENSOR_NUMBER
   // Initialize min and max variables for temperature calculation
@@ -498,7 +498,7 @@ void update_values_battery2() {  //This function maps all the values fetched via
   datalayer.battery2.status.temperature_max_dC = BMS2_highest_cell_temperature * 10;
 
   //Map all cell voltages to the global array
-  memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages, 126 * sizeof(uint16_t));
+  memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages, NOF_CELLS * sizeof(uint16_t));
 }
 
 void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {


### PR DESCRIPTION
### What
This PR implements cellvoltage reading for BYD Atto 3

### Why
Better monitoring of battery

### How
Code based on the reverse engineering done in https://github.com/dalathegreat/Battery-Emulator/issues/894 by @demon1300 :raised_hands: 
