### PR TITLE
Microfeature: Make LED modes customizable in USER_SETTINGS

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -155,6 +155,14 @@
 // 3000 = 300.0V, Target discharge voltage (Value can be tuned on the fly via webserver). Not used unless BATTERY_USE_VOLTAGE_LIMITS = true
 #define BATTERY_MAX_DISCHARGE_VOLTAGE 3000
 
+/* LED settings. Optional customization for how the blinking pattern on the LED should behave.
+* CLASSIC   - Slow up/down ramp. If CLASSIC, then a ramp up and ramp down will finish in LED_PERIOD_MS milliseconds
+* FLOW      - Ramp up/down depending on flow of energy
+* HEARTBEAT - Heartbeat-like LED pattern that reacts to the system state with color and BPM
+*/
+#define LED_MODE HEARTBEAT
+#define LED_PERIOD_MS 3000
+
 /* Do not change any code below this line */
 /* Only change battery specific settings above and in "USER_SETTINGS.cpp" */
 typedef enum { CAN_NATIVE = 0, CANFD_NATIVE = 1, CAN_ADDON_MCP2515 = 2, CANFD_ADDON_MCP2518 = 3 } CAN_Interface;

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -160,7 +160,7 @@
 * FLOW      - Ramp up/down depending on flow of energy
 * HEARTBEAT - Heartbeat-like LED pattern that reacts to the system state with color and BPM
 */
-#define LED_MODE HEARTBEAT
+#define LED_MODE CLASSIC
 #define LED_PERIOD_MS 3000
 
 /* Do not change any code below this line */

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -97,6 +97,10 @@ typedef struct {
 
   /** The current battery status, which for now has the name real_bms_status */
   real_bms_status_enum real_bms_status = BMS_DISCONNECTED;
+
+  /** LED mode, customizable by user */
+  led_mode_enum led_mode = LED_MODE;
+
 } DATALAYER_BATTERY_STATUS_TYPE;
 
 typedef struct {

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -16,7 +16,7 @@ static const float heartbeat_peak1 = 0.80;
 static const float heartbeat_peak2 = 0.55;
 static const float heartbeat_deviation = 0.05;
 
-static LED led(LED_MODE_DEFAULT);
+static LED led(datalayer.battery.status.led_mode);
 
 void led_init(void) {
   led.init();
@@ -31,14 +31,14 @@ led_color led_get_color() {
 void LED::exe(void) {
 
   // Update brightness
-  switch (mode) {
-    case led_mode::FLOW:
+  switch (datalayer.battery.status.led_mode) {
+    case led_mode_enum::FLOW:
       flow_run();
       break;
-    case led_mode::HEARTBEAT:
+    case led_mode_enum::HEARTBEAT:
       heartbeat_run();
       break;
-    case led_mode::CLASSIC:
+    case led_mode_enum::CLASSIC:
     default:
       classic_run();
       break;

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -4,8 +4,6 @@
 #include "../../include.h"
 #include "../../lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h"
 
-enum led_mode { CLASSIC, FLOW, HEARTBEAT };
-
 class LED {
  public:
   led_color color = led_color::GREEN;
@@ -14,9 +12,9 @@ class LED {
       : pixels(1, LED_PIN, NEO_GRB + NEO_KHZ800),
         max_brightness(LED_MAX_BRIGHTNESS),
         brightness(LED_MAX_BRIGHTNESS),
-        mode(led_mode::CLASSIC) {}
+        mode(led_mode_enum::CLASSIC) {}
 
-  LED(led_mode mode)
+  LED(led_mode_enum mode)
       : pixels(1, LED_PIN, NEO_GRB + NEO_KHZ800),
         max_brightness(LED_MAX_BRIGHTNESS),
         brightness(LED_MAX_BRIGHTNESS),
@@ -29,7 +27,7 @@ class LED {
   Adafruit_NeoPixel pixels;
   uint8_t max_brightness;
   uint8_t brightness;
-  led_mode mode;
+  led_mode_enum mode;
 
   void classic_run(void);
   void flow_run(void);

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -7,6 +7,7 @@ enum bms_status_enum { STANDBY = 0, INACTIVE = 1, DARKSTART = 2, ACTIVE = 3, FAU
 enum real_bms_status_enum { BMS_DISCONNECTED = 0, BMS_STANDBY = 1, BMS_ACTIVE = 2, BMS_FAULT = 3 };
 enum battery_chemistry_enum { NCA, NMC, LFP };
 enum led_color { GREEN, YELLOW, RED, BLUE };
+enum led_mode_enum { CLASSIC, FLOW, HEARTBEAT };
 enum PrechargeState {
   AUTO_PRECHARGE_IDLE,
   AUTO_PRECHARGE_START,

--- a/Software/src/system_settings.h
+++ b/Software/src/system_settings.h
@@ -37,21 +37,4 @@
 */
 #define MAX_AMOUNT_CELLS 192
 
-/** LED 
- * 
- * Parameter: LED_MODE_DEFAULT
- * Description:
- * The default LED mode. Available modes:
- * CLASSIC   - slow up/down ramp
- * FLOW      - slow ramp up or down depending on flow of energy
- * HEARTBEAT - Heartbeat-like LED pattern that reacts to the system state with color and BPM
- * 
- * Parameter: LED_PERIOD_MS
- * Description:
- * The period of whatever LED mode is active. If CLASSIC, then a ramp up and ramp down will finish in
- * LED_PERIOD_MS milliseconds
-*/
-#define LED_MODE_DEFAULT FLOW
-#define LED_PERIOD_MS 3000
-
 #endif


### PR DESCRIPTION
### What
This PR makes the LED pattern customizable in USER_SETTINGS.h

### Why
Previously you had to edit Software/src/system_settings.h to get the LED modes to change. Not a lot of users even knew about this feature

### How
Now we move it to USER_SETTINGS, for easy tuning
