### PR TITLE
Minor (final) Daly BMS  changes

### DIFF
--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -37,6 +37,9 @@ void update_values_battery() {
   else if (SOC > 8000)
     adaptive_power_limit = ((10000 - (uint32_t)SOC) * POWER_PER_PERCENT) / 100;
 
+  if (temperature_min_dC < LOW_TEMP_POWER_LIMIT_START && adaptive_power_limit > LOW_TEMP_POWER_LIMIT)
+    adaptive_power_limit = LOW_TEMP_POWER_LIMIT;
+
   if (adaptive_power_limit < datalayer.battery.status.max_charge_power_W)
     datalayer.battery.status.max_charge_power_W = adaptive_power_limit;
   if (SOC < 2000 && adaptive_power_limit < datalayer.battery.status.max_discharge_power_W)

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -1,11 +1,9 @@
-#include "DALY-BMS.h"
+#include "../include.h"
 #ifdef DALY_BMS
 #include <cstdint>
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "../include.h"
-#include "RENAULT-TWIZY.h"
-#include "RJXZS-BMS.h"
+#include "DALY-BMS.h"
 
 /* Do not change code below unless you are sure what you are doing */
 
@@ -42,7 +40,7 @@ void update_values_battery() {
   if (SOC < 2000 && adaptive_power_limit < datalayer.battery.status.max_discharge_power_W)
     datalayer.battery.status.max_discharge_power_W = adaptive_power_limit;
 
-  int32_t temperature_limit = (POWER_PER_DEGREE_C * (int32_t)temperature_min_dC + POWER_AT_0_DEGREE_C) / 10;
+  int32_t temperature_limit = POWER_PER_DEGREE_C * (int32_t)temperature_min_dC / 10 + POWER_AT_0_DEGREE_C;
   if (temperature_limit <= 0 || temperature_min_dC < BATTERY_MINTEMPERATURE ||
       temperature_max_dC > BATTERY_MAXTEMPERATURE)
     temperature_limit = 0;

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -7,9 +7,9 @@
 #define MIN_PACK_VOLTAGE_DV 460   //480 = 48.0V
 #define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 3200  //Battery is put into emergency stop if one cell goes below this value
-#define POWER_PER_PERCENT 50  // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
-#define LOW_TEMP_POWER_LIMIT 800       // max power when temperature below limit
-#define LOW_TEMP_POWER_LIMIT_START 50  // start limiting when below 50 = 5.0 °C
+#define POWER_PER_PERCENT 50     // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
+#define POWER_PER_DEGREE_C 60    // max power added/removed per degree above/below 0°C
+#define POWER_AT_0_DEGREE_C 800  // power at 0°C
 
 /* Do not modify any rows below*/
 #define BATTERY_SELECTED

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -8,6 +8,8 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define POWER_PER_PERCENT 50  // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
+#define LOW_TEMP_POWER_LIMIT 800       // max power when temperature below limit
+#define LOW_TEMP_POWER_LIMIT_START 50  // start limiting when below 50 = 5.0 °C
 
 /* Do not modify any rows below*/
 #define BATTERY_SELECTED

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -3,10 +3,10 @@
 
 /* Tweak these according to your battery build */
 #define CELL_COUNT 14
-#define MAX_PACK_VOLTAGE_DV 588   //588 = 58.8V
-#define MIN_PACK_VOLTAGE_DV 518   //518 = 51.8V
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
+#define MAX_PACK_VOLTAGE_DV 580   //580 = 58.0V
+#define MIN_PACK_VOLTAGE_DV 460   //480 = 48.0V
+#define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
+#define MIN_CELL_VOLTAGE_MV 3200  //Battery is put into emergency stop if one cell goes below this value
 #define POWER_PER_PERCENT 50  // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
 #define LOW_TEMP_POWER_LIMIT 800       // max power when temperature below limit
 #define LOW_TEMP_POWER_LIMIT_START 50  // start limiting when below 50 = 5.0 °C

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -25,8 +25,13 @@ String settings_processor(const String& var) {
         "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
         "onclick='editPassword()'>Edit</button></h4>";
 
+#ifndef RS485_BATTERY_SELECTED
     content += "<h4 style='color: white;'>Battery interface: <span id='Battery'>" +
                String(getCANInterfaceName(can_config.battery)) + "</span></h4>";
+#endif
+#ifdef RS485_BATTERY_SELECTED
+    content += "<h4 style='color: white;'>Battery interface: RS485<span id='Battery'></span></h4>";
+#endif
 
 #ifdef DOUBLE_BATTERY
     content += "<h4 style='color: white;'>Battery #2 interface: <span id='Battery'>" +


### PR DESCRIPTION
Some minor leftover changes I made to the Daly BMS code. As of today battery is in daily use and works fine.

The changes include:
- Adjust webservice to display RS485 for battery connection when `RS485_BATTERY_SELECTED` is set
- Add a low temperature limit to Daly BMS (checking the various battery datasheets this could be way more complicated including charge/discharge differences, temperature to power curves, 30s peak power etc. For now this very simple approach should keep the battery safe when having the maximum charge/discharge low enough)
- Adjust default Daly BMS settings to the most common LV battery voltage range

Final installation Pictures:

![photo_2025-03-03_09-42-25](https://github.com/user-attachments/assets/ccab6743-0136-4d58-b557-921f1224bcc4)

![signal-2025-03-01-163024](https://github.com/user-attachments/assets/eb78c744-ef4f-48f1-a12b-e1139300298a)
