### PR TITLE
Bugfix: Prevent logging incoming FD twice

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -297,7 +297,9 @@ void print_can_frame(CAN_frame frame, frameDirection msgDir) {
 }
 
 void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
-  print_can_frame(*rx_frame, frameDirection(MSG_RX));
+  if (interface != CANFD_NATIVE) {  //Avoid printing twice in receive_frame_canfd_addon
+    print_can_frame(*rx_frame, frameDirection(MSG_RX));
+  }
 
 #ifdef LOG_CAN_TO_SD
   add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -297,12 +297,18 @@ void print_can_frame(CAN_frame frame, frameDirection msgDir) {
 }
 
 void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
-  if (interface != CANFD_NATIVE) {  //Avoid printing twice in receive_frame_canfd_addon
+  if (interface !=
+      CANFD_NATIVE) {  //Avoid printing twice due to receive_frame_canfd_addon sending to both FD interfaces
+    //TODO: This check can be removed later when refactored to use inline functions for logging
     print_can_frame(*rx_frame, frameDirection(MSG_RX));
   }
 
 #ifdef LOG_CAN_TO_SD
-  add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
+  if (interface !=
+      CANFD_NATIVE) {  //Avoid printing twice due to receive_frame_canfd_addon sending to both FD interfaces
+    //TODO: This check can be removed later when refactored to use inline functions for logging
+    add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
+  }
 #endif
 
   if (interface == can_config.battery) {


### PR DESCRIPTION
### What
This PR fixes a bug where the incoming CAN-FD frames are logged twice

### Why
Bug, reported in https://github.com/dalathegreat/Battery-Emulator/issues/938

### How
We now skip logging twice :)
