### PR TITLE
Improvement: Optimize CAN-Native driver and event handling

### DIFF
--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -228,6 +228,12 @@ typedef struct {
   uint8_t can_replay_interface = CAN_NATIVE;
   /** bool, determines if CAN replay should loop or not */
   bool loop_playback = false;
+  /** bool, Native CAN failed to send flag */
+  bool can_native_send_fail = false;
+  /** bool, MCP2515 CAN failed to send flag */
+  bool can_2515_send_fail = false;
+  /** uint16_t, MCP2518 CANFD failed to send flag */
+  bool can_2518_send_fail = false;
 
 } DATALAYER_SYSTEM_INFO_TYPE;
 

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -19,6 +19,26 @@ battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
 
 void update_machineryprotection() {
+  // Check health status of CAN interfaces
+  if (datalayer.system.info.can_native_send_fail) {
+    set_event(EVENT_CAN_NATIVE_TX_FAILURE, 0);
+    datalayer.system.info.can_native_send_fail = false;
+  } else {
+    clear_event(EVENT_CAN_NATIVE_TX_FAILURE);
+  }
+  if (datalayer.system.info.can_2515_send_fail) {
+    set_event(EVENT_CAN_BUFFER_FULL, 0);
+    datalayer.system.info.can_2515_send_fail = false;
+  } else {
+    clear_event(EVENT_CAN_BUFFER_FULL);
+  }
+  if (datalayer.system.info.can_2518_send_fail) {
+    set_event(EVENT_CANFD_BUFFER_FULL, 0);
+    datalayer.system.info.can_2518_send_fail = false;
+  } else {
+    clear_event(EVENT_CANFD_BUFFER_FULL);
+  }
+
   // Start checking that the battery is within reason. Incase we see any funny business, raise an event!
 
   // Pause function is on OR we have a critical fault event active

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -136,7 +136,7 @@ void init_events(void) {
   events.entries[EVENT_CAN_BUFFER_FULL].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_OVERRUN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CAN_CORRUPTED_WARNING].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_CAN_NATIVE_TX_FAILURE].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_CAN_NATIVE_TX_FAILURE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_BATTERY_MISSING].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CAN_BATTERY2_MISSING].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_CHARGER_MISSING].level = EVENT_LEVEL_INFO;
@@ -275,9 +275,9 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_CANMCP2515_INIT_FAILURE:
       return "CAN-MCP addon initialization failed. Check hardware";
     case EVENT_CANFD_BUFFER_FULL:
-      return "MCP2518FD buffer overflowed. Some CAN messages were not sent. Contact developers.";
+      return "MCP2518FD message failed to send. Buffer full or no one on the bus to ACK the message!";
     case EVENT_CAN_BUFFER_FULL:
-      return "MCP2515 buffer overflowed. Some CAN messages were not sent. Contact developers.";
+      return "MCP2515 message failed to send. Buffer full or no one on the bus to ACK the message!";
     case EVENT_CAN_OVERRUN:
       return "CAN message failed to send within defined time. Contact developers, CPU load might be too high.";
     case EVENT_CAN_CORRUPTED_WARNING:

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -264,7 +264,7 @@ int CAN_init() {
 	return 0;
 }
 
-int CAN_write_frame(const CAN_frame_t *p_frame) {
+bool CAN_write_frame(const CAN_frame_t *p_frame) {
 	if (sem_tx_complete == NULL) {
 		return 0;
 	}

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -266,13 +266,13 @@ int CAN_init() {
 
 int CAN_write_frame(const CAN_frame_t *p_frame) {
 	if (sem_tx_complete == NULL) {
-		return -1;
+		return 0;
 	}
 
 	// Write the frame to the controller
 	CAN_write_frame_phy(p_frame);
 
-	return xSemaphoreTake(sem_tx_complete, 20) == pdTRUE ? 0 : -1;
+	return xSemaphoreTake(sem_tx_complete, 20) == pdTRUE ? 1 : 0;
 }
 
 int CAN_stop() {

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.h
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.h
@@ -104,9 +104,9 @@ int CAN_init(void);
  * \brief Send a can frame
  *
  * \param	p_frame	Pointer to the frame to be send, see #CAN_frame_t
- * \return  0 Frame has been written to the module
+ * \return  1 Frame has been written to the module
  */
-int CAN_write_frame(const CAN_frame_t *p_frame);
+bool CAN_write_frame(const CAN_frame_t *p_frame);
 
 /**
  * \brief Stops the CAN Module

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
@@ -5,20 +5,14 @@
 int ESP32CAN::CANInit() {
   return CAN_init();
 }
-int ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame) {
+bool ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame) {
   static unsigned long start_time;
-  int result = -1;
+  bool result = false;
   if (tx_ok) {
     result = CAN_write_frame(p_frame);
-    tx_ok = (result == 0) ? true : false;
-    if (tx_ok == false) {
-      #ifdef DEBUG_VIA_USB
-      Serial.println("CAN failure! Check wires");
-      #endif
-      set_event(EVENT_CAN_NATIVE_TX_FAILURE, 0);
+    tx_ok = result;
+    if (!tx_ok) {
       start_time = millis();
-    } else {
-      clear_event(EVENT_CAN_NATIVE_TX_FAILURE);
     }
   } else {
     if ((millis() - start_time) >= 20) {
@@ -27,6 +21,7 @@ int ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame) {
   }
   return result;
 }
+
 int ESP32CAN::CANStop() {
   return CAN_stop();
 }

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.h
@@ -9,7 +9,7 @@ class ESP32CAN {
   bool tx_ok = true;
   int CANInit();
   int CANConfigFilter(const CAN_filter_t* p_filter);
-  int CANWriteFrame(const CAN_frame_t* p_frame);
+  bool CANWriteFrame(const CAN_frame_t* p_frame);
   int CANStop();
   void CANSetCfg(CAN_device_t* can_cfg);
 };


### PR DESCRIPTION
### What
This PR improves low level performance of the CAN driver. It also changes how CAN TX fail events are handled

### Why
Performance improvements are nice :sunglasses: 

### How
By moving out serial printing / event triggering from inside the CAN driver, we increase performance significantly in the event that it would fail to send. The SAFETY.cpp loop now keeps track of every CAN interface, and checks every 1000ms if something has occurred. 

The PR also changes a native CAN TX fail event from Error -> Warning. This was an old assumption that a single TX fail on this CAN channel would be tied to battery, but with the new can_config option the battery is necessarily not connected to the CAN native port. We keep the 60s without CAN from battery as an error event.
