### PR TITLE
Improvement: More CAN performance

### DIFF
--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.c
@@ -266,13 +266,13 @@ int CAN_init() {
 
 bool CAN_write_frame(const CAN_frame_t *p_frame) {
 	if (sem_tx_complete == NULL) {
-		return 0;
+		return false;
 	}
 
 	// Write the frame to the controller
 	CAN_write_frame_phy(p_frame);
 
-	return xSemaphoreTake(sem_tx_complete, 20) == pdTRUE ? 1 : 0;
+	return xSemaphoreTake(sem_tx_complete, 20) == pdTRUE ? true : false;
 }
 
 int CAN_stop() {

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.h
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/CAN.h
@@ -93,6 +93,10 @@ typedef struct {
 	uint8_t 			AMR3;				/**< \brief Acceptance Mask Register AMR3 */
 } CAN_filter_t;
 
+extern void gpio_matrix_in(uint32_t gpio, uint32_t signal_idx, bool inv);
+extern void gpio_matrix_out(uint32_t gpio, uint32_t signal_idx, bool out_inv, bool oen_inv);
+extern void gpio_pad_select_gpio(uint8_t gpio_num);
+
 /**
  * \brief Initialize the CAN Module
  *

--- a/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
+++ b/Software/src/lib/miwagner-ESP32-Arduino-CAN/ESP32CAN.cpp
@@ -6,20 +6,7 @@ int ESP32CAN::CANInit() {
   return CAN_init();
 }
 bool ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame) {
-  static unsigned long start_time;
-  bool result = false;
-  if (tx_ok) {
-    result = CAN_write_frame(p_frame);
-    tx_ok = result;
-    if (!tx_ok) {
-      start_time = millis();
-    }
-  } else {
-    if ((millis() - start_time) >= 20) {
-      tx_ok = true;
-    }
-  }
-  return result;
+  return CAN_write_frame(p_frame);
 }
 
 int ESP32CAN::CANStop() {


### PR DESCRIPTION
### What
This PR removes an old delay() workaround in the CAN native driver

### Why
More performance

### How
Previosly we had implemented a hacky yield function, that blocked further CAN sending for 20ms incase one CAN message fails to send. This was done to avoid locking up the board. **Something** has changed in the ESP32, and now this workaround is no longer needed! Good for us, since removing it makes the function call much faster.

Bonus, this PR also gets rid of the three compilation warnings that were present in platformIO
Fixes #667
