### PR TITLE
Make transmit_obd_can_frame canFD aware.

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -2338,7 +2338,7 @@ void transmit_can_battery() {
     transmit_can_frame(&MEB_585, can_config.battery);       // Systeminfo
     transmit_can_frame(&MEB_1A5555A6, can_config.battery);  // Temperature QBit
 
-    transmit_obd_can_frame(0x18DA05F1, can_config.battery);
+    transmit_obd_can_frame(0x18DA05F1, can_config.battery, true);
   }
 }
 

--- a/Software/src/communication/can/obd.cpp
+++ b/Software/src/communication/can/obd.cpp
@@ -109,8 +109,9 @@ void handle_obd_frame(CAN_frame& rx_frame) {
 #endif
 }
 
-void transmit_obd_can_frame(unsigned int address, int interface) {
+void transmit_obd_can_frame(unsigned int address, int interface, bool canFD) {
   static CAN_frame OBD_frame;
+  OBD_frame.FD = canFD;
   OBD_frame.ID = address;
   OBD_frame.ext_ID = address > 0x7FF;
   OBD_frame.DLC = 8;

--- a/Software/src/communication/can/obd.h
+++ b/Software/src/communication/can/obd.h
@@ -6,6 +6,6 @@
 
 void handle_obd_frame(CAN_frame& rx_frame);
 
-void transmit_obd_can_frame(unsigned int address, int interface);
+void transmit_obd_can_frame(unsigned int address, int interface, bool canFD);
 
 #endif  // _OBD_H_


### PR DESCRIPTION
### What
MEB needs OBD requests to be canFD.

### Why
No response from battery if sent as normal can.

### How
Add a parameter to the function call so the calling side can choose between normal can and FD can.
