### PR TITLE
Bugfix: Separate Deye offgrid BYD CAN fixes to avoid Solis misbehaving

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -45,9 +45,10 @@
 //#define TEST_FAKE_BATTERY
 //#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires CAN_ADDON setup)
 
-/* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/BYD-Battery-Emulator-For-Gen24/wiki */
+/* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/Battery-Emulator/wiki */
 //#define AFORE_CAN        //Enable this line to emulate an "Afore battery" over CAN bus
-//#define BYD_CAN  //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+//#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
+//#define BYD_CAN_DEYE     //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus, with Deye specific fixes
 //#define BYD_KOSTAL_RS485 //Enable this line to emulate a "BYD 11kWh HVM battery" over Kostal RS485
 //#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
 //#define FERROAMP_CAN     //Enable this line to emulate a "Pylon 4x96V Force H2" over CAN Bus

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -126,6 +126,8 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //SOC (100.00%)
   BYD_150.data.u8[0] = (datalayer.battery.status.reported_soc >> 8);
   BYD_150.data.u8[1] = (datalayer.battery.status.reported_soc & 0x00FF);
+#ifdef BYD_CAN_DEYE
+  // Fix for avoiding offgrid Deye inverters to underdischarge batteries
   if (datalayer.battery.status.max_charge_current_dA == 0) {
     //Force to 100.00% incase battery no longer wants to charge
     BYD_150.data.u8[0] = (10000 >> 8);
@@ -136,6 +138,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
     BYD_150.data.u8[0] = 0;
     BYD_150.data.u8[1] = 0;
   }
+#endif  //BYD_CAN_DEYE
   //StateOfHealth (100.00%)
   BYD_150.data.u8[2] = (datalayer.battery.status.soh_pptt >> 8);
   BYD_150.data.u8[3] = (datalayer.battery.status.soh_pptt & 0x00FF);

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -11,6 +11,11 @@
 #include "BYD-CAN.h"
 #endif
 
+#ifdef BYD_CAN_DEYE
+#define BYD_CAN
+#include "BYD-CAN.h"
+#endif
+
 #ifdef BYD_MODBUS
 #include "BYD-MODBUS.h"
 #endif


### PR DESCRIPTION
### What
This PR adds a new configuration option for Deye, `BYD_CAN_DEYE`

### Why
The Deye specific offgrid overdischarge fixes implemented in #875 , seem to intefere with the operation of Solis inverters

### How
The user can now switch between the two following BYD_CAN options:

//#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
//#define BYD_CAN_DEYE     //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus, with Deye specific fixes