### PR TITLE
Inverter allows

### DIFF
--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -363,6 +363,7 @@ void receive_RS485()  // Runs as fast as possible to handle the serial stream
                   tmpframe[38] = calculate_kostal_crc(tmpframe, 38);
                   null_stuffer(tmpframe, 40);
                   send_kostal(tmpframe, 40);
+                  datalayer.system.status.inverter_allows_contactor_closing = true;
                   if (!startupMillis) {
                     startupMillis = currentMillis;
                   }


### PR DESCRIPTION
### What
inverter_allows_contactor_closing is set to true when the inverter requests battery info frame

### Why
For an unknown reason, the inverter doesn't always send the battery control message after startup.