### PR TITLE
Update typo while decoding error flags in TESLA-BATTERY.cpp

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1633,7 +1633,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       battery_OverDchgCurrentFault = ((rx_frame.data.u8[0] & 0x10) >> 4);
       battery_OverChargeCurrentFault = ((rx_frame.data.u8[0] & 0x20) >> 5);
       battery_OverCurrentFault = ((rx_frame.data.u8[0] & 0x40) >> 6);
-      battery_OverTemperatureFault = ((rx_frame.data.u8[1] & 0x80) >> 7);
+      battery_OverTemperatureFault = ((rx_frame.data.u8[0] & 0x80) >> 7);
       battery_OverVoltageFault = (rx_frame.data.u8[1] & 0x01);
       battery_UnderVoltageFault = ((rx_frame.data.u8[1] & 0x02) >> 1);
       battery_PrimaryBmbMiaFault = ((rx_frame.data.u8[1] & 0x04) >> 2);


### PR DESCRIPTION
Noticed a typo in TESLA-BATTERY.cpp. There was two flags decoded from the same source bit.