### PR TITLE
Fix compilation error Renault Twizy

### DIFF
--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -9,4 +9,7 @@
 #define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 3400  //Battery is put into emergency stop if one cell goes below this value
 
+void setup_battery(void);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 #endif


### PR DESCRIPTION
### What
Adds function declarations to the header file for the Renault Twiggy battery

### Why
To fix the compilation error seen in #1006.

Fixes #1006

### How
By defining missing declarations in header file created in #537.
