### PR TITLE
Bugfix: Tesla, extend pyrofuse event check

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -824,8 +824,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
   } else {
     clear_event(EVENT_INTERNAL_OPEN_FAULT);
   }
-  //Voltage missing, pyrofuse most likely blown
-  if (datalayer.battery.status.voltage_dV == 10) {
+  //Voltage between 0.5-5.0V, pyrofuse most likely blown
+  if (datalayer.battery.status.voltage_dV >= 5 && datalayer.battery.status.voltage_dV <= 50) {
     set_event(EVENT_BATTERY_FUSE, 0);
   } else {
     clear_event(EVENT_BATTERY_FUSE);


### PR DESCRIPTION
### What
This PR extends the voltage range check for determining if the Pyrofuse is blown on a tesla battery

### Why
The original check did not catch all cases of blown pyro, since it just checked if voltage is 1.0VDC

### How
The new check verifies if the voltage is between 0.5V-5.0V, and if it is, we fire the event!
