### PR TITLE
Renault Zoe Gen2: add NVROL reset function

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -65,11 +65,13 @@ static uint16_t battery_pack_time = 0;
 static uint16_t battery_soc_min = 0;
 static uint16_t battery_soc_max = 0;
 
-CAN_frame ZOE_373 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x373,
-                     .data = {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
+CAN_frame ZOE_373 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x373,
+    .data = {0xC1, 0x40, 0x5D, 0xB2, 0x00, 0x01, 0xff,
+             0xe3}};  // FIXME: remove if not needed: {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
 CAN_frame ZOE_POLL_18DADBF1 = {.FD = false,
                                .ext_ID = true,
                                .DLC = 8,
@@ -382,6 +384,7 @@ void transmit_can_battery(unsigned long currentMillis) {
     if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
       previousMillis100 = currentMillis;
 
+      /* FIXME: remove if not needed
       if ((counter_373 / 5) % 2 == 0) {  // Alternate every 5 messages between these two
         ZOE_373.data.u8[2] = 0xB2;
         ZOE_373.data.u8[3] = 0xB2;
@@ -390,6 +393,7 @@ void transmit_can_battery(unsigned long currentMillis) {
         ZOE_373.data.u8[3] = 0x5D;
       }
       counter_373 = (counter_373 + 1) % 10;
+      */
 
       transmit_can_frame(&ZOE_373, can_config.battery);
     }

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -23,7 +23,6 @@ https://github.com/fesch/CanZE/tree/master/app/src/main/assets/ZOE_Ph2
 /*
 
 /* Do not change code below unless you are sure what you are doing */
-static bool nvrol_reset_flag = false;
 static uint16_t battery_soc = 0;
 static uint16_t battery_usable_soc = 5000;
 static uint16_t battery_soh = 10000;
@@ -373,9 +372,11 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 }
 
 void transmit_can_battery(unsigned long currentMillis) {
-  if (nvrol_reset_flag) {
+  if (datalayer_extended.zoePH2.UserRequestNVROLReset) {
     // Send NVROL reset frames
     transmit_reset_nvrol_frames();
+    // after transmitting the NVROL reset frames, set the nvrol reset flag to false, to continue normal operation
+    datalayer_extended.zoePH2.UserRequestNVROLReset = false;
   } else {
     // Send 100ms CAN Message
     if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -449,9 +450,6 @@ void transmit_reset_nvrol_frames(void) {
 
   // after transmitting these frames, wait 30 s
   wait_ms(30000);
-
-  // after waiting, set the nvrol reset flag to false, to continue normal operation
-  nvrol_reset_flag = false;
 }
 
 void wait_ms(int duration_ms) {

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -12,6 +12,24 @@
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
+/**
+ * @brief Reset NVROL, by sending specific frames
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void transmit_reset_nvrol_frames(void);
+
+/**
+ * @brief Wait function
+ *
+ * @param[in] duration_ms wait duration in ms
+ *
+ * @return void
+ */
+void wait_ms(int duration_ms);
+
 #define POLL_SOC 0x9001
 #define POLL_USABLE_SOC 0x9002
 #define POLL_SOH 0x9003

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -13,6 +13,16 @@ void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 /**
+ * @brief Transmit CAN frame 0x376
+ * 
+ * @param[in] void
+ * 
+ * @return void
+ * 
+ */
+void transmit_can_frame_376(void);
+
+/**
  * @brief Reset NVROL, by sending specific frames
  *
  * @param[in] void


### PR DESCRIPTION
### What

#### Aim 🚀
This PR implements the NVROL reset function described on [ljames28/Renault-Zoe-PH2-ZE50](https://github.com/ljames28/Renault-Zoe-PH2-ZE50-Canbus-LBC-Information?tab=readme-ov-file#commands), and as is mentioned on #587.

#### Testing ⚠️⚡Testers welcome ⚡ ⚠️
This PR shall be checked by someone that has a Renault Zoe Gen2 battery.

Fixes #587

### How
By implementing a new function `transmit_reset_nvrol_frames()` that implements the following pseudo code:

```
cansend 18DADBF1#021003AAAAAAAAAA
sleep 0.1
cansend 18DADBF1#043101B00900AAAA
sleep 1
cansend 18DADBF1#021003AAAAAAAAAA
sleep 0.1
cansend 18DADBF1#042E928101AAAAAA
sleep 30
```

Source: [ljames28/Renault-Zoe-PH2-ZE50 | Commands](https://github.com/ljames28/Renault-Zoe-PH2-ZE50-Canbus-LBC-Information?tab=readme-ov-file#commands)