### PR TITLE
New Battery: Add support for 50kWh standard range Atto3

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -14,8 +14,12 @@
 
 /* Do not modify the rows below */
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4410  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3800
+#define CELLCOUNT_EXTENDED 126
+#define CELLCOUNT_STANDARD 104
+#define MAX_PACK_VOLTAGE_EXTENDED_DV 4410  //Extended range
+#define MIN_PACK_VOLTAGE_EXTENDED_DV 3800  //Extended range
+#define MAX_PACK_VOLTAGE_STANDARD_DV 3640  //Standard range
+#define MIN_PACK_VOLTAGE_STANDARD_DV 3136  //Standard range
 #define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 3800  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -4,7 +4,7 @@
 #include "../include.h"
 
 #define USE_ESTIMATED_SOC  // If enabled, SOC is estimated from pack voltage. Useful for locked packs. \
-                           // Uncomment this only if you know your BMS is unlocked and able to send SOC%
+                           // Comment out this only if you know your BMS is unlocked and able to send SOC%
 #define MAXPOWER_CHARGE_W 10000
 #define MAXPOWER_DISCHARGE_W 10000
 


### PR DESCRIPTION
### What
This PR implements support for Standard range 50kWh Atto 3 batteries.

### Why
Current implementation does not support 50kWh packs, only extended range 60kWh packs. Fixes #1022 

### How
We now startup in NOT_DETERMINED_YET state, and later on switch between STANDARD_RANGE or EXTENDED_RANGE

Switching between these modes happens automatically, and it will affect the following values:
- Max pack voltage
- Min pack voltage
- Cell count (104 vs 125)
- Estimated SOC from voltage (New map added for standard range
- Total pack capacity

Testers wanted! Both Extended range and Standard range!