### PR TITLE
Add missing break

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -1099,6 +1099,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       switch (pid_reply) {
         case PID_SOC:
           battery_soc_polled = rx_frame.data.u8[4] * 4;  // 135*4 = 54.0%
+          break;
         case PID_VOLTAGE:
           battery_voltage_polled = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
           break;


### PR DESCRIPTION
### What
Add a missing break in a case statement.

### Why
Should be there.

### How
Add a missing break in a case statement.
