### PR TITLE
Housekeeping: Fix compilation warning from build system

### DIFF
--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -34,14 +34,14 @@ CAN_frame PYLON_7320 = {
     .ext_ID = true,
     .DLC = 8,
     .ID = 0x7320,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, VOLTAGE_LEVEL,
+    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
              (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_7321 = {
     .FD = false,
     .ext_ID = true,
     .DLC = 8,
     .ID = 0x7321,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, VOLTAGE_LEVEL,
+    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
              (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_4210 = {.FD = false,
                         .ext_ID = true,

--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -29,20 +29,20 @@ CAN_frame PYLON_7311 = {.FD = false,
                         .DLC = 8,
                         .ID = 0x7311,
                         .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7320 = {
-    .FD = false,
-    .ext_ID = true,
-    .DLC = 8,
-    .ID = 0x7320,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
-             (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_7321 = {
-    .FD = false,
-    .ext_ID = true,
-    .DLC = 8,
-    .ID = 0x7321,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
-             (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+CAN_frame PYLON_7320 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7320,
+                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+CAN_frame PYLON_7321 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7321,
+                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_4210 = {.FD = false,
                         .ext_ID = true,
                         .DLC = 8,

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -34,14 +34,14 @@ CAN_frame PYLON_7320 = {
     .ext_ID = true,
     .DLC = 8,
     .ID = 0x7320,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, VOLTAGE_LEVEL,
+    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
              (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_7321 = {
     .FD = false,
     .ext_ID = true,
     .DLC = 8,
     .ID = 0x7321,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, VOLTAGE_LEVEL,
+    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
              (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_4210 = {.FD = false,
                         .ext_ID = true,

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -29,20 +29,20 @@ CAN_frame PYLON_7311 = {.FD = false,
                         .DLC = 8,
                         .ID = 0x7311,
                         .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7320 = {
-    .FD = false,
-    .ext_ID = true,
-    .DLC = 8,
-    .ID = 0x7320,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
-             (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_7321 = {
-    .FD = false,
-    .ext_ID = true,
-    .DLC = 8,
-    .ID = 0x7321,
-    .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES, CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF),
-             (uint8_t)(VOLTAGE_LEVEL >> 8), AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+CAN_frame PYLON_7320 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7320,
+                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+CAN_frame PYLON_7321 = {.FD = false,
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x7321,
+                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
 CAN_frame PYLON_4210 = {.FD = false,
                         .ext_ID = true,
                         .DLC = 8,


### PR DESCRIPTION
### What
This PR fixes the compilation warning in Ferroamp and Pylon CAN protocol

![image](https://github.com/user-attachments/assets/923f136f-bac5-4e15-a2e4-0f9043fa08db)

### Why
To make build system work again

### How
Careful assigning of correct bits to u8 value
