### PR TITLE
Feature: Tesla BMS ECU reset

### DIFF
--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -7,7 +7,6 @@ typedef struct {
   /** uint32_t */
   /** Total energy capacity in Watt-hours */
   uint32_t total_capacity_Wh = BATTERY_WH_MAX;
-  uint32_t reported_total_capacity_Wh = BATTERY_WH_MAX;
 
   /** uint16_t */
   /** The maximum intended packvoltage, in deciVolt. 4900 = 490.0 V */
@@ -45,9 +44,6 @@ typedef struct {
    * battery.settings.soc_scaling_active
    */
   uint32_t reported_remaining_capacity_Wh;
-
-  int32_t total_charged_battery_Wh = 0;
-  int32_t total_discharged_battery_Wh = 0;
 
   /** Maximum allowed battery discharge power in Watts. Set by battery */
   uint32_t max_discharge_power_W = 0;
@@ -142,6 +138,7 @@ typedef struct {
   /* Bool for specifying if user has requested manual function */
   bool user_requests_balancing = false;
   bool user_requests_isolation_clear = false;
+  bool user_requests_bms_ecu_reset = false;
   /* Forced balancing max time & start timestamp */
   uint32_t balancing_time_ms = 3600000;  //1h default, (60min*60sec*1000ms)
   uint32_t balancing_start_time_ms = 0;  //For keeping track when balancing started

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -506,8 +506,8 @@ String advanced_battery_processor(const String& var) {
     float energy_buffer_m1 = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer_m1) * 0.01;
     float expected_energy_remaining_m1 =
         static_cast<float>(datalayer_extended.tesla.battery_expected_energy_remaining_m1) * 0.02;
-    float total_discharge = static_cast<float>(datalayer.battery.status.total_discharged_battery_Wh) * 0.001;
-    float total_charge = static_cast<float>(datalayer.battery.status.total_charged_battery_Wh) * 0.001;
+    float total_discharge = static_cast<float>(datalayer_extended.tesla.battery_total_discharge);
+    float total_charge = static_cast<float>(datalayer_extended.tesla.battery_total_charge);
     float packMass = static_cast<float>(datalayer_extended.tesla.battery_packMass);
     float platformMaxBusVoltage =
         static_cast<float>(datalayer_extended.tesla.battery_platformMaxBusVoltage) * 0.1 + 375;
@@ -657,7 +657,8 @@ String advanced_battery_processor(const String& var) {
 
     //Buttons for user action
     content += "<button onclick='askClearIsolation()'>Clear isolation fault</button>";
-    //0x20A 522 HVP_contatorState
+    content += "<button onclick='askBMSReset()'>BMS reset</button>";
+    //0x20A 522 HVP_contactorState
     content += "<h4>Contactor Status: " + String(contactorText[datalayer_extended.tesla.status_contactor]) + "</h4>";
     content += "<h4>HVIL: " + String(hvilStatusState[datalayer_extended.tesla.hvil_status]) + "</h4>";
     content +=
@@ -683,7 +684,7 @@ String advanced_battery_processor(const String& var) {
            sizeof(datalayer_extended.tesla.BMS_SerialNumber));
     readableSerialNumber[14] = '\0';  // Null terminate the string
     content += "<h4>BMS Serial number: " + String(readableSerialNumber) + "</h4>";
-    // Comment what data you would like to dislay, order can be changed.
+    // Comment what data you would like to display, order can be changed.
     //0x352 850 BMS_energyStatus
     if (datalayer_extended.tesla.BMS352_mux == false) {
       content += "<h3>BMS 0x352 w/o mux</h3>";  //if using older BMS <2021 and comment 0x352 without MUX
@@ -1186,10 +1187,6 @@ String advanced_battery_processor(const String& var) {
       }
       content += " &deg;C</h4>";
     }
-    content +=
-        "<h4>Total charged: " + String(datalayer.battery.status.total_charged_battery_Wh / 1000.0, 1) + " kWh</h4>";
-    content += "<h4>Total discharged: " + String(datalayer.battery.status.total_discharged_battery_Wh / 1000.0, 1) +
-               " kWh</h4>";
 #endif  //MEB_BATTERY
 
 #ifdef RENAULT_ZOE_GEN2_BATTERY
@@ -1443,6 +1440,18 @@ String advanced_battery_processor(const String& var) {
     content += "function clearIsolation() {";
     content += "  var xhr = new XMLHttpRequest();";
     content += "  xhr.open('GET', '/clearIsolation', true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function goToMainPage() { window.location.href = '/'; }";
+    content += "</script>";
+    content += "<script>";
+    content +=
+        "function askBMSReset() { if (window.confirm('Are you sure you want to reset the BMS "
+        "ECU?')) { "
+        "bmsECUReset(); } }";
+    content += "function bmsECUReset() {";
+    content += "  var xhr = new XMLHttpRequest();";
+    content += "  xhr.open('GET', '/bmsECUReset', true);";
     content += "  xhr.send();";
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -579,6 +579,15 @@ void init_webserver() {
     request->send(200, "text/plain", "Updated successfully");
   });
 
+  // Route for resetting BMS ECU on Tesla
+  server.on("/bmsECUReset", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
+      return request->requestAuthentication();
+    }
+    datalayer.battery.settings.user_requests_bms_ecu_reset = true;
+    request->send(200, "text/plain", "Updated successfully");
+  });
+
   // Route for resetting SOH on Nissan LEAF batteries
   server.on("/resetSOH", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
@@ -1054,30 +1063,16 @@ String processor(const String& var) {
     uint16_t cell_delta_mv =
         datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV;
 
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) +
-                 "&percnt; (real: " + String(socRealFloat, 2) + "&percnt;)</h4>";
-    else
-      content += "<h4 style='color: white;'>SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
-
+    content += "<h4 style='color: white;'>Real SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
+    content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) + "&percnt;</h4>";
     content += "<h4 style='color: white;'>SOH: " + String(sohFloat, 2) + "&percnt;</h4>";
-    content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) +
-               " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
+    content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) + " V</h4>";
+    content += "<h4 style='color: white;'>Current: " + String(currentFloat, 1) + " A</h4>";
     content += formatPowerValue("Power", powerFloat, "", 1);
-
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled total capacity: " +
-                 formatPowerValue(datalayer.battery.info.reported_total_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery.info.total_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Total capacity", datalayer.battery.info.total_capacity_Wh, "h", 1);
-
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                 formatPowerValue(datalayer.battery.status.reported_remaining_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Remaining capacity", datalayer.battery.status.remaining_capacity_Wh, "h", 1);
+    content += formatPowerValue("Total capacity", datalayer.battery.info.total_capacity_Wh, "h", 1);
+    content += formatPowerValue("Real Remaining capacity", datalayer.battery.status.remaining_capacity_Wh, "h", 1);
+    content +=
+        formatPowerValue("Scaled Remaining capacity", datalayer.battery.status.reported_remaining_capacity_Wh, "h", 1);
 
     if (datalayer.system.settings.equipment_stop_active) {
       content += formatPowerValue("Max discharge power", datalayer.battery.status.max_discharge_power_W, "", 1, "red");
@@ -1101,15 +1096,15 @@ String processor(const String& var) {
       }
     }
 
-    content += "<h4>Cell min/max: " + String(datalayer.battery.status.cell_min_voltage_mV) + " mV / " +
-               String(datalayer.battery.status.cell_max_voltage_mV) + " mV</h4>";
+    content += "<h4>Cell max: " + String(datalayer.battery.status.cell_max_voltage_mV) + " mV</h4>";
+    content += "<h4>Cell min: " + String(datalayer.battery.status.cell_min_voltage_mV) + " mV</h4>";
     if (cell_delta_mv > datalayer.battery.info.max_cell_voltage_deviation_mV) {
       content += "<h4 style='color: red;'>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
     } else {
       content += "<h4>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
     }
-    content +=
-        "<h4>Temperature min/max: " + String(tempMinFloat, 1) + " &deg;C / " + String(tempMaxFloat, 1) + " &deg;C</h4>";
+    content += "<h4>Temperature max: " + String(tempMaxFloat, 1) + " &deg;C</h4>";
+    content += "<h4>Temperature min: " + String(tempMinFloat, 1) + " &deg;C</h4>";
 
     content += "<h4>System status: ";
     switch (datalayer.battery.status.bms_status) {
@@ -1275,30 +1270,16 @@ String processor(const String& var) {
     tempMinFloat = static_cast<float>(datalayer.battery2.status.temperature_min_dC) / 10.0;  // Convert to float
     cell_delta_mv = datalayer.battery2.status.cell_max_voltage_mV - datalayer.battery2.status.cell_min_voltage_mV;
 
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) +
-                 "&percnt; (real: " + String(socRealFloat, 2) + "&percnt;)</h4>";
-    else
-      content += "<h4 style='color: white;'>SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
-
+    content += "<h4 style='color: white;'>Real SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
+    content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) + "&percnt;</h4>";
     content += "<h4 style='color: white;'>SOH: " + String(sohFloat, 2) + "&percnt;</h4>";
-    content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) +
-               " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
+    content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) + " V</h4>";
+    content += "<h4 style='color: white;'>Current: " + String(currentFloat, 1) + " A</h4>";
     content += formatPowerValue("Power", powerFloat, "", 1);
-
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled total capacity: " +
-                 formatPowerValue(datalayer.battery2.info.reported_total_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery2.info.total_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Total capacity", datalayer.battery2.info.total_capacity_Wh, "h", 1);
-
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                 formatPowerValue(datalayer.battery2.status.reported_remaining_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery2.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Remaining capacity", datalayer.battery2.status.remaining_capacity_Wh, "h", 1);
+    content += formatPowerValue("Total capacity", datalayer.battery2.info.total_capacity_Wh, "h", 1);
+    content += formatPowerValue("Real Remaining capacity", datalayer.battery2.status.remaining_capacity_Wh, "h", 1);
+    content +=
+        formatPowerValue("Scaled Remaining capacity", datalayer.battery2.status.reported_remaining_capacity_Wh, "h", 1);
 
     if (datalayer.system.settings.equipment_stop_active) {
       content += formatPowerValue("Max discharge power", datalayer.battery2.status.max_discharge_power_W, "", 1, "red");
@@ -1312,15 +1293,15 @@ String processor(const String& var) {
       content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
     }
 
-    content += "<h4>Cell min/max: " + String(datalayer.battery2.status.cell_min_voltage_mV) + " mV / " +
-               String(datalayer.battery2.status.cell_max_voltage_mV) + " mV</h4>";
+    content += "<h4>Cell max: " + String(datalayer.battery2.status.cell_max_voltage_mV) + " mV</h4>";
+    content += "<h4>Cell min: " + String(datalayer.battery2.status.cell_min_voltage_mV) + " mV</h4>";
     if (cell_delta_mv > datalayer.battery2.info.max_cell_voltage_deviation_mV) {
       content += "<h4 style='color: red;'>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
     } else {
       content += "<h4>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
     }
-    content +=
-        "<h4>Temperature min/max: " + String(tempMinFloat, 1) + " &deg;C / " + String(tempMaxFloat, 1) + " &deg;C</h4>";
+    content += "<h4>Temperature max: " + String(tempMaxFloat, 1) + " &deg;C</h4>";
+    content += "<h4>Temperature min: " + String(tempMinFloat, 1) + " &deg;C</h4>";
     if (datalayer.battery.status.bms_status == ACTIVE) {
       content += "<h4>System status: OK </h4>";
     } else if (datalayer.battery.status.bms_status == UPDATING) {
@@ -1592,13 +1573,6 @@ void onOTAEnd(bool success) {
 template <typename T>  // This function makes power values appear as W when under 1000, and kW when over
 String formatPowerValue(String label, T value, String unit, int precision, String color) {
   String result = "<h4 style='color: " + color + ";'>" + label + ": ";
-  result += formatPowerValue(value, unit, precision);
-  result += "</h4>";
-  return result;
-}
-template <typename T>  // This function makes power values appear as W when under 1000, and kW when over
-String formatPowerValue(T value, String unit, int precision) {
-  String result = "";
 
   if (std::is_same<T, float>::value || std::is_same<T, uint16_t>::value || std::is_same<T, uint32_t>::value) {
     float convertedValue = static_cast<float>(value);
@@ -1610,6 +1584,6 @@ String formatPowerValue(T value, String unit, int precision) {
     }
   }
 
-  result += unit;
+  result += unit + "</h4>";
   return result;
 }


### PR DESCRIPTION

What

This PR implements BMS ECU reset for the Tesla BMS (does basic checking to make sure contactors are open and ECU allows reset), and some basic logging of UDS responses. Needs wider testing and feedback.

Why

Once the BMS goes into an error state, manual intervention was needed (unplug power, yellow connector etc.)

How

Implementing the same CAN UDS command sequences Tesla's tools do.
