### PR TITLE
Crash fix: Remove faulty DEBUG_LOG section

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -290,10 +290,7 @@ void core_loop(void* task_time_us) {
       datalayer.system.status.wifi_task_10s_max_us = 0;
       datalayer.system.status.mqtt_task_10s_max_us = 0;
     }
-#endif  // FUNCTION_TIME_MEASUREMENT
-#ifdef DEBUG_LOG
-    logging.log_bms_status(datalayer.battery.status.real_bms_status);
-#endif
+#endif                     // FUNCTION_TIME_MEASUREMENT
     esp_task_wdt_reset();  // Reset watchdog to prevent reset
     vTaskDelayUntil(&xLastWakeTime, xFrequency);
   }

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -134,27 +134,3 @@ void Logging::printf(const char* fmt, ...) {
   previous_message_was_newline = message_buffer[size - 1] == '\n';
 #endif  // DEBUG_LOG
 }
-
-void Logging::log_bms_status(real_bms_status_enum bms_status) {
-  static real_bms_status_enum previous_state = BMS_FAULT;
-  if (previous_state != bms_status) {
-    switch (bms_status) {
-      case BMS_ACTIVE:
-        logging.printf("Battery%s BMS state changed to: OK\n");
-        break;
-      case BMS_DISCONNECTED:
-        logging.printf("Battery%s BMS state changed to: DISCONNECTED\n");
-        break;
-      case BMS_FAULT:
-        logging.printf("Battery%s BMS state changed to: FAULT\n");
-        break;
-      case BMS_STANDBY:
-        logging.printf("Battery%s BMS state changed to: STANDBY\n");
-        break;
-      default:
-        logging.printf("Battery%s BMS state changed to: ??\n");
-        break;
-    }
-    previous_state = bms_status;
-  }
-}


### PR DESCRIPTION
### What
This PR fixes a crash (Core  1 panic'ed (LoadProhibited). Exception was unhandled.) that would occur when the DEBUG_LOG option was enabled in the code

### Why
Crashes are bad. Hopefully fixes https://github.com/dalathegreat/Battery-Emulator/issues/972

### How
Quickfix, remove the faulty code section
