### PR TITLE
Feature: Add negative SOC scaling 📉

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -427,6 +427,12 @@ void update_calculated_values() {
     calc_soc = 10000 * (calc_soc - datalayer.battery.settings.min_percentage);
     calc_soc = calc_soc / (datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage);
     datalayer.battery.status.reported_soc = calc_soc;
+    //Extra safety since we allow scaling negatively, if real% is < 1.00%, zero it out
+    if (datalayer.battery.status.real_soc < 100) {
+      datalayer.battery.status.reported_soc = 0;
+    } else {
+      datalayer.battery.status.reported_soc = calc_soc;
+    }
 
     // Calculate the scaled remaining capacity in Wh
     if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -113,7 +113,7 @@ typedef struct {
   /** Minimum percentage setting. Set this value to the lowest real SOC
    * you want the inverter to be able to use. At this real SOC, the inverter
    * will "see" 0% */
-  uint16_t min_percentage = BATTERY_MINPERCENTAGE;
+  int16_t min_percentage = BATTERY_MINPERCENTAGE;
   /** Maximum percentage setting. Set this value to the highest real SOC
    * you want the inverter to be able to use. At this real SOC, the inverter
    * will "see" 100% */

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -209,10 +209,11 @@ String settings_processor(const String& var) {
         "100.0');}}}";
     content +=
         "function editSocMin(){var value=prompt('Inverter will see completely discharged (0pct)SOC when this value is "
-        "reached. Enter new minimum SOC value that battery will discharge to "
-        "(0-50.0):');if(value!==null){if(value>=0&&value<=50){var xhr=new "
+        "reached. Advanced users can set to negative values. Enter new minimum SOC value that battery will discharge "
+        "to "
+        "(-10.0to50.0):');if(value!==null){if(value>=-10&&value<=50){var xhr=new "
         "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateSocMin?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 and "
+        "updateSocMin?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between -10 and "
         "50.0');}}}";
     content +=
         "function editMaxChargeA(){var value=prompt('Some inverters needs to be artificially limited. Enter new "


### PR DESCRIPTION
### What
This PR implements the possibility to do negative SOC scaling

### Why
Some inverters restrict the possibility to use the entire battery. For instance with Fronius inverters, it is not possible to go below 5% battery SOC%. This can now be circumvented, by applying negatively scaled SOC.

User requested feature, fixes 1039

### How
The settings page now accepts -10.0% as the new minimum

![image](https://github.com/user-attachments/assets/eafdecf9-d95b-4d52-9dcd-37fbc5dd14c9)

Example, real battery SOC is at 1.2%, but we tell inverter that we are still at 10.2%. This would be perfect for an inverter brand that never allows discharging past 10%.

![image](https://github.com/user-attachments/assets/ba1c8b8d-a3a9-4d8e-8938-f3a23d9d7ec0)
