### PR TITLE
Microfeature: Add CPU temperature monitoring in Webserver :thermometer: 

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -336,6 +336,9 @@ void check_interconnect_available() {
 #endif  // DOUBLE_BATTERY
 
 void update_calculated_values() {
+  /* Update CPU temperature*/
+  datalayer.system.info.CPU_temperature = temperatureRead();
+
   /* Calculate allowed charge/discharge currents*/
   if (datalayer.battery.status.voltage_dV > 10) {
     // Only update value when we have voltage available to avoid div0. TODO: This should be based on nominal voltage

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -215,6 +215,8 @@ typedef struct {
 } DATALAYER_SHUNT_TYPE;
 
 typedef struct {
+  /** ESP32 main CPU temperature, for displaying on webserver and for safeties */
+  float CPU_temperature = 0;
   /** array with type of battery used, for displaying on webserver */
   char battery_protocol[64] = {0};
   /** array with type of inverter protocol used, for displaying on webserver */

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -928,7 +928,7 @@ String processor(const String& var) {
 #ifdef HW_STARK
     content += " Hardware: Stark CMR Module";
 #endif  // HW_STARK
-    content += "</h4>";
+    content += " @ " + String(datalayer.system.info.CPU_temperature, 1) + " &deg;C</h4>";
     content += "<h4>Uptime: " + uptime_formatter::getUptime() + "</h4>";
 #ifdef FUNCTION_TIME_MEASUREMENT
     // Load information


### PR DESCRIPTION
### What
This PR implements CPU temperature monitoring, for the ESP32 chip running all the Battery-Emulator code

### Why
Paving way for adding safeties for CPU temp monitoring. This first stage now adds the value to webserver

### How
CPU temperature value now shown at the top of the Webserver page, next to the Hardware used:

![image](https://github.com/user-attachments/assets/38bee3ca-fc96-47b6-a146-0fb6b3e356aa)
