### PR TITLE
Bugfix: Add rescaling of CMFA-EV raw SOC

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -70,7 +70,7 @@ static unsigned long previousMillis100ms = 0;
 static unsigned long previousMillis10ms = 0;
 
 #define MAXSOC 9000  //90.00 Raw SOC displays this value when battery is at 100%
-#define MINSOC 1000  //10.00 Raw SOC displays this value when battery is at 0%
+#define MINSOC 500   //5.00 Raw SOC displays this value when battery is at 0%
 
 static uint8_t heartbeat = 0;   //Alternates between 0x55 and 0xAA every 5th frame
 static uint8_t heartbeat2 = 0;  //Alternates between 0x55 and 0xAA every 5th frame

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -4,7 +4,7 @@
 
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 3040  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2150
+#define MIN_PACK_VOLTAGE_DV 2185
 #define MAX_CELL_DEVIATION_MV 100
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value


### PR DESCRIPTION
### What
This PR implements scaling on the raw SOC value reported by the CMFA EV battery

### Why
Raw SOC value will show 90% when full, so we cannot use it as-is

### How
The software adds two new defines

```
#define MAXSOC 9000  //90.00 Raw SOC displays this value when battery is at 100%
#define MINSOC 500  //5.00 Raw SOC displays this value when battery is at 0%
```

We use these to re-scale the raw SOC to a usable value, using a static version of a stochastic oscillator (https://en.wikipedia.org/wiki/Stochastic_oscillator). This makes it possible to get a nice usable display value out of the raw value.