### PR TITLE
Atto3: Add crashed BMS unlocking :lock: 

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -269,7 +269,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.bydAtto3.battery_temperatures[9] = battery_daughterboard_temperatures[9];
 
   // Update requests from webserver datalayer
-  if (datalayer_extended.bydAtto3.UserRequestCrashReset) {
+  if (datalayer_extended.bydAtto3.UserRequestCrashReset && stateMachineClearCrash == NOT_RUNNING) {
     stateMachineClearCrash = STARTED;
     datalayer_extended.bydAtto3.UserRequestCrashReset = false;
   }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -164,6 +164,9 @@ typedef struct {
 
 typedef struct {
   /** bool */
+  /** User requesting crash reset via WebUI*/
+  bool UserRequestCrashReset = false;
+  /** bool */
   /** Which SOC method currently used. 0 = Estimated, 1 = Measured */
   bool SOC_method = 0;
   /** uint16_t */

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -487,6 +487,7 @@ String advanced_battery_processor(const String& var) {
 
 #ifdef BYD_ATTO_3_BATTERY
     static const char* SOCmethod[2] = {"Estimated from voltage", "Measured by BMS"};
+    content += "<button onclick='askResetCrash()'>Unlock crashed BMS</button>";
     content += "<h4>SOC method used: " + String(SOCmethod[datalayer_extended.bydAtto3.SOC_method]) + "</h4>";
     content += "<h4>SOC estimated: " + String(datalayer_extended.bydAtto3.SOC_estimated) + "</h4>";
     content += "<h4>SOC highprec: " + String(datalayer_extended.bydAtto3.SOC_highprec) + "</h4>";
@@ -1496,6 +1497,18 @@ String advanced_battery_processor(const String& var) {
     content += "function teslaResetBMS() {";
     content += "  var xhr = new XMLHttpRequest();";
     content += "  xhr.open('GET', '/teslaResetBMS', true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function goToMainPage() { window.location.href = '/'; }";
+    content += "</script>";
+    content += "<script>";
+    content +=
+        "function askResetCrash() { if (window.confirm('Are you sure you want to reset crash data? "
+        "Note this will unlock your BMS and enable contactor closing and SOC calculation.')) { "
+        "resetCrash(); } }";
+    content += "function resetCrash() {";
+    content += "  var xhr = new XMLHttpRequest();";
+    content += "  xhr.open('GET', '/resetCrash', true);";
     content += "  xhr.send();";
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -597,6 +597,15 @@ void init_webserver() {
     request->send(200, "text/plain", "Updated successfully");
   });
 
+  // Route for resetting Crash data on BYD Atto3 batteries
+  server.on("/resetCrash", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
+      return request->requestAuthentication();
+    }
+    datalayer_extended.bydAtto3.UserRequestCrashReset = true;
+    request->send(200, "text/plain", "Updated successfully");
+  });
+
   // Route for erasing DTC on Volvo/Polestar batteries
   server.on("/volvoEraseDTC", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {


### PR DESCRIPTION
### What
This PR makes it possible to unlock crashed BYD Atto3 batteries :closed_lock_with_key: 

### Why
When Atto 3 EVs are crashed hard enough to trigger airbags, the BMS will lock itself and prevent contactor closing. The SOC% will also stop updating. This is problematic, and users of these batteries have suffered. Previous workarounds have been to bypass contactors, and estimate SOC% from voltage.

This is no longer a problem, since we now have the OEM commands to unlock crashed batteries :raised_hands: 

### How
This feature adds a button in the "More Battery Info" page in the webserver, that when pressed will unlock the crashed battery.

![image](https://github.com/user-attachments/assets/be01f218-0b79-436a-b9f4-e05f98467019)

 After battery is unlocked, you can remove the "USE_ESTIMATED_SOC" from the BYD-ATTO-3-BATTERY.h file. Enjoy the easy contactor closing that this feature brings :raised_hands: 

Massive thanks to EVL on the Discord for providing the log files from a BYD VDS2100 Diagnostic Tester Scan Tool

