### PR TITLE
Feature: Add ESP32 CPU overheat event

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -19,6 +19,13 @@ battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
 
 void update_machineryprotection() {
+  // Check if the CPU is too hot
+  if (datalayer.system.info.CPU_temperature > 80.0f) {
+    set_event(EVENT_CPU_OVERHEAT, 0);
+  } else {
+    clear_event(EVENT_CPU_OVERHEAT);
+  }
+
   // Check health status of CAN interfaces
   if (datalayer.system.info.can_native_send_fail) {
     set_event(EVENT_CAN_NATIVE_TX_FAILURE, 0);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -47,6 +47,7 @@ void init_events(void) {
   events.entries[EVENT_CAN_CHARGER_MISSING].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CAN_INVERTER_MISSING].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CONTACTOR_WELDED].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CPU_OVERHEAT].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_WATER_INGRESS].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DISCHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
@@ -191,6 +192,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Inverter not sending messages via CAN for the last 60 seconds. Check wiring!";
     case EVENT_CONTACTOR_WELDED:
       return "Contactors sticking/welded. Inspect battery with caution!";
+    case EVENT_CPU_OVERHEAT:
+      return "Battery-Emulator CPU overheating! Increase airflow/cooling to increase hardware lifespan!";
     case EVENT_CHARGE_LIMIT_EXCEEDED:
       return "Inverter is charging faster than battery is allowing.";
     case EVENT_DISCHARGE_LIMIT_EXCEEDED:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -21,6 +21,7 @@
   XX(EVENT_CAN_NATIVE_TX_FAILURE)              \
   XX(EVENT_CHARGE_LIMIT_EXCEEDED)              \
   XX(EVENT_CONTACTOR_WELDED)                   \
+  XX(EVENT_CPU_OVERHEAT)                       \
   XX(EVENT_DISCHARGE_LIMIT_EXCEEDED)           \
   XX(EVENT_WATER_INGRESS)                      \
   XX(EVENT_12V_LOW)                            \


### PR DESCRIPTION
### What
This PR implements a safety check for CPU temperature

### Why
So we can alert end users if the hardware is getting too hot, affecting lifespan of the hardware

### How
We now check if the CPU temp exceeds 80*C, and if it does, we raise a warning event with a helpful note

"Battery-Emulator CPU overheating! Increase airflow/cooling to increase hardware lifespan!"