### PR TITLE
Safety: Write charge/discharge power to 0 incase packvoltage get out of hand :warning: 

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -79,6 +79,7 @@ void update_machineryprotection() {
   // Battery voltage is over designed max voltage!
   if (datalayer.battery.status.voltage_dV > datalayer.battery.info.max_design_voltage_dV) {
     set_event(EVENT_BATTERY_OVERVOLTAGE, datalayer.battery.status.voltage_dV);
+    datalayer.battery.status.max_charge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_OVERVOLTAGE);
   }
@@ -86,6 +87,7 @@ void update_machineryprotection() {
   // Battery voltage is under designed min voltage!
   if (datalayer.battery.status.voltage_dV < datalayer.battery.info.min_design_voltage_dV) {
     set_event(EVENT_BATTERY_UNDERVOLTAGE, datalayer.battery.status.voltage_dV);
+    datalayer.battery.status.max_discharge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_UNDERVOLTAGE);
   }


### PR DESCRIPTION
### What
This PR implements additional safety functions on PACK_OVERVOLTAGE and PACK_UNDERVOLTAGE scenarios

### Why
To increase safety of the system

### How
Now instead of just firing a warning Event, we write allowed charge power to 0W incase the pack voltage goes above the limits set by the battery integration. Same is done for discharge power, incase of a pack undervoltage scenario.