### PR TITLE
Common standard image build

### DIFF
--- a/.github/workflows/build-common-image.yml
+++ b/.github/workflows/build-common-image.yml
@@ -1,0 +1,60 @@
+# This is the name of the workflow, visible on GitHub UI.
+name: Compile Common Image
+
+# Here we tell GitHub when to run the workflow.
+on:
+  # The workflow is run when a commit is pushed or for a
+  # Pull Request.
+  - push
+  - pull_request
+
+# This is the list of jobs that will be run concurrently.
+jobs:
+  # This pre-job is run to skip workflows in case a workflow is already run, i.e. because the workflow is triggered by both push and pull_request
+  skip-duplicate-actions:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  build-common-image:
+    needs: skip-duplicate-actions
+    if: needs.skip-duplicate-actions.outputs.should_skip != 'true'
+
+    # This is the platform GitHub will use to run our workflow.
+    runs-on: ubuntu-latest
+
+    # This is the list of steps this job will run.
+    steps:
+      # First we clone the repo using the `checkout` action.
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
+
+      # We use the `arduino/setup-arduino-cli` action to install and
+      # configure the Arduino CLI on the system.
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      # We then install the platform.
+      - name: Install platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32
+
+      # Finally, we compile the sketch, using the FQBN that was set
+      # in the build matrix, and using build flags to define the
+      # battery and inverter set in the build matrix.
+      - name: Compile Sketch
+        run: arduino-cli compile --fqbn esp32:esp32:esp32 --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -DBUILD_EM_ALL -DHW_LILYGO" ./Software

--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -114,4 +114,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -54,7 +54,7 @@ jobs:
           - BMW_PHEV_BATTERY
           - BYD_ATTO_3_BATTERY
           - CELLPOWER_BMS
-          - CHADEMO_BATTERY
+          #- CHADEMO_BATTERY    TODO: Re-enable after GPIO allocation issue fixed
           - CMFA_EV_BATTERY
           - FOXESS_BATTERY
           - IMIEV_CZERO_ION_BATTERY

--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -65,9 +65,9 @@ jobs:
           - MEB_BATTERY
           - MG_5_BATTERY
           - NISSAN_LEAF_BATTERY
-          - ORION_BMS
+          # - ORION_BMS         TODO
           - PYLON_BATTERY
-          - RJXZS_BMS
+          # - RJXZS_BMS         TODO
           - RANGE_ROVER_PHEV_BATTERY
           - RENAULT_KANGOO_BATTERY
           - RENAULT_TWIZY_BATTERY

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -115,7 +115,7 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
 
 
   # This is the name of the job.
@@ -200,7 +200,7 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
 
   # This is the name of the job.
   build-matrix-batteries-R-to-Z:
@@ -288,4 +288,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/.github/workflows/compile-all-hardware.yml
+++ b/.github/workflows/compile-all-hardware.yml
@@ -90,4 +90,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -105,4 +105,4 @@ jobs:
       # in the build matrix, and using build flags to define the
       # battery and inverter set in the build matrix.
       - name: Compile Sketch
-        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property build.partitions=min_spiffs --build-property upload.maximum_size=1966080 --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -71,6 +71,9 @@ Logging logging;
 InverterProtocol* inverter;
 BatteryBase* battery;
 
+// TODO: Proper charger selection
+Charger* charger = nullptr;
+
 // Initialization
 void setup() {
   init_serial();
@@ -114,7 +117,7 @@ void setup() {
     // TODO: Handle error, this could be out-of-memory
   }
 
-  if (inverter->usesCAN() || battery->usesCAN()) {
+  if (inverter->usesCAN() || battery->usesCAN() || charger) {
     init_CAN();
   }
 
@@ -226,9 +229,9 @@ void transmit_can() {
     inverter->transmit_can();
   }
 
-#ifdef CHARGER_SELECTED
-  transmit_can_charger();
-#endif  // CHARGER_SELECTED
+  if (charger) {
+    charger->transmit_can();
+  }
 
 #ifdef CAN_SHUNT_SELECTED
   transmit_can_shunt();

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -71,8 +71,6 @@ Logging logging;
 InverterProtocol* inverter;
 BatteryBase* battery;
 BatteryBase* battery2;
-
-// TODO: Proper charger selection
 Charger* charger = nullptr;
 
 // Initialization
@@ -115,6 +113,11 @@ void setup() {
 
   battery = init_battery(userSelectedBatteryType);
   if (battery == nullptr) {
+    // TODO: Handle error, this could be out-of-memory
+  }
+
+  if (userSelectedChargerType != ChargerType::None) {
+    charger = init_charger(userSelectedChargerType);
     // TODO: Handle error, this could be out-of-memory
   }
 

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -42,15 +42,15 @@ const char* mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
 const char* mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
 const char* mqtt_topic_name =
-    "BEdev";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
+    "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
 const char* mqtt_object_id_prefix =
-    "be_dev";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
+    "be";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
 const char* mqtt_device_name =
-    "Battery Emulator dev";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
+    "Battery Emulator";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
 const char* ha_device_id =
-    "battery-emulator-dev";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
-#endif                       // MQTT_MANUAL_TOPIC_OBJECT_NAME
-#endif                       // USE_MQTT
+    "battery-emulator";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
+#endif                   // MQTT_MANUAL_TOPIC_OBJECT_NAME
+#endif                   // USE_MQTT
 
 #ifdef EQUIPMENT_STOP_BUTTON
 // Equipment stop button behavior. Use NC button for safety reasons.

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -42,15 +42,15 @@ const char* mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
 const char* mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
 const char* mqtt_topic_name =
-    "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
+    "BEdev";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
 const char* mqtt_object_id_prefix =
-    "be_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
+    "bedev_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
 const char* mqtt_device_name =
-    "Battery Emulator";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
+    "Battery Emulator dev";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
 const char* ha_device_id =
-    "battery-emulator";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
-#endif                   // MQTT_MANUAL_TOPIC_OBJECT_NAME
-#endif                   // USE_MQTT
+    "battery-emulator-dev";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
+#endif                       // MQTT_MANUAL_TOPIC_OBJECT_NAME
+#endif                       // USE_MQTT
 
 #ifdef EQUIPMENT_STOP_BUTTON
 // Equipment stop button behavior. Use NC button for safety reasons.

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -42,15 +42,15 @@ const char* mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
 const char* mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
 const char* mqtt_topic_name =
-    "BEdev";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
+    "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
 const char* mqtt_object_id_prefix =
-    "bedev_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
+    "be_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
 const char* mqtt_device_name =
-    "Battery Emulator dev";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
+    "Battery Emulator";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
 const char* ha_device_id =
-    "battery-emulator-dev";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
-#endif                       // MQTT_MANUAL_TOPIC_OBJECT_NAME
-#endif                       // USE_MQTT
+    "battery-emulator";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
+#endif                   // MQTT_MANUAL_TOPIC_OBJECT_NAME
+#endif                   // USE_MQTT
 
 #ifdef EQUIPMENT_STOP_BUTTON
 // Equipment stop button behavior. Use NC button for safety reasons.

--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -42,15 +42,15 @@ const char* mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
 const char* mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
 #ifdef MQTT_MANUAL_TOPIC_OBJECT_NAME
 const char* mqtt_topic_name =
-    "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
+    "BEdev";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
 const char* mqtt_object_id_prefix =
-    "be_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
+    "be_dev";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
 const char* mqtt_device_name =
-    "Battery Emulator";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
+    "Battery Emulator dev";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
 const char* ha_device_id =
-    "battery-emulator";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
-#endif                   // MQTT_MANUAL_TOPIC_OBJECT_NAME
-#endif                   // USE_MQTT
+    "battery-emulator-dev";  // Custom device ID in Home Assistant. Previously, the ID was always "battery-emulator"
+#endif                       // MQTT_MANUAL_TOPIC_OBJECT_NAME
+#endif                       // USE_MQTT
 
 #ifdef EQUIPMENT_STOP_BUTTON
 // Equipment stop button behavior. Use NC button for safety reasons.

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -83,11 +83,11 @@
 
 /* Contactor settings. If you have a battery that does not activate contactors via CAN, configure this section */
 #define PRECHARGE_TIME_MS 500  //Precharge time in milliseconds. Modify to suit your inverter (See wiki for more info)
-#define CONTACTOR_CONTROL  //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
+//#define CONTACTOR_CONTROL  //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
 //#define CONTACTOR_CONTROL_DOUBLE_BATTERY //Enable this line to have the emulator hardware control secondary set of contactors for double battery setups (See wiki for pins)
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation. CONTACTOR_CONTROL must be enabled.
 //#define NC_CONTACTORS         //Enable this line to control normally closed contactors. CONTACTOR_CONTROL must be enabled for this option. Extremely rare setting!
-#define PERIODIC_BMS_RESET  //Enable to have the emulator powercycle the connected battery every 24hours via GPIO. Useful for some batteries like Nissan LEAF
+//#define PERIODIC_BMS_RESET  //Enable to have the emulator powercycle the connected battery every 24hours via GPIO. Useful for some batteries like Nissan LEAF
 //#define REMOTE_BMS_RESET      //Enable to allow the emulator to remotely trigger a powercycle of the battery via MQTT. Useful for some batteries like Nissan LEAF
 // PERIODIC_BMS_RESET_AT Uses NTP server, internet required. In 24 Hour format WITHOUT leading 0. e.g 0230 should be 230. Time Zone is set in USER_SETTINGS.cpp
 //#define PERIODIC_BMS_RESET_AT 525
@@ -130,7 +130,7 @@
 //#define FUNCTION_TIME_MEASUREMENT  // Enable this to record execution times and present them in the web UI (WARNING, raises CPU load, do not use for production)
 
 /* MQTT options */
-#define MQTT                        // Enable this line to enable MQTT
+//#define MQTT                        // Enable this line to enable MQTT
 #define MQTT_QOS 0                  // MQTT Quality of Service (0, 1, or 2)
 #define MQTT_PUBLISH_CELL_VOLTAGES  // Enable this line to publish cell voltages to MQTT
 #define MQTT_TIMEOUT 2000           // MQTT timeout in milliseconds

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -8,6 +8,14 @@
 /* There are also some options for battery limits and extra functionality */
 /* To edit battery specific limits, see also the USER_SETTINGS.cpp file*/
 
+// Defining BUILD_EM_ALL builds in support for all batteries and inverter protocols
+// and allows selecting them at run-time.
+#define BUILD_EM_ALL
+
+#ifdef BUILD_EM_ALL
+#define HW_LILYGO
+#endif
+
 /* Select battery used */
 //#define BMW_I3_BATTERY
 //#define BMW_IX_BATTERY
@@ -75,11 +83,11 @@
 
 /* Contactor settings. If you have a battery that does not activate contactors via CAN, configure this section */
 #define PRECHARGE_TIME_MS 500  //Precharge time in milliseconds. Modify to suit your inverter (See wiki for more info)
-//#define CONTACTOR_CONTROL     //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
+#define CONTACTOR_CONTROL  //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
 //#define CONTACTOR_CONTROL_DOUBLE_BATTERY //Enable this line to have the emulator hardware control secondary set of contactors for double battery setups (See wiki for pins)
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation. CONTACTOR_CONTROL must be enabled.
 //#define NC_CONTACTORS         //Enable this line to control normally closed contactors. CONTACTOR_CONTROL must be enabled for this option. Extremely rare setting!
-//#define PERIODIC_BMS_RESET    //Enable to have the emulator powercycle the connected battery every 24hours via GPIO. Useful for some batteries like Nissan LEAF
+#define PERIODIC_BMS_RESET  //Enable to have the emulator powercycle the connected battery every 24hours via GPIO. Useful for some batteries like Nissan LEAF
 //#define REMOTE_BMS_RESET      //Enable to allow the emulator to remotely trigger a powercycle of the battery via MQTT. Useful for some batteries like Nissan LEAF
 // PERIODIC_BMS_RESET_AT Uses NTP server, internet required. In 24 Hour format WITHOUT leading 0. e.g 0230 should be 230. Time Zone is set in USER_SETTINGS.cpp
 //#define PERIODIC_BMS_RESET_AT 525
@@ -122,7 +130,7 @@
 //#define FUNCTION_TIME_MEASUREMENT  // Enable this to record execution times and present them in the web UI (WARNING, raises CPU load, do not use for production)
 
 /* MQTT options */
-// #define MQTT     // Enable this line to enable MQTT
+#define MQTT                        // Enable this line to enable MQTT
 #define MQTT_QOS 0                  // MQTT Quality of Service (0, 1, or 2)
 #define MQTT_PUBLISH_CELL_VOLTAGES  // Enable this line to publish cell voltages to MQTT
 #define MQTT_TIMEOUT 2000           // MQTT timeout in milliseconds
@@ -162,7 +170,7 @@
 #define BATTERY_MAX_DISCHARGE_VOLTAGE 3000
 
 /* LED settings. Optional customization for how the blinking pattern on the LED should behave.
-* CLASSIC   - Slow up/down ramp. If CLASSIC, then a ramp up and ramp down will finish in LED_PERIOD_MS milliseconds
+* CLASSIC   - Slow up/down ramp. If CLASSIC, then a ramp up and ramp down will finish in LED_PERIOD time period
 * FLOW      - Ramp up/down depending on flow of energy
 * HEARTBEAT - Heartbeat-like LED pattern that reacts to the system state with color and BPM
 */
@@ -204,10 +212,6 @@ extern IPAddress subnet;
 
 #if defined(DEBUG_VIA_USB) || defined(DEBUG_VIA_WEB) || defined(LOG_TO_SD)
 #define DEBUG_LOG
-#endif
-
-#if defined(MEB_BATTERY)
-#define PRECHARGE_CONTROL
 #endif
 
 #endif  // __USER_SETTINGS_H__

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -9,12 +9,8 @@
 /* To edit battery specific limits, see also the USER_SETTINGS.cpp file*/
 
 // Defining BUILD_EM_ALL builds in support for all batteries and inverter protocols
-// and allows selecting them at run-time.
+// and allows selecting them at run-time. This should be enabled at build time.
 #define BUILD_EM_ALL
-
-#ifdef BUILD_EM_ALL
-#define HW_LILYGO
-#endif
 
 /* Select battery used */
 //#define BMW_I3_BATTERY
@@ -52,7 +48,6 @@
 //#define VOLVO_SPA_BATTERY
 //#define VOLVO_SPA_HYBRID_BATTERY
 //#define TEST_FAKE_BATTERY
-//#define DOUBLE_BATTERY  //Enable this line if you use two identical batteries at the same time (requires separate CAN setup)
 
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/Battery-Emulator/wiki */
 //#define AFORE_CAN        //Enable this line to emulate an "Afore battery" over CAN bus
@@ -76,14 +71,14 @@
 //#define SUNGROW_CAN      //Enable this line to emulate a "Sungrow SBR064" over CAN bus
 
 /* Select hardware used for Battery-Emulator */
-//#define HW_LILYGO
+#define HW_LILYGO
 //#define HW_STARK
 //#define HW_3LB
 //#define HW_DEVKIT
 
 /* Contactor settings. If you have a battery that does not activate contactors via CAN, configure this section */
 #define PRECHARGE_TIME_MS 500  //Precharge time in milliseconds. Modify to suit your inverter (See wiki for more info)
-//#define CONTACTOR_CONTROL  //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
+#define CONTACTOR_CONTROL  //Enable this line to have the emulator handle automatic precharge/contactor+/contactor- closing sequence (See wiki for pins)
 //#define CONTACTOR_CONTROL_DOUBLE_BATTERY //Enable this line to have the emulator hardware control secondary set of contactors for double battery setups (See wiki for pins)
 //#define PWM_CONTACTOR_CONTROL //Enable this line to use PWM for CONTACTOR_CONTROL, which lowers power consumption and heat generation. CONTACTOR_CONTROL must be enabled.
 //#define NC_CONTACTORS         //Enable this line to control normally closed contactors. CONTACTOR_CONTROL must be enabled for this option. Extremely rare setting!
@@ -130,7 +125,7 @@
 //#define FUNCTION_TIME_MEASUREMENT  // Enable this to record execution times and present them in the web UI (WARNING, raises CPU load, do not use for production)
 
 /* MQTT options */
-//#define MQTT                        // Enable this line to enable MQTT
+#define MQTT                        // Enable this line to enable MQTT
 #define MQTT_QOS 0                  // MQTT Quality of Service (0, 1, or 2)
 #define MQTT_PUBLISH_CELL_VOLTAGES  // Enable this line to publish cell voltages to MQTT
 #define MQTT_TIMEOUT 2000           // MQTT timeout in milliseconds

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -42,6 +42,11 @@
 #define VOLVO_SPA_HYBRID_BATTERY
 #endif
 
+#ifdef MEB_BATTERY
+#define PRECHARGE_CONTROL
+#include "MEB-BATTERY.h"
+#endif
+
 #ifdef BMW_SBOX
 #include "BMW-SBOX.h"
 void handle_incoming_can_frame_shunt(CAN_frame rx_frame);
@@ -118,11 +123,6 @@ void setup_can_shunt();
 #include "KIA-HYUNDAI-HYBRID-BATTERY.h"
 #endif
 
-#ifdef MEB_BATTERY
-#include "MEB-BATTERY.h"
-#define PRECHARGE_CONTROL
-#endif
-
 #ifdef MG_5_BATTERY
 #include "MG-5-BATTERY.h"
 #endif
@@ -186,11 +186,6 @@ void setup_can_shunt();
 
 #ifdef VOLVO_SPA_HYBRID_BATTERY
 #include "VOLVO-SPA-HYBRID-BATTERY.h"
-#endif
-
-#ifdef DOUBLE_BATTERY
-void update_values_battery2();
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame);
 #endif
 
 #endif

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -2,6 +2,46 @@
 #define BATTERIES_H
 #include "../../USER_SETTINGS.h"
 
+// Selection of batteries to the common image.
+#ifdef BUILD_EM_ALL
+#define BMW_I3_BATTERY
+#define BMW_IX_BATTERY
+#define BMW_PHEV_BATTERY
+#define BOLT_AMPERA_BATTERY
+#define BYD_ATTO_3_BATTERY
+#define CELLPOWER_BMS
+#define CMFA_EV_BATTERY
+// TODO: Chademo has conflict usage of GPIO: Need to implement run-time allocation of GPIO resources.
+//#define CHADEMO_BATTERY
+#define FOXESS_BATTERY
+//#define ORION_BMS
+#define SONO_BATTERY
+#define STELLANTIS_ECMP_BATTERY
+#define IMIEV_CZERO_ION_BATTERY
+#define JAGUAR_IPACE_BATTERY
+#define KIA_E_GMP_BATTERY
+#define KIA_HYUNDAI_64_BATTERY
+#define KIA_HYUNDAI_HYBRID_BATTERY
+#define MEB_BATTERY
+#define MG_5_BATTERY
+#define NISSAN_LEAF_BATTERY
+#define PYLON_BATTERY
+#define DALY_BMS
+//#define RJXZS_BMS
+#define RANGE_ROVER_PHEV_BATTERY
+#define RENAULT_KANGOO_BATTERY
+#define RENAULT_TWIZY_BATTERY
+#define RENAULT_ZOE_GEN1_BATTERY
+#define RENAULT_ZOE_GEN2_BATTERY
+#define SANTA_FE_PHEV_BATTERY
+//#define SIMPBMS_BATTERY
+#define TESLA_MODEL_SX_BATTERY
+#define TESLA_MODEL_3Y_BATTERY
+#define TEST_FAKE_BATTERY
+#define VOLVO_SPA_BATTERY
+#define VOLVO_SPA_HYBRID_BATTERY
+#endif
+
 #ifdef BMW_SBOX
 #include "BMW-SBOX.h"
 void handle_incoming_can_frame_shunt(CAN_frame rx_frame);
@@ -80,6 +120,7 @@ void setup_can_shunt();
 
 #ifdef MEB_BATTERY
 #include "MEB-BATTERY.h"
+#define PRECHARGE_CONTROL
 #endif
 
 #ifdef MG_5_BATTERY
@@ -145,17 +186,6 @@ void setup_can_shunt();
 
 #ifdef VOLVO_SPA_HYBRID_BATTERY
 #include "VOLVO-SPA-HYBRID-BATTERY.h"
-#endif
-
-void setup_battery(void);
-void update_values_battery();
-
-#ifdef RS485_BATTERY_SELECTED
-void transmit_rs485();
-void receive_RS485();
-#else
-void handle_incoming_can_frame_battery(CAN_frame rx_frame);
-void transmit_can_battery();
 #endif
 
 #ifdef DOUBLE_BATTERY

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -2,6 +2,7 @@
 #define BMW_I3_BATTERY_H
 #include <Arduino.h>
 #include "../include.h"
+#include "Battery.h"
 
 #define BATTERY_SELECTED
 
@@ -19,7 +20,362 @@
 #define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
 #define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
 #define NUMBER_OF_CELLS 96
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class BMWi3Battery : public CanBattery {
+ public:
+  BMWi3Battery() : CanBattery(BMWi3) {}
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BMW i3";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void update_values2();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
+  unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send
+  unsigned long previousMillis500 = 0;    // will store last time a 500ms CAN Message was send
+  unsigned long previousMillis640 = 0;    // will store last time a 600ms CAN Message was send
+  unsigned long previousMillis1000 = 0;   // will store last time a 1000ms CAN Message was send
+  unsigned long previousMillis5000 = 0;   // will store last time a 5000ms CAN Message was send
+  unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
+
+#define ALIVE_MAX_VALUE 14  // BMW CAN messages contain alive counter, goes from 0...14
+
+  enum BatterySize { BATTERY_60AH, BATTERY_94AH, BATTERY_120AH };
+  BatterySize detectedBattery = BATTERY_60AH;
+  BatterySize detectedBattery2 = BATTERY_60AH;  // For double battery setups
+
+  enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST };
+
+  CmdState cmdState = SOC;
+
+  /* CAN messages from PT-CAN2 not needed to operate the battery
+0AA 105 13D 0BB 0AD 0A5 150 100 1A1 10E 153 197 429 1AA 12F 59A 2E3 2BE 211 2b3 3FD 2E8 2B7 108 29D 29C 29B 2C0 330
+3E9 32F 19E 326 55E 515 509 50A 51A 2F5 3A4 432 3C9 
+*/
+
+  CAN_frame BMW_10B = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 3,
+                       .ID = 0x10B,
+                       .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command
+  CAN_frame BMW_12F = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x12F,
+                       .data = {0xE6, 0x24, 0x86, 0x1A, 0xF1, 0x31, 0x30, 0x00}};  //0x12F Wakeup VCU
+  CAN_frame BMW_13E = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x13E,
+                       .data = {0xFF, 0x31, 0xFA, 0xFA, 0xFA, 0xFA, 0x0C, 0x00}};
+  CAN_frame BMW_192 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x192,
+                       .data = {0xFF, 0xFF, 0xA3, 0x8F, 0x93, 0xFF, 0xFF, 0xFF}};
+  CAN_frame BMW_19B = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x19B,
+                       .data = {0x20, 0x40, 0x40, 0x55, 0xFD, 0xFF, 0xFF, 0xFF}};
+  CAN_frame BMW_1D0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x1D0,
+                       .data = {0x4D, 0xF0, 0xAE, 0xF8, 0xFF, 0xFF, 0xFF, 0xFF}};
+  CAN_frame BMW_2CA = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x2CA, .data = {0x57, 0x57}};
+  CAN_frame BMW_2E2 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x2E2,
+                       .data = {0x4F, 0xDB, 0x7F, 0xB9, 0x07, 0x51, 0xff, 0x00}};
+  CAN_frame BMW_30B = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x30B,
+                       .data = {0xe1, 0xf0, 0xff, 0xff, 0xf1, 0xff, 0xff, 0xff}};
+  CAN_frame BMW_328 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x328,
+                       .data = {0xB0, 0xE4, 0x87, 0x0E, 0x30, 0x22}};
+  CAN_frame BMW_37B = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x37B,
+                       .data = {0x40, 0x00, 0x00, 0xFF, 0xFF, 0x00}};
+  CAN_frame BMW_380 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 7,
+                       .ID = 0x380,
+                       .data = {0x56, 0x5A, 0x37, 0x39, 0x34, 0x34, 0x34}};
+  CAN_frame BMW_3A0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3A0,
+                       .data = {0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFC}};
+  CAN_frame BMW_3A7 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 7,
+                       .ID = 0x3A7,
+                       .data = {0x05, 0xF5, 0x0A, 0x00, 0x4F, 0x11, 0xF0}};
+  CAN_frame BMW_3C5 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3C5,
+                       .data = {0x30, 0x05, 0x47, 0x70, 0x2c, 0xce, 0xc3, 0x34}};
+  CAN_frame BMW_3CA = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3CA,
+                       .data = {0x87, 0x80, 0x30, 0x0C, 0x0C, 0x81, 0xFF, 0xFF}};
+  CAN_frame BMW_3D0 = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x3D0, .data = {0xFD, 0xFF}};
+  CAN_frame BMW_3E4 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x3E4,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF}};
+  CAN_frame BMW_3E5 = {.FD = false, .ext_ID = false, .DLC = 3, .ID = 0x3E5, .data = {0xFC, 0xFF, 0xFF}};
+  CAN_frame BMW_3E8 = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x3E8, .data = {0xF0, 0xFF}};  //1000ms OBD reset
+  CAN_frame BMW_3EC = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3EC,
+                       .data = {0xF5, 0x10, 0x00, 0x00, 0x80, 0x25, 0x0F, 0xFC}};
+  CAN_frame BMW_3F9 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3F9,
+                       .data = {0xA7, 0x2A, 0x00, 0xE2, 0xA6, 0x30, 0xC3, 0xFF}};
+  CAN_frame BMW_3FB = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 6,
+                       .ID = 0x3FB,
+                       .data = {0xFF, 0xFF, 0xFF, 0xFF, 0x5F, 0x00}};
+  CAN_frame BMW_3FC = {.FD = false, .ext_ID = false, .DLC = 3, .ID = 0x3FC, .data = {0xC0, 0xF9, 0x0F}};
+  CAN_frame BMW_418 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x418,
+                       .data = {0xFF, 0x7C, 0xFF, 0x00, 0xC0, 0x3F, 0xFF, 0xFF}};
+  CAN_frame BMW_41D = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x41D, .data = {0xFF, 0xF7, 0x7F, 0xFF}};
+  CAN_frame BMW_433 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 4,
+                       .ID = 0x433,
+                       .data = {0xFF, 0x00, 0x0F, 0xFF}};  // HV specification
+  CAN_frame BMW_512 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x512,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12}};  // 0x512 Network management
+  CAN_frame BMW_592_0 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x592,
+                         .data = {0x86, 0x10, 0x07, 0x21, 0x6e, 0x35, 0x5e, 0x86}};
+  CAN_frame BMW_592_1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x592,
+                         .data = {0x86, 0x21, 0xb4, 0xdd, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BMW_5F8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5F8,
+                       .data = {0x64, 0x01, 0x00, 0x0B, 0x92, 0x03, 0x00, 0x05}};
+  CAN_frame BMW_6F1_CELL = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 5,
+                            .ID = 0x6F1,
+                            .data = {0x07, 0x03, 0x22, 0xDD, 0xBF}};
+  CAN_frame BMW_6F1_SOH = {.FD = false, .ext_ID = false, .DLC = 5, .ID = 0x6F1, .data = {0x07, 0x03, 0x22, 0x63, 0x35}};
+  CAN_frame BMW_6F1_SOC = {.FD = false, .ext_ID = false, .DLC = 5, .ID = 0x6F1, .data = {0x07, 0x03, 0x22, 0xDD, 0xBC}};
+  CAN_frame BMW_6F1_CELL_VOLTAGE_AVG = {.FD = false,
+                                        .ext_ID = false,
+                                        .DLC = 5,
+                                        .ID = 0x6F1,
+                                        .data = {0x07, 0x03, 0x22, 0xDF, 0xA0}};
+  CAN_frame BMW_6F1_CONTINUE = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x6F1, .data = {0x07, 0x30, 0x00, 0x02}};
+  CAN_frame BMW_6F4_CELL_VOLTAGE_CELLNO = {.FD = false,
+                                           .ext_ID = false,
+                                           .DLC = 7,
+                                           .ID = 0x6F4,
+                                           .data = {0x07, 0x05, 0x31, 0x01, 0xAD, 0x6E, 0x01}};
+  CAN_frame BMW_6F4_CELL_CONTINUE = {.FD = false,
+                                     .ext_ID = false,
+                                     .DLC = 6,
+                                     .ID = 0x6F4,
+                                     .data = {0x07, 0x04, 0x31, 0x03, 0xAD, 0x6E}};
+
+  //The above CAN messages need to be sent towards the battery to keep it alive
+
+  uint8_t startup_counter_contactor = 0;
+  uint8_t alive_counter_20ms = 0;
+  uint8_t alive_counter_100ms = 0;
+  uint8_t alive_counter_200ms = 0;
+  uint8_t alive_counter_500ms = 0;
+  uint8_t alive_counter_1000ms = 0;
+  uint8_t alive_counter_5000ms = 0;
+  uint8_t BMW_1D0_counter = 0;
+  uint8_t BMW_13E_counter = 0;
+  uint8_t BMW_380_counter = 0;
+  uint32_t BMW_328_counter = 0;
+
+  bool battery_awake = false;
+  bool battery2_awake = false;
+  bool battery_info_available = false;
+  bool battery2_info_available = false;
+  bool skipCRCCheck = false;
+  bool CRCCheckPassedPreviously = false;
+  bool skipCRCCheck_battery2 = false;
+  bool CRCCheckPassedPreviously_battery2 = false;
+
+  uint16_t cellvoltage_temp_mV = 0;
+  uint32_t battery_serial_number = 0;
+  uint32_t battery_available_power_shortterm_charge = 0;
+  uint32_t battery_available_power_shortterm_discharge = 0;
+  uint32_t battery_available_power_longterm_charge = 0;
+  uint32_t battery_available_power_longterm_discharge = 0;
+  uint32_t battery_BEV_available_power_shortterm_charge = 0;
+  uint32_t battery_BEV_available_power_shortterm_discharge = 0;
+  uint32_t battery_BEV_available_power_longterm_charge = 0;
+  uint32_t battery_BEV_available_power_longterm_discharge = 0;
+  uint16_t battery_energy_content_maximum_Wh = 0;
+  uint16_t battery_display_SOC = 0;
+  uint16_t battery_volts = 0;
+  uint16_t battery_HVBatt_SOC = 0;
+  uint16_t battery_DC_link_voltage = 0;
+  uint16_t battery_max_charge_voltage = 0;
+  uint16_t battery_min_discharge_voltage = 0;
+  uint16_t battery_predicted_energy_charge_condition = 0;
+  uint16_t battery_predicted_energy_charging_target = 0;
+  uint16_t battery_actual_value_power_heating = 0;  //0 - 4094 W
+  uint16_t battery_prediction_voltage_shortterm_charge = 0;
+  uint16_t battery_prediction_voltage_shortterm_discharge = 0;
+  uint16_t battery_prediction_voltage_longterm_charge = 0;
+  uint16_t battery_prediction_voltage_longterm_discharge = 0;
+  uint16_t battery_prediction_duration_charging_minutes = 0;
+  uint16_t battery_target_voltage_in_CV_mode = 0;
+  uint16_t battery_soc = 0;
+  uint16_t battery_soc_hvmax = 0;
+  uint16_t battery_soc_hvmin = 0;
+  uint16_t battery_capacity_cah = 0;
+  int16_t battery_temperature_HV = 0;
+  int16_t battery_temperature_heat_exchanger = 0;
+  int16_t battery_temperature_max = 0;
+  int16_t battery_temperature_min = 0;
+  int16_t battery_max_charge_amperage = 0;
+  int16_t battery_max_discharge_amperage = 0;
+  int16_t battery_current = 0;
+  uint8_t battery_status_error_isolation_external_Bordnetz = 0;
+  uint8_t battery_status_error_isolation_internal_Bordnetz = 0;
+  uint8_t battery_request_cooling = 0;
+  uint8_t battery_status_valve_cooling = 0;
+  uint8_t battery_status_error_locking = 0;
+  uint8_t battery_status_precharge_locked = 0;
+  uint8_t battery_status_disconnecting_switch = 0;
+  uint8_t battery_status_emergency_mode = 0;
+  uint8_t battery_request_service = 0;
+  uint8_t battery_error_emergency_mode = 0;
+  uint8_t battery_status_error_disconnecting_switch = 0;
+  uint8_t battery_status_warning_isolation = 0;
+  uint8_t battery_status_cold_shutoff_valve = 0;
+  uint8_t battery_request_open_contactors = 0;
+  uint8_t battery_request_open_contactors_instantly = 0;
+  uint8_t battery_request_open_contactors_fast = 0;
+  uint8_t battery_charging_condition_delta = 0;
+  uint8_t battery_status_service_disconnection_plug = 0;
+  uint8_t battery_status_measurement_isolation = 0;
+  uint8_t battery_request_abort_charging = 0;
+  uint8_t battery_prediction_time_end_of_charging_minutes = 0;
+  uint8_t battery_request_operating_mode = 0;
+  uint8_t battery_request_charging_condition_minimum = 0;
+  uint8_t battery_request_charging_condition_maximum = 0;
+  uint8_t battery_status_cooling_HV = 0;      //1 works, 2 does not start
+  uint8_t battery_status_diagnostics_HV = 0;  // 0 all OK, 1 HV protection function error, 2 diag not yet expired
+  uint8_t battery_status_diagnosis_powertrain_maximum_multiplexer = 0;
+  uint8_t battery_status_diagnosis_powertrain_immediate_multiplexer = 0;
+  uint8_t battery_ID2 = 0;
+  uint8_t battery_soh = 99;
+
+  uint16_t cellvoltage2_temp_mV = 0;
+  uint32_t battery2_serial_number = 0;
+  uint32_t battery2_available_power_shortterm_charge = 0;
+  uint32_t battery2_available_power_shortterm_discharge = 0;
+  uint32_t battery2_available_power_longterm_charge = 0;
+  uint32_t battery2_available_power_longterm_discharge = 0;
+  uint32_t battery2_BEV_available_power_shortterm_charge = 0;
+  uint32_t battery2_BEV_available_power_shortterm_discharge = 0;
+  uint32_t battery2_BEV_available_power_longterm_charge = 0;
+  uint32_t battery2_BEV_available_power_longterm_discharge = 0;
+  uint16_t battery2_energy_content_maximum_Wh = 0;
+  uint16_t battery2_display_SOC = 0;
+  uint16_t battery2_volts = 0;
+  uint16_t battery2_HVBatt_SOC = 0;
+  uint16_t battery2_DC_link_voltage = 0;
+  uint16_t battery2_max_charge_voltage = 0;
+  uint16_t battery2_min_discharge_voltage = 0;
+  uint16_t battery2_predicted_energy_charge_condition = 0;
+  uint16_t battery2_predicted_energy_charging_target = 0;
+  uint16_t battery2_actual_value_power_heating = 0;  //0 - 4094 W
+  uint16_t battery2_prediction_voltage_shortterm_charge = 0;
+  uint16_t battery2_prediction_voltage_shortterm_discharge = 0;
+  uint16_t battery2_prediction_voltage_longterm_charge = 0;
+  uint16_t battery2_prediction_voltage_longterm_discharge = 0;
+  uint16_t battery2_prediction_duration_charging_minutes = 0;
+  uint16_t battery2_target_voltage_in_CV_mode = 0;
+  uint16_t battery2_soc = 0;
+  uint16_t battery2_soc_hvmax = 0;
+  uint16_t battery2_soc_hvmin = 0;
+  uint16_t battery2_capacity_cah = 0;
+  int16_t battery2_temperature_HV = 0;
+  int16_t battery2_temperature_heat_exchanger = 0;
+  int16_t battery2_temperature_max = 0;
+  int16_t battery2_temperature_min = 0;
+  int16_t battery2_max_charge_amperage = 0;
+  int16_t battery2_max_discharge_amperage = 0;
+  int16_t battery2_current = 0;
+  uint8_t battery2_status_error_isolation_external_Bordnetz = 0;
+  uint8_t battery2_status_error_isolation_internal_Bordnetz = 0;
+  uint8_t battery2_request_cooling = 0;
+  uint8_t battery2_status_valve_cooling = 0;
+  uint8_t battery2_status_error_locking = 0;
+  uint8_t battery2_status_precharge_locked = 0;
+  uint8_t battery2_status_disconnecting_switch = 0;
+  uint8_t battery2_status_emergency_mode = 0;
+  uint8_t battery2_request_service = 0;
+  uint8_t battery2_error_emergency_mode = 0;
+  uint8_t battery2_status_error_disconnecting_switch = 0;
+  uint8_t battery2_status_warning_isolation = 0;
+  uint8_t battery2_status_cold_shutoff_valve = 0;
+  uint8_t battery2_request_open_contactors = 0;
+  uint8_t battery2_request_open_contactors_instantly = 0;
+  uint8_t battery2_request_open_contactors_fast = 0;
+  uint8_t battery2_charging_condition_delta = 0;
+  uint8_t battery2_status_service_disconnection_plug = 0;
+  uint8_t battery2_status_measurement_isolation = 0;
+  uint8_t battery2_request_abort_charging = 0;
+  uint8_t battery2_prediction_time_end_of_charging_minutes = 0;
+  uint8_t battery2_request_operating_mode = 0;
+  uint8_t battery2_request_charging_condition_minimum = 0;
+  uint8_t battery2_request_charging_condition_maximum = 0;
+  uint8_t battery2_status_cooling_HV = 0;      //1 works, 2 does not start
+  uint8_t battery2_status_diagnostics_HV = 0;  // 0 all OK, 1 HV protection function error, 2 diag not yet expired
+  uint8_t battery2_status_diagnosis_powertrain_maximum_multiplexer = 0;
+  uint8_t battery2_status_diagnosis_powertrain_immediate_multiplexer = 0;
+  uint8_t battery2_ID2 = 0;
+  uint8_t battery2_soh = 99;
+
+  uint8_t message_data[50];
+  uint8_t next_data = 0;
+  uint8_t current_cell_polled = 0;
+};
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef BMW_I3_BATTERY_H
 #define BMW_I3_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 #include "Battery.h"
 
@@ -23,18 +24,26 @@
 
 class BMWi3Battery : public CanBattery {
  public:
-  BMWi3Battery() : CanBattery(BMWi3) {}
+  BMWi3Battery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface, int wakeup_pin) : CanBattery(BMWi3) {
+    m_target = target;
+    m_can_interface = can_interface;
+    m_wakeup_pin = wakeup_pin;
+  }
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "BMW i3";
 
+  virtual bool supportsDoubleBattery() { return true; };
   virtual void setup();
   virtual void update_values();
-  virtual void update_values2();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
  private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
+  int m_wakeup_pin;
+
   unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
   unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -421,7 +421,7 @@ void BMWIXBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -5,393 +5,15 @@
 #include "../devboard/utils/events.h"
 #include "BMW-IX-BATTERY.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
-static unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send
-static unsigned long previousMillis500 = 0;    // will store last time a 500ms CAN Message was send
-static unsigned long previousMillis640 = 0;    // will store last time a 600ms CAN Message was send
-static unsigned long previousMillis1000 = 0;   // will store last time a 1000ms CAN Message was send
-static unsigned long previousMillis5000 = 0;   // will store last time a 5000ms CAN Message was send
-static unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
 
-#define ALIVE_MAX_VALUE 14  // BMW CAN messages contain alive counter, goes from 0...14
-
-enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST };
-
-static CmdState cmdState = SOC;
-
-/*
-Suspected Vehicle comms required:
-  0x06D DLC? 1000ms - counters?
-  0x2F1 DLC? 1000ms  during run : 0xFF, 0xFF, 0xFF, 0xFF, 0x9B, 0x00, 0xF3, 0xFF - at startup  0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xF3, 0xFF.   Suspect byte [4] is a counter
-  0x439 DLC4 1000ms  STATIC 
-  0x0C0 DLC2 200ms needs counter
-  0x587 DLC8 appears at startup   0x78 0x07 0x00 0x00 0xFF 0xFF 0xFF 0xFF , 0x01 0x03 0x80 0xFF 0xFF 0xFF 0xFF 0xFF,  0x78 0x07 0x00 0x00 0xFF 0xFF 0xFF 0xFF,   0x06 0x00 0x00 0xFF 0xFF 0xFF 0xFF 0xFF, 0x01 0x03 0x82 0xFF 0xFF 0xFF 0xFF 0xFF, 0x01 0x03 0x80 0xFF 0xFF 0xFF 0xFF 0xFF
-
-SME Output:
-  0x08F DLC48  10ms    - Appears to have analog readings like volt/temp/current
-  0x12B8D087 5000ms  - Extended ID
-  0x1D2 DLC8  1000ms
-  0x20B DLC8  1000ms
-  0x2E2 DLC16 1000ms
-  0x2F1 DLC8  1000ms
-  0x31F DLC16 100ms - 2 downward counters?
-  0x453 DLC20 200ms
-  0x486 DLC48  1000ms
-  0x49C DLC8 1000ms
-  0x4A1 DLC8 1000ms
-  0x4BB DLC64  200ms - seems multplexed on [0]
-  0x4D0 DLC64 1000ms - some slow/flickering values - possible change during fault
-  0x510 DLC8 100ms  STATIC 40 10 40 00 6F DF 19 00  during run -  Startup sends this once: 0x40 0x10 0x02 0x00 0x00 0x00 0x00 0x00
-  0x607 UDS Response
-
-No vehicle  log available, SME asks for:
-  0x125 (CCU)
-  0x16E (CCU)
-  0x340 (CCU)
-  0x4F8 (CCU)
-  0x188 (CCU)
-  0x91 (EME1)
-  0xAA (EME2)
-  0x?? Suspect there is a drive mode flag somewhere - balancing might only be active in some modes
-
-TODO
-- Request batt serial number on F1 8C (already parsing RX)
-
-*/
-
-//Vehicle CAN START
-CAN_frame BMWiX_06D = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x06D,
-    .data = {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
-        0xFF}};  // 1000ms BDC Output - [0] static [1,2][3,4] counter x2. 3,4 is 9 higher than 1,2 is needed? [5-7] static
-
-CAN_frame BMWiX_0C0 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 2,
-    .ID = 0x0C0,
-    .data = {
-        0xF0,
-        0x00}};  // Keep Alive 2 BDC>SME  200ms First byte cycles F0 > FE  second byte 00 static - MINIMUM ID TO KEEP SME AWAKE
-
-CAN_frame BMWiX_276 = {.FD = true,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x476,
-                       .data = {0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF,
-                                0xFC}};  // 5000ms BDC Output - Suspected keep alive Static CONFIRM NEEDED
-
-CAN_frame BMWiX_2F1 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x2F1,
-    .data = {0xFF, 0xFF, 0xD0, 0x39, 0x94, 0x00, 0xF3, 0xFF}};  // 1000ms BDC Output - Static values - varies at startup
-
-CAN_frame BMWiX_439 = {.FD = true,
-                       .ext_ID = false,
-                       .DLC = 4,
-                       .ID = 0x439,
-                       .data = {0xFF, 0x3F, 0xFF, 0xF3}};  // 1000ms BDC Output
-
-CAN_frame
-    BMWiX_486 =
-        {
-            .FD = true,
-            .ext_ID = false,
-            .DLC = 48,
-            .ID = 0x486,
-            .data =
-                {
-                    0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE,
-                    0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF,
-                    0xFE, 0xFF, 0xFF, 0x7F, 0x33, 0xFD, 0xFD, 0xFD, 0xFD, 0xC0, 0x41, 0xFF, 0xFF,
-                    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};  // 1000ms BDC Output - Suspected keep alive Static CONFIRM NEEDED
-
-CAN_frame BMWiX_49C = {.FD = true,
-                       .ext_ID = false,
-                       .DLC = 4,
-                       .ID = 0x49C,
-                       .data = {0xD2, 0xF2, 0xC0, 0xFF, 0xFF, 0xFF, 0xFF,
-                                0xFF}};  // 1000ms BDC Output - Suspected keep alive Static CONFIRM NEEDED
-
-CAN_frame BMWiX_510 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x510,
-    .data = {0x40, 0x10, 0x00, 0x00, 0x00, 0x80, 0x00,
-             0x00}};  // 100ms BDC Output - Values change in car logs, these bytes are the most common
-
-CAN_frame BMWiX_12B8D087 = {.FD = true,
-                            .ext_ID = true,
-                            .DLC = 2,
-                            .ID = 0x12B8D087,
-                            .data = {0xFC, 0xFF}};  // 5000ms SME Output - Static values
-//Vehicle CAN END
-
-//Request Data CAN START
-CAN_frame BMWiX_6F4 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0xC7}};  // Generic UDS Request data from SME. byte 4 selects requested value
-CAN_frame BMWiX_6F4_REQUEST_SLEEPMODE = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 4,
-    .ID = 0x6F4,
-    .data = {0x07, 0x02, 0x11, 0x04}};  // UDS Request  Request BMS/SME goes to Sleep Mode
-CAN_frame BMWiX_6F4_REQUEST_HARD_RESET = {.FD = true,
-                                          .ext_ID = false,
-                                          .DLC = 4,
-                                          .ID = 0x6F4,
-                                          .data = {0x07, 0x02, 0x11, 0x01}};  // UDS Request  Hard reset of BMS/SME
-CAN_frame BMWiX_6F4_REQUEST_CELL_TEMP = {.FD = true,
-                                         .ext_ID = false,
-                                         .DLC = 5,
-                                         .ID = 0x6F4,
-                                         .data = {0x07, 0x03, 0x22, 0xDD, 0xC0}};  // UDS Request Cell Temperatures
-CAN_frame BMWiX_6F4_REQUEST_SOC = {.FD = true,
-                                   .ext_ID = false,
-                                   .DLC = 5,
-                                   .ID = 0x6F4,
-                                   .data = {0x07, 0x03, 0x22, 0xE5, 0xCE}};  // Min/Avg/Max SOC%
-CAN_frame BMWiX_6F4_REQUEST_CAPACITY = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0xC7}};  //Current and max capacity kWh. Stored in kWh as 0.01 scale with -50  bias
-CAN_frame BMWiX_6F4_REQUEST_MINMAXCELLV = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x53}};  //Min and max cell voltage   10V = Qualifier Invalid
-CAN_frame BMWiX_6F4_REQUEST_MAINVOLTAGE_POSTCONTACTOR = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x4A}};  //Main Battery Voltage (After Contactor)
-CAN_frame BMWiX_6F4_REQUEST_MAINVOLTAGE_PRECONTACTOR = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x4D}};  //Main Battery Voltage (Pre Contactor)
-CAN_frame BMWiX_6F4_REQUEST_BATTERYCURRENT = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x61}};  //Current amps 32bit signed MSB. dA . negative is discharge
-CAN_frame BMWiX_6F4_REQUEST_CELL_VOLTAGE = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x54}};  //MultiFrameIndividual Cell Voltages
-CAN_frame BMWiX_6F4_REQUEST_T30VOLTAGE = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0xA7}};  //Terminal 30 Voltage (12V SME supply)
-CAN_frame BMWiX_6F4_REQUEST_EOL_ISO = {.FD = true,
-                                       .ext_ID = false,
-                                       .DLC = 5,
-                                       .ID = 0x6F4,
-                                       .data = {0x07, 0x03, 0x22, 0xA8, 0x60}};  //Request EOL Reading including ISO
-CAN_frame BMWiX_6F4_REQUEST_SOH = {.FD = true,
-                                   .ext_ID = false,
-                                   .DLC = 5,
-                                   .ID = 0x6F4,
-                                   .data = {0x07, 0x03, 0x22, 0xE5, 0x45}};  //SOH Max Min Mean Request
-CAN_frame BMWiX_6F4_REQUEST_DATASUMMARY = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {
-        0x07, 0x03, 0x22, 0xE5,
-        0x45}};  //MultiFrame Summary Request, includes SOC/SOH/MinMax/MaxCapac/RemainCapac/max v and t at last charge. slow refreshrate
-CAN_frame BMWiX_6F4_REQUEST_PYRO = {.FD = true,
-                                    .ext_ID = false,
-                                    .DLC = 5,
-                                    .ID = 0x6F4,
-                                    .data = {0x07, 0x03, 0x22, 0xAC, 0x93}};  //Pyro Status
-CAN_frame BMWiX_6F4_REQUEST_UPTIME = {.FD = true,
-                                      .ext_ID = false,
-                                      .DLC = 5,
-                                      .ID = 0x6F4,
-                                      .data = {0x07, 0x03, 0x22, 0xE4, 0xC0}};  // Uptime and Vehicle Time Status
-CAN_frame BMWiX_6F4_REQUEST_HVIL = {.FD = true,
-                                    .ext_ID = false,
-                                    .DLC = 5,
-                                    .ID = 0x6F4,
-                                    .data = {0x07, 0x03, 0x22, 0xE5, 0x69}};  // Request HVIL State
-CAN_frame BMWiX_6F4_REQUEST_BALANCINGSTATUS = {.FD = true,
-                                               .ext_ID = false,
-                                               .DLC = 5,
-                                               .ID = 0x6F4,
-                                               .data = {0x07, 0x03, 0x22, 0xE4, 0xCA}};  // Request Balancing Data
-CAN_frame BMWiX_6F4_REQUEST_MAX_CHARGE_DISCHARGE_AMPS = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x62}};  // Request allowable charge discharge amps
-CAN_frame BMWiX_6F4_REQUEST_VOLTAGE_QUALIFIER_CHECK = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x4B}};  // Request HV Voltage Qualifier
-CAN_frame BMWiX_6F4_REQUEST_CONTACTORS_CLOSE = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 6,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x51, 0x01}};  // Request Contactors Close - Unconfirmed
-CAN_frame BMWiX_6F4_REQUEST_CONTACTORS_OPEN = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 6,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x51, 0x01}};  // Request Contactors Open - Unconfirmed
-CAN_frame BMWiX_6F4_REQUEST_BALANCING_START = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 6,
-    .ID = 0x6F4,
-    .data = {0xF4, 0x04, 0x71, 0x01, 0xAE, 0x77}};  // Request Balancing command?
-CAN_frame BMWiX_6F4_REQUEST_BALANCING_START2 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 6,
-    .ID = 0x6F4,
-    .data = {0xF4, 0x04, 0x31, 0x01, 0xAE, 0x77}};  // Request Balancing command?
-CAN_frame BMWiX_6F4_REQUEST_PACK_VOLTAGE_LIMITS = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 5,
-    .ID = 0x6F4,
-    .data = {0x07, 0x03, 0x22, 0xE5, 0x4C}};  // Request pack voltage limits
-
-CAN_frame BMWiX_6F4_CONTINUE_DATA = {.FD = true,
-                                     .ext_ID = false,
-                                     .DLC = 4,
-                                     .ID = 0x6F4,
-                                     .data = {0x07, 0x30, 0x00, 0x02}};
-
-//Action Requests:
-CAN_frame BMW_10B = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 3,
-                     .ID = 0x10B,
-                     .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command?
-
-CAN_frame BMWiX_6F4_CELL_SOC = {.FD = true,
-                                .ext_ID = false,
-                                .DLC = 5,
-                                .ID = 0x6F4,
-                                .data = {0x07, 0x03, 0x22, 0xE5, 0x9A}};
-CAN_frame BMWiX_6F4_CELL_TEMP = {.FD = true,
-                                 .ext_ID = false,
-                                 .DLC = 5,
-                                 .ID = 0x6F4,
-                                 .data = {0x07, 0x03, 0x22, 0xE5, 0xCA}};
-//Request Data CAN End
-
-static bool battery_awake = false;
-
-//Setup UDS values to poll for
-CAN_frame* UDS_REQUESTS100MS[] = {&BMWiX_6F4_REQUEST_CELL_TEMP,
-                                  &BMWiX_6F4_REQUEST_SOC,
-                                  &BMWiX_6F4_REQUEST_CAPACITY,
-                                  &BMWiX_6F4_REQUEST_MINMAXCELLV,
-                                  &BMWiX_6F4_REQUEST_MAINVOLTAGE_POSTCONTACTOR,
-                                  &BMWiX_6F4_REQUEST_MAINVOLTAGE_PRECONTACTOR,
-                                  &BMWiX_6F4_REQUEST_BATTERYCURRENT,
-                                  &BMWiX_6F4_REQUEST_CELL_VOLTAGE,
-                                  &BMWiX_6F4_REQUEST_T30VOLTAGE,
-                                  &BMWiX_6F4_REQUEST_SOH,
-                                  &BMWiX_6F4_REQUEST_UPTIME,
-                                  &BMWiX_6F4_REQUEST_PYRO,
-                                  &BMWiX_6F4_REQUEST_EOL_ISO,
-                                  &BMWiX_6F4_REQUEST_HVIL,
-                                  &BMWiX_6F4_REQUEST_MAX_CHARGE_DISCHARGE_AMPS,
-                                  &BMWiX_6F4_REQUEST_BALANCINGSTATUS,
-                                  &BMWiX_6F4_REQUEST_PACK_VOLTAGE_LIMITS};
-int numUDSreqs = sizeof(UDS_REQUESTS100MS) / sizeof(UDS_REQUESTS100MS[0]);  // Number of elements in the array
-
-//iX Intermediate vars
-static bool battery_info_available = false;
-static uint32_t battery_serial_number = 0;
-static int32_t battery_current = 0;
-static int16_t battery_voltage = 370;  //Startup with valid values - needs fixing in future
-static int16_t terminal30_12v_voltage = 0;
-static int16_t battery_voltage_after_contactor = 0;
-static int16_t min_soc_state = 5000;
-static int16_t avg_soc_state = 5000;
-static int16_t max_soc_state = 5000;
-static int16_t min_soh_state = 9900;  // Uses E5 45, also available in 78 73
-static int16_t avg_soh_state = 9900;  // Uses E5 45, also available in 78 73
-static int16_t max_soh_state = 9900;  // Uses E5 45, also available in 78 73
-static uint16_t max_design_voltage = 0;
-static uint16_t min_design_voltage = 0;
-static int32_t remaining_capacity = 0;
-static int32_t max_capacity = 0;
-static int16_t min_battery_temperature = 0;
-static int16_t avg_battery_temperature = 0;
-static int16_t max_battery_temperature = 0;
-static int16_t main_contactor_temperature = 0;
-static int16_t min_cell_voltage = 3700;  //Startup with valid values - needs fixing in future
-static int16_t max_cell_voltage = 3700;  //Startup with valid values - needs fixing in future
-static unsigned long min_cell_voltage_lastchanged = 0;
-static unsigned long max_cell_voltage_lastchanged = 0;
-static unsigned min_cell_voltage_lastreceived = 0;
-static unsigned max_cell_voltage_lastreceived = 0;
-static uint32_t sme_uptime = 0;               //Uses E4 C0
-static int16_t allowable_charge_amps = 0;     //E5 62
-static int16_t allowable_discharge_amps = 0;  //E5 62
-static int32_t iso_safety_positive = 0;       //Uses A8 60
-static int32_t iso_safety_negative = 0;       //Uses A8 60
-static int32_t iso_safety_parallel = 0;       //Uses A8 60
-static int16_t count_full_charges = 0;        //TODO  42
-static int16_t count_charges = 0;             //TODO  42
-static int16_t hvil_status = 0;
-static int16_t voltage_qualifier_status = 0;    //0 = Valid, 1 = Invalid
-static int16_t balancing_status = 0;            //4 = not active
-static uint8_t contactors_closed = 0;           //TODO  E5 BF  or E5 51
-static uint8_t contactor_status_precharge = 0;  //TODO E5 BF
-static uint8_t contactor_status_negative = 0;   //TODO E5 BF
-static uint8_t contactor_status_positive = 0;   //TODO E5 BF
-static uint8_t pyro_status_pss1 = 0;            //Using AC 93
-static uint8_t pyro_status_pss4 = 0;            //Using AC 93
-static uint8_t pyro_status_pss6 = 0;            //Using AC 93
-static uint8_t uds_req_id_counter = 0;
-static uint8_t detected_number_of_cells = 108;
 const unsigned long STALE_PERIOD =
     STALE_PERIOD_CONFIG;  // Time in milliseconds to check for staleness (e.g., 5000 ms = 5 seconds)
 
-static byte iX_0C0_counter = 0xF0;  // Initialize to 0xF0
-
-//End iX Intermediate vars
-
-static uint8_t current_cell_polled = 0;
-
 // Function to check if a value has gone stale over a specified time period
-bool isStale(int16_t currentValue, uint16_t& lastValue, unsigned long& lastChangeTime) {
+static bool isStale(int16_t currentValue, uint16_t& lastValue, unsigned long& lastChangeTime) {
   unsigned long currentTime = millis();
 
   // Check if the value has changed
@@ -406,7 +28,7 @@ bool isStale(int16_t currentValue, uint16_t& lastValue, unsigned long& lastChang
   return (currentTime - lastChangeTime >= STALE_PERIOD);
 }
 
-static uint8_t increment_uds_req_id_counter(uint8_t index) {
+uint8_t BMWIXBattery::increment_uds_req_id_counter(uint8_t index) {
   index++;
   if (index >= numUDSreqs) {
     index = 0;
@@ -431,7 +53,7 @@ static byte increment_0C0_counter(byte counter) {
   return counter;
 }
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the battery datalayer
+void BMWIXBattery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
 
   datalayer.battery.status.real_soc = avg_soc_state;
 
@@ -524,7 +146,8 @@ void update_values_battery() {  //This function maps all the values fetched via 
     datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   }
 }
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+
+void BMWIXBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   battery_awake = true;
   switch (rx_frame.ID) {
     case 0x112:
@@ -732,7 +355,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void BMWIXBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   //if (battery_awake) { //We can always send CAN as the iX BMS will wake up on vehicle comms
@@ -788,10 +411,7 @@ void transmit_can_battery() {
 // }
 //} //We can always send CAN as the iX BMS will wake up on vehicle comms
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
-
+void BMWIXBattery::setup(void) {  // Performs one time setup at startup
   //Reset Battery at bootup
   transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET, can_config.battery);
 

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef BMW_IX_BATTERY_H
 #define BMW_IX_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define BATTERY_SELECTED

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -16,7 +16,399 @@
 #define RAMPDOWN_SOC 9000  // (90.00) SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define STALE_PERIOD_CONFIG \
   900000;  //Number of milliseconds before critical values are classed as stale/stuck 900000 = 900 seconds
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class BMWIXBattery : public CanBattery {
+ public:
+  BMWIXBattery() : CanBattery(BMWIX) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BMW iX and i4-7 platform";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  uint8_t increment_uds_req_id_counter(uint8_t index);
+
+  unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
+  unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send
+  unsigned long previousMillis500 = 0;    // will store last time a 500ms CAN Message was send
+  unsigned long previousMillis640 = 0;    // will store last time a 600ms CAN Message was send
+  unsigned long previousMillis1000 = 0;   // will store last time a 1000ms CAN Message was send
+  unsigned long previousMillis5000 = 0;   // will store last time a 5000ms CAN Message was send
+  unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
+
+#define ALIVE_MAX_VALUE 14  // BMW CAN messages contain alive counter, goes from 0...14
+
+  enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST };
+
+  CmdState cmdState = SOC;
+
+  /*
+  Suspected Vehicle comms required:
+    0x06D DLC? 1000ms - counters?
+    0x2F1 DLC? 1000ms  during run : 0xFF, 0xFF, 0xFF, 0xFF, 0x9B, 0x00, 0xF3, 0xFF - at startup  0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xF3, 0xFF.   Suspect byte [4] is a counter
+    0x439 DLC4 1000ms  
+    0x0C0 DLC2 200ms needs counter
+    0x587 DLC8 appears at startup   0x78 0x07 0x00 0x00 0xFF 0xFF 0xFF 0xFF , 0x01 0x03 0x80 0xFF 0xFF 0xFF 0xFF 0xFF,  0x78 0x07 0x00 0x00 0xFF 0xFF 0xFF 0xFF,   0x06 0x00 0x00 0xFF 0xFF 0xFF 0xFF 0xFF, 0x01 0x03 0x82 0xFF 0xFF 0xFF 0xFF 0xFF, 0x01 0x03 0x80 0xFF 0xFF 0xFF 0xFF 0xFF
+  
+  SME Output:
+    0x08F DLC48  10ms    - Appears to have analog readings like volt/temp/current
+    0x12B8D087 5000ms  - Extended ID
+    0x1D2 DLC8  1000ms
+    0x20B DLC8  1000ms
+    0x2E2 DLC16 1000ms
+    0x2F1 DLC8  1000ms
+    0x31F DLC16 100ms - 2 downward counters?
+    0x453 DLC20 200ms
+    0x486 DLC48  1000ms
+    0x49C DLC8 1000ms
+    0x4A1 DLC8 1000ms
+    0x4BB DLC64  200ms - seems multplexed on [0]
+    0x4D0 DLC64 1000ms - some slow/flickering values - possible change during fault
+    0x510 DLC8 100ms  40 10 40 00 6F DF 19 00  during run -  Startup sends this once: 0x40 0x10 0x02 0x00 0x00 0x00 0x00 0x00
+    0x607 UDS Response
+  
+  No vehicle  log available, SME asks for:
+    0x125 (CCU)
+    0x16E (CCU)
+    0x340 (CCU)
+    0x4F8 (CCU)
+    0x188 (CCU)
+    0x91 (EME1)
+    0xAA (EME2)
+    0x?? Suspect there is a drive mode flag somewhere - balancing might only be active in some modes
+  
+  TODO
+  - Request batt serial number on F1 8C (already parsing RX)
+  
+  */
+
+  //Vehicle CAN START
+  CAN_frame BMWiX_06D = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x06D,
+      .data = {
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+          0xFF}};  // 1000ms BDC Output - [0] [1,2][3,4] counter x2. 3,4 is 9 higher than 1,2 is needed? [5-7] static
+
+  CAN_frame BMWiX_0C0 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 2,
+      .ID = 0x0C0,
+      .data = {
+          0xF0,
+          0x00}};  // Keep Alive 2 BDC>SME  200ms First byte cycles F0 > FE  second byte 00 - MINIMUM ID TO KEEP SME AWAKE
+
+  CAN_frame BMWiX_276 = {.FD = true,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x476,
+                         .data = {0xFF, 0xFF, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF,
+                                  0xFC}};  // 5000ms BDC Output - Suspected keep alive Static CONFIRM NEEDED
+
+  CAN_frame BMWiX_2F1 = {.FD = true,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x2F1,
+                         .data = {0xFF, 0xFF, 0xD0, 0x39, 0x94, 0x00, 0xF3,
+                                  0xFF}};  // 1000ms BDC Output - Static values - varies at startup
+
+  CAN_frame BMWiX_439 = {.FD = true,
+                         .ext_ID = false,
+                         .DLC = 4,
+                         .ID = 0x439,
+                         .data = {0xFF, 0x3F, 0xFF, 0xF3}};  // 1000ms BDC Output
+
+  CAN_frame
+      BMWiX_486 =
+          {.FD = true,
+           .ext_ID = false,
+           .DLC = 48,
+           .ID = 0x486,
+           .data = {0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE,
+                    0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF, 0xFE, 0xFF,
+                    0xFE, 0xFF, 0xFF, 0x7F, 0x33, 0xFD, 0xFD, 0xFD, 0xFD, 0xC0, 0x41, 0xFF, 0xFF,
+                    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};  // 1000ms BDC Output - Suspected keep alive CONFIRM NEEDED
+
+  CAN_frame BMWiX_49C = {.FD = true,
+                         .ext_ID = false,
+                         .DLC = 4,
+                         .ID = 0x49C,
+                         .data = {0xD2, 0xF2, 0xC0, 0xFF, 0xFF, 0xFF, 0xFF,
+                                  0xFF}};  // 1000ms BDC Output - Suspected keep alive CONFIRM NEEDED
+
+  CAN_frame BMWiX_510 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x510,
+      .data = {0x40, 0x10, 0x00, 0x00, 0x00, 0x80, 0x00,
+               0x00}};  // 100ms BDC Output - Values change in car logs, these bytes are the most common
+
+  CAN_frame BMWiX_12B8D087 = {.FD = true,
+                              .ext_ID = true,
+                              .DLC = 2,
+                              .ID = 0x12B8D087,
+                              .data = {0xFC, 0xFF}};  // 5000ms SME Output - Static values
+  //Vehicle CAN END
+
+  //Request Data CAN START
+  CAN_frame BMWiX_6F4 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0xC7}};  // Generic UDS Request data from SME. byte 4 selects requested value
+  CAN_frame BMWiX_6F4_REQUEST_SLEEPMODE = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 4,
+      .ID = 0x6F4,
+      .data = {0x07, 0x02, 0x11, 0x04}};  // UDS Request  Request BMS/SME goes to Sleep Mode
+  CAN_frame BMWiX_6F4_REQUEST_HARD_RESET = {.FD = true,
+                                            .ext_ID = false,
+                                            .DLC = 4,
+                                            .ID = 0x6F4,
+                                            .data = {0x07, 0x02, 0x11, 0x01}};  // UDS Request  Hard reset of BMS/SME
+  CAN_frame BMWiX_6F4_REQUEST_CELL_TEMP = {.FD = true,
+                                           .ext_ID = false,
+                                           .DLC = 5,
+                                           .ID = 0x6F4,
+                                           .data = {0x07, 0x03, 0x22, 0xDD, 0xC0}};  // UDS Request Cell Temperatures
+  CAN_frame BMWiX_6F4_REQUEST_SOC = {.FD = true,
+                                     .ext_ID = false,
+                                     .DLC = 5,
+                                     .ID = 0x6F4,
+                                     .data = {0x07, 0x03, 0x22, 0xE5, 0xCE}};  // Min/Avg/Max SOC%
+  CAN_frame BMWiX_6F4_REQUEST_CAPACITY = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5,
+               0xC7}};  //Current and max capacity kWh. Stored in kWh as 0.01 scale with -50  bias
+  CAN_frame BMWiX_6F4_REQUEST_MINMAXCELLV = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x53}};  //Min and max cell voltage   10V = Qualifier Invalid
+  CAN_frame BMWiX_6F4_REQUEST_MAINVOLTAGE_POSTCONTACTOR = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x4A}};  //Main Battery Voltage (After Contactor)
+  CAN_frame BMWiX_6F4_REQUEST_MAINVOLTAGE_PRECONTACTOR = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x4D}};  //Main Battery Voltage (Pre Contactor)
+  CAN_frame BMWiX_6F4_REQUEST_BATTERYCURRENT = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x61}};  //Current amps 32bit signed MSB. dA . negative is discharge
+  CAN_frame BMWiX_6F4_REQUEST_CELL_VOLTAGE = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x54}};  //MultiFrameIndividual Cell Voltages
+  CAN_frame BMWiX_6F4_REQUEST_T30VOLTAGE = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0xA7}};  //Terminal 30 Voltage (12V SME supply)
+  CAN_frame BMWiX_6F4_REQUEST_EOL_ISO = {.FD = true,
+                                         .ext_ID = false,
+                                         .DLC = 5,
+                                         .ID = 0x6F4,
+                                         .data = {0x07, 0x03, 0x22, 0xA8, 0x60}};  //Request EOL Reading including ISO
+  CAN_frame BMWiX_6F4_REQUEST_SOH = {.FD = true,
+                                     .ext_ID = false,
+                                     .DLC = 5,
+                                     .ID = 0x6F4,
+                                     .data = {0x07, 0x03, 0x22, 0xE5, 0x45}};  //SOH Max Min Mean Request
+  CAN_frame BMWiX_6F4_REQUEST_DATASUMMARY = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {
+          0x07, 0x03, 0x22, 0xE5,
+          0x45}};  //MultiFrame Summary Request, includes SOC/SOH/MinMax/MaxCapac/RemainCapac/max v and t at last charge. slow refreshrate
+  CAN_frame BMWiX_6F4_REQUEST_PYRO = {.FD = true,
+                                      .ext_ID = false,
+                                      .DLC = 5,
+                                      .ID = 0x6F4,
+                                      .data = {0x07, 0x03, 0x22, 0xAC, 0x93}};  //Pyro Status
+  CAN_frame BMWiX_6F4_REQUEST_UPTIME = {.FD = true,
+                                        .ext_ID = false,
+                                        .DLC = 5,
+                                        .ID = 0x6F4,
+                                        .data = {0x07, 0x03, 0x22, 0xE4, 0xC0}};  // Uptime and Vehicle Time Status
+  CAN_frame BMWiX_6F4_REQUEST_HVIL = {.FD = true,
+                                      .ext_ID = false,
+                                      .DLC = 5,
+                                      .ID = 0x6F4,
+                                      .data = {0x07, 0x03, 0x22, 0xE5, 0x69}};  // Request HVIL State
+  CAN_frame BMWiX_6F4_REQUEST_BALANCINGSTATUS = {.FD = true,
+                                                 .ext_ID = false,
+                                                 .DLC = 5,
+                                                 .ID = 0x6F4,
+                                                 .data = {0x07, 0x03, 0x22, 0xE4, 0xCA}};  // Request Balancing Data
+  CAN_frame BMWiX_6F4_REQUEST_MAX_CHARGE_DISCHARGE_AMPS = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x62}};  // Request allowable charge discharge amps
+  CAN_frame BMWiX_6F4_REQUEST_VOLTAGE_QUALIFIER_CHECK = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x4B}};  // Request HV Voltage Qualifier
+  CAN_frame BMWiX_6F4_REQUEST_CONTACTORS_CLOSE = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 6,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x51, 0x01}};  // Request Contactors Close - Unconfirmed
+  CAN_frame BMWiX_6F4_REQUEST_CONTACTORS_OPEN = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 6,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x51, 0x01}};  // Request Contactors Open - Unconfirmed
+  CAN_frame BMWiX_6F4_REQUEST_BALANCING_START = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 6,
+      .ID = 0x6F4,
+      .data = {0xF4, 0x04, 0x71, 0x01, 0xAE, 0x77}};  // Request Balancing command?
+  CAN_frame BMWiX_6F4_REQUEST_BALANCING_START2 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 6,
+      .ID = 0x6F4,
+      .data = {0xF4, 0x04, 0x31, 0x01, 0xAE, 0x77}};  // Request Balancing command?
+  CAN_frame BMWiX_6F4_REQUEST_PACK_VOLTAGE_LIMITS = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F4,
+      .data = {0x07, 0x03, 0x22, 0xE5, 0x4C}};  // Request pack voltage limits
+
+  CAN_frame BMWiX_6F4_CONTINUE_DATA = {.FD = true,
+                                       .ext_ID = false,
+                                       .DLC = 4,
+                                       .ID = 0x6F4,
+                                       .data = {0x07, 0x30, 0x00, 0x02}};
+
+  //Action Requests:
+  CAN_frame BMW_10B = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 3,
+                       .ID = 0x10B,
+                       .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command?
+
+  CAN_frame BMWiX_6F4_CELL_SOC = {.FD = true,
+                                  .ext_ID = false,
+                                  .DLC = 5,
+                                  .ID = 0x6F4,
+                                  .data = {0x07, 0x03, 0x22, 0xE5, 0x9A}};
+  CAN_frame BMWiX_6F4_CELL_TEMP = {.FD = true,
+                                   .ext_ID = false,
+                                   .DLC = 5,
+                                   .ID = 0x6F4,
+                                   .data = {0x07, 0x03, 0x22, 0xE5, 0xCA}};
+  //Request Data CAN End
+
+  bool battery_awake = false;
+
+  //Setup UDS values to poll for
+  CAN_frame* UDS_REQUESTS100MS[17] = {&BMWiX_6F4_REQUEST_CELL_TEMP,
+                                      &BMWiX_6F4_REQUEST_SOC,
+                                      &BMWiX_6F4_REQUEST_CAPACITY,
+                                      &BMWiX_6F4_REQUEST_MINMAXCELLV,
+                                      &BMWiX_6F4_REQUEST_MAINVOLTAGE_POSTCONTACTOR,
+                                      &BMWiX_6F4_REQUEST_MAINVOLTAGE_PRECONTACTOR,
+                                      &BMWiX_6F4_REQUEST_BATTERYCURRENT,
+                                      &BMWiX_6F4_REQUEST_CELL_VOLTAGE,
+                                      &BMWiX_6F4_REQUEST_T30VOLTAGE,
+                                      &BMWiX_6F4_REQUEST_SOH,
+                                      &BMWiX_6F4_REQUEST_UPTIME,
+                                      &BMWiX_6F4_REQUEST_PYRO,
+                                      &BMWiX_6F4_REQUEST_EOL_ISO,
+                                      &BMWiX_6F4_REQUEST_HVIL,
+                                      &BMWiX_6F4_REQUEST_MAX_CHARGE_DISCHARGE_AMPS,
+                                      &BMWiX_6F4_REQUEST_BALANCINGSTATUS,
+                                      &BMWiX_6F4_REQUEST_PACK_VOLTAGE_LIMITS};
+  int numUDSreqs = sizeof(UDS_REQUESTS100MS) / sizeof(UDS_REQUESTS100MS[0]);  // Number of elements in the array
+
+  //iX Intermediate vars
+  bool battery_info_available = false;
+  uint32_t battery_serial_number = 0;
+  int32_t battery_current = 0;
+  int16_t battery_voltage = 370;  //Startup with valid values - needs fixing in future
+  int16_t terminal30_12v_voltage = 0;
+  int16_t battery_voltage_after_contactor = 0;
+  int16_t min_soc_state = 5000;
+  int16_t avg_soc_state = 5000;
+  int16_t max_soc_state = 5000;
+  int16_t min_soh_state = 9900;  // Uses E5 45, also available in 78 73
+  int16_t avg_soh_state = 9900;  // Uses E5 45, also available in 78 73
+  int16_t max_soh_state = 9900;  // Uses E5 45, also available in 78 73
+  uint16_t max_design_voltage = 0;
+  uint16_t min_design_voltage = 0;
+  int32_t remaining_capacity = 0;
+  int32_t max_capacity = 0;
+  int16_t min_battery_temperature = 0;
+  int16_t avg_battery_temperature = 0;
+  int16_t max_battery_temperature = 0;
+  int16_t main_contactor_temperature = 0;
+  int16_t min_cell_voltage = 3700;  //Startup with valid values - needs fixing in future
+  int16_t max_cell_voltage = 3700;  //Startup with valid values - needs fixing in future
+  unsigned long min_cell_voltage_lastchanged = 0;
+  unsigned long max_cell_voltage_lastchanged = 0;
+  unsigned min_cell_voltage_lastreceived = 0;
+  unsigned max_cell_voltage_lastreceived = 0;
+  uint32_t sme_uptime = 0;               //Uses E4 C0
+  int16_t allowable_charge_amps = 0;     //E5 62
+  int16_t allowable_discharge_amps = 0;  //E5 62
+  int32_t iso_safety_positive = 0;       //Uses A8 60
+  int32_t iso_safety_negative = 0;       //Uses A8 60
+  int32_t iso_safety_parallel = 0;       //Uses A8 60
+  int16_t count_full_charges = 0;        //TODO  42
+  int16_t count_charges = 0;             //TODO  42
+  int16_t hvil_status = 0;
+  int16_t voltage_qualifier_status = 0;    //0 = Valid, 1 = Invalid
+  int16_t balancing_status = 0;            //4 = not active
+  uint8_t contactors_closed = 0;           //TODO  E5 BF  or E5 51
+  uint8_t contactor_status_precharge = 0;  //TODO E5 BF
+  uint8_t contactor_status_negative = 0;   //TODO E5 BF
+  uint8_t contactor_status_positive = 0;   //TODO E5 BF
+  uint8_t pyro_status_pss1 = 0;            //Using AC 93
+  uint8_t pyro_status_pss4 = 0;            //Using AC 93
+  uint8_t pyro_status_pss6 = 0;            //Using AC 93
+  uint8_t uds_req_id_counter = 0;
+  uint8_t detected_number_of_cells = 108;
+
+  byte iX_0C0_counter = 0xF0;  // Initialize to 0xF0
+
+  //End iX Intermediate vars
+
+  uint8_t current_cell_polled = 0;
+};
 
 #endif

--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -718,7 +718,7 @@ void BMWPhevBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/BMW-PHEV-BATTERY.h
+++ b/Software/src/battery/BMW-PHEV-BATTERY.h
@@ -16,7 +16,395 @@
 #define RAMPDOWN_SOC 9000  // (90.00) SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define STALE_PERIOD_CONFIG \
   3600000;  //Number of milliseconds before critical values are classed as stale/stuck 1800000 = 3600 seconds / 60mins
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class BMWPhevBattery : public CanBattery {
+ public:
+  BMWPhevBattery() : CanBattery(BMWPhev) {}
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BMW PHEV Battery";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  void startUDSMultiFrameReception(uint16_t totalLength, uint8_t moduleID);
+  bool storeUDSPayload(const uint8_t* payload, uint8_t length);
+  bool isUDSMessageComplete();
+  void processCellVoltages();
+  void wake_battery_via_canbus();
+
+  unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
+  unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send
+  unsigned long previousMillis500 = 0;    // will store last time a 500ms CAN Message was send
+  unsigned long previousMillis640 = 0;    // will store last time a 600ms CAN Message was send
+  unsigned long previousMillis1000 = 0;   // will store last time a 1000ms CAN Message was send
+  unsigned long previousMillis5000 = 0;   // will store last time a 5000ms CAN Message was send
+  unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
+
+#define ALIVE_MAX_VALUE 14  // BMW CAN messages contain alive counter, goes from 0...14
+
+  enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST };
+
+  CmdState cmdState = SOC;
+
+  // A structure to keep track of the ongoing multi-frame UDS response
+  typedef struct {
+    bool UDS_inProgress;                // Are we currently receiving a multi-frame message?
+    uint16_t UDS_expectedLength;        // Expected total payload length
+    uint16_t UDS_bytesReceived;         // How many bytes have been stored so far
+    uint8_t UDS_moduleID;               // The "module" indicated by the first frame
+    uint8_t receivedInBatch;            // Number of CFs received in the current batch
+    uint8_t UDS_buffer[256];            // Buffer for the reassembled data
+    unsigned long UDS_lastFrameMillis;  // Timestamp of last frame (for timeouts, if desired)
+  } UDS_RxContext;
+
+  // A single global UDS context, since only one module can respond at a time
+  UDS_RxContext gUDSContext;
+
+  //Vehicle CAN START
+
+  CAN_frame BMWiX_0C0 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 2,
+      .ID = 0x0C0,
+      .data = {
+          0xF0,
+          0x08}};  // Keep Alive 2 BDC>SME  200ms First byte cycles F0 > FE  second byte 08 - MINIMUM ID TO KEEP SME AWAKE
+
+  CAN_frame BMW_13E = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x13E,
+                       .data = {0xFF, 0x31, 0xFA, 0xFA, 0xFA, 0xFA, 0x0C, 0x00}};
+
+  //Vehicle CAN END
+
+  //Request Data CAN START
+
+  CAN_frame BMW_PHEV_BUS_WAKEUP_REQUEST = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 4,
+      .ID = 0x554,
+      .data = {
+          0x5A, 0xA5, 0x5A,
+          0xA5}};  // Won't work at 500kbps! Ideally sent at 50kbps - but can also achieve wakeup at 100kbps (helps with library support but might not be as reliable). Might need to be sent twice + clear buffer
+
+  CAN_frame BMWPHEV_6F1_REQUEST_SOC = {.FD = false,
+                                       .ext_ID = false,
+                                       .DLC = 5,
+                                       .ID = 0x6F1,
+                                       .data = {0x07, 0x03, 0x22, 0xDD, 0xC4}};  //  SOC%
+
+  CAN_frame BMWPHEV_6F1_REQUEST_SOH = {.FD = false,
+                                       .ext_ID = false,
+                                       .DLC = 5,
+                                       .ID = 0x6F1,
+                                       .data = {0x07, 0x03, 0x22, 0xDD, 0x7B}};  //  SOH%
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CURRENT = {.FD = false,
+                                           .ext_ID = false,
+                                           .DLC = 5,
+                                           .ID = 0x6F1,
+                                           .data = {0x07, 0x03, 0x22, 0xDD, 0x69}};  //  SOH%
+
+  CAN_frame BMWPHEV_6F1_REQUEST_VOLTAGE_LIMITS = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDD, 0x7E}};  //  Pack Voltage Limits  Multi Frame
+
+  CAN_frame BMWPHEV_6F1_REQUEST_PAIRED_VIN = {.FD = false,
+                                              .ext_ID = false,
+                                              .DLC = 5,
+                                              .ID = 0x6F1,
+                                              .data = {0x07, 0x03, 0x22, 0xF1, 0x90}};  //  SME Paired VIN
+
+  CAN_frame BMWPHEV_6F1_REQUEST_ISO_READING1 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {
+          0x07, 0x03, 0x22, 0xDD,
+          0x6A}};  // MULTI FRAME ISOLATIONSWIDERSTAND 62 DD 6A [07 D0] [07 D0] [07 D0] [01] [01] [01] 00 00 00 00 00   [EXT Reading] [INT reading] [ EXT - 0 not plausible, 1 plausible]
+
+  CAN_frame BMWPHEV_6F1_REQUEST_ISO_READING2 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xD6,
+               0xD9}};  //  R_ISO_ROH 62 D6 D9 [07 FF] [13] (2047kohm) quality of reading 0-21 (19)
+
+  CAN_frame BMWPHEV_6F1_REQUEST_PACK_INFO = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDF, 0x71}};  //   62 DF 71 00 60 1C 25 1C? Cell Count, Module Count
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CURRENT_LIMITS = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDD, 0x7D}};  //  Pack Current Limits  Multi Frame
+
+  CAN_frame BMWPHEV_6F1_REQUEST_MAINVOLTAGE_PRECONTACTOR = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDD, 0xB4}};  //Main Battery Voltage (Pre Contactor)
+
+  CAN_frame BMWPHEV_6F1_REQUEST_MAINVOLTAGE_POSTCONTACTOR = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDD, 0x66}};  //Main Battery Voltage (After Contactor)
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CELLSUMMARY = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDF, 0xA0}};  //Min and max cell voltage + temps   6.55V = Qualifier Invalid?
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CELLS_INDIVIDUAL_VOLTS = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {0x07, 0x03, 0x22, 0xDF, 0xA5}};  //All individual cell voltages
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CELL_TEMP = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 5,
+      .ID = 0x6F1,
+      .data = {
+          0x07, 0x03, 0x22, 0xDD,
+          0xC0}};  // UDS Request Cell Temperatures min max avg. Has continue frame min in first, then max + avg in second frame
+
+  CAN_frame BMW_6F1_REQUEST_CONTINUE_MULTIFRAME = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {
+          0x07, 0x30, 0x03, 0x00, 0x00, 0x00, 0x00,
+          0x00}};  //Request continued frames from UDS Multiframe request  byte[2] is the request messages to return per continue. default 0x03, all is 0x00
+
+  CAN_frame BMW_6F1_REQUEST_HARD_RESET = {.FD = false,
+                                          .ext_ID = false,
+                                          .DLC = 4,
+                                          .ID = 0x6F1,
+                                          .data = {0x07, 0x03, 0x11, 0x01}};  // Reset BMS - TBC
+
+  CAN_frame BMWPHEV_6F1_REQUEST_CONTACTORS_CLOSE = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x2E, 0xDD, 0x61, 0x01, 0x00, 0x00}};  // Request Contactors Close - Unconfirmed
+  CAN_frame BMWPHEV_6F1_REQUEST_CONTACTORS_OPEN = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 6,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x2E, 0xDD, 0x61, 0x00, 0x00, 0x00}};  // Request Contactors Open - Unconfirmed
+
+  CAN_frame BMWPHEV_6F1_REQUEST_BALANCING_STATUS = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x31, 0x03, 0xAD, 0x6B, 0x00,
+               0x00}};  // Balancing status.  Response 7DLC F1 05 71 03 AD 6B 01   (01 = active)  (03 not active)
+
+  CAN_frame BMWPHEV_6F1_REQUEST_ISOLATION_TEST = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x31, 0x01, 0xAD, 0x61, 0x00, 0x00}};  // Start Isolation Test
+
+  CAN_frame BMWPHEV_6F1_REQUEST_BALANCING_START = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x31, 0x01, 0xAD, 0x6B, 0x00, 0x00}};  // Balancing start request
+
+  CAN_frame BMWPHEV_6F1_REQUEST_BALANCING_STOP = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x6F1,
+      .data = {0x07, 0x04, 0x31, 0x02, 0xAD, 0x6B, 0x00, 0x00}};  // Balancing stop request
+
+  //Action Requests:
+  CAN_frame BMW_10B = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 3,
+                       .ID = 0x10B,
+                       .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command?
+
+  CAN_frame BMWPHEV_6F1_CELL_SOC = {.FD = false,
+                                    .ext_ID = false,
+                                    .DLC = 5,
+                                    .ID = 0x6F1,
+                                    .data = {0x07, 0x03, 0x22, 0xE5, 0x9A}};
+  CAN_frame BMWPHEV_6F1_CELL_TEMP = {.FD = false,
+                                     .ext_ID = false,
+                                     .DLC = 5,
+                                     .ID = 0x6F1,
+                                     .data = {0x07, 0x03, 0x22, 0xE5, 0xCA}};
+  //Request Data CAN End
+
+  bool battery_awake = false;
+
+  //Setup Fast UDS values to poll for
+  CAN_frame* UDS_REQUESTS_FAST[6] = {&BMWPHEV_6F1_REQUEST_CELLSUMMARY,
+                                     &BMWPHEV_6F1_REQUEST_SOC,
+                                     &BMWPHEV_6F1_REQUEST_CURRENT,
+                                     &BMWPHEV_6F1_REQUEST_VOLTAGE_LIMITS,
+                                     &BMWPHEV_6F1_REQUEST_MAINVOLTAGE_PRECONTACTOR,
+                                     &BMWPHEV_6F1_REQUEST_MAINVOLTAGE_POSTCONTACTOR};
+  int numFastUDSreqs =
+      sizeof(UDS_REQUESTS_FAST) / sizeof(UDS_REQUESTS_FAST[0]);  //Store Number of elements in the array
+
+  //Setup Slow UDS values to poll for
+  CAN_frame* UDS_REQUESTS_SLOW[8] = {&BMWPHEV_6F1_REQUEST_ISO_READING1,           &BMWPHEV_6F1_REQUEST_ISO_READING2,
+                                     &BMWPHEV_6F1_REQUEST_CURRENT_LIMITS,         &BMWPHEV_6F1_REQUEST_SOH,
+                                     &BMWPHEV_6F1_REQUEST_CELLS_INDIVIDUAL_VOLTS, &BMWPHEV_6F1_REQUEST_CELL_TEMP,
+                                     &BMWPHEV_6F1_REQUEST_BALANCING_STATUS,       &BMWPHEV_6F1_REQUEST_PAIRED_VIN};
+  int numSlowUDSreqs =
+      sizeof(UDS_REQUESTS_SLOW) / sizeof(UDS_REQUESTS_SLOW[0]);  // Store Number of elements in the array
+
+  //PHEV intermediate vars
+  //#define UDS_LOG //Useful for logging multiframe handling
+  uint16_t battery_max_charge_voltage = 0;
+  int16_t battery_max_charge_amperage = 0;
+  uint16_t battery_min_discharge_voltage = 0;
+  int16_t battery_max_discharge_amperage = 0;
+
+  uint8_t startup_counter_contactor = 0;
+  uint8_t alive_counter_20ms = 0;
+  uint8_t BMW_13E_counter = 0;
+
+  uint32_t battery_BEV_available_power_shortterm_charge = 0;
+  uint32_t battery_BEV_available_power_shortterm_discharge = 0;
+  uint32_t battery_BEV_available_power_longterm_charge = 0;
+  uint32_t battery_BEV_available_power_longterm_discharge = 0;
+
+  uint16_t battery_predicted_energy_charge_condition = 0;
+  uint16_t battery_predicted_energy_charging_target = 0;
+
+  uint16_t battery_prediction_voltage_shortterm_charge = 0;
+  uint16_t battery_prediction_voltage_shortterm_discharge = 0;
+  uint16_t battery_prediction_voltage_longterm_charge = 0;
+  uint16_t battery_prediction_voltage_longterm_discharge = 0;
+
+  uint8_t battery_status_service_disconnection_plug = 0;
+  uint8_t battery_status_measurement_isolation = 0;
+  uint8_t battery_request_abort_charging = 0;
+  uint16_t battery_prediction_duration_charging_minutes = 0;
+  uint8_t battery_prediction_time_end_of_charging_minutes = 0;
+  uint16_t battery_energy_content_maximum_kWh = 0;
+
+  uint8_t battery_request_operating_mode = 0;
+  uint16_t battery_target_voltage_in_CV_mode = 0;
+  uint8_t battery_request_charging_condition_minimum = 0;
+  uint8_t battery_request_charging_condition_maximum = 0;
+  uint16_t battery_display_SOC = 0;
+
+  uint8_t battery_status_error_isolation_external_Bordnetz = 0;
+  uint8_t battery_status_error_isolation_internal_Bordnetz = 0;
+  uint8_t battery_request_cooling = 0;
+  uint8_t battery_status_valve_cooling = 0;
+  uint8_t battery_status_error_locking = 0;
+  uint8_t battery_status_precharge_locked = 0;
+  uint8_t battery_status_disconnecting_switch = 0;
+  uint8_t battery_status_emergency_mode = 0;
+  uint8_t battery_request_service = 0;
+  uint8_t battery_error_emergency_mode = 0;
+  uint8_t battery_status_error_disconnecting_switch = 0;
+  uint8_t battery_status_warning_isolation = 0;
+  uint8_t battery_status_cold_shutoff_valve = 0;
+  int16_t battery_temperature_HV = 0;
+  int16_t battery_temperature_heat_exchanger = 0;
+  int16_t battery_temperature_max = 0;
+  int16_t battery_temperature_min = 0;
+  bool pack_limit_info_available = false;
+  bool cell_limit_info_available = false;
+
+  //iX Intermediate vars
+
+  uint32_t battery_serial_number = 0;
+  int32_t battery_current = 0;
+  int16_t battery_voltage = 3700;  //Initialize as valid - should be fixed in future
+  int16_t terminal30_12v_voltage = 0;
+  int16_t battery_voltage_after_contactor = 0;
+  int16_t min_soc_state = 5000;
+  int16_t avg_soc_state = 5000;
+  int16_t max_soc_state = 5000;
+  int16_t min_soh_state = 9999;  // Uses E5 45, also available in 78 73
+  int16_t avg_soh_state = 9999;  // Uses E5 45, also available in 78 73
+  int16_t max_soh_state = 9999;  // Uses E5 45, also available in 78 73
+  uint16_t max_design_voltage = 0;
+  uint16_t min_design_voltage = 0;
+  int32_t remaining_capacity = 0;
+  int32_t max_capacity = 0;
+
+  int16_t main_contactor_temperature = 0;
+  int16_t min_cell_voltage = 3700;  //Initialize as valid - should be fixed in future
+  int16_t max_cell_voltage = 3700;  //Initialize as valid - should be fixed in future
+  unsigned long min_cell_voltage_lastchanged = 0;
+  unsigned long max_cell_voltage_lastchanged = 0;
+  unsigned min_cell_voltage_lastreceived = 0;
+  unsigned max_cell_voltage_lastreceived = 0;
+  int16_t allowable_charge_amps = 0;     //E5 62
+  int16_t allowable_discharge_amps = 0;  //E5 62
+
+  int32_t iso_safety_int_kohm = 0;  //STAT_ISOWIDERSTAND_INT_WERT
+  int32_t iso_safety_ext_kohm = 0;  //STAT_ISOWIDERSTAND_EXT_STD_WERT
+  int32_t iso_safety_trg_kohm = 0;
+  int32_t iso_safety_ext_plausible = 0;  //STAT_ISOWIDERSTAND_EXT_TRG_PLAUS
+  int32_t iso_safety_int_plausible = 0;  //STAT_ISOWIDERSTAND_EXT_TRG_WERT
+  int32_t iso_safety_trg_plausible = 0;
+  int32_t iso_safety_kohm = 0;          //STAT_R_ISO_ROH_01_WERT
+  int32_t iso_safety_kohm_quality = 0;  //STAT_R_ISO_ROH_QAL_01_INFO Quality of measurement 0-21 (higher better)
+
+  uint8_t paired_vin[17] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};  //17 Byte array for paired VIN
+
+  int16_t count_full_charges = 0;  //TODO  42
+  int16_t count_charges = 0;       //TODO  42
+  int16_t hvil_status = 0;
+  int16_t voltage_qualifier_status = 0;    //0 = Valid, 1 = Invalid
+  int16_t balancing_status = 0;            //4 = not active
+  uint8_t contactors_closed = 0;           //TODO  E5 BF  or E5 51
+  uint8_t contactor_status_precharge = 0;  //TODO E5 BF
+  uint8_t contactor_status_negative = 0;   //TODO E5 BF
+  uint8_t contactor_status_positive = 0;   //TODO E5 BF
+  uint8_t uds_fast_req_id_counter = 0;
+  uint8_t uds_slow_req_id_counter = 0;
+  uint8_t detected_number_of_cells = 96;
+
+  byte iX_0C0_counter = 0xF0;  // Initialize to 0xF0
+
+  //End iX Intermediate vars
+
+  uint8_t current_cell_polled = 0;
+};
 
 #endif

--- a/Software/src/battery/BMW-SBOX.cpp
+++ b/Software/src/battery/BMW-SBOX.cpp
@@ -135,8 +135,7 @@ void transmit_can_shunt() {
       datalayer.shunt.contactors_engaged = false;
       SBOX_100.data.u8[0] = 0x55;  // All open
 
-      if (datalayer.system.status.battery_allows_contactor_closing &&
-          datalayer.system.status.inverter_allows_contactor_closing &&
+      if (battery->contactor_closing_allowed() && datalayer.system.status.inverter_allows_contactor_closing &&
           !datalayer.system.settings.equipment_stop_active &&
           (datalayer.shunt.measured_voltage_mV > MINIMUM_INPUT_VOLTAGE * 1000)) {
         contactorStatus = PRECHARGE;

--- a/Software/src/battery/BMW-SBOX.h
+++ b/Software/src/battery/BMW-SBOX.h
@@ -19,4 +19,15 @@ void transmit_can(CAN_frame* tx_frame, int interface);
 #define CONTACTOR_CONTROL_T2 5000  // Precharge time before precharge resistor is bypassed by positive contactor
 #define CONTACTOR_CONTROL_T3 2000  // Precharge relay lead time after positive contactor has been engaged
 
+class BMWSboxBattery : public CanBattery {
+ public:
+  BMWSboxBattery() : CanBattery(BMWSBox) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BMW SBOX";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
+
 #endif

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -707,18 +707,14 @@ void BoltAmperaBattery::transmit_can() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
+void BoltAmperaBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
-}
-
-void BoltAmperaBattery::setup() {
-  setup_battery();
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -5,6 +5,8 @@
 #include "../devboard/utils/events.h"
 #include "BOLT-AMPERA-BATTERY.h"
 
+#include "../communication/can/comm_can.h"
+
 /*
 TODOs left for this implementation
 - The battery has 3 CAN ports. One of the internal modules is responsible for the 7E4 polls, the battery for the 7E7 polls
@@ -18,114 +20,6 @@ TODOs left for this implementation
 - Discharge max power (can be estimated)
 - SOH% (low prio))
 */
-
-/*TODO, messages we might need to send towards the battery to keep it happy and close contactors
-0x262 Battery Block Voltage Diag Status HV (Who sends this? Battery?)
-0x272 Battery Cell Voltage Diag Status HV (Who sends this? Battery?)
-0x274 Battery Temperature Sensor diagnostic status HV (Who sends this? Battery?)
-0x270 Battery VoltageSensor BalancingSwitches diagnostic status (Who sends this? Battery?)
-0x214 Charger coolant temp info HV
-0x20E Hybrid balancing request HV
-0x30E High Voltage Charger Command HV
-0x30C HVEM Provide Charging HV
-0x316 OBHV Charge Process PEV HV
-0x30F OBHV Charg Statn Current stat HV
-0x312 OBHV Charg Statns Energy allocation HV
-0x310 OBHV Charg Statn Vlt Energy Power HV
-0x306 Off board HVCS Limit HV
-0x309 Off board HVCS Min Limit HV
-0x305 Vehicle Charging limit stat HV
-0x314 Vehicle req energy transfer HV <<<<<<<<<< Sounds like contactor request resides here TODO
-0x460 Energy Storage System Temp HV (Who sends this? Battery?)
-*/
-
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis20ms = 0;   // will store last time a 20ms CAN Message was send
-static unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis120ms = 0;  // will store last time a 120ms CAN Message was send
-
-CAN_frame BOLT_778 = {.FD = false,  // Unsure of what this message is, added only as example
-                      .ext_ID = false,
-                      .DLC = 7,
-                      .ID = 0x778,
-                      .data = {0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame BOLT_POLL_7E4 = {.FD = false,  // VICM_HV poll
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame BOLT_ACK_7E4 = {.FD = false,  //VICM_HV ack
-                          .ext_ID = false,
-                          .DLC = 8,
-                          .ID = 0x7E4,
-                          .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame BOLT_POLL_7E7 = {.FD = false,  //VITM_HV poll
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E7,
-                           .data = {0x03, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame BOLT_ACK_7E7 = {.FD = false,  //VITM_HV ack
-                          .ext_ID = false,
-                          .DLC = 8,
-                          .ID = 0x7E7,
-                          .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-// Other PID requests in the vehicle
-// All HV ECUs - 0x101
-// HPCC HV - 0x243 replies on 0x643
-// OBCM HV - 0x244 replies on 0x644
-// VICM_HV - 0x7E4 replies 0x7EC (This is battery)
-// VICM2_HV - 0x7E6 replies 0x7EF (Tis is battery also)
-// VITM_HV - 0x7E7 replies on 7EF (This is battery)
-
-static uint16_t battery_cell_voltages[96];  //array with all the cellvoltages
-static uint16_t battery_capacity_my17_18 = 0;
-static uint16_t battery_capacity_my19plus = 0;
-static uint16_t battery_SOC_display = 0;
-static uint16_t battery_SOC_raw_highprec = 0;
-static uint16_t battery_max_temperature = 0;
-static uint16_t battery_min_temperature = 0;
-static uint16_t battery_min_cell_voltage = 0;
-static uint16_t battery_max_cell_voltage = 0;
-static uint16_t battery_internal_resistance = 0;
-static uint16_t battery_lowest_cell = 0;
-static uint16_t battery_highest_cell = 0;
-static uint16_t battery_voltage_polled = 0;
-static uint16_t battery_voltage_periodic = 0;
-static uint16_t battery_vehicle_isolation = 0;
-static uint16_t battery_isolation_kohm = 0;
-static uint16_t battery_HV_locked = 0;
-static uint16_t battery_crash_event = 0;
-static uint16_t battery_HVIL = 0;
-static uint16_t battery_HVIL_status = 0;
-static uint16_t battery_5V_ref = 0;
-static int16_t battery_current_7E4 = 0;
-static int16_t battery_module_temp_1 = 0;
-static int16_t battery_module_temp_2 = 0;
-static int16_t battery_module_temp_3 = 0;
-static int16_t battery_module_temp_4 = 0;
-static int16_t battery_module_temp_5 = 0;
-static int16_t battery_module_temp_6 = 0;
-static uint16_t battery_cell_average_voltage = 0;
-static uint16_t battery_cell_average_voltage_2 = 0;
-static uint16_t battery_terminal_voltage = 0;
-static uint16_t battery_ignition_power_mode = 0;
-static int16_t battery_current_7E7 = 0;
-static int16_t temperature_1 = 0;
-static int16_t temperature_2 = 0;
-static int16_t temperature_3 = 0;
-static int16_t temperature_4 = 0;
-static int16_t temperature_5 = 0;
-static int16_t temperature_6 = 0;
-static int16_t temperature_highest = 0;
-static int16_t temperature_lowest = 0;
-static uint8_t mux = 0;
-static uint8_t poll_index_7E4 = 0;
-static uint16_t currentpoll_7E4 = POLL_7E4_CAPACITY_EST_GEN1;
-static uint16_t reply_poll_7E4 = 0;
-static uint8_t poll_index_7E7 = 0;
-static uint16_t currentpoll_7E7 = POLL_7E7_CURRENT;
-static uint16_t reply_poll_7E7 = 0;
 
 const uint16_t poll_commands_7E4[19] = {POLL_7E4_CAPACITY_EST_GEN1,
                                         POLL_7E4_CAPACITY_EST_GEN2,
@@ -202,7 +96,7 @@ const uint16_t poll_commands_7E7[108] = {POLL_7E7_CURRENT,          POLL_7E7_5V_
                                          POLL_7E7_CELL_93,          POLL_7E7_CELL_94,
                                          POLL_7E7_CELL_95,          POLL_7E7_CELL_96};
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the battery datalayer
+void BoltAmperaBattery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
 
   datalayer.battery.status.real_soc = battery_SOC_display;
 
@@ -279,7 +173,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.boltampera.battery_current_7E4 = battery_current_7E4;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x200:  //High voltage Battery Cell Voltage Matrix 1
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -769,7 +663,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void BoltAmperaBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   //Send 20ms message
@@ -813,9 +707,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Chevrolet Bolt EV/Opel Ampera-e", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
@@ -823,6 +715,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
   datalayer.system.status.battery_allows_contactor_closing = true;
+}
+
+void BoltAmperaBattery::setup() {
+  setup_battery();
 }
 
 #endif

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -176,7 +176,125 @@
 #define POLL_7E7_CELL_119 0x4257
 #define POLL_7E7_CELL_120 0x4258
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class BoltAmperaBattery : public CanBattery {
+ public:
+  BoltAmperaBattery() : CanBattery(BoltAmpera) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Chevrolet Bolt EV/Opel Ampera-e";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  /*TODO, messages we might need to send towards the battery to keep it happy and close contactors
+0x262 Battery Block Voltage Diag Status HV (Who sends this? Battery?)
+0x272 Battery Cell Voltage Diag Status HV (Who sends this? Battery?)
+0x274 Battery Temperature Sensor diagnostic status HV (Who sends this? Battery?)
+0x270 Battery VoltageSensor BalancingSwitches diagnostic status (Who sends this? Battery?)
+0x214 Charger coolant temp info HV
+0x20E Hybrid balancing request HV
+0x30E High Voltage Charger Command HV
+0x30C HVEM Provide Charging HV
+0x316 OBHV Charge Process PEV HV
+0x30F OBHV Charg Statn Current stat HV
+0x312 OBHV Charg Statns Energy allocation HV
+0x310 OBHV Charg Statn Vlt Energy Power HV
+0x306 Off board HVCS Limit HV
+0x309 Off board HVCS Min Limit HV
+0x305 Vehicle Charging limit stat HV
+0x314 Vehicle req energy transfer HV <<<<<<<<<< Sounds like contactor request resides here TODO
+0x460 Energy Storage System Temp HV (Who sends this? Battery?)
+*/
+
+  /* Do not change code below unless you are sure what you are doing */
+  unsigned long previousMillis20ms = 0;   // will store last time a 20ms CAN Message was send
+  unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis120ms = 0;  // will store last time a 120ms CAN Message was send
+
+  CAN_frame BOLT_778 = {.FD = false,  // Unsure of what this message is, added only as example
+                        .ext_ID = false,
+                        .DLC = 7,
+                        .ID = 0x778,
+                        .data = {0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BOLT_POLL_7E4 = {.FD = false,  // VICM_HV poll
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BOLT_ACK_7E4 = {.FD = false,  //VICM_HV ack
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x7E4,
+                            .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BOLT_POLL_7E7 = {.FD = false,  //VITM_HV poll
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E7,
+                             .data = {0x03, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BOLT_ACK_7E7 = {.FD = false,  //VITM_HV ack
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x7E7,
+                            .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  // Other PID requests in the vehicle
+  // All HV ECUs - 0x101
+  // HPCC HV - 0x243 replies on 0x643
+  // OBCM HV - 0x244 replies on 0x644
+  // VICM_HV - 0x7E4 replies 0x7EC (This is battery)
+  // VICM2_HV - 0x7E6 replies 0x7EF (Tis is battery also)
+  // VITM_HV - 0x7E7 replies on 7EF (This is battery)
+
+  uint16_t battery_cell_voltages[96];  //array with all the cellvoltages
+  uint16_t battery_capacity_my17_18 = 0;
+  uint16_t battery_capacity_my19plus = 0;
+  uint16_t battery_SOC_display = 0;
+  uint16_t battery_SOC_raw_highprec = 0;
+  uint16_t battery_max_temperature = 0;
+  uint16_t battery_min_temperature = 0;
+  uint16_t battery_min_cell_voltage = 0;
+  uint16_t battery_max_cell_voltage = 0;
+  uint16_t battery_internal_resistance = 0;
+  uint16_t battery_lowest_cell = 0;
+  uint16_t battery_highest_cell = 0;
+  uint16_t battery_voltage_polled = 0;
+  uint16_t battery_voltage_periodic = 0;
+  uint16_t battery_vehicle_isolation = 0;
+  uint16_t battery_isolation_kohm = 0;
+  uint16_t battery_HV_locked = 0;
+  uint16_t battery_crash_event = 0;
+  uint16_t battery_HVIL = 0;
+  uint16_t battery_HVIL_status = 0;
+  uint16_t battery_5V_ref = 0;
+  int16_t battery_current_7E4 = 0;
+  int16_t battery_module_temp_1 = 0;
+  int16_t battery_module_temp_2 = 0;
+  int16_t battery_module_temp_3 = 0;
+  int16_t battery_module_temp_4 = 0;
+  int16_t battery_module_temp_5 = 0;
+  int16_t battery_module_temp_6 = 0;
+  uint16_t battery_cell_average_voltage = 0;
+  uint16_t battery_cell_average_voltage_2 = 0;
+  uint16_t battery_terminal_voltage = 0;
+  uint16_t battery_ignition_power_mode = 0;
+  int16_t battery_current_7E7 = 0;
+  int16_t temperature_1 = 0;
+  int16_t temperature_2 = 0;
+  int16_t temperature_3 = 0;
+  int16_t temperature_4 = 0;
+  int16_t temperature_5 = 0;
+  int16_t temperature_6 = 0;
+  int16_t temperature_highest = 0;
+  int16_t temperature_lowest = 0;
+  uint8_t mux = 0;
+  uint8_t poll_index_7E4 = 0;
+  uint16_t currentpoll_7E4 = POLL_7E4_CAPACITY_EST_GEN1;
+  uint16_t reply_poll_7E4 = 0;
+  uint8_t poll_index_7E7 = 0;
+  uint16_t currentpoll_7E7 = POLL_7E7_CURRENT;
+  uint16_t reply_poll_7E7 = 0;
+};
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -60,7 +60,7 @@ void BydAtto3Battery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   if (BMS_voltage > 0) {
-    datalayer.battery.status.voltage_dV = BMS_voltage * 10;
+    m_target->status.voltage_dV = BMS_voltage * 10;
   }
 
 #ifdef USE_ESTIMATED_SOC
@@ -68,32 +68,32 @@ void BydAtto3Battery::
   // We instead estimate the SOC% based on the battery voltage.
   // This is a bad solution, you wont be able to use 100% of the battery
   if (battery_type == EXTENDED_RANGE) {
-    datalayer.battery.status.real_soc = estimateSOCextended(datalayer.battery.status.voltage_dV);
+    m_target->status.real_soc = estimateSOCextended(m_target->status.voltage_dV);
   }
   if (battery_type == STANDARD_RANGE) {
-    datalayer.battery.status.real_soc = estimateSOCstandard(datalayer.battery.status.voltage_dV);
+    m_target->status.real_soc = estimateSOCstandard(m_target->status.voltage_dV);
   }
   SOC_method = ESTIMATED;
 #else  // Pack is not crashed, we can use periodically transmitted SOC
-  datalayer.battery.status.real_soc = battery_highprecision_SOC * 10;
+  m_target->status.real_soc = battery_highprecision_SOC * 10;
   SOC_method = MEASURED;
 #endif
 
-  datalayer.battery.status.current_dA = -BMS_current;
+  m_target->status.current_dA = -BMS_current;
 
-  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+  m_target->status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(m_target->status.real_soc) / 10000) * m_target->info.total_capacity_Wh);
 
-  datalayer.battery.status.max_discharge_power_W = MAXPOWER_DISCHARGE_W;  //TODO: Map from CAN later on
+  m_target->status.max_discharge_power_W = MAXPOWER_DISCHARGE_W;  //TODO: Map from CAN later on
 
-  datalayer.battery.status.max_charge_power_W = MAXPOWER_CHARGE_W;  //TODO: Map from CAN later on
+  m_target->status.max_charge_power_W = MAXPOWER_CHARGE_W;  //TODO: Map from CAN later on
 
-  datalayer.battery.status.cell_max_voltage_mV = BMS_highest_cell_voltage_mV;
+  m_target->status.cell_max_voltage_mV = BMS_highest_cell_voltage_mV;
 
-  datalayer.battery.status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
+  m_target->status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
 
   //Map all cell voltages to the global array
-  memcpy(datalayer.battery.status.cell_voltages_mV, battery_cellvoltages, CELLCOUNT_EXTENDED * sizeof(uint16_t));
+  memcpy(m_target->status.cell_voltages_mV, battery_cellvoltages, CELLCOUNT_EXTENDED * sizeof(uint16_t));
 
   // Check if we are on Standard range or Extended range battery.
   // We use a variety of checks to ensure we catch a potential Standard range battery
@@ -112,16 +112,16 @@ void BydAtto3Battery::
 
   switch (battery_type) {
     case STANDARD_RANGE:
-      datalayer.battery.info.total_capacity_Wh = 50000;
-      datalayer.battery.info.number_of_cells = CELLCOUNT_STANDARD;
-      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_STANDARD_DV;
-      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_STANDARD_DV;
+      m_target->info.total_capacity_Wh = 50000;
+      m_target->info.number_of_cells = CELLCOUNT_STANDARD;
+      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_STANDARD_DV;
+      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_STANDARD_DV;
       break;
     case EXTENDED_RANGE:
-      datalayer.battery.info.total_capacity_Wh = 60000;
-      datalayer.battery.info.number_of_cells = CELLCOUNT_EXTENDED;
-      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_EXTENDED_DV;
-      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_EXTENDED_DV;
+      m_target->info.total_capacity_Wh = 60000;
+      m_target->info.number_of_cells = CELLCOUNT_EXTENDED;
+      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_EXTENDED_DV;
+      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_EXTENDED_DV;
       break;
     case NOT_DETERMINED_YET:
     default:
@@ -152,16 +152,18 @@ void BydAtto3Battery::
     }
   }
   //Write the result to datalayer
-  datalayer.battery.status.temperature_min_dC = battery_calc_min_temperature * 10;
-  datalayer.battery.status.temperature_max_dC = battery_calc_max_temperature * 10;
+  m_target->status.temperature_min_dC = battery_calc_min_temperature * 10;
+  m_target->status.temperature_max_dC = battery_calc_max_temperature * 10;
 #else   //User does not need filtering out a broken sensor, just use the min-max the BMS sends
-  datalayer.battery.status.temperature_min_dC = BMS_lowest_cell_temperature * 10;
-  datalayer.battery.status.temperature_max_dC = BMS_highest_cell_temperature * 10;
+  m_target->status.temperature_min_dC = BMS_lowest_cell_temperature * 10;
+  m_target->status.temperature_max_dC = BMS_highest_cell_temperature * 10;
 #endif  //!SKIP_TEMPERATURE_SENSOR_NUMBER
+
+  // TODO: Now both battery 1+2 update these same fields which is probably incorrect!
 
   // Update webserver datalayer
   datalayer_extended.bydAtto3.SOC_method = SOC_method;
-  datalayer_extended.bydAtto3.SOC_estimated = datalayer.battery.status.real_soc;
+  datalayer_extended.bydAtto3.SOC_estimated = m_target->status.real_soc;
   //Once we implement switching logic, remember to change from where the estimated is taken
   datalayer_extended.bydAtto3.SOC_highprec = battery_highprecision_SOC;
   datalayer_extended.bydAtto3.SOC_polled = BMS_SOC;
@@ -182,52 +184,52 @@ void BydAtto3Battery::
 void BydAtto3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x244:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x245:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[0] == 0x01) {
         battery_temperature_ambient = (rx_frame.data.u8[4] - 40);
       }
       break;
     case 0x286:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x334:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x338:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x344:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x345:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x347:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x34A:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x35E:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x360:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x36C:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x438:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x43A:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x43B:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x43C:
       if (rx_frame.data.u8[0] == 0x00) {
@@ -246,7 +248,7 @@ void BydAtto3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
       break;
     case 0x43D:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_frame_index = rx_frame.data.u8[0];
 
       if (battery_frame_index < (CELLCOUNT_EXTENDED / 3)) {
@@ -258,27 +260,27 @@ void BydAtto3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
       break;
     case 0x444:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
       //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
       break;
     case 0x445:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x446:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x447:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_highprecision_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8) | rx_frame.data.u8[4];  // 03 E0 = 992 = 99.2%
       battery_lowest_temperature = (rx_frame.data.u8[1] - 40);                                //Best guess for now
       battery_highest_temperature = (rx_frame.data.u8[3] - 40);                               //Best guess for now
       break;
     case 0x47B:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x524:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x7EF:  //OBD2 PID reply from battery
       switch (rx_frame.data.u8[3]) {
@@ -328,10 +330,10 @@ void BydAtto3Battery::transmit_can() {
     previousMillis50 = currentMillis;
 
     // Set close contactors to allowed (Useful for crashed packs, started via contactor control thru GPIO)
-    if (datalayer.battery.status.bms_status == ACTIVE) {
-      datalayer.system.status.battery_allows_contactor_closing = true;
+    if (m_target->status.bms_status == ACTIVE) {
+      allow_contactor_closing();
     } else {  // Fault state, open contactors!
-      datalayer.system.status.battery_allows_contactor_closing = false;
+      disallow_contactor_closing();
     }
 
     counter_50ms++;
@@ -356,10 +358,7 @@ void BydAtto3Battery::transmit_can() {
     ATTO_3_12D.data.u8[6] = (0x0F | (frame6_counter << 4));
     ATTO_3_12D.data.u8[7] = (0x09 | (frame7_counter << 4));
 
-    transmit_can_frame(&ATTO_3_12D, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&ATTO_3_12D, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&ATTO_3_12D, m_can_interface);
   }
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -377,10 +376,7 @@ void BydAtto3Battery::transmit_can() {
       ATTO_3_441.data.u8[7] = 0xF5;
     }
 
-    transmit_can_frame(&ATTO_3_441, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&ATTO_3_441, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&ATTO_3_441, m_can_interface);
   }
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500 >= INTERVAL_500_MS) {
@@ -424,211 +420,17 @@ void BydAtto3Battery::transmit_can() {
         break;
     }
 
-    transmit_can_frame(&ATTO_3_7E7_POLL, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&ATTO_3_7E7_POLL, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&ATTO_3_7E7_POLL, m_can_interface);
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_EXTENDED_DV;  //Startup in extremes
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_STANDARD_DV;  //We later determine range
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-#ifdef DOUBLE_BATTERY
-  datalayer.battery2.info.number_of_cells = CELLCOUNT_STANDARD;
-  datalayer.battery2.info.chemistry = battery_chemistry_enum::LFP;
-  datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
-  datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
-  datalayer.battery2.info.max_cell_voltage_mV = datalayer.battery.info.max_cell_voltage_mV;
-  datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
-  datalayer.battery2.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-#endif  //DOUBLE_BATTERY
-}
-
-#ifdef DOUBLE_BATTERY
-
-void update_values_battery2() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
-
-  if (BMS2_voltage > 0) {
-    datalayer.battery2.status.voltage_dV = BMS2_voltage * 10;
-  }
-
-  // We instead estimate the SOC% based on the battery2 voltage
-  // This is a very bad solution, and as soon as an usable SOC% value has been found on CAN, we should switch to that!
-  if (battery_type == EXTENDED_RANGE) {
-    datalayer.battery2.status.real_soc = estimateSOCextended(datalayer.battery2.status.voltage_dV);
-  }
-  if (battery_type == STANDARD_RANGE) {
-    datalayer.battery2.status.real_soc = estimateSOCstandard(datalayer.battery2.status.voltage_dV);
-  }
-
-  datalayer.battery2.status.current_dA = -BMS2_current;
-
-  datalayer.battery2.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery2.status.real_soc) / 10000) * datalayer.battery2.info.total_capacity_Wh);
-
-  datalayer.battery2.status.max_discharge_power_W = 10000;  //TODO: Map from CAN later on
-
-  datalayer.battery2.status.max_charge_power_W = 10000;  //TODO: Map from CAN later on
-
-  datalayer.battery2.status.cell_max_voltage_mV = BMS2_highest_cell_voltage_mV;
-
-  datalayer.battery2.status.cell_min_voltage_mV = BMS2_lowest_cell_voltage_mV;
-
-  datalayer.battery2.status.temperature_min_dC = BMS2_lowest_cell_temperature * 10;  // Add decimals
-
-  datalayer.battery2.status.temperature_max_dC = BMS2_highest_cell_temperature * 10;
-
-  //Map all cell voltages to the global array
-  memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages, CELLCOUNT_EXTENDED * sizeof(uint16_t));
-
-  datalayer.battery2.info.total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-  datalayer.battery2.info.number_of_cells = datalayer.battery.info.number_of_cells;
-  datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
-  datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
-}
-
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x244:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x245:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      if (rx_frame.data.u8[0] == 0x01) {
-        battery2_temperature_ambient = (rx_frame.data.u8[4] - 40);
-      }
-      break;
-    case 0x286:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x334:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x338:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x344:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x345:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x347:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x34A:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x35E:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x360:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x36C:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x438:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x43A:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x43B:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x43C:  // Daughterboard temperatures reside in this CAN message
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      if (rx_frame.data.u8[0] == 0x00) {
-        battery2_daughterboard_temperatures[0] = (rx_frame.data.u8[1] - 40);
-        battery2_daughterboard_temperatures[1] = (rx_frame.data.u8[2] - 40);
-        battery2_daughterboard_temperatures[2] = (rx_frame.data.u8[3] - 40);
-        battery2_daughterboard_temperatures[3] = (rx_frame.data.u8[4] - 40);
-        battery2_daughterboard_temperatures[4] = (rx_frame.data.u8[5] - 40);
-        battery2_daughterboard_temperatures[5] = (rx_frame.data.u8[6] - 40);
-      }
-      if (rx_frame.data.u8[0] == 0x01) {
-        battery2_daughterboard_temperatures[6] = (rx_frame.data.u8[1] - 40);
-        battery2_daughterboard_temperatures[7] = (rx_frame.data.u8[2] - 40);
-        battery2_daughterboard_temperatures[8] = (rx_frame.data.u8[3] - 40);
-        battery2_daughterboard_temperatures[9] = (rx_frame.data.u8[4] - 40);
-      }
-      break;
-    case 0x43D:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_frame_index = rx_frame.data.u8[0];
-      if (battery2_frame_index < (CELLCOUNT_EXTENDED / 3)) {
-        uint8_t base2_index = battery2_frame_index * 3;
-        for (uint8_t i = 0; i < 3; i++) {
-          battery2_cellvoltages[base2_index + i] =
-              (((rx_frame.data.u8[2 * (i + 1)] & 0x0F) << 8) | rx_frame.data.u8[2 * i + 1]);
-        }
-      }
-      break;
-    case 0x444:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x445:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x446:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x447:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_highprecision_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8) | rx_frame.data.u8[4];
-      battery2_lowest_temperature = (rx_frame.data.u8[1] - 40);
-      battery2_highest_temperature = (rx_frame.data.u8[3] - 40);
-      break;
-    case 0x47B:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x524:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x7EF:  //OBD2 PID reply from battery2
-      switch (rx_frame.data.u8[3]) {
-        case POLL_FOR_BATTERY_SOC:
-          BMS2_SOC = rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_VOLTAGE:
-          BMS2_voltage = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_CURRENT:
-          BMS2_current = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]) - 5000;
-          break;
-        case POLL_FOR_LOWEST_TEMP_CELL:
-          BMS2_lowest_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
-        case POLL_FOR_HIGHEST_TEMP_CELL:
-          BMS2_highest_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
-        case POLL_FOR_BATTERY_PACK_AVG_TEMP:
-          BMS2_average_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
-        case POLL_FOR_BATTERY_CELL_MV_MAX:
-          BMS2_highest_cell_voltage_mV = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_CELL_MV_MIN:
-          BMS2_lowest_cell_voltage_mV = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        default:  //Unrecognized reply
-          break;
-      }
-      break;
-    default:
-      break;
-  }
-}
-#endif  //DOUBLE_BATTERY
-
-void BydAtto3Battery::setup() {
-  setup_battery();
+void BydAtto3Battery::setup(void) {  // Performs one time setup at startup
+  m_target->info.chemistry = battery_chemistry_enum::LFP;
+  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_EXTENDED_DV;  //Startup in extremes
+  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_STANDARD_DV;  //We later determine range
+  m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef ATTO_3_BATTERY_H
 #define ATTO_3_BATTERY_H
 
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define USE_ESTIMATED_SOC  // If enabled, SOC is estimated from pack voltage. Useful for locked packs. \
@@ -26,7 +27,10 @@
 
 class BydAtto3Battery : public CanBattery {
  public:
-  BydAtto3Battery() : CanBattery(BydAtto3) {}
+  BydAtto3Battery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(BydAtto3) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
   virtual const char* name() { return Name; };
   static constexpr char* Name = "BYD Atto 3";
 
@@ -36,6 +40,9 @@ class BydAtto3Battery : public CanBattery {
   virtual void transmit_can();
 
  private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
+
 #define NOT_DETERMINED_YET 0
 #define STANDARD_RANGE 1
 #define EXTENDED_RANGE 2
@@ -67,25 +74,6 @@ class BydAtto3Battery : public CanBattery {
   uint8_t battery_frame_index = 0;
 #define NOF_CELLS 126
   uint16_t battery_cellvoltages[NOF_CELLS] = {0};
-#ifdef DOUBLE_BATTERY
-  int16_t battery2_temperature_ambient = 0;
-  int16_t battery2_daughterboard_temperatures[10];
-  int16_t battery2_lowest_temperature = 0;
-  int16_t battery2_highest_temperature = 0;
-  int16_t battery2_calc_min_temperature = 0;
-  int16_t battery2_calc_max_temperature = 0;
-  uint16_t battery2_highprecision_SOC = 0;
-  uint16_t BMS2_SOC = 0;
-  uint16_t BMS2_voltage = 0;
-  int16_t BMS2_current = 0;
-  int16_t BMS2_lowest_cell_temperature = 0;
-  int16_t BMS2_highest_cell_temperature = 0;
-  int16_t BMS2_average_cell_temperature = 0;
-  uint16_t BMS2_lowest_cell_voltage_mV = 3300;
-  uint16_t BMS2_highest_cell_voltage_mV = 3300;
-  uint8_t battery2_frame_index = 0;
-  uint16_t battery2_cellvoltages[NOF_CELLS] = {0};
-#endif  //DOUBLE_BATTERY
 #define POLL_FOR_BATTERY_SOC 0x05
 #define POLL_FOR_BATTERY_VOLTAGE 0x08
 #define POLL_FOR_BATTERY_CURRENT 0x09

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -24,7 +24,96 @@
 #define MAX_CELL_VOLTAGE_MV 3800  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class BydAtto3Battery : public CanBattery {
+ public:
+  BydAtto3Battery() : CanBattery(BydAtto3) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BYD Atto 3";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+#define NOT_DETERMINED_YET 0
+#define STANDARD_RANGE 1
+#define EXTENDED_RANGE 2
+  uint8_t battery_type = NOT_DETERMINED_YET;
+  unsigned long previousMillis50 = 0;   // will store last time a 50ms CAN Message was send
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
+  bool SOC_method = false;
+  uint8_t counter_50ms = 0;
+  uint8_t counter_100ms = 0;
+  uint8_t frame6_counter = 0xB;
+  uint8_t frame7_counter = 0x5;
+  uint16_t battery_voltage = 0;
+  int16_t battery_temperature_ambient = 0;
+  int16_t battery_daughterboard_temperatures[10];
+  int16_t battery_lowest_temperature = 0;
+  int16_t battery_highest_temperature = 0;
+  int16_t battery_calc_min_temperature = 0;
+  int16_t battery_calc_max_temperature = 0;
+  uint16_t battery_highprecision_SOC = 0;
+  uint16_t BMS_SOC = 0;
+  uint16_t BMS_voltage = 0;
+  int16_t BMS_current = 0;
+  int16_t BMS_lowest_cell_temperature = 0;
+  int16_t BMS_highest_cell_temperature = 0;
+  int16_t BMS_average_cell_temperature = 0;
+  uint16_t BMS_lowest_cell_voltage_mV = 3300;
+  uint16_t BMS_highest_cell_voltage_mV = 3300;
+  uint8_t battery_frame_index = 0;
+#define NOF_CELLS 126
+  uint16_t battery_cellvoltages[NOF_CELLS] = {0};
+#ifdef DOUBLE_BATTERY
+  int16_t battery2_temperature_ambient = 0;
+  int16_t battery2_daughterboard_temperatures[10];
+  int16_t battery2_lowest_temperature = 0;
+  int16_t battery2_highest_temperature = 0;
+  int16_t battery2_calc_min_temperature = 0;
+  int16_t battery2_calc_max_temperature = 0;
+  uint16_t battery2_highprecision_SOC = 0;
+  uint16_t BMS2_SOC = 0;
+  uint16_t BMS2_voltage = 0;
+  int16_t BMS2_current = 0;
+  int16_t BMS2_lowest_cell_temperature = 0;
+  int16_t BMS2_highest_cell_temperature = 0;
+  int16_t BMS2_average_cell_temperature = 0;
+  uint16_t BMS2_lowest_cell_voltage_mV = 3300;
+  uint16_t BMS2_highest_cell_voltage_mV = 3300;
+  uint8_t battery2_frame_index = 0;
+  uint16_t battery2_cellvoltages[NOF_CELLS] = {0};
+#endif  //DOUBLE_BATTERY
+#define POLL_FOR_BATTERY_SOC 0x05
+#define POLL_FOR_BATTERY_VOLTAGE 0x08
+#define POLL_FOR_BATTERY_CURRENT 0x09
+#define POLL_FOR_LOWEST_TEMP_CELL 0x2f
+#define POLL_FOR_HIGHEST_TEMP_CELL 0x31
+#define POLL_FOR_BATTERY_PACK_AVG_TEMP 0x32
+#define POLL_FOR_BATTERY_CELL_MV_MAX 0x2D
+#define POLL_FOR_BATTERY_CELL_MV_MIN 0x2B
+#define UNKNOWN_POLL_1 0xFC
+#define ESTIMATED 0
+#define MEASURED 1
+  uint16_t poll_state = POLL_FOR_BATTERY_SOC;
+
+  CAN_frame ATTO_3_12D = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x12D,
+                          .data = {0xA0, 0x28, 0x02, 0xA0, 0x0C, 0x71, 0xCF, 0x49}};
+  CAN_frame ATTO_3_441 = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x441,
+                          .data = {0x98, 0x3A, 0x88, 0x13, 0x07, 0x00, 0xFF, 0x8C}};
+  CAN_frame ATTO_3_7E7_POLL = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7E7,  //Poll PID 03 22 00 05 (POLL_FOR_BATTERY_SOC)
+                               .data = {0x03, 0x22, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00}};
+};
 
 #endif

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -47,6 +47,8 @@ class BatteryBase {
   BatteryType type() { return m_type; }
   virtual const char* name() = 0;
 
+  /// @brief Whether the battery supports double instances.
+  virtual bool supportsDoubleBattery() { return false; };
   virtual void setup() = 0;
   virtual void update_values() = 0;
 
@@ -62,12 +64,16 @@ class BatteryBase {
 
   virtual bool requiresPrechargeControl() { return false; }
 
+  bool contactor_closing_allowed() { return m_contactor_closing_allowed; }
+  void allow_contactor_closing() { m_contactor_closing_allowed = true; }
+  void disallow_contactor_closing() { m_contactor_closing_allowed = false; }
+
   static const char* name_for_type(BatteryType type);
 
  protected:
-  BatteryBase(BatteryType type) : m_type(type) {}
-
+  BatteryBase(BatteryType type) : m_type(type), m_contactor_closing_allowed(false) {}
   BatteryType m_type;
+  bool m_contactor_closing_allowed;
 };
 
 // Abstract base class for all batteries using CAN bus
@@ -98,9 +104,15 @@ class RS485Battery : public BatteryBase {
 
 std::vector<BatteryType> supported_battery_types();
 
-BatteryBase* init_battery(BatteryType type);
+BatteryBase* init_battery(BatteryType type, BatteryBase* pair = nullptr);
 
 extern BatteryBase* battery;
+extern BatteryBase* battery2;
 extern BatteryType userSelectedBatteryType;
+extern bool secondBatteryInUse;
+
+inline bool double_battery() {
+  return secondBatteryInUse && battery2 != nullptr;
+}
 
 #endif

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -1,0 +1,106 @@
+#ifndef BATTERY_H
+#define BATTERY_H
+
+#include <vector>
+#include "../devboard/utils/types.h"
+
+// Enum number values used in user settings. Retain numbering.
+enum BatteryType {
+  BMWi3 = 1,
+  BMWIX = 2,
+  BMWPhev = 3,
+  BMWSBox = 4,
+  BoltAmpera = 5,
+  BydAtto3 = 6,
+  CellPower = 7,
+  Chademo = 8,
+  CmfaEv = 33,
+  Daly = 9,
+  Ecmp = 32,
+  Foxess = 10,
+  ImievCzeroIon = 11,
+  JaguarIpace = 12,
+  KiaEGmp = 13,
+  KiaHyundai64 = 14,
+  KiaHyundaiHybrid = 15,
+  Meb = 16,
+  Mg5 = 17,
+  NissanLeaf = 18,
+  Pylon = 19,
+  RangeRoverPhev = 20,
+  RenaultKangoo = 21,
+  RenaultTwizy = 22,
+  RenaultZoeGen1 = 23,
+  RenaultZoeGen2 = 24,
+  SantaFePhev = 25,
+  Sono = 26,
+  Tesla3Y = 27,
+  TeslaSX = 28,
+  TestFake = 29,
+  VolvoSpa = 30,
+  VolvoSpaHybrid = 31,
+  HighestBatteryType = 34
+};
+
+class BatteryBase {
+ public:
+  BatteryType type() { return m_type; }
+  virtual const char* name() = 0;
+
+  virtual void setup() = 0;
+  virtual void update_values() = 0;
+
+  virtual bool usesCAN() = 0;
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
+  /// @brief Called to ask the battery implementation to transmit any CAN messages it needs to send.
+  virtual void transmit_can() = 0;
+
+  virtual bool usesRS485() = 0;
+  virtual int rs485_baudrate() { return 0; }
+  virtual void transmit_RS485() = 0;
+  virtual void receive_RS485() = 0;
+
+  virtual bool requiresPrechargeControl() { return false; }
+
+  static const char* name_for_type(BatteryType type);
+
+ protected:
+  BatteryBase(BatteryType type) : m_type(type) {}
+
+  BatteryType m_type;
+};
+
+// Abstract base class for all batteries using CAN bus
+class CanBattery : public BatteryBase {
+ public:
+  virtual bool usesCAN() { return true; }
+
+  virtual bool usesRS485() { return false; }
+  virtual int rs485_baudrate() { return 0; }
+  virtual void transmit_RS485() {}
+  virtual void receive_RS485() {}
+
+ protected:
+  CanBattery(BatteryType type) : BatteryBase(type) {}
+};
+
+// Abstract base class for all batteries using RS485 bus
+class RS485Battery : public BatteryBase {
+  virtual bool usesCAN() { return false; }
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame) {};
+  virtual void transmit_can() {};
+
+  virtual bool usesRS485() { return true; }
+
+ protected:
+  RS485Battery(BatteryType type) : BatteryBase(type) {}
+};
+
+std::vector<BatteryType> supported_battery_types();
+
+BatteryBase* init_battery(BatteryType type);
+
+extern BatteryBase* battery;
+extern BatteryType userSelectedBatteryType;
+
+#endif

--- a/Software/src/battery/BatteryCommon.cpp
+++ b/Software/src/battery/BatteryCommon.cpp
@@ -2,8 +2,9 @@
 #include "Battery.h"
 
 BatteryType userSelectedBatteryType = BatteryType::TestFake;
+extern bool secondBatteryInUse = false;
 
-BatteryBase* init_battery(BatteryType type) {
+BatteryBase* init_battery(BatteryType type, BatteryBase* pair) {
 
   // To support selecting a battery at compile time, we need to use the
   // #ifdefs here. If this support is not needed, the #ifdefs can be removed.
@@ -11,7 +12,8 @@ BatteryBase* init_battery(BatteryType type) {
   switch (type) {
 #ifdef BMW_I3_BATTERY
     case BMWi3:
-      battery = new BMWi3Battery();
+      battery = new BMWi3Battery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                 pair ? can_config.battery_double : can_config.battery, pair ? WUP_PIN2 : WUP_PIN1);
       break;
 #endif
 
@@ -35,7 +37,8 @@ BatteryBase* init_battery(BatteryType type) {
 
 #ifdef BYD_ATTO_3_BATTERY
     case BydAtto3:
-      battery = new BydAtto3Battery();
+      battery = new BydAtto3Battery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                    pair ? can_config.battery_double : can_config.battery);
       break;
 #endif
 
@@ -83,7 +86,8 @@ BatteryBase* init_battery(BatteryType type) {
 
 #ifdef KIA_HYUNDAI_64_BATTERY
     case KiaHyundai64:
-      battery = new KiaHyundai64Battery();
+      battery = new KiaHyundai64Battery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                        pair ? can_config.battery_double : can_config.battery);
       break;
 #endif
 
@@ -107,13 +111,15 @@ BatteryBase* init_battery(BatteryType type) {
 
 #ifdef NISSAN_LEAF_BATTERY
     case NissanLeaf:
-      battery = new NissanLeafBattery();
+      battery = new NissanLeafBattery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                      pair ? can_config.battery_double : can_config.battery);
       break;
 #endif
 
 #ifdef PYLON_BATTERY
     case Pylon:
-      battery = new PylonBattery();
+      battery = new PylonBattery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                 pair ? can_config.battery_double : can_config.battery);
       break;
 #endif
 
@@ -131,13 +137,20 @@ BatteryBase* init_battery(BatteryType type) {
 
 #ifdef TEST_FAKE_BATTERY
     case TestFake:
-      battery = new TestFakeBattery();
+      battery = new TestFakeBattery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                    pair ? can_config.battery_double : can_config.battery);
       break;
 #endif
 
 #ifdef RENAULT_ZOE_GEN1_BATTERY
     case RenaultZoeGen1:
       battery = new RenaultZoeBattery();
+      break;
+#endif
+
+#ifdef RENAULT_ZOE_GEN2_BATTERY
+    case RenaultZoeGen2:
+      battery = new RenaultZoeGen2Battery();
       break;
 #endif
 
@@ -152,9 +165,23 @@ BatteryBase* init_battery(BatteryType type) {
       battery = new RangeRoverPhevBattery();
       break;
 #endif
-      /*case RenaultZoeGen2:
-            battery = new RenaultZoeGen2Battery();
-            break;*/
+
+#ifdef SANTA_FE_PHEV_BATTERY_H
+    case SantaFePhev:
+      battery = new SantaFePhevBattery(pair ? &datalayer.battery2 : &datalayer.battery,
+                                       pair ? can_config.battery_double : can_config.battery);
+      break;
+#endif
+#ifdef VOLVO_SPA_BATTERY_H
+    case VolvoSpa:
+      battery = new VolvoSpaBattery();
+      break;
+#endif
+#ifdef VOLVO_SPA_HYBRID_BATTERY_H
+    case VolvoSpaHybrid:
+      battery = new VolvoSpaHybridBattery();
+      break;
+#endif
     default:
       return nullptr;
   }
@@ -277,6 +304,22 @@ const char* BatteryBase::name_for_type(BatteryType type) {
 #ifdef RENAULT_ZOE_GEN1_BATTERY
     case RenaultZoeGen1:
       return RenaultZoeBattery::Name;
+#endif
+
+#ifdef RENAULT_ZOE_GEN2_BATTERY
+    case RenaultZoeGen2:
+      return RenaultZoeGen2Battery::Name;
+#endif
+
+#ifdef VOLVO_SPA_BATTERY_H
+    case VolvoSpa:
+      return VolvoSpaBattery::Name;
+#endif
+
+#ifdef VOLVO_SPA_HYBRID_BATTERY_H
+    case VolvoSpaHybrid:
+      return VolvoSpaHybridBattery::Name;
+      break;
 #endif
 
     default:

--- a/Software/src/battery/BatteryCommon.cpp
+++ b/Software/src/battery/BatteryCommon.cpp
@@ -1,0 +1,298 @@
+#include "../include.h"
+#include "Battery.h"
+
+BatteryType userSelectedBatteryType = BatteryType::TestFake;
+
+BatteryBase* init_battery(BatteryType type) {
+
+  // To support selecting a battery at compile time, we need to use the
+  // #ifdefs here. If this support is not needed, the #ifdefs can be removed.
+
+  switch (type) {
+#ifdef BMW_I3_BATTERY
+    case BMWi3:
+      battery = new BMWi3Battery();
+      break;
+#endif
+
+#ifdef BMW_IX_BATTERY
+    case BMWIX:
+      battery = new BMWIXBattery();
+      break;
+#endif
+
+#ifdef BMW_PHEV_BATTERY
+    case BMWPhev:
+      battery = new BMWPhevBattery();
+      break;
+#endif
+
+#ifdef BOLT_AMPERA_BATTERY
+    case BoltAmpera:
+      battery = new BoltAmperaBattery();
+      break;
+#endif
+
+#ifdef BYD_ATTO_3_BATTERY
+    case BydAtto3:
+      battery = new BydAtto3Battery();
+      break;
+#endif
+
+#ifdef CELLPOWER_BMS
+    case CellPower:
+      battery = new CellPowerBms();
+      break;
+#endif
+
+#ifdef DALY_BMS
+    case Daly:
+      battery = new DalyBms();
+      break;
+#endif
+
+#ifdef STELLANTIS_ECMP_BATTERY
+    case Ecmp:
+      battery = new StellantisEcmpBattery();
+      break;
+#endif
+
+#ifdef FOXESS_BATTERY
+    case Foxess:
+      battery = new FoxessBattery();
+      break;
+#endif
+
+#ifdef IMIEV_CZERO_ION_BATTERY
+    case ImievCzeroIon:
+      battery = new ImievCzeroIonBattery();
+      break;
+#endif
+
+#ifdef JAGUAR_IPACE_BATTERY
+    case JaguarIpace:
+      battery = new JaguarIpaceBattery();
+      break;
+#endif
+
+#ifdef KIA_E_GMP_BATTERY
+    case KiaEGmp:
+      battery = new KiaEGmpBattery();
+      break;
+#endif
+
+#ifdef KIA_HYUNDAI_64_BATTERY
+    case KiaHyundai64:
+      battery = new KiaHyundai64Battery();
+      break;
+#endif
+
+#ifdef KIA_HYUNDAI_HYBRID_BATTERY
+    case KiaHyundaiHybrid:
+      battery = new KiaHyundaiHybridBattery();
+      break;
+#endif
+
+#ifdef MEB_BATTERY
+    case Meb:
+      battery = new MebBattery();
+      break;
+#endif
+
+#ifdef MG_5_BATTERY
+    case Mg5:
+      battery = new MG5Battery();
+      break;
+#endif
+
+#ifdef NISSAN_LEAF_BATTERY
+    case NissanLeaf:
+      battery = new NissanLeafBattery();
+      break;
+#endif
+
+#ifdef PYLON_BATTERY
+    case Pylon:
+      battery = new PylonBattery();
+      break;
+#endif
+
+#ifdef TESLA_MODEL_3Y_BATTERY
+    case Tesla3Y:
+      battery = new Tesla3YBattery();
+      break;
+#endif
+
+#ifdef TESLA_MODEL_SX_BATTERY
+    case TeslaSX:
+      battery = new TeslaSXBattery();
+      break;
+#endif
+
+#ifdef TEST_FAKE_BATTERY
+    case TestFake:
+      battery = new TestFakeBattery();
+      break;
+#endif
+
+#ifdef RENAULT_ZOE_GEN1_BATTERY
+    case RenaultZoeGen1:
+      battery = new RenaultZoeBattery();
+      break;
+#endif
+
+#ifdef RENAULT_KANGOO_BATTERY
+    case RenaultKangoo:
+      battery = new RenaultKangooBattery();
+      break;
+#endif
+
+#ifdef RANGE_ROVER_PHEV_BATTERY
+    case RangeRoverPhev:
+      battery = new RangeRoverPhevBattery();
+      break;
+#endif
+      /*case RenaultZoeGen2:
+            battery = new RenaultZoeGen2Battery();
+            break;*/
+    default:
+      return nullptr;
+  }
+
+  return battery;
+}
+
+const char* BatteryBase::name_for_type(BatteryType type) {
+  switch (type) {
+#ifdef BMW_I3_BATTERY
+    case BMWi3:
+      return BMWi3Battery::Name;
+#endif
+
+#ifdef BMW_IX_BATTERY
+    case BMWIX:
+      return BMWIXBattery::Name;
+#endif
+
+#ifdef BMW_PHEV_BATTERY
+    case BMWPhev:
+      return BMWPhevBattery::Name;
+#endif
+
+#ifdef BOLT_AMPERA_BATTERY
+    case BoltAmpera:
+      return BoltAmperaBattery::Name;
+#endif
+
+#ifdef BYD_ATTO_3_BATTERY
+    case BydAtto3:
+      return BydAtto3Battery::Name;
+#endif
+
+#ifdef CELLPOWER_BMS
+    case CellPower:
+      return CellPowerBms::Name;
+#endif
+
+#ifdef CHADEMO_BATTERY
+    case Chademo:
+      return ChademoBattery::Name;
+#endif
+
+#ifdef DALY_BMS
+    case Daly:
+      return DalyBms::Name;
+#endif
+
+#ifdef STELLANTIS_ECMP_BATTERY
+    case Ecmp:
+      return StellantisEcmpBattery::Name;
+#endif
+
+#ifdef TEST_FAKE_BATTERY
+    case TestFake:
+      return TestFakeBattery::Name;
+#endif
+
+#ifdef FOXESS_BATTERY
+    case Foxess:
+      return FoxessBattery::Name;
+#endif
+
+#ifdef IMIEV_CZERO_ION_BATTERY
+    case ImievCzeroIon:
+      return ImievCzeroIonBattery::Name;
+#endif
+
+#ifdef JAGUAR_IPACE_BATTERY
+    case JaguarIpace:
+      return JaguarIpaceBattery::Name;
+#endif
+
+#ifdef KIA_E_GMP_BATTERY
+    case KiaEGmp:
+      return KiaEGmpBattery::Name;
+#endif
+
+#ifdef KIA_HYUNDAI_64_BATTERY
+    case KiaHyundai64:
+      return KiaHyundai64Battery::Name;
+#endif
+
+#ifdef KIA_HYUNDAI_HYBRID_BATTERY
+    case KiaHyundaiHybrid:
+      return KiaHyundaiHybridBattery::Name;
+#endif
+
+#ifdef MEB_BATTERY
+    case Meb:
+      return MebBattery::Name;
+#endif
+
+#ifdef MG_5_BATTERY
+    case Mg5:
+      return MG5Battery::Name;
+#endif
+
+#ifdef NISSAN_LEAF_BATTERY
+    case NissanLeaf:
+      return NissanLeafBattery::Name;
+#endif
+
+#ifdef PYLON_BATTERY
+    case Pylon:
+      return PylonBattery::Name;
+#endif
+
+#ifdef TESLA_MODEL_3Y_BATTERY
+    case Tesla3Y:
+      return Tesla3YBattery::Name;
+#endif
+
+#ifdef TESLA_MODEL_SX_BATTERY
+    case TeslaSX:
+      return TeslaSXBattery::Name;
+#endif
+
+#ifdef RENAULT_ZOE_GEN1_BATTERY
+    case RenaultZoeGen1:
+      return RenaultZoeBattery::Name;
+#endif
+
+    default:
+      return nullptr;
+  }
+}
+
+std::vector<BatteryType> supported_battery_types() {
+  std::vector<BatteryType> types;
+
+  for (int i = 1; i < static_cast<int>(HighestBatteryType); i++) {
+    auto type = static_cast<BatteryType>(i);
+    if (CanBattery::name_for_type(type) != nullptr) {
+      types.push_back(type);
+    }
+  }
+
+  return types;
+}

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -232,7 +232,7 @@ void CellPowerBms::transmit_can() {
 }
 
 void CellPowerBms::setup(void) {  // Performs one time setup at startup
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -6,110 +6,8 @@
 #include "CELLPOWER-BMS.h"
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis1s = 0;  // will store last time a 1s CAN Message was sent
 
-//Actual content messages
-// Optional add-on charger module. Might not be needed to send these towards the BMS to keep it happy.
-CAN_frame CELLPOWER_18FF50E9 = {.FD = false,
-                                .ext_ID = true,
-                                .DLC = 5,
-                                .ID = 0x18FF50E9,
-                                .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame CELLPOWER_18FF50E8 = {.FD = false,
-                                .ext_ID = true,
-                                .DLC = 5,
-                                .ID = 0x18FF50E8,
-                                .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame CELLPOWER_18FF50E7 = {.FD = false,
-                                .ext_ID = true,
-                                .DLC = 5,
-                                .ID = 0x18FF50E7,
-                                .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame CELLPOWER_18FF50E5 = {.FD = false,
-                                .ext_ID = true,
-                                .DLC = 5,
-                                .ID = 0x18FF50E5,
-                                .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static bool system_state_discharge = false;
-static bool system_state_charge = false;
-static bool system_state_cellbalancing = false;
-static bool system_state_tricklecharge = false;
-static bool system_state_idle = false;
-static bool system_state_chargecompleted = false;
-static bool system_state_maintenancecharge = false;
-static bool IO_state_main_positive_relay = false;
-static bool IO_state_main_negative_relay = false;
-static bool IO_state_charge_enable = false;
-static bool IO_state_precharge_relay = false;
-static bool IO_state_discharge_enable = false;
-static bool IO_state_IO_6 = false;
-static bool IO_state_IO_7 = false;
-static bool IO_state_IO_8 = false;
-static bool error_Cell_overvoltage = false;
-static bool error_Cell_undervoltage = false;
-static bool error_Cell_end_of_life_voltage = false;
-static bool error_Cell_voltage_misread = false;
-static bool error_Cell_over_temperature = false;
-static bool error_Cell_under_temperature = false;
-static bool error_Cell_unmanaged = false;
-static bool error_LMU_over_temperature = false;
-static bool error_LMU_under_temperature = false;
-static bool error_Temp_sensor_open_circuit = false;
-static bool error_Temp_sensor_short_circuit = false;
-static bool error_SUB_communication = false;
-static bool error_LMU_communication = false;
-static bool error_Over_current_IN = false;
-static bool error_Over_current_OUT = false;
-static bool error_Short_circuit = false;
-static bool error_Leak_detected = false;
-static bool error_Leak_detection_failed = false;
-static bool error_Voltage_difference = false;
-static bool error_BMCU_supply_over_voltage = false;
-static bool error_BMCU_supply_under_voltage = false;
-static bool error_Main_positive_contactor = false;
-static bool error_Main_negative_contactor = false;
-static bool error_Precharge_contactor = false;
-static bool error_Midpack_contactor = false;
-static bool error_Precharge_timeout = false;
-static bool error_Emergency_connector_override = false;
-static bool warning_High_cell_voltage = false;
-static bool warning_Low_cell_voltage = false;
-static bool warning_High_cell_temperature = false;
-static bool warning_Low_cell_temperature = false;
-static bool warning_High_LMU_temperature = false;
-static bool warning_Low_LMU_temperature = false;
-static bool warning_SUB_communication_interfered = false;
-static bool warning_LMU_communication_interfered = false;
-static bool warning_High_current_IN = false;
-static bool warning_High_current_OUT = false;
-static bool warning_Pack_resistance_difference = false;
-static bool warning_High_pack_resistance = false;
-static bool warning_Cell_resistance_difference = false;
-static bool warning_High_cell_resistance = false;
-static bool warning_High_BMCU_supply_voltage = false;
-static bool warning_Low_BMCU_supply_voltage = false;
-static bool warning_Low_SOC = false;
-static bool warning_Balancing_required_OCV_model = false;
-static bool warning_Charger_not_responding = false;
-static uint16_t cell_voltage_max_mV = 3700;
-static uint16_t cell_voltage_min_mV = 3700;
-static int8_t pack_temperature_high_C = 0;
-static int8_t pack_temperature_low_C = 0;
-static uint16_t battery_pack_voltage_dV = 3700;
-static int16_t battery_pack_current_dA = 0;
-static uint8_t battery_SOH_percentage = 99;
-static uint8_t battery_SOC_percentage = 50;
-static uint16_t battery_remaining_dAh = 0;
-static uint8_t cell_with_highest_voltage = 0;
-static uint8_t cell_with_lowest_voltage = 0;
-static uint16_t requested_charge_current_dA = 0;
-static uint16_t average_charge_current_dA = 0;
-static uint16_t actual_charge_current_dA = 0;
-static bool requested_exceeding_average_current = 0;
-static bool error_state = false;
-
-void update_values_battery() {
+void CellPowerBms::update_values() {
 
   /* Update values from CAN */
 
@@ -213,7 +111,8 @@ void update_values_battery() {
     //TODO, shall we react on this?
   }
 }
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+
+void CellPowerBms::handle_incoming_can_frame(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x1A4:  //PDO1_TX - 200ms
@@ -316,7 +215,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void CellPowerBms::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 1s CAN Message
   if (currentMillis - previousMillis1s >= INTERVAL_1_S) {
@@ -332,9 +231,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Cellpower BMS", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void CellPowerBms::setup(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CELLPOWER-BMS.h
+++ b/Software/src/battery/CELLPOWER-BMS.h
@@ -13,7 +13,119 @@
 #define BATTERY_SELECTED
 #define NATIVECAN_250KBPS
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class CellPowerBms : public CanBattery {
+ public:
+  CellPowerBms() : CanBattery(CellPower) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Cellpower BMS";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  unsigned long previousMillis1s = 0;  // will store last time a 1s CAN Message was sent
+
+  //Actual content messages
+  // Optional add-on charger module. Might not be needed to send these towards the BMS to keep it happy.
+  CAN_frame CELLPOWER_18FF50E9 = {.FD = false,
+                                  .ext_ID = true,
+                                  .DLC = 5,
+                                  .ID = 0x18FF50E9,
+                                  .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CELLPOWER_18FF50E8 = {.FD = false,
+                                  .ext_ID = true,
+                                  .DLC = 5,
+                                  .ID = 0x18FF50E8,
+                                  .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CELLPOWER_18FF50E7 = {.FD = false,
+                                  .ext_ID = true,
+                                  .DLC = 5,
+                                  .ID = 0x18FF50E7,
+                                  .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CELLPOWER_18FF50E5 = {.FD = false,
+                                  .ext_ID = true,
+                                  .DLC = 5,
+                                  .ID = 0x18FF50E5,
+                                  .data = {0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  bool system_state_discharge = false;
+  bool system_state_charge = false;
+  bool system_state_cellbalancing = false;
+  bool system_state_tricklecharge = false;
+  bool system_state_idle = false;
+  bool system_state_chargecompleted = false;
+  bool system_state_maintenancecharge = false;
+  bool IO_state_main_positive_relay = false;
+  bool IO_state_main_negative_relay = false;
+  bool IO_state_charge_enable = false;
+  bool IO_state_precharge_relay = false;
+  bool IO_state_discharge_enable = false;
+  bool IO_state_IO_6 = false;
+  bool IO_state_IO_7 = false;
+  bool IO_state_IO_8 = false;
+  bool error_Cell_overvoltage = false;
+  bool error_Cell_undervoltage = false;
+  bool error_Cell_end_of_life_voltage = false;
+  bool error_Cell_voltage_misread = false;
+  bool error_Cell_over_temperature = false;
+  bool error_Cell_under_temperature = false;
+  bool error_Cell_unmanaged = false;
+  bool error_LMU_over_temperature = false;
+  bool error_LMU_under_temperature = false;
+  bool error_Temp_sensor_open_circuit = false;
+  bool error_Temp_sensor_short_circuit = false;
+  bool error_SUB_communication = false;
+  bool error_LMU_communication = false;
+  bool error_Over_current_IN = false;
+  bool error_Over_current_OUT = false;
+  bool error_Short_circuit = false;
+  bool error_Leak_detected = false;
+  bool error_Leak_detection_failed = false;
+  bool error_Voltage_difference = false;
+  bool error_BMCU_supply_over_voltage = false;
+  bool error_BMCU_supply_under_voltage = false;
+  bool error_Main_positive_contactor = false;
+  bool error_Main_negative_contactor = false;
+  bool error_Precharge_contactor = false;
+  bool error_Midpack_contactor = false;
+  bool error_Precharge_timeout = false;
+  bool error_Emergency_connector_override = false;
+  bool warning_High_cell_voltage = false;
+  bool warning_Low_cell_voltage = false;
+  bool warning_High_cell_temperature = false;
+  bool warning_Low_cell_temperature = false;
+  bool warning_High_LMU_temperature = false;
+  bool warning_Low_LMU_temperature = false;
+  bool warning_SUB_communication_interfered = false;
+  bool warning_LMU_communication_interfered = false;
+  bool warning_High_current_IN = false;
+  bool warning_High_current_OUT = false;
+  bool warning_Pack_resistance_difference = false;
+  bool warning_High_pack_resistance = false;
+  bool warning_Cell_resistance_difference = false;
+  bool warning_High_cell_resistance = false;
+  bool warning_High_BMCU_supply_voltage = false;
+  bool warning_Low_BMCU_supply_voltage = false;
+  bool warning_Low_SOC = false;
+  bool warning_Balancing_required_OCV_model = false;
+  bool warning_Charger_not_responding = false;
+  uint16_t cell_voltage_max_mV = 3700;
+  uint16_t cell_voltage_min_mV = 3700;
+  int8_t pack_temperature_high_C = 0;
+  int8_t pack_temperature_low_C = 0;
+  uint16_t battery_pack_voltage_dV = 3700;
+  int16_t battery_pack_current_dA = 0;
+  uint8_t battery_SOH_percentage = 99;
+  uint8_t battery_SOC_percentage = 50;
+  uint16_t battery_remaining_dAh = 0;
+  uint8_t cell_with_highest_voltage = 0;
+  uint8_t cell_with_lowest_voltage = 0;
+  uint16_t requested_charge_current_dA = 0;
+  uint16_t average_charge_current_dA = 0;
+  uint16_t actual_charge_current_dA = 0;
+  bool requested_exceeding_average_current = 0;
+  bool error_state = false;
+};
 
 #endif

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -893,7 +893,7 @@ void handle_chademo_sequence() {
       //        Commented unless needed for debug
       logging.println("CHADEMO_EVSE_START State");
 #endif
-      datalayer.system.status.battery_allows_contactor_closing = true;
+      allow_contactor_closing();
       x109_evse_state.s.status.ChgDischStopControl = 1;
       x109_evse_state.s.status.EVSE_status = 0;
 
@@ -1042,7 +1042,7 @@ void ChademoBattery::setup(void) {  // Performs one time setup at startup
   CHADEMO_Status = CHADEMO_IDLE;
 
   /* disallow contactors until permissions is granted by vehicle */
-  datalayer.system.status.battery_allows_contactor_closing = false;
+  disallow_contactor_closing();
 
   /* Pretend that we know the SOH, assert that it is 99% */
   datalayer.battery.status.soh_pptt = 9900;

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -108,7 +108,7 @@ CAN_frame CHADEMO_209 = {.FD = false,
                          .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 //This function maps all the values fetched via CAN to the correct parameters used for the inverter
-void update_values_battery() {
+void ChademoBattery::update_values() {
 
   datalayer.battery.status.real_soc = x102_chg_session.StateOfCharge;
 
@@ -365,7 +365,7 @@ inline void process_vehicle_vendor_ID(CAN_frame rx_frame) {
       ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[1]);  //Actually more bytes, but not needed for our purpose
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void ChademoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 #ifdef CH_CAN_DEBUG
   logging.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
   logging.print("  ");
@@ -655,7 +655,7 @@ void update_evse_discharge_capabilities(CAN_frame& f) {
   CHADEMO_208.data.u8[7] = highByte(x208_evse_dischg_cap.lower_threshold_voltage);
 }
 
-void transmit_can_battery() {
+void ChademoBattery::transmit_can() {
 
   unsigned long currentMillis = millis();
 
@@ -1028,7 +1028,7 @@ void handle_chademo_sequence() {
   return;
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+void ChademoBattery::setup(void) {  // Performs one time setup at startup
 
   pinMode(CHADEMO_PIN_2, OUTPUT);
   digitalWrite(CHADEMO_PIN_2, LOW);
@@ -1038,9 +1038,6 @@ void setup_battery(void) {  // Performs one time setup at startup
   digitalWrite(CHADEMO_LOCK, LOW);
   pinMode(CHADEMO_PIN_4, INPUT);
   pinMode(CHADEMO_PIN_7, INPUT);
-
-  strncpy(datalayer.system.info.battery_protocol, "Chademo V2X mode", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
 
   CHADEMO_Status = CHADEMO_IDLE;
 

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -12,7 +12,15 @@
 // other measurement sources may be added in the future
 #define ISA_SHUNT
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class ChademoBattery : public CanBattery {
+ public:
+  ChademoBattery() : CanBattery(Chademo) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Chademo V2X mode";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+}
 
 #endif

--- a/Software/src/battery/CHADEMO-SHUNTS.h
+++ b/Software/src/battery/CHADEMO-SHUNTS.h
@@ -23,6 +23,4 @@ void ISA_getCONFIG(uint8_t i);
 void ISA_getCAN_ID(uint8_t i);
 void ISA_getINFO(uint8_t i);
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-
 #endif

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -1025,7 +1025,7 @@ void CmfaEvBattery::transmit_can() {
 }
 
 void CmfaEvBattery::setup(void) {  // Performs one time setup at startup
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 72;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -152,7 +152,15 @@
 #define PID_POLL_UNKNOWNx 0xF195
 */
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class CmfaEvBattery : public CanBattery {
+ public:
+  CmfaEvBattery() : CanBattery(CmfaEv) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "CMFA platform, 27 kWh battery";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -19,7 +19,7 @@ static uint16_t cellvoltage_max_mV = 0;
 static uint16_t SOC = 0;
 static bool has_fault = false;
 
-void update_values_battery() {
+void DalyBms::update_values() {
   datalayer.battery.status.real_soc = SOC;
   datalayer.battery.status.voltage_dV = voltage_dV;  //value is *10 (3700 = 370.0)
   datalayer.battery.status.current_dA = current_dA;  //value is *10 (150 = 15.0)
@@ -60,9 +60,7 @@ void update_values_battery() {
   datalayer.battery.status.real_bms_status = has_fault ? BMS_FAULT : BMS_ACTIVE;
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "DALY RS485", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void DalyBms::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = CELL_COUNT;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
@@ -153,7 +151,7 @@ void decode_packet(uint8_t command, uint8_t data[8]) {
   }
 }
 
-void transmit_rs485() {
+void DalyBms::transmit_RS485() {
   static uint8_t nextCommand = 0x90;
 
   if (millis() - lastPacket > 60) {
@@ -177,7 +175,7 @@ void transmit_rs485() {
   }
 }
 
-void receive_RS485() {
+void DalyBms::receive_RS485() {
   static uint8_t recv_buff[13] = {0};
   static uint8_t recv_len = 0;
 

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -13,7 +13,19 @@
 
 /* Do not modify any rows below*/
 #define BATTERY_SELECTED
-#define RS485_BATTERY_SELECTED
-#define RS485_BAUDRATE 9600
+
+class DalyBms : public RS485Battery {
+ public:
+  DalyBms() : RS485Battery(Daly) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "DALY RS485";
+
+  virtual void setup();
+  virtual void update_values();
+
+  virtual int rs485_baudrate() { return 9600; }
+  virtual void transmit_RS485();
+  virtual void receive_RS485();
+};
 
 #endif

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -6,7 +6,15 @@
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 250
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class StellantisEcmpBattery : public CanBattery {
+ public:
+  StellantisEcmpBattery() : CanBattery(Ecmp) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "ECMP battery";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef FOXESS_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "FOXESS-BATTERY.h"
@@ -13,80 +14,9 @@ TODO:
 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
 
-CAN_frame FOX_1871 = {.FD = false,  //Inverter request data from battery. Content varies depending on state
-                      .ext_ID = true,
-                      .DLC = 8,
-                      .ID = 0x1871,
-                      .data = {0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static uint32_t total_watt_hours = 0;
-static uint16_t max_charge_power_dA = 0;
-static uint16_t max_discharge_power_dA = 0;
-static uint16_t cut_mv_max = 0;
-static uint16_t cut_mv_min = 0;
-static uint16_t cycle_count = 0;
-static uint16_t max_ac_voltage = 0;
-static uint16_t cellvoltages_mV[128] = {0};
-static int16_t temperature_average = 0;
-static int16_t pack1_current_sensor = 0;
-static int16_t pack2_current_sensor = 0;
-static int16_t pack3_current_sensor = 0;
-static int16_t pack4_current_sensor = 0;
-static int16_t pack5_current_sensor = 0;
-static int16_t pack6_current_sensor = 0;
-static int16_t pack7_current_sensor = 0;
-static int16_t pack8_current_sensor = 0;
-static int16_t pack1_temperature_avg_high = 0;
-static int16_t pack2_temperature_avg_high = 0;
-static int16_t pack3_temperature_avg_high = 0;
-static int16_t pack4_temperature_avg_high = 0;
-static int16_t pack5_temperature_avg_high = 0;
-static int16_t pack6_temperature_avg_high = 0;
-static int16_t pack7_temperature_avg_high = 0;
-static int16_t pack8_temperature_avg_high = 0;
-static int16_t pack1_temperature_avg_low = 0;
-static int16_t pack2_temperature_avg_low = 0;
-static int16_t pack3_temperature_avg_low = 0;
-static int16_t pack4_temperature_avg_low = 0;
-static int16_t pack5_temperature_avg_low = 0;
-static int16_t pack6_temperature_avg_low = 0;
-static int16_t pack7_temperature_avg_low = 0;
-static int16_t pack8_temperature_avg_low = 0;
-static uint16_t pack1_voltage = 0;
-static uint16_t pack2_voltage = 0;
-static uint16_t pack3_voltage = 0;
-static uint16_t pack4_voltage = 0;
-static uint16_t pack5_voltage = 0;
-static uint16_t pack6_voltage = 0;
-static uint16_t pack7_voltage = 0;
-static uint16_t pack8_voltage = 0;
-static uint8_t pack1_SOC = 0;
-static uint8_t pack2_SOC = 0;
-static uint8_t pack3_SOC = 0;
-static uint8_t pack4_SOC = 0;
-static uint8_t pack5_SOC = 0;
-static uint8_t pack6_SOC = 0;
-static uint8_t pack7_SOC = 0;
-static uint8_t pack8_SOC = 0;
-static uint8_t pack_error = 0;
-static uint8_t firmware_pack_minor = 0;
-static uint8_t firmware_pack_major = 0;
-static uint8_t STATUS_OPERATIONAL_PACKS =
-    0;  //0x1875 b2 contains status for operational packs (responding) in binary so 01111111 is pack 8 not operational, 11101101 is pack 5 & 2 not operational
-static uint8_t NUMBER_OF_PACKS = 0;  //1-8
-static uint8_t contactor_status = 0;
-static uint8_t statemachine_polling = 0;
-static bool charging_disabled = false;
-static bool b0_idle = false;
-static bool b1_ok_discharge = false;
-static bool b2_ok_charge = false;
-static bool b3_discharging = false;
-static bool b4_charging = false;
-static bool b5_operational = false;
-static bool b6_active_error = false;
-
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void FoxessBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
@@ -146,7 +76,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void FoxessBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1872:  //BMS_Limits
       datalayer.battery.info.max_design_voltage_dV = (uint16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
@@ -474,7 +404,8 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
+
+void FoxessBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   // Send 500ms CAN Message
@@ -645,15 +576,17 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "FoxESS HV2600/ECS4100 OEM battery", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {              // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 0;  //Startup with no cells, populates later when we know packsize
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+}
+
+void FoxessBattery::setup() {
+  setup_battery();
 }
 
 #endif

--- a/Software/src/battery/FOXESS-BATTERY.h
+++ b/Software/src/battery/FOXESS-BATTERY.h
@@ -10,7 +10,90 @@
 #define MAX_CELL_DEVIATION_MV 250
 #define MAX_CELL_VOLTAGE_MV 3800  //LiFePO4 Prismaticc Cell
 #define MIN_CELL_VOLTAGE_MV 2700  //LiFePO4 Prismatic Cell
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class FoxessBattery : public CanBattery {
+ public:
+  FoxessBattery() : CanBattery(Foxess) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "FoxESS HV2600/ECS4100 OEM battery";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
+
+  CAN_frame FOX_1871 = {.FD = false,  //Inverter request data from battery. Content varies depending on state
+                        .ext_ID = true,
+                        .DLC = 8,
+                        .ID = 0x1871,
+                        .data = {0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  uint32_t total_watt_hours = 0;
+  uint16_t max_charge_power_dA = 0;
+  uint16_t max_discharge_power_dA = 0;
+  uint16_t cut_mv_max = 0;
+  uint16_t cut_mv_min = 0;
+  uint16_t cycle_count = 0;
+  uint16_t max_ac_voltage = 0;
+  uint16_t cellvoltages_mV[128] = {0};
+  int16_t temperature_average = 0;
+  int16_t pack1_current_sensor = 0;
+  int16_t pack2_current_sensor = 0;
+  int16_t pack3_current_sensor = 0;
+  int16_t pack4_current_sensor = 0;
+  int16_t pack5_current_sensor = 0;
+  int16_t pack6_current_sensor = 0;
+  int16_t pack7_current_sensor = 0;
+  int16_t pack8_current_sensor = 0;
+  int16_t pack1_temperature_avg_high = 0;
+  int16_t pack2_temperature_avg_high = 0;
+  int16_t pack3_temperature_avg_high = 0;
+  int16_t pack4_temperature_avg_high = 0;
+  int16_t pack5_temperature_avg_high = 0;
+  int16_t pack6_temperature_avg_high = 0;
+  int16_t pack7_temperature_avg_high = 0;
+  int16_t pack8_temperature_avg_high = 0;
+  int16_t pack1_temperature_avg_low = 0;
+  int16_t pack2_temperature_avg_low = 0;
+  int16_t pack3_temperature_avg_low = 0;
+  int16_t pack4_temperature_avg_low = 0;
+  int16_t pack5_temperature_avg_low = 0;
+  int16_t pack6_temperature_avg_low = 0;
+  int16_t pack7_temperature_avg_low = 0;
+  int16_t pack8_temperature_avg_low = 0;
+  uint16_t pack1_voltage = 0;
+  uint16_t pack2_voltage = 0;
+  uint16_t pack3_voltage = 0;
+  uint16_t pack4_voltage = 0;
+  uint16_t pack5_voltage = 0;
+  uint16_t pack6_voltage = 0;
+  uint16_t pack7_voltage = 0;
+  uint16_t pack8_voltage = 0;
+  uint8_t pack1_SOC = 0;
+  uint8_t pack2_SOC = 0;
+  uint8_t pack3_SOC = 0;
+  uint8_t pack4_SOC = 0;
+  uint8_t pack5_SOC = 0;
+  uint8_t pack6_SOC = 0;
+  uint8_t pack7_SOC = 0;
+  uint8_t pack8_SOC = 0;
+  uint8_t pack_error = 0;
+  uint8_t firmware_pack_minor = 0;
+  uint8_t firmware_pack_major = 0;
+  uint8_t STATUS_OPERATIONAL_PACKS =
+      0;  //0x1875 b2 contains status for operational packs (responding) in binary so 01111111 is pack 8 not operational, 11101101 is pack 5 & 2 not operational
+  uint8_t NUMBER_OF_PACKS = 0;  //1-8
+  uint8_t contactor_status = 0;
+  uint8_t statemachine_polling = 0;
+  bool charging_disabled = false;
+  bool b0_idle = false;
+  bool b1_ok_discharge = false;
+  bool b2_ok_charge = false;
+  bool b3_discharging = false;
+  bool b4_charging = false;
+  bool b5_operational = false;
+  bool b6_active_error = false;
+};
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef IMIEV_CZERO_ION_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "IMIEV-CZERO-ION-BATTERY.h"
@@ -8,35 +9,9 @@
 //Figure out if CAN messages need to be sent to keep the system happy?
 
 /* Do not change code below unless you are sure what you are doing */
-static uint8_t errorCode = 0;  //stores if we have an error code active from battery control logic
-static uint8_t BMU_Detected = 0;
-static uint8_t CMU_Detected = 0;
 
-static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was sent
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
-
-static int pid_index = 0;
-static int cmu_id = 0;
-static int voltage_index = 0;
-static int temp_index = 0;
-static uint8_t BMU_SOC = 0;
-static int temp_value = 0;
-static double temp1 = 0;
-static double temp2 = 0;
-static double temp3 = 0;
-static double voltage1 = 0;
-static double voltage2 = 0;
-static double BMU_Current = 0;
-static double BMU_PackVoltage = 0;
-static double BMU_Power = 0;
-static double cell_voltages[88];      //array with all the cellvoltages
-static double cell_temperatures[88];  //array with all the celltemperatures
-static double max_volt_cel = 3.70;
-static double min_volt_cel = 3.70;
-static double max_temp_cel = 20.00;
-static double min_temp_cel = 19.00;
-
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void ImievCzeroIonBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   datalayer.battery.status.real_soc = (uint16_t)(BMU_SOC * 100);  //increase BMU_SOC range from 0-100 -> 100.00
 
   datalayer.battery.status.voltage_dV = (uint16_t)(BMU_PackVoltage * 10);  // Multiply by 10 and cast to uint16_t
@@ -129,7 +104,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void ImievCzeroIonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x374:  //BMU message, 10ms - SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -207,7 +182,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void ImievCzeroIonBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -223,14 +198,16 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "I-Miev / C-Zero / Ion Triplet", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+}
+
+void ImievCzeroIonBattery::setup() {
+  setup_battery();
 }
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -10,7 +10,44 @@
 #define MAX_CELL_VOLTAGE_MV 4150  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2750  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class ImievCzeroIonBattery : public CanBattery {
+ public:
+  ImievCzeroIonBattery() : CanBattery(ImievCzeroIon) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "I-Miev / C-Zero / Ion Triplet";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  uint8_t errorCode = 0;  //stores if we have an error code active from battery control logic
+  uint8_t BMU_Detected = 0;
+  uint8_t CMU_Detected = 0;
+
+  unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was sent
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
+
+  int pid_index = 0;
+  int cmu_id = 0;
+  int voltage_index = 0;
+  int temp_index = 0;
+  uint8_t BMU_SOC = 0;
+  int temp_value = 0;
+  double temp1 = 0;
+  double temp2 = 0;
+  double temp3 = 0;
+  double voltage1 = 0;
+  double voltage2 = 0;
+  double BMU_Current = 0;
+  double BMU_PackVoltage = 0;
+  double BMU_Power = 0;
+  double cell_voltages[88];      //array with all the cellvoltages
+  double cell_temperatures[88];  //array with all the celltemperatures
+  double max_volt_cel = 3.70;
+  double min_volt_cel = 3.70;
+  double max_temp_cel = 20.00;
+  double min_temp_cel = 19.00;
+};
 
 #endif

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef JAGUAR_IPACE_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "JAGUAR-IPACE-BATTERY.h"
@@ -56,13 +57,13 @@ CAN_frame ipace_keep_alive = {.FD = false,
                               .ID = 0x59e,
                               .data = {0x9E, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};*/
 
-void print_units(char* header, int value, char* units) {
+static void print_units(char* header, int value, char* units) {
   logging.print(header);
   logging.print(value);
   logging.print(units);
 }
 
-void update_values_battery() {
+static void update_values_battery() {
 
   datalayer.battery.status.real_soc = HVBattAvgSOC * 100;  //Add two decimals
 
@@ -119,7 +120,7 @@ void update_values_battery() {
 #endif
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
@@ -242,7 +243,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   logging.println("");
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   /* Send keep-alive every 200ms */
@@ -253,9 +254,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
@@ -264,6 +263,22 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 
   datalayer.system.status.battery_allows_contactor_closing = true;
+}
+
+void JaguarIpaceBattery::setup() {
+  setup_battery();
+}
+
+void JaguarIpaceBattery::update_values() {
+  update_values_battery();
+}
+
+void JaguarIpaceBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
+  ::handle_incoming_can_frame_battery(rx_frame);
+}
+
+void JaguarIpaceBattery::transmit_can() {
+  transmit_can_battery();
 }
 
 #endif

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -254,7 +254,7 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
+void JaguarIpaceBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 108;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
@@ -262,11 +262,7 @@ static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 
-  datalayer.system.status.battery_allows_contactor_closing = true;
-}
-
-void JaguarIpaceBattery::setup() {
-  setup_battery();
+  allow_contactor_closing();
 }
 
 void JaguarIpaceBattery::update_values() {

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -9,7 +9,15 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class JaguarIpaceBattery : public CanBattery {
+ public:
+  JaguarIpaceBattery() : CanBattery(JaguarIpace) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Jaguar I-PACE";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1138,20 +1138,16 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  startMillis = millis();          // Record the starting time
+void KiaEGmpBattery::setup(void) {  // Performs one time setup at startup
+  startMillis = millis();           // Record the starting time
 
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 192;  // TODO: will vary depending on battery
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-}
-
-void KiaEGmpBattery::setup() {
-  setup_battery();
 }
 
 void KiaEGmpBattery::update_values() {

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -19,7 +19,15 @@ extern ACAN2517FD canfd;
 #define RAMPDOWN_SOC 9000           // 90.00 SOC% to start ramping down from max charge power towards 0 at 100.00%
 #define RAMPDOWNPOWERALLOWED 10000  // What power we ramp down from towards top balancing
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class KiaEGmpBattery : public CanBattery {
+ public:
+  KiaEGmpBattery() : CanBattery(KiaEGmp) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Kia/Hyundai EGMP platform";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -1,153 +1,15 @@
 #include "../include.h"
 #ifdef KIA_HYUNDAI_64_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/events.h"
 #include "KIA-HYUNDAI-64-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis10 = 0;   // will store last time a 10s CAN Message was send
 
-static uint16_t soc_calculated = 0;
-static uint16_t SOC_BMS = 0;
-static uint16_t SOC_Display = 0;
-static uint16_t batterySOH = 1000;
-static uint16_t CellVoltMax_mV = 3700;
-static uint16_t CellVoltMin_mV = 3700;
-static uint16_t allowedDischargePower = 0;
-static uint16_t allowedChargePower = 0;
-static uint16_t batteryVoltage = 0;
-static uint16_t inverterVoltageFrameHigh = 0;
-static uint16_t inverterVoltage = 0;
-static uint16_t cellvoltages_mv[98];
-static int16_t leadAcidBatteryVoltage = 120;
-static int16_t batteryAmps = 0;
-static int16_t temperatureMax = 0;
-static int16_t temperatureMin = 0;
-static int16_t poll_data_pid = 0;
-static bool holdPidCounter = false;
-static uint8_t CellVmaxNo = 0;
-static uint8_t CellVminNo = 0;
-static uint8_t batteryManagementMode = 0;
-static uint8_t BMS_ign = 0;
-static uint8_t batteryRelay = 0;
-static uint8_t waterleakageSensor = 164;
-static uint8_t counter_200 = 0;
-static int8_t temperature_water_inlet = 0;
-static int8_t heatertemp = 0;
-static int8_t powerRelayTemperature = 0;
-static bool startedUp = false;
-
-#ifdef DOUBLE_BATTERY
-static uint8_t counter_200_2 = 0;
-static uint16_t battery2_soc_calculated = 0;
-static uint16_t battery2_SOC_BMS = 0;
-static uint16_t battery2_SOC_Display = 0;
-static uint16_t battery2_batterySOH = 1000;
-static uint16_t battery2_CellVoltMax_mV = 3700;
-static uint16_t battery2_CellVoltMin_mV = 3700;
-static uint16_t battery2_allowedDischargePower = 0;
-static uint16_t battery2_allowedChargePower = 0;
-static uint16_t battery2_batteryVoltage = 0;
-static uint16_t battery2_inverterVoltageFrameHigh = 0;
-static uint16_t battery2_inverterVoltage = 0;
-static uint16_t battery2_cellvoltages_mv[98];
-static int16_t battery2_leadAcidBatteryVoltage = 120;
-static int16_t battery2_batteryAmps = 0;
-static int16_t battery2_temperatureMax = 0;
-static int16_t battery2_temperatureMin = 0;
-static int16_t battery2_poll_data_pid = 0;
-static bool battery2_holdPidCounter = false;
-static uint8_t battery2_CellVmaxNo = 0;
-static uint8_t battery2_CellVminNo = 0;
-static uint8_t battery2_batteryManagementMode = 0;
-static uint8_t battery2_BMS_ign = 0;
-static uint8_t battery2_batteryRelay = 0;
-static uint8_t battery2_waterleakageSensor = 164;
-static uint8_t battery2_counter_200 = 0;
-static int8_t battery2_temperature_water_inlet = 0;
-static int8_t battery2_heatertemp = 0;
-static int8_t battery2_powerRelayTemperature = 0;
-static bool battery2_startedUp = false;
-CAN_frame KIA_HYUNDAI_200_2 = {.FD = false,
-                               .ext_ID = false,
-                               .DLC = 8,
-                               .ID = 0x200,
-                               .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};  //2nd battery
-#endif                                                                                     //DOUBLE_BATTERY
-
-CAN_frame KIA_HYUNDAI_200 = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x200,
-                             .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};
-CAN_frame KIA_HYUNDAI_523 = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x523,
-                             .data = {0x08, 0x38, 0x36, 0x36, 0x33, 0x34, 0x00, 0x01}};
-CAN_frame KIA_HYUNDAI_524 = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x524,
-                             .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-//553 Needed frame 200ms
-CAN_frame KIA64_553 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x553,
-                       .data = {0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00}};
-//57F Needed frame 100ms
-CAN_frame KIA64_57F = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x57F,
-                       .data = {0x80, 0x0A, 0x72, 0x00, 0x00, 0x00, 0x00, 0x72}};
-//Needed frame 100ms
-CAN_frame KIA64_2A1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x2A1,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame KIA64_7E4_id1 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
-CAN_frame KIA64_7E4_id2 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 02
-CAN_frame KIA64_7E4_id3 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 03
-CAN_frame KIA64_7E4_id4 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 04
-CAN_frame KIA64_7E4_id5 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 05
-CAN_frame KIA64_7E4_id6 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x7E4,
-                           .data = {0x03, 0x22, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 06
-CAN_frame KIA64_7E4_ack = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x7E4,
-    .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
-
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void KiaHyundai64Battery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 
@@ -251,7 +113,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void update_number_of_cells() {
+void KiaHyundai64Battery::update_number_of_cells() {
   //If we have cell values and number_of_cells not initialized yet
   if (cellvoltages_mv[0] > 0 && datalayer.battery.info.number_of_cells == 0) {
     // Check if we have 98S or 90S battery
@@ -269,7 +131,7 @@ void update_number_of_cells() {
   }
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4DE:
       startedUp = true;
@@ -924,7 +786,7 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 }
 #endif  //DOUBLE_BATTERY
 
-void transmit_can_battery() {
+void KiaHyundai64Battery::transmit_can() {
   unsigned long currentMillis = millis();
 
   if (!startedUp) {
@@ -1055,9 +917,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Kia/Hyundai 64/40kWh battery", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void setup_battery(void) {                                                 // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
@@ -1071,6 +931,10 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
   datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
 #endif  //DOUBLE_BATTERY
+}
+
+void KiaHyundai64Battery::setup() {
+  setup_battery();
 }
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -11,28 +11,28 @@
 void KiaHyundai64Battery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
-  datalayer.battery.status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
+  m_target->status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 
-  datalayer.battery.status.soh_pptt = (batterySOH * 10);  //Increase decimals from 100.0% -> 100.00%
+  m_target->status.soh_pptt = (batterySOH * 10);  //Increase decimals from 100.0% -> 100.00%
 
-  datalayer.battery.status.voltage_dV = batteryVoltage;  //value is *10 (3700 = 370.0)
+  m_target->status.voltage_dV = batteryVoltage;  //value is *10 (3700 = 370.0)
 
-  datalayer.battery.status.current_dA = -batteryAmps;  //value is *10 (150 = 15.0) , invert the sign
+  m_target->status.current_dA = -batteryAmps;  //value is *10 (150 = 15.0) , invert the sign
 
-  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+  m_target->status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(m_target->status.real_soc) / 10000) * m_target->info.total_capacity_Wh);
 
-  datalayer.battery.status.max_charge_power_W = allowedChargePower * 10;
+  m_target->status.max_charge_power_W = allowedChargePower * 10;
 
-  datalayer.battery.status.max_discharge_power_W = allowedDischargePower * 10;
+  m_target->status.max_discharge_power_W = allowedDischargePower * 10;
 
-  datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
+  m_target->status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 
-  datalayer.battery.status.temperature_max_dC = (int8_t)temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
+  m_target->status.temperature_max_dC = (int8_t)temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
 
-  datalayer.battery.status.cell_max_voltage_mV = CellVoltMax_mV;
+  m_target->status.cell_max_voltage_mV = CellVoltMax_mV;
 
-  datalayer.battery.status.cell_min_voltage_mV = CellVoltMin_mV;
+  m_target->status.cell_min_voltage_mV = CellVoltMin_mV;
 
   if (waterleakageSensor == 0) {
     set_event(EVENT_WATER_INGRESS, 0);
@@ -43,7 +43,7 @@ void KiaHyundai64Battery::
   }
 
   // Update webserver datalayer
-  datalayer_extended.KiaHyundai64.total_cell_count = datalayer.battery.info.number_of_cells;
+  datalayer_extended.KiaHyundai64.total_cell_count = m_target->info.number_of_cells;
   datalayer_extended.KiaHyundai64.battery_12V = leadAcidBatteryVoltage;
   datalayer_extended.KiaHyundai64.waterleakageSensor = waterleakageSensor;
   datalayer_extended.KiaHyundai64.temperature_water_inlet = temperature_water_inlet;
@@ -67,7 +67,7 @@ void KiaHyundai64Battery::
   logging.print(" Amps  |  ");
   logging.print((uint16_t)batteryVoltage / 10.0, 1);
   logging.print(" Volts  |  ");
-  logging.print((int16_t)datalayer.battery.status.active_power_W);
+  logging.print((int16_t)m_target->status.active_power_W);
   logging.println(" Watts");
   logging.print("Allowed Charge ");
   logging.print((uint16_t)allowedChargePower * 10);
@@ -115,18 +115,18 @@ void KiaHyundai64Battery::
 
 void KiaHyundai64Battery::update_number_of_cells() {
   //If we have cell values and number_of_cells not initialized yet
-  if (cellvoltages_mv[0] > 0 && datalayer.battery.info.number_of_cells == 0) {
+  if (cellvoltages_mv[0] > 0 && m_target->info.number_of_cells == 0) {
     // Check if we have 98S or 90S battery
-    if (datalayer.battery.status.cell_voltages_mV[97] > 0) {
-      datalayer.battery.info.number_of_cells = 98;
-      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;
-      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_98S_DV;
-      datalayer.battery.info.total_capacity_Wh = 64000;
+    if (m_target->status.cell_voltages_mV[97] > 0) {
+      m_target->info.number_of_cells = 98;
+      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;
+      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_98S_DV;
+      m_target->info.total_capacity_Wh = 64000;
     } else {
-      datalayer.battery.info.number_of_cells = 90;
-      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_90S_DV;
-      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;
-      datalayer.battery.info.total_capacity_Wh = 40000;
+      m_target->info.number_of_cells = 90;
+      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_90S_DV;
+      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;
+      m_target->info.total_capacity_Wh = 40000;
     }
   }
 }
@@ -138,7 +138,7 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x542:  //BMS SOC
       startedUp = true;
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       SOC_Display = rx_frame.data.u8[0] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x594:
@@ -183,17 +183,17 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
         poll_data_pid++;
         if (poll_data_pid == 1) {
-          transmit_can_frame(&KIA64_7E4_id1, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id1, m_can_interface);
         } else if (poll_data_pid == 2) {
-          transmit_can_frame(&KIA64_7E4_id2, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id2, m_can_interface);
         } else if (poll_data_pid == 3) {
-          transmit_can_frame(&KIA64_7E4_id3, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id3, m_can_interface);
         } else if (poll_data_pid == 4) {
-          transmit_can_frame(&KIA64_7E4_id4, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id4, m_can_interface);
         } else if (poll_data_pid == 5) {
-          transmit_can_frame(&KIA64_7E4_id5, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id5, m_can_interface);
         } else if (poll_data_pid == 6) {
-          transmit_can_frame(&KIA64_7E4_id6, can_config.battery);
+          transmit_can_frame(&KIA64_7E4_id6, m_can_interface);
         }
       }
       break;
@@ -202,7 +202,7 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
             transmit_can_frame(&KIA64_7E4_ack,
-                               can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+                               m_can_interface);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -373,7 +373,7 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
             }
           }
           //Map all cell voltages to the global array
-          memcpy(datalayer.battery.status.cell_voltages_mV, cellvoltages_mv, 98 * sizeof(uint16_t));
+          memcpy(m_target->status.cell_voltages_mV, cellvoltages_mv, 98 * sizeof(uint16_t));
           //Update number of cells
           update_number_of_cells();
           break;
@@ -395,397 +395,6 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   }
 }
 
-#ifdef DOUBLE_BATTERY
-void update_values_battery2() {  // Handle the values coming in from battery #2
-  /* Start with mapping all values */
-  datalayer.battery2.status.real_soc = (battery2_SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
-
-  datalayer.battery2.status.soh_pptt = (battery2_batterySOH * 10);  //Increase decimals from 100.0% -> 100.00%
-
-  datalayer.battery2.status.voltage_dV = battery2_batteryVoltage;  //value is *10 (3700 = 370.0)
-
-  datalayer.battery2.status.current_dA = -battery2_batteryAmps;  //value is *10 (150 = 15.0) , invert the sign
-
-  datalayer.battery2.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery2.status.real_soc) / 10000) * datalayer.battery2.info.total_capacity_Wh);
-
-  datalayer.battery2.status.max_charge_power_W = battery2_allowedChargePower * 10;
-
-  datalayer.battery2.status.max_discharge_power_W = battery2_allowedDischargePower * 10;
-
-  datalayer.battery2.status.temperature_min_dC =
-      (int8_t)battery2_temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
-
-  datalayer.battery2.status.temperature_max_dC =
-      (int8_t)battery2_temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
-
-  datalayer.battery2.status.cell_max_voltage_mV = battery2_CellVoltMax_mV;
-
-  datalayer.battery2.status.cell_min_voltage_mV = battery2_CellVoltMin_mV;
-
-  if (battery2_waterleakageSensor == 0) {
-    set_event(EVENT_WATER_INGRESS, 0);
-  }
-
-  if (battery2_leadAcidBatteryVoltage < 110) {
-    set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
-  }
-
-  // Update webserver datalayer
-  datalayer_extended.KiaHyundai64.battery2_total_cell_count = datalayer.battery2.info.number_of_cells;
-  datalayer_extended.KiaHyundai64.battery2_battery_12V = battery2_leadAcidBatteryVoltage;
-  datalayer_extended.KiaHyundai64.battery2_waterleakageSensor = battery2_waterleakageSensor;
-  datalayer_extended.KiaHyundai64.battery2_temperature_water_inlet = battery2_temperature_water_inlet;
-  datalayer_extended.KiaHyundai64.battery2_powerRelayTemperature = battery2_powerRelayTemperature * 2;
-  datalayer_extended.KiaHyundai64.battery2_batteryManagementMode = battery2_batteryManagementMode;
-  datalayer_extended.KiaHyundai64.battery2_BMS_ign = battery2_BMS_ign;
-  datalayer_extended.KiaHyundai64.battery2_batteryRelay = battery2_batteryRelay;
-
-  //Perform logging if configured to do so
-#ifdef DEBUG_LOG
-  logging.println();  //sepatator
-  logging.println("Values from battery: ");
-  logging.print("SOC BMS: ");
-  logging.print((uint16_t)battery2_SOC_BMS / 10.0, 1);
-  logging.print("%  |  SOC Display: ");
-  logging.print((uint16_t)battery2_SOC_Display / 10.0, 1);
-  logging.print("%  |  SOH ");
-  logging.print((uint16_t)battery2_batterySOH / 10.0, 1);
-  logging.println("%");
-  logging.print((int16_t)battery2_batteryAmps / 10.0, 1);
-  logging.print(" Amps  |  ");
-  logging.print((uint16_t)battery2_batteryVoltage / 10.0, 1);
-  logging.print(" Volts  |  ");
-  logging.print((int16_t)datalayer.battery2.status.active_power_W);
-  logging.println(" Watts");
-  logging.print("Allowed Charge ");
-  logging.print((uint16_t)battery2_allowedChargePower * 10);
-  logging.print(" W  |  Allowed Discharge ");
-  logging.print((uint16_t)battery2_allowedDischargePower * 10);
-  logging.println(" W");
-  logging.print("MaxCellVolt ");
-  logging.print(battery2_CellVoltMax_mV);
-  logging.print(" mV  No  ");
-  logging.print(battery2_CellVmaxNo);
-  logging.print("  |  MinCellVolt ");
-  logging.print(battery2_CellVoltMin_mV);
-  logging.print(" mV  No  ");
-  logging.println(battery2_CellVminNo);
-  logging.print("TempHi ");
-  logging.print((int16_t)battery2_temperatureMax);
-  logging.print("°C  TempLo ");
-  logging.print((int16_t)battery2_temperatureMin);
-  logging.print("°C  WaterInlet ");
-  logging.print((int8_t)battery2_temperature_water_inlet);
-  logging.print("°C  PowerRelay ");
-  logging.print((int8_t)battery2_powerRelayTemperature * 2);
-  logging.println("°C");
-  logging.print("Aux12volt: ");
-  logging.print((int16_t)battery2_leadAcidBatteryVoltage / 10.0, 1);
-  logging.println("V  |  ");
-  logging.print("BmsManagementMode ");
-  logging.print((uint8_t)battery2_batteryManagementMode, BIN);
-  if (bitRead((uint8_t)battery2_BMS_ign, 2) == 1) {
-    logging.print("  |  BmsIgnition ON");
-  } else {
-    logging.print("  |  BmsIgnition OFF");
-  }
-
-  if (bitRead((uint8_t)battery2_batteryRelay, 0) == 1) {
-    logging.print("  |  PowerRelay ON");
-  } else {
-    logging.print("  |  PowerRelay OFF");
-  }
-  logging.print("  |  Inverter ");
-  logging.print(battery2_inverterVoltage);
-  logging.println(" Volts");
-#endif
-}
-
-void update_number_of_cells_battery2() {
-  //If we have cell values and number_of_cells not initialized yet
-  if (battery2_cellvoltages_mv[0] > 0 && datalayer.battery2.info.number_of_cells == 0) {
-    // Check if we have 98S or 90S battery
-    if (datalayer.battery2.status.cell_voltages_mV[97] > 0) {
-      datalayer.battery2.info.number_of_cells = 98;
-      datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;
-      datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_98S_DV;
-      datalayer.battery2.info.total_capacity_Wh = 64000;
-    } else {
-      datalayer.battery2.info.number_of_cells = 90;
-      datalayer.battery2.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_90S_DV;
-      datalayer.battery2.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;
-      datalayer.battery2.info.total_capacity_Wh = 40000;
-    }
-  }
-}
-
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x4DE:
-      battery2_startedUp = true;
-      break;
-    case 0x542:  //BMS SOC
-      battery2_startedUp = true;
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_SOC_Display = rx_frame.data.u8[0] * 5;  //100% = 200 ( 200 * 5 = 1000 )
-      break;
-    case 0x594:
-      battery2_startedUp = true;
-      battery2_allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
-      battery2_allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
-      battery2_SOC_BMS = rx_frame.data.u8[5] * 5;  //100% = 200 ( 200 * 5 = 1000 )
-      break;
-    case 0x595:
-      battery2_startedUp = true;
-      battery2_batteryVoltage = (rx_frame.data.u8[7] << 8) + rx_frame.data.u8[6];
-      battery2_batteryAmps = (rx_frame.data.u8[5] << 8) + rx_frame.data.u8[4];
-      if (battery2_counter_200 > 3) {
-        //KIA_HYUNDAI_524.data.u8[0] = (uint8_t)(battery2_batteryVoltage / 10);
-        //KIA_HYUNDAI_524.data.u8[1] = (uint8_t)((battery2_batteryVoltage / 10) >> 8);
-      }  //VCU measured voltage sent back to bms (Not required since battery1 writes this)
-      break;
-    case 0x596:
-      battery2_startedUp = true;
-      battery2_leadAcidBatteryVoltage = rx_frame.data.u8[1];  //12v Battery Volts
-      battery2_temperatureMin = rx_frame.data.u8[6];          //Lowest temp in battery
-      battery2_temperatureMax = rx_frame.data.u8[7];          //Highest temp in battery
-      break;
-    case 0x598:
-      battery2_startedUp = true;
-      break;
-    case 0x5D5:
-      battery2_startedUp = true;
-      battery2_waterleakageSensor =
-          rx_frame.data.u8[3];  //Water sensor inside pack, value 164 is no water --> 0 is short
-      battery2_powerRelayTemperature = rx_frame.data.u8[7];
-      break;
-    case 0x5D8:
-      battery2_startedUp = true;
-
-      //PID data is polled after last message sent from battery every other time:
-      if (battery2_holdPidCounter == true) {
-        battery2_holdPidCounter = false;
-      } else {
-        battery2_holdPidCounter = true;
-        if (battery2_poll_data_pid >= 6) {  //polling one of six PIDs at 100ms*2, resolution = 1200ms
-          battery2_poll_data_pid = 0;
-        }
-        battery2_poll_data_pid++;
-        if (battery2_poll_data_pid == 1) {
-          transmit_can_frame(&KIA64_7E4_id1, can_config.battery_double);
-        } else if (battery2_poll_data_pid == 2) {
-          transmit_can_frame(&KIA64_7E4_id2, can_config.battery_double);
-        } else if (battery2_poll_data_pid == 3) {
-          transmit_can_frame(&KIA64_7E4_id3, can_config.battery_double);
-        } else if (battery2_poll_data_pid == 4) {
-          transmit_can_frame(&KIA64_7E4_id4, can_config.battery_double);
-        } else if (battery2_poll_data_pid == 5) {
-          transmit_can_frame(&KIA64_7E4_id5, can_config.battery_double);
-        } else if (battery2_poll_data_pid == 6) {
-          transmit_can_frame(&KIA64_7E4_id6, can_config.battery_double);
-        }
-      }
-      break;
-    case 0x7EC:  //Data From polled PID group, BigEndian
-      switch (rx_frame.data.u8[0]) {
-        case 0x10:  //"PID Header"
-          if (rx_frame.data.u8[4] == battery2_poll_data_pid) {
-            transmit_can_frame(&KIA64_7E4_ack,
-                               can_config.battery_double);  //Send ack to BMS if the same frame is sent as polled
-          }
-          break;
-        case 0x21:  //First frame in PID group
-          if (battery2_poll_data_pid == 1) {
-            battery2_batteryRelay = rx_frame.data.u8[7];
-          } else if (battery2_poll_data_pid == 2) {
-            battery2_cellvoltages_mv[0] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[1] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[2] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[3] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[4] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[5] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 3) {
-            battery2_cellvoltages_mv[32] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[33] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[34] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[35] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[36] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[37] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 4) {
-            battery2_cellvoltages_mv[64] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[65] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[66] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[67] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[68] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[69] = (rx_frame.data.u8[7] * 20);
-          }
-          break;
-        case 0x22:  //Second datarow in PID group
-          if (battery2_poll_data_pid == 2) {
-            battery2_cellvoltages_mv[6] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[7] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[8] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[9] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[10] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[11] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[12] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 3) {
-            battery2_cellvoltages_mv[38] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[39] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[40] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[41] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[42] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[43] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[44] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 4) {
-            battery2_cellvoltages_mv[70] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[71] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[72] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[73] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[74] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[75] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[76] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 6) {
-            battery2_batteryManagementMode = rx_frame.data.u8[5];
-          }
-          break;
-        case 0x23:  //Third datarow in PID group
-          if (battery2_poll_data_pid == 1) {
-            battery2_temperature_water_inlet = rx_frame.data.u8[6];
-            battery2_CellVoltMax_mV = (rx_frame.data.u8[7] * 20);  //(volts *50) *20 =mV
-          } else if (battery2_poll_data_pid == 2) {
-            battery2_cellvoltages_mv[13] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[14] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[15] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[16] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[17] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[18] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[19] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 3) {
-            battery2_cellvoltages_mv[45] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[46] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[47] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[48] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[49] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[50] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[51] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 4) {
-            battery2_cellvoltages_mv[77] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[78] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[79] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[80] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[81] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[82] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[83] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 5) {
-            battery2_heatertemp = rx_frame.data.u8[7];
-          }
-          break;
-        case 0x24:  //Fourth datarow in PID group
-          if (battery2_poll_data_pid == 1) {
-            battery2_CellVmaxNo = rx_frame.data.u8[1];
-            battery2_CellVminNo = rx_frame.data.u8[3];
-            battery2_CellVoltMin_mV = (rx_frame.data.u8[2] * 20);  //(volts *50) *20 =mV
-          } else if (battery2_poll_data_pid == 2) {
-            battery2_cellvoltages_mv[20] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[21] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[22] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[23] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[24] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[25] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[26] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 3) {
-            battery2_cellvoltages_mv[52] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[53] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[54] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[55] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[56] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[57] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[58] = (rx_frame.data.u8[7] * 20);
-          } else if (battery2_poll_data_pid == 4) {
-            battery2_cellvoltages_mv[84] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[85] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[86] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[87] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[88] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[89] = (rx_frame.data.u8[6] * 20);
-            if (rx_frame.data.u8[7] > 4) {                                // Data only valid on 98S
-              battery2_cellvoltages_mv[90] = (rx_frame.data.u8[7] * 20);  // Perform extra checks
-            }
-          } else if (battery2_poll_data_pid == 5) {
-            battery2_batterySOH = ((rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3]);
-          }
-          break;
-        case 0x25:  //Fifth datarow in PID group
-          if (battery2_poll_data_pid == 2) {
-            battery2_cellvoltages_mv[27] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[28] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[29] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[30] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[31] = (rx_frame.data.u8[5] * 20);
-          } else if (battery2_poll_data_pid == 3) {
-            battery2_cellvoltages_mv[59] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[60] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[61] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[62] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[63] = (rx_frame.data.u8[5] * 20);
-          } else if (battery2_poll_data_pid == 4) {  // Data only valid on 98S
-            if (rx_frame.data.u8[1] > 4) {           // Perform extra checks
-              battery2_cellvoltages_mv[91] = (rx_frame.data.u8[1] * 20);
-            }
-            if (rx_frame.data.u8[2] > 4) {  // Perform extra checks
-              battery2_cellvoltages_mv[92] = (rx_frame.data.u8[2] * 20);
-            }
-            if (rx_frame.data.u8[3] > 4) {  // Perform extra checks
-              battery2_cellvoltages_mv[93] = (rx_frame.data.u8[3] * 20);
-            }
-            if (rx_frame.data.u8[4] > 4) {  // Perform extra checks
-              battery2_cellvoltages_mv[94] = (rx_frame.data.u8[4] * 20);
-            }
-            if (rx_frame.data.u8[5] > 4) {  // Perform extra checks
-              battery2_cellvoltages_mv[95] = (rx_frame.data.u8[5] * 20);
-            }
-          } else if (battery2_poll_data_pid == 5) {  // Data only valid on 98S
-            if (rx_frame.data.u8[4] > 4) {           // Perform extra checks
-              battery2_cellvoltages_mv[96] = (rx_frame.data.u8[4] * 20);
-            }
-            if (rx_frame.data.u8[5] > 4) {  // Perform extra checks
-              battery2_cellvoltages_mv[97] = (rx_frame.data.u8[5] * 20);
-            }
-          }
-          break;
-        case 0x26:  //Sixth datarow in PID group
-          //We have read all cells, check that content is valid:
-          for (uint8_t i = 85; i < 97; ++i) {
-            if (battery2_cellvoltages_mv[i] < 300) {  // Zero the value if it's below 300
-              battery2_cellvoltages_mv[i] = 0;  // Some packs incorrectly report the last unpopulated cells as 20-60mV
-            }
-          }
-          //Map all cell voltages to the global array
-          memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages_mv, 98 * sizeof(uint16_t));
-          //Update number of cells
-          update_number_of_cells_battery2();
-          break;
-        case 0x27:  //Seventh datarow in PID group
-          if (battery2_poll_data_pid == 1) {
-            battery2_BMS_ign = rx_frame.data.u8[6];
-            battery2_inverterVoltageFrameHigh = rx_frame.data.u8[7];
-          }
-          break;
-        case 0x28:  //Eighth datarow in PID group
-          if (battery2_poll_data_pid == 1) {
-            battery2_inverterVoltage = (battery2_inverterVoltageFrameHigh << 8) + rx_frame.data.u8[1];
-          }
-          break;
-      }
-      break;
-    default:
-      break;
-  }
-}
-#endif  //DOUBLE_BATTERY
-
 void KiaHyundai64Battery::transmit_can() {
   unsigned long currentMillis = millis();
 
@@ -797,16 +406,11 @@ void KiaHyundai64Battery::transmit_can() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    transmit_can_frame(&KIA64_553, can_config.battery);
-    transmit_can_frame(&KIA64_57F, can_config.battery);
-    transmit_can_frame(&KIA64_2A1, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    if (battery2_startedUp && datalayer.system.status.battery2_allows_contactor_closing) {
-      transmit_can_frame(&KIA64_553, can_config.battery_double);
-      transmit_can_frame(&KIA64_57F, can_config.battery_double);
-      transmit_can_frame(&KIA64_2A1, can_config.battery_double);
+    if (contactor_closing_allowed()) {
+      transmit_can_frame(&KIA64_553, m_can_interface);
+      transmit_can_frame(&KIA64_57F, m_can_interface);
+      transmit_can_frame(&KIA64_2A1, m_can_interface);
     }
-#endif  // DOUBLE_BATTERY
   }
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
@@ -818,123 +422,62 @@ void KiaHyundai64Battery::transmit_can() {
     }
     previousMillis10 = currentMillis;
 
-    switch (counter_200) {
-      case 0:
-        KIA_HYUNDAI_200.data.u8[5] = 0x17;
-        ++counter_200;
-        break;
-      case 1:
-        KIA_HYUNDAI_200.data.u8[5] = 0x57;
-        ++counter_200;
-        break;
-      case 2:
-        KIA_HYUNDAI_200.data.u8[5] = 0x97;
-        ++counter_200;
-        break;
-      case 3:
-        KIA_HYUNDAI_200.data.u8[5] = 0xD7;
-        ++counter_200;
-        break;
-      case 4:
-        KIA_HYUNDAI_200.data.u8[3] = 0x10;
-        KIA_HYUNDAI_200.data.u8[5] = 0xFF;
-        ++counter_200;
-        break;
-      case 5:
-        KIA_HYUNDAI_200.data.u8[5] = 0x3B;
-        ++counter_200;
-        break;
-      case 6:
-        KIA_HYUNDAI_200.data.u8[5] = 0x7B;
-        ++counter_200;
-        break;
-      case 7:
-        KIA_HYUNDAI_200.data.u8[5] = 0xBB;
-        ++counter_200;
-        break;
-      case 8:
-        KIA_HYUNDAI_200.data.u8[5] = 0xFB;
-        counter_200 = 5;
-        break;
-    }
-
-    transmit_can_frame(&KIA_HYUNDAI_200, can_config.battery);
-
-    transmit_can_frame(&KIA_HYUNDAI_523, can_config.battery);
-
-    transmit_can_frame(&KIA_HYUNDAI_524, can_config.battery);
-
-#ifdef DOUBLE_BATTERY
-
-    if (battery2_startedUp && datalayer.system.status.battery2_allows_contactor_closing) {
-      switch (counter_200_2) {
+    if (contactor_closing_allowed()) {
+      switch (counter_200) {
         case 0:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0x17;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0x17;
+          ++counter_200;
           break;
         case 1:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0x57;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0x57;
+          ++counter_200;
           break;
         case 2:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0x97;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0x97;
+          ++counter_200;
           break;
         case 3:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0xD7;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0xD7;
+          ++counter_200;
           break;
         case 4:
-          KIA_HYUNDAI_200_2.data.u8[3] = 0x10;
-          KIA_HYUNDAI_200_2.data.u8[5] = 0xFF;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[3] = 0x10;
+          KIA_HYUNDAI_200.data.u8[5] = 0xFF;
+          ++counter_200;
           break;
         case 5:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0x3B;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0x3B;
+          ++counter_200;
           break;
         case 6:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0x7B;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0x7B;
+          ++counter_200;
           break;
         case 7:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0xBB;
-          ++counter_200_2;
+          KIA_HYUNDAI_200.data.u8[5] = 0xBB;
+          ++counter_200;
           break;
         case 8:
-          KIA_HYUNDAI_200_2.data.u8[5] = 0xFB;
-          counter_200_2 = 5;
+          KIA_HYUNDAI_200.data.u8[5] = 0xFB;
+          counter_200 = 5;
           break;
       }
 
-      transmit_can_frame(&KIA_HYUNDAI_200_2, can_config.battery_double);
+      transmit_can_frame(&KIA_HYUNDAI_200, m_can_interface);
 
-      transmit_can_frame(&KIA_HYUNDAI_523, can_config.battery_double);
+      transmit_can_frame(&KIA_HYUNDAI_523, m_can_interface);
 
-      transmit_can_frame(&KIA_HYUNDAI_524, can_config.battery_double);
+      transmit_can_frame(&KIA_HYUNDAI_524, m_can_interface);
     }
-#endif  // DOUBLE_BATTERY
   }
 }
 
-void setup_battery(void) {                                                 // Performs one time setup at startup
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-
-#ifdef DOUBLE_BATTERY
-  datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
-  datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
-  datalayer.battery2.info.max_cell_voltage_mV = datalayer.battery.info.max_cell_voltage_mV;
-  datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
-  datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
-#endif  //DOUBLE_BATTERY
-}
-
-void KiaHyundai64Battery::setup() {
-  setup_battery();
+void KiaHyundai64Battery::setup(void) {                            // Performs one time setup at startup
+  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;  //Start with 98S value. Precised later
+  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_90S_DV;  //Start with 90S value. Precised later
+  m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef KIA_HYUNDAI_64_BATTERY_H
 #define KIA_HYUNDAI_64_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define BATTERY_SELECTED
@@ -16,9 +17,13 @@ void update_number_of_cells();
 
 class KiaHyundai64Battery : public CanBattery {
  public:
-  KiaHyundai64Battery() : CanBattery(KiaHyundai64) {}
+  KiaHyundai64Battery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(KiaHyundai64) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Kia/Hyundai 64/40kWh battery";
+  virtual bool supportsDoubleBattery() { return true; };
 
   virtual void setup();
   virtual void update_values();
@@ -26,6 +31,8 @@ class KiaHyundai64Battery : public CanBattery {
   virtual void transmit_can();
 
  private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
   void update_number_of_cells();
 
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
@@ -60,44 +67,6 @@ class KiaHyundai64Battery : public CanBattery {
   int8_t heatertemp = 0;
   int8_t powerRelayTemperature = 0;
   bool startedUp = false;
-
-#ifdef DOUBLE_BATTERY
-  uint8_t counter_200_2 = 0;
-  uint16_t battery2_soc_calculated = 0;
-  uint16_t battery2_SOC_BMS = 0;
-  uint16_t battery2_SOC_Display = 0;
-  uint16_t battery2_batterySOH = 1000;
-  uint16_t battery2_CellVoltMax_mV = 3700;
-  uint16_t battery2_CellVoltMin_mV = 3700;
-  uint16_t battery2_allowedDischargePower = 0;
-  uint16_t battery2_allowedChargePower = 0;
-  uint16_t battery2_batteryVoltage = 0;
-  uint16_t battery2_inverterVoltageFrameHigh = 0;
-  uint16_t battery2_inverterVoltage = 0;
-  uint16_t battery2_cellvoltages_mv[98];
-  int16_t battery2_leadAcidBatteryVoltage = 120;
-  int16_t battery2_batteryAmps = 0;
-  int16_t battery2_temperatureMax = 0;
-  int16_t battery2_temperatureMin = 0;
-  int16_t battery2_poll_data_pid = 0;
-  bool battery2_holdPidCounter = false;
-  uint8_t battery2_CellVmaxNo = 0;
-  uint8_t battery2_CellVminNo = 0;
-  uint8_t battery2_batteryManagementMode = 0;
-  uint8_t battery2_BMS_ign = 0;
-  uint8_t battery2_batteryRelay = 0;
-  uint8_t battery2_waterleakageSensor = 164;
-  uint8_t battery2_counter_200 = 0;
-  int8_t battery2_temperature_water_inlet = 0;
-  int8_t battery2_heatertemp = 0;
-  int8_t battery2_powerRelayTemperature = 0;
-  bool battery2_startedUp = false;
-  CAN_frame KIA_HYUNDAI_200_2 = {.FD = false,
-                                 .ext_ID = false,
-                                 .DLC = 8,
-                                 .ID = 0x200,
-                                 .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};  //2nd battery
-#endif                                                                                       //DOUBLE_BATTERY
 
   CAN_frame KIA_HYUNDAI_200 = {.FD = false,
                                .ext_ID = false,

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -12,8 +12,162 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2950  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
 void update_number_of_cells();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class KiaHyundai64Battery : public CanBattery {
+ public:
+  KiaHyundai64Battery() : CanBattery(KiaHyundai64) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Kia/Hyundai 64/40kWh battery";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  void update_number_of_cells();
+
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis10 = 0;   // will store last time a 10s CAN Message was send
+
+  uint16_t soc_calculated = 0;
+  uint16_t SOC_BMS = 0;
+  uint16_t SOC_Display = 0;
+  uint16_t batterySOH = 1000;
+  uint16_t CellVoltMax_mV = 3700;
+  uint16_t CellVoltMin_mV = 3700;
+  uint16_t allowedDischargePower = 0;
+  uint16_t allowedChargePower = 0;
+  uint16_t batteryVoltage = 0;
+  uint16_t inverterVoltageFrameHigh = 0;
+  uint16_t inverterVoltage = 0;
+  uint16_t cellvoltages_mv[98];
+  int16_t leadAcidBatteryVoltage = 120;
+  int16_t batteryAmps = 0;
+  int16_t temperatureMax = 0;
+  int16_t temperatureMin = 0;
+  int16_t poll_data_pid = 0;
+  bool holdPidCounter = false;
+  uint8_t CellVmaxNo = 0;
+  uint8_t CellVminNo = 0;
+  uint8_t batteryManagementMode = 0;
+  uint8_t BMS_ign = 0;
+  uint8_t batteryRelay = 0;
+  uint8_t waterleakageSensor = 164;
+  uint8_t counter_200 = 0;
+  int8_t temperature_water_inlet = 0;
+  int8_t heatertemp = 0;
+  int8_t powerRelayTemperature = 0;
+  bool startedUp = false;
+
+#ifdef DOUBLE_BATTERY
+  uint8_t counter_200_2 = 0;
+  uint16_t battery2_soc_calculated = 0;
+  uint16_t battery2_SOC_BMS = 0;
+  uint16_t battery2_SOC_Display = 0;
+  uint16_t battery2_batterySOH = 1000;
+  uint16_t battery2_CellVoltMax_mV = 3700;
+  uint16_t battery2_CellVoltMin_mV = 3700;
+  uint16_t battery2_allowedDischargePower = 0;
+  uint16_t battery2_allowedChargePower = 0;
+  uint16_t battery2_batteryVoltage = 0;
+  uint16_t battery2_inverterVoltageFrameHigh = 0;
+  uint16_t battery2_inverterVoltage = 0;
+  uint16_t battery2_cellvoltages_mv[98];
+  int16_t battery2_leadAcidBatteryVoltage = 120;
+  int16_t battery2_batteryAmps = 0;
+  int16_t battery2_temperatureMax = 0;
+  int16_t battery2_temperatureMin = 0;
+  int16_t battery2_poll_data_pid = 0;
+  bool battery2_holdPidCounter = false;
+  uint8_t battery2_CellVmaxNo = 0;
+  uint8_t battery2_CellVminNo = 0;
+  uint8_t battery2_batteryManagementMode = 0;
+  uint8_t battery2_BMS_ign = 0;
+  uint8_t battery2_batteryRelay = 0;
+  uint8_t battery2_waterleakageSensor = 164;
+  uint8_t battery2_counter_200 = 0;
+  int8_t battery2_temperature_water_inlet = 0;
+  int8_t battery2_heatertemp = 0;
+  int8_t battery2_powerRelayTemperature = 0;
+  bool battery2_startedUp = false;
+  CAN_frame KIA_HYUNDAI_200_2 = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x200,
+                                 .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};  //2nd battery
+#endif                                                                                       //DOUBLE_BATTERY
+
+  CAN_frame KIA_HYUNDAI_200 = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x200,
+                               .data = {0x00, 0x80, 0xD8, 0x04, 0x00, 0x17, 0xD0, 0x00}};
+  CAN_frame KIA_HYUNDAI_523 = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x523,
+                               .data = {0x08, 0x38, 0x36, 0x36, 0x33, 0x34, 0x00, 0x01}};
+  CAN_frame KIA_HYUNDAI_524 = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x524,
+                               .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  //553 Needed frame 200ms
+  CAN_frame KIA64_553 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x553,
+                         .data = {0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x80, 0x00}};
+  //57F Needed frame 100ms
+  CAN_frame KIA64_57F = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x57F,
+                         .data = {0x80, 0x0A, 0x72, 0x00, 0x00, 0x00, 0x00, 0x72}};
+  //Needed frame 100ms
+  CAN_frame KIA64_2A1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x2A1,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame KIA64_7E4_id1 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 01
+  CAN_frame KIA64_7E4_id2 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 02
+  CAN_frame KIA64_7E4_id3 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 03
+  CAN_frame KIA64_7E4_id4 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 04
+  CAN_frame KIA64_7E4_id5 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 05
+  CAN_frame KIA64_7E4_id6 = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x03, 0x22, 0x01, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Poll PID 03 22 01 06
+  CAN_frame KIA64_7E4_ack = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x7E4,
+      .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
+};
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -10,7 +10,16 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class KiaHyundaiHybridBattery : public CanBattery {
+ public:
+  KiaHyundaiHybridBattery() : CanBattery(KiaHyundaiHybrid) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Kia/Hyundai Hybrid";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -16,358 +16,6 @@ TODO list
 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis10ms = 0;   // will store last time a 10ms CAN Message was send
-static unsigned long previousMillis20ms = 0;   // will store last time a 20ms CAN Message was send
-static unsigned long previousMillis40ms = 0;   // will store last time a 40ms CAN Message was send
-static unsigned long previousMillis50ms = 0;   // will store last time a 50ms CAN Message was send
-static unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis200ms = 0;  // will store last time a 200ms CAN Message was send
-static unsigned long previousMillis500ms = 0;  // will store last time a 200ms CAN Message was send
-static unsigned long previousMillis1s = 0;     // will store last time a 1s CAN Message was send
-
-static bool toggle = false;
-static uint8_t counter_1000ms = 0;
-static uint8_t counter_200ms = 0;
-static uint8_t counter_100ms = 0;
-static uint8_t counter_50ms = 0;
-static uint8_t counter_40ms = 0;
-static uint8_t counter_20ms = 0;
-static uint8_t counter_10ms = 0;
-static uint8_t counter_040 = 0;
-static uint8_t counter_0F7 = 0;
-static uint8_t counter_3b5 = 0;
-
-static uint32_t poll_pid = PID_CELLVOLTAGE_CELL_85;  // We start here to quickly determine the cell size of the pack.
-static bool nof_cells_determined = false;
-static uint32_t pid_reply = 0;
-static uint16_t battery_soc_polled = 0;
-static uint16_t battery_voltage_polled = 1480;
-static int16_t battery_current_polled = 0;
-static int16_t battery_max_temp = 600;
-static int16_t battery_min_temp = 600;
-static uint16_t battery_max_charge_voltage = 0;
-static uint16_t battery_min_discharge_voltage = 0;
-static uint16_t battery_allowed_charge_power = 0;
-static uint16_t battery_allowed_discharge_power = 0;
-static uint16_t cellvoltages_polled[108];
-static uint16_t tempval = 0;
-static uint8_t BMS_16A954A6_CRC = 0;
-static uint8_t BMS_5A2_counter = 0;
-static uint8_t BMS_5CA_counter = 0;
-static uint8_t BMS_0CF_counter = 0;
-static uint8_t BMS_0C0_counter = 0;
-static uint8_t BMS_578_counter = 0;
-static uint8_t BMS_16A954A6_counter = 0;
-static bool BMS_ext_limits_active =
-    false;  //The current current limits of the HV battery are expanded to start the combustion engine / confirmation of the request
-static uint8_t BMS_mode =
-    0x07;  //0: standby; Gates open; Communication active 1: Main contactor closed / HV network activated / normal driving operation
-//2: assigned depending on the project (e.g. balancing, extended DC fast charging) //3: external charging
-static uint8_t BMS_HVIL_status = 0;         //0 init, 1 seated, 2 open, 3 fault
-static bool BMS_fault_performance = false;  //Error: Battery performance is limited (e.g. due to sensor or fan failure)
-static uint16_t BMS_current = 16300;
-static bool BMS_fault_emergency_shutdown_crash =
-    false;  //Error: Safety-critical error (crash detection) Battery contactors are already opened / will be opened immediately Signal is read directly by the EMS and initiates an AKS of the PWR and an active discharge of the DC link
-static uint32_t BMS_voltage_intermediate = 2000;
-static uint32_t BMS_voltage = 1480;
-static uint8_t BMS_status_voltage_free =
-    0;  //0=Init, 1=BMS intermediate circuit voltage-free (U_Zwkr < 20V), 2=BMS intermediate circuit not voltage-free (U_Zwkr >/= 25V, hysteresis), 3=Error
-static bool BMS_OBD_MIL = false;
-static uint8_t BMS_error_status =
-    0x7;  //0 Component_IO, 1 Restricted_CompFkt_Isoerror_I, 2 Restricted_CompFkt_Isoerror_II, 3 Restricted_CompFkt_Interlock, 4 Restricted_CompFkt_SD, 5 Restricted_CompFkt_Performance red, 6 = No component function, 7 = Init
-static uint16_t BMS_capacity_ah = 0;
-static bool BMS_error_lamp_req = false;
-static bool BMS_warning_lamp_req = false;
-static uint8_t BMS_Kl30c_Status = 0;  // 0 init, 1 closed, 2 open, 3 fault
-static bool service_disconnect_switch_missing = false;
-static bool pilotline_open = false;
-static bool balancing_request = false;
-static uint8_t battery_diagnostic = 0;
-static uint16_t battery_Wh_left = 0;
-static uint16_t battery_Wh_max = 1000;
-static uint8_t battery_potential_status = 0;
-static uint8_t battery_temperature_warning = 0;
-static uint16_t max_discharge_power_watt = 0;
-static uint16_t max_discharge_current_amp = 0;
-static uint16_t max_charge_power_watt = 0;
-static uint16_t max_charge_current_amp = 0;
-static uint16_t battery_SOC = 1;
-static uint16_t usable_energy_amount_Wh = 0;
-static uint8_t status_HV_line = 0;  //0 init, 1 No open HV line, 2 open HV line detected, 3 fault
-static uint8_t warning_support = 0;
-static bool battery_heating_active = false;
-static uint16_t power_discharge_percentage = 0;
-static uint16_t power_charge_percentage = 0;
-static uint16_t actual_battery_voltage = 0;
-static uint16_t regen_battery = 0;
-static uint16_t energy_extracted_from_battery = 0;
-static uint16_t max_fastcharging_current_amp = 0;  //maximum DC charging current allowed
-static uint8_t BMS_Status_DCLS =
-    0;  //Status of the voltage monitoring on the DC charging interface. 0 inactive, 1 I_O , 2 N_I_O , 3 active
-static uint16_t DC_voltage_DCLS =
-    0;  //Factor 1, DC voltage of the charging station. Measurement between the DC HV lines.
-static uint16_t DC_voltage_chargeport =
-    0;  //Factor 0.5,  Current voltage at the HV battery DC charging terminals; Outlet to the DC charging plug.
-static uint8_t BMS_welded_contactors_status =
-    0;  //0: Init no diagnostic result, 1: no contactor welded, 2: at least 1 contactor welded, 3: Protection status detection error
-static bool BMS_error_shutdown_request =
-    false;  // Fault: Fault condition, requires battery contactors to be opened internal battery error; Advance notification of an impending opening of the battery contactors by the BMS
-static bool BMS_error_shutdown =
-    false;  // Fault: Fault condition, requires battery contactors to be opened Internal battery error, battery contactors opened without notice by the BMS
-static uint16_t power_battery_heating_watt = 0;
-static uint16_t power_battery_heating_req_watt = 0;
-static uint8_t cooling_request =
-    0;  //0 = No cooling, 1 = Light cooling, cabin prio, 2= higher cooling, 3 = immediate cooling, 4 = emergency cooling
-static uint8_t heating_request = 0;       //0 = init, 1= maintain temp, 2=higher demand, 3 = immediate heat demand
-static uint8_t balancing_active = false;  //0 = init, 1 active, 2 not active
-static bool charging_active = false;
-static uint16_t max_energy_Wh = 0;
-static uint16_t max_charge_percent = 0;
-static uint16_t min_charge_percent = 0;
-static uint16_t isolation_resistance_kOhm = 0;
-static bool battery_heating_installed = false;
-static bool error_NT_circuit = false;
-static uint8_t pump_1_control = 0;             //0x0D not installed, 0x0E init, 0x0F fault
-static uint8_t pump_2_control = 0;             //0x0D not installed, 0x0E init, 0x0F fault
-static uint8_t target_flow_temperature_C = 0;  //*0,5 -40
-static uint8_t return_temperature_C = 0;       //*0,5 -40
-static uint8_t status_valve_1 = 0;             //0 not active, 1 active, 5 not installed, 6 init, 7 fault
-static uint8_t status_valve_2 = 0;             //0 not active, 1 active, 5 not installed, 6 init, 7 fault
-static uint8_t temperature_request =
-    0;  //0 high cooling, 1 medium cooling, 2 low cooling, 3 no temp requirement init, 4 low heating , 5 medium heating, 6 high heating, 7 circulation
-static uint16_t performance_index_discharge_peak_temperature_percentage = 0;
-static uint16_t performance_index_charge_peak_temperature_percentage = 0;
-static uint8_t temperature_status_discharge =
-    0;  //0 init, 1 temp under optimal, 2 temp optimal, 3 temp over optimal, 7 fault
-static uint8_t temperature_status_charge =
-    0;  //0 init, 1 temp under optimal, 2 temp optimal, 3 temp over optimal, 7 fault
-static uint8_t isolation_fault =
-    0;  //0 init, 1 no iso fault, 2 iso fault threshold1, 3 iso fault threshold2, 4 IWU defective
-static uint8_t isolation_status =
-    0;  // 0 init, 1 = larger threshold1, 2 = smaller threshold1 total, 3 = smaller threshold1 intern, 4 = smaller threshold2 total, 5 = smaller threshold2 intern, 6 = no measurement, 7 = measurement active
-static uint8_t actual_temperature_highest_C = 0;    //*0,5 -40
-static uint8_t actual_temperature_lowest_C = 0;     //*0,5 -40
-static uint16_t actual_cellvoltage_highest_mV = 0;  //bias 1000
-static uint16_t actual_cellvoltage_lowest_mV = 0;   //bias 1000
-static uint16_t predicted_power_dyn_standard_watt = 0;
-static uint8_t predicted_time_dyn_standard_minutes = 0;
-static uint8_t mux = 0;
-static uint16_t cellvoltages[160] = {0};
-static uint16_t duration_discharge_power_watt = 0;
-static uint16_t duration_charge_power_watt = 0;
-static uint16_t maximum_voltage = 0;
-static uint16_t minimum_voltage = 0;
-static uint8_t battery_serialnumber[26];
-static uint8_t realtime_overcurrent_monitor = 0;
-static uint8_t realtime_CAN_communication_fault = 0;
-static uint8_t realtime_overcharge_warning = 0;
-static uint8_t realtime_SOC_too_high = 0;
-static uint8_t realtime_SOC_too_low = 0;
-static uint8_t realtime_SOC_jumping_warning = 0;
-static uint8_t realtime_temperature_difference_warning = 0;
-static uint8_t realtime_cell_overtemperature_warning = 0;
-static uint8_t realtime_cell_undertemperature_warning = 0;
-static uint8_t realtime_battery_overvoltage_warning = 0;
-static uint8_t realtime_battery_undervoltage_warning = 0;
-static uint8_t realtime_cell_overvoltage_warning = 0;
-static uint8_t realtime_cell_undervoltage_warning = 0;
-static uint8_t realtime_cell_imbalance_warning = 0;
-static uint8_t realtime_warning_battery_unathorized = 0;
-static bool component_protection_active = false;
-static bool shutdown_active = false;
-static bool transportation_mode_active = false;
-static uint8_t KL15_mode = 0;
-static uint8_t bus_knockout_timer = 0;
-static uint8_t hybrid_wakeup_reason = 0;
-static uint8_t wakeup_type = 0;
-static bool instrumentation_cluster_request = false;
-static uint8_t seconds = 0;
-static uint32_t first_can_msg = 0;
-static uint32_t last_can_msg_timestamp = 0;
-static bool hv_requested = false;
-static int32_t kwh_charge = 0;
-static int32_t kwh_discharge = 0;
-
-#define TIME_YEAR 2024
-#define TIME_MONTH 8
-#define TIME_DAY 20
-#define TIME_HOUR 10
-#define TIME_MINUTE 5
-#define TIME_SECOND 0
-
-#define BMS_TARGET_HV_OFF 0
-#define BMS_TARGET_HV_ON 1
-#define BMS_TARGET_AC_CHARGING_EXT 3  //(HS + AC_2 contactors closed)
-#define BMS_TARGET_AC_CHARGING 4      //(HS + AC contactors closed)
-#define BMS_TARGET_DC_CHARGING 6      //(HS + DC contactors closed)
-#define BMS_TARGET_INIT 7
-
-#define DC_FASTCHARGE_NO_START_REQUEST 0x00
-#define DC_FASTCHARGE_VEHICLE 0x40
-#define DC_FASTCHARGE_LS1 0x80
-#define DC_FASTCHARGE_LS2 0xC0
-
-CAN_frame MEB_POLLING_FRAME = {.FD = true,
-                               .ext_ID = true,
-                               .DLC = 8,
-                               .ID = 0x1C40007B,  // SOC 02 8C
-                               .data = {0x03, 0x22, 0x02, 0x8C, 0x55, 0x55, 0x55, 0x55}};
-CAN_frame MEB_ACK_FRAME = {.FD = true,
-                           .ext_ID = true,
-                           .DLC = 8,
-                           .ID = 0x1C40007B,  // Ack
-                           .data = {0x30, 0x00, 0x00, 0x55, 0x55, 0x55, 0x55, 0x55}};
-//Messages needed for contactor closing
-CAN_frame MEB_040 = {.FD = true,  // Airbag
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x040,  //Frame5 has HV deactivate request. Needs to be 0x00
-                     .data = {0x7E, 0x83, 0x00, 0x01, 0x00, 0x00, 0x15, 0x00}};
-CAN_frame MEB_0C0 = {
-    .FD = true,  // EM1 message
-    .ext_ID = false,
-    .DLC = 32,
-    .ID = 0x0C0,  //Frame 5-6 and maybe 7-8 important (external voltage at inverter)
-    .data = {0x77, 0x0A, 0xFE, 0xE7, 0x7F, 0x10, 0x27, 0x00, 0xE0, 0x7F, 0xFF, 0xF3, 0x3F, 0xFF, 0xF3, 0x3F,
-             0xFC, 0x0F, 0x00, 0x00, 0xC0, 0xFF, 0xFE, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_0FC = {
-    .FD = true,  //
-    .ext_ID = false,
-    .DLC = 48,
-    .ID = 0x0FC,  //This message contains emergency regen request?(byte19), battery needs to see this message
-    .data = {0x07, 0x08, 0x00, 0x00, 0x7E, 0x00, 0x40, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-             0xFE, 0xFE, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-             0x00, 0x00, 0x00, 0xF4, 0x01, 0x40, 0xFF, 0xEB, 0x7F, 0x0A, 0x88, 0xE3, 0x81, 0xAF, 0x42}};
-CAN_frame MEB_6B2 = {.FD = true,  // Diagnostics
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x6B2,
-                     .data = {0x6A, 0xA7, 0x37, 0x80, 0xC9, 0xBD, 0xF6, 0xC2}};
-CAN_frame MEB_17FC007B_poll = {.FD = true,  // Non period request
-                               .ext_ID = true,
-                               .DLC = 8,
-                               .ID = 0x17FC007B,
-                               .data = {0x03, 0x22, 0x1E, 0x3D, 0x55, 0x55, 0x55, 0x55}};
-CAN_frame MEB_1A5555A6 = {.FD = true,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1A5555A6,
-                          .data = {0x00, 0x00, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_585 = {
-    .FD = true,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x585,
-    .data = {0xCF, 0x38, 0xAF, 0x5B, 0x25, 0x00, 0x00, 0x00}};  // CF 38 AF 5B 25 00 00 00 in start4.log
-//                     .data = {0xCF, 0x38, 0x20, 0x02, 0x25, 0xF7, 0x30, 0x00}}; // CF 38 AF 5B 25 00 00 00 in start4.log
-CAN_frame MEB_5F5 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5F5,
-                     .data = {0x23, 0x02, 0x39, 0xC0, 0x1B, 0x8B, 0xC8, 0x1B}};
-CAN_frame MEB_641 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x641,
-                     .data = {0x37, 0x18, 0x00, 0x00, 0xF0, 0x00, 0xAA, 0x70}};
-CAN_frame MEB_3C0 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 4,
-                     .ID = 0x3C0,
-                     .data = {0x66, 0x00, 0x00, 0x00}};  // Klemmen_status_01
-CAN_frame MEB_0FD = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x0FD,  //CRC and counter, otherwise static
-                     .data = {0x5F, 0xD0, 0x1F, 0x81, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_16A954FB = {.FD = true,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x16A954FB,
-                          .data = {0x00, 0xC0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_1A555548 = {.FD = true,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1A555548,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_1A55552B = {.FD = true,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1A55552B,
-                          .data = {0x00, 0x00, 0x00, 0xA0, 0x02, 0x04, 0x00, 0x30}};
-CAN_frame MEB_569 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x569,  //HVEM
-                     .data = {0x00, 0x00, 0x01, 0x3A, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_16A954B4 = {.FD = true,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x16A954B4,  //eTM
-                          .data = {0xFE, 0xB6, 0x0D, 0x00, 0x00, 0xD5, 0x48, 0xFD}};
-CAN_frame MEB_1B000046 = {.FD = false,  // Not FD
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1B000046,  // Klima
-                          .data = {0x00, 0x40, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_1B000010 = {.FD = false,  // Not FD
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1B000010,  // Gateway
-                          .data = {0x00, 0x50, 0x08, 0x50, 0x01, 0xFF, 0x30, 0x00}};
-CAN_frame MEB_1B0000B9 = {.FD = false,  // Not FD
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x1B0000B9,  //DC/DC converter
-                          .data = {0x00, 0x40, 0x08, 0x08, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame MEB_153 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x153,  // Static content
-                     .data = {0x00, 0x00, 0x00, 0xFF, 0xEF, 0xFE, 0xFF, 0xFF}};
-CAN_frame MEB_5E1 = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5E1,  // Static content
-                     .data = {0x7F, 0x2A, 0x00, 0x60, 0xFE, 0x00, 0x00, 0x00}};
-CAN_frame MEB_3BE = {.FD = true,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3BE,  // CRC, otherwise Static content
-                     .data = {0x57, 0x0D, 0x00, 0x00, 0x00, 0x02, 0x04, 0x40}};
-CAN_frame MEB_272 = {.FD = true,  //HVLM_14
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x272,  // Static content
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x48, 0x08, 0x00, 0x94}};
-CAN_frame MEB_503 = {.FD = true,  //HVK_01
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x503,  // Content varies. Frame1 & 3 has HV req
-                     .data = {0x5D, 0x61, 0x00, 0xFF, 0x7F, 0x80, 0xE3, 0x03}};
-CAN_frame MEB_14C = {
-    .FD = true,  //Motor message
-    .ext_ID = false,
-    .DLC = 32,
-    .ID = 0x14C,  //CRC needed, static content otherwise
-    .data = {0x38, 0x0A, 0xFF, 0x01, 0x01, 0xFF, 0x01, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE,
-             0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0x25, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE}};
-
-uint32_t can_msg_received = 0;
-#define RX_0x17F0007B 0x0001
-#define RX_0x12DD54D0 0x0002
-#define RX_0x12DD54D1 0x0004
-#define RX_0x12DD54D2 0x0008
-#define RX_0x1A555550 0x0010
-#define RX_0x1A555551 0x0020
-#define RX_0x1A5555B2 0x0040
-#define RX_0x16A954A6 0x0080
-#define RX_0x1A5555B0 0x0100
-#define RX_0x1A5555B1 0x0200
-#define RX_0x5A2 0x0400
-#define RX_0x5CA 0x0800
-#define RX_0x0CF 0x1000
-#define RX_DEFAULT 0xE000
 
 /** Calculate the CRC checksum for VAG CAN Messages
  *
@@ -538,7 +186,8 @@ uint8_t vw_crc_calc(uint8_t* inputBytes, uint8_t length, uint32_t address) {
   return crc;
 }
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void MebBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = battery_SOC * 5;  //*0.05*100
 
@@ -645,7 +294,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.meb.charging_active = charging_active;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   last_can_msg_timestamp = millis();
   if (first_can_msg == 0) {
 #ifdef DEBUG_LOG
@@ -1627,7 +1276,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void MebBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 10ms CAN Message
   if (currentMillis > last_can_msg_timestamp + 500) {
@@ -2381,9 +2030,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Volkswagen Group MEB platform via CAN-FD", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void MebBattery::setup(void) {                   // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 108;  //Startup in 108S mode. We figure out the actual count later.
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_108S_DV;  //Defined later to correct pack size
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_84S_DV;   //Defined later to correct pack size

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -1,7 +1,7 @@
 #ifndef MEB_BATTERY_H
 #define MEB_BATTERY_H
 #include <Arduino.h>
-#include "../include.h"
+#include "Battery.h"
 
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_84S_DV 3528  //5000 = 500.0V

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -151,7 +151,369 @@
 #define PID_TEMP_POINT_17 0x1EBE
 #define PID_TEMP_POINT_18 0x1EBF
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class MebBattery : public CanBattery {
+ public:
+  MebBattery() : CanBattery(Meb) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Volkswagen Group MEB platform via CAN-FD";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+  virtual bool requiresPrechargeControl() { return true; }
+
+ private:
+  unsigned long previousMillis10ms = 0;   // will store last time a 10ms CAN Message was send
+  unsigned long previousMillis20ms = 0;   // will store last time a 20ms CAN Message was send
+  unsigned long previousMillis40ms = 0;   // will store last time a 40ms CAN Message was send
+  unsigned long previousMillis50ms = 0;   // will store last time a 50ms CAN Message was send
+  unsigned long previousMillis100ms = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis200ms = 0;  // will store last time a 200ms CAN Message was send
+  unsigned long previousMillis500ms = 0;  // will store last time a 200ms CAN Message was send
+  unsigned long previousMillis1s = 0;     // will store last time a 1s CAN Message was send
+
+  bool toggle = false;
+  uint8_t counter_1000ms = 0;
+  uint8_t counter_200ms = 0;
+  uint8_t counter_100ms = 0;
+  uint8_t counter_50ms = 0;
+  uint8_t counter_40ms = 0;
+  uint8_t counter_20ms = 0;
+  uint8_t counter_10ms = 0;
+  uint8_t counter_040 = 0;
+  uint8_t counter_0F7 = 0;
+  uint8_t counter_3b5 = 0;
+
+  uint32_t poll_pid = PID_CELLVOLTAGE_CELL_85;  // We start here to quickly determine the cell size of the pack.
+  bool nof_cells_determined = false;
+  uint32_t pid_reply = 0;
+  uint16_t battery_soc_polled = 0;
+  uint16_t battery_voltage_polled = 1480;
+  int16_t battery_current_polled = 0;
+  int16_t battery_max_temp = 600;
+  int16_t battery_min_temp = 600;
+  uint16_t battery_max_charge_voltage = 0;
+  uint16_t battery_min_discharge_voltage = 0;
+  uint16_t battery_allowed_charge_power = 0;
+  uint16_t battery_allowed_discharge_power = 0;
+  uint16_t cellvoltages_polled[108];
+  uint16_t tempval = 0;
+  uint8_t BMS_16A954A6_CRC = 0;
+  uint8_t BMS_5A2_counter = 0;
+  uint8_t BMS_5CA_counter = 0;
+  uint8_t BMS_0CF_counter = 0;
+  uint8_t BMS_0C0_counter = 0;
+  uint8_t BMS_578_counter = 0;
+  uint8_t BMS_16A954A6_counter = 0;
+  bool BMS_ext_limits_active =
+      false;  //The current current limits of the HV battery are expanded to start the combustion engine / confirmation of the request
+  uint8_t BMS_mode =
+      0x07;  //0: standby; Gates open; Communication active 1: Main contactor closed / HV network activated / normal driving operation
+  //2: assigned depending on the project (e.g. balancing, extended DC fast charging) //3: external charging
+  uint8_t BMS_HVIL_status = 0;         //0 init, 1 seated, 2 open, 3 fault
+  bool BMS_fault_performance = false;  //Error: Battery performance is limited (e.g. due to sensor or fan failure)
+  uint16_t BMS_current = 16300;
+  bool BMS_fault_emergency_shutdown_crash =
+      false;  //Error: Safety-critical error (crash detection) Battery contactors are already opened / will be opened immediately Signal is read directly by the EMS and initiates an AKS of the PWR and an active discharge of the DC link
+  uint32_t BMS_voltage_intermediate = 2000;
+  uint32_t BMS_voltage = 1480;
+  uint8_t BMS_status_voltage_free =
+      0;  //0=Init, 1=BMS intermediate circuit voltage-free (U_Zwkr < 20V), 2=BMS intermediate circuit not voltage-free (U_Zwkr >/= 25V, hysteresis), 3=Error
+  bool BMS_OBD_MIL = false;
+  uint8_t BMS_error_status =
+      0x7;  //0 Component_IO, 1 Restricted_CompFkt_Isoerror_I, 2 Restricted_CompFkt_Isoerror_II, 3 Restricted_CompFkt_Interlock, 4 Restricted_CompFkt_SD, 5 Restricted_CompFkt_Performance red, 6 = No component function, 7 = Init
+  uint16_t BMS_capacity_ah = 0;
+  bool BMS_error_lamp_req = false;
+  bool BMS_warning_lamp_req = false;
+  uint8_t BMS_Kl30c_Status = 0;  // 0 init, 1 closed, 2 open, 3 fault
+  bool service_disconnect_switch_missing = false;
+  bool pilotline_open = false;
+  bool balancing_request = false;
+  uint8_t battery_diagnostic = 0;
+  uint16_t battery_Wh_left = 0;
+  uint16_t battery_Wh_max = 1000;
+  uint8_t battery_potential_status = 0;
+  uint8_t battery_temperature_warning = 0;
+  uint16_t max_discharge_power_watt = 0;
+  uint16_t max_discharge_current_amp = 0;
+  uint16_t max_charge_power_watt = 0;
+  uint16_t max_charge_current_amp = 0;
+  uint16_t battery_SOC = 1;
+  uint16_t usable_energy_amount_Wh = 0;
+  uint8_t status_HV_line = 0;  //0 init, 1 No open HV line, 2 open HV line detected, 3 fault
+  uint8_t warning_support = 0;
+  bool battery_heating_active = false;
+  uint16_t power_discharge_percentage = 0;
+  uint16_t power_charge_percentage = 0;
+  uint16_t actual_battery_voltage = 0;
+  uint16_t regen_battery = 0;
+  uint16_t energy_extracted_from_battery = 0;
+  uint16_t max_fastcharging_current_amp = 0;  //maximum DC charging current allowed
+  uint8_t BMS_Status_DCLS =
+      0;  //Status of the voltage monitoring on the DC charging interface. 0 inactive, 1 I_O , 2 N_I_O , 3 active
+  uint16_t DC_voltage_DCLS = 0;  //Factor 1, DC voltage of the charging station. Measurement between the DC HV lines.
+  uint16_t DC_voltage_chargeport =
+      0;  //Factor 0.5,  Current voltage at the HV battery DC charging terminals; Outlet to the DC charging plug.
+  uint8_t BMS_welded_contactors_status =
+      0;  //0: Init no diagnostic result, 1: no contactor welded, 2: at least 1 contactor welded, 3: Protection status detection error
+  bool BMS_error_shutdown_request =
+      false;  // Fault: Fault condition, requires battery contactors to be opened internal battery error; Advance notification of an impending opening of the battery contactors by the BMS
+  bool BMS_error_shutdown =
+      false;  // Fault: Fault condition, requires battery contactors to be opened Internal battery error, battery contactors opened without notice by the BMS
+  uint16_t power_battery_heating_watt = 0;
+  uint16_t power_battery_heating_req_watt = 0;
+  uint8_t cooling_request =
+      0;  //0 = No cooling, 1 = Light cooling, cabin prio, 2= higher cooling, 3 = immediate cooling, 4 = emergency cooling
+  uint8_t heating_request = 0;       //0 = init, 1= maintain temp, 2=higher demand, 3 = immediate heat demand
+  uint8_t balancing_active = false;  //0 = init, 1 active, 2 not active
+  bool charging_active = false;
+  uint16_t max_energy_Wh = 0;
+  uint16_t max_charge_percent = 0;
+  uint16_t min_charge_percent = 0;
+  uint16_t isolation_resistance_kOhm = 0;
+  bool battery_heating_installed = false;
+  bool error_NT_circuit = false;
+  uint8_t pump_1_control = 0;             //0x0D not installed, 0x0E init, 0x0F fault
+  uint8_t pump_2_control = 0;             //0x0D not installed, 0x0E init, 0x0F fault
+  uint8_t target_flow_temperature_C = 0;  //*0,5 -40
+  uint8_t return_temperature_C = 0;       //*0,5 -40
+  uint8_t status_valve_1 = 0;             //0 not active, 1 active, 5 not installed, 6 init, 7 fault
+  uint8_t status_valve_2 = 0;             //0 not active, 1 active, 5 not installed, 6 init, 7 fault
+  uint8_t temperature_request =
+      0;  //0 high cooling, 1 medium cooling, 2 low cooling, 3 no temp requirement init, 4 low heating , 5 medium heating, 6 high heating, 7 circulation
+  uint16_t performance_index_discharge_peak_temperature_percentage = 0;
+  uint16_t performance_index_charge_peak_temperature_percentage = 0;
+  uint8_t temperature_status_discharge =
+      0;                                  //0 init, 1 temp under optimal, 2 temp optimal, 3 temp over optimal, 7 fault
+  uint8_t temperature_status_charge = 0;  //0 init, 1 temp under optimal, 2 temp optimal, 3 temp over optimal, 7 fault
+  uint8_t isolation_fault =
+      0;  //0 init, 1 no iso fault, 2 iso fault threshold1, 3 iso fault threshold2, 4 IWU defective
+  uint8_t isolation_status =
+      0;  // 0 init, 1 = larger threshold1, 2 = smaller threshold1 total, 3 = smaller threshold1 intern, 4 = smaller threshold2 total, 5 = smaller threshold2 intern, 6 = no measurement, 7 = measurement active
+  uint8_t actual_temperature_highest_C = 0;    //*0,5 -40
+  uint8_t actual_temperature_lowest_C = 0;     //*0,5 -40
+  uint16_t actual_cellvoltage_highest_mV = 0;  //bias 1000
+  uint16_t actual_cellvoltage_lowest_mV = 0;   //bias 1000
+  uint16_t predicted_power_dyn_standard_watt = 0;
+  uint8_t predicted_time_dyn_standard_minutes = 0;
+  uint8_t mux = 0;
+  uint16_t cellvoltages[160] = {0};
+  uint16_t duration_discharge_power_watt = 0;
+  uint16_t duration_charge_power_watt = 0;
+  uint16_t maximum_voltage = 0;
+  uint16_t minimum_voltage = 0;
+  uint8_t battery_serialnumber[26];
+  uint8_t realtime_overcurrent_monitor = 0;
+  uint8_t realtime_CAN_communication_fault = 0;
+  uint8_t realtime_overcharge_warning = 0;
+  uint8_t realtime_SOC_too_high = 0;
+  uint8_t realtime_SOC_too_low = 0;
+  uint8_t realtime_SOC_jumping_warning = 0;
+  uint8_t realtime_temperature_difference_warning = 0;
+  uint8_t realtime_cell_overtemperature_warning = 0;
+  uint8_t realtime_cell_undertemperature_warning = 0;
+  uint8_t realtime_battery_overvoltage_warning = 0;
+  uint8_t realtime_battery_undervoltage_warning = 0;
+  uint8_t realtime_cell_overvoltage_warning = 0;
+  uint8_t realtime_cell_undervoltage_warning = 0;
+  uint8_t realtime_cell_imbalance_warning = 0;
+  uint8_t realtime_warning_battery_unathorized = 0;
+  bool component_protection_active = false;
+  bool shutdown_active = false;
+  bool transportation_mode_active = false;
+  uint8_t KL15_mode = 0;
+  uint8_t bus_knockout_timer = 0;
+  uint8_t hybrid_wakeup_reason = 0;
+  uint8_t wakeup_type = 0;
+  bool instrumentation_cluster_request = false;
+  uint8_t seconds = 0;
+  uint32_t first_can_msg = 0;
+  uint32_t last_can_msg_timestamp = 0;
+  bool hv_requested = false;
+  int32_t kwh_charge = 0;
+  int32_t kwh_discharge = 0;
+
+#define TIME_YEAR 2024
+#define TIME_MONTH 8
+#define TIME_DAY 20
+#define TIME_HOUR 10
+#define TIME_MINUTE 5
+#define TIME_SECOND 0
+
+#define BMS_TARGET_HV_OFF 0
+#define BMS_TARGET_HV_ON 1
+#define BMS_TARGET_AC_CHARGING_EXT 3  //(HS + AC_2 contactors closed)
+#define BMS_TARGET_AC_CHARGING 4      //(HS + AC contactors closed)
+#define BMS_TARGET_DC_CHARGING 6      //(HS + DC contactors closed)
+#define BMS_TARGET_INIT 7
+
+#define DC_FASTCHARGE_NO_START_REQUEST 0x00
+#define DC_FASTCHARGE_VEHICLE 0x40
+#define DC_FASTCHARGE_LS1 0x80
+#define DC_FASTCHARGE_LS2 0xC0
+
+  CAN_frame MEB_POLLING_FRAME = {.FD = true,
+                                 .ext_ID = true,
+                                 .DLC = 8,
+                                 .ID = 0x1C40007B,  // SOC 02 8C
+                                 .data = {0x03, 0x22, 0x02, 0x8C, 0x55, 0x55, 0x55, 0x55}};
+  CAN_frame MEB_ACK_FRAME = {.FD = true,
+                             .ext_ID = true,
+                             .DLC = 8,
+                             .ID = 0x1C40007B,  // Ack
+                             .data = {0x30, 0x00, 0x00, 0x55, 0x55, 0x55, 0x55, 0x55}};
+  //Messages needed for contactor closing
+  CAN_frame MEB_040 = {.FD = true,  // Airbag
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x040,  //Frame5 has HV deactivate request. Needs to be 0x00
+                       .data = {0x7E, 0x83, 0x00, 0x01, 0x00, 0x00, 0x15, 0x00}};
+  CAN_frame MEB_0C0 = {
+      .FD = true,  // EM1 message
+      .ext_ID = false,
+      .DLC = 32,
+      .ID = 0x0C0,  //Frame 5-6 and maybe 7-8 important (external voltage at inverter)
+      .data = {0x77, 0x0A, 0xFE, 0xE7, 0x7F, 0x10, 0x27, 0x00, 0xE0, 0x7F, 0xFF, 0xF3, 0x3F, 0xFF, 0xF3, 0x3F,
+               0xFC, 0x0F, 0x00, 0x00, 0xC0, 0xFF, 0xFE, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_0FC = {
+      .FD = true,  //
+      .ext_ID = false,
+      .DLC = 48,
+      .ID = 0x0FC,  //This message contains emergency regen request?(byte19), battery needs to see this message
+      .data = {0x07, 0x08, 0x00, 0x00, 0x7E, 0x00, 0x40, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+               0xFE, 0xFE, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+               0x00, 0x00, 0x00, 0xF4, 0x01, 0x40, 0xFF, 0xEB, 0x7F, 0x0A, 0x88, 0xE3, 0x81, 0xAF, 0x42}};
+  CAN_frame MEB_6B2 = {.FD = true,  // Diagnostics
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x6B2,
+                       .data = {0x6A, 0xA7, 0x37, 0x80, 0xC9, 0xBD, 0xF6, 0xC2}};
+  CAN_frame MEB_17FC007B_poll = {.FD = true,  // Non period request
+                                 .ext_ID = true,
+                                 .DLC = 8,
+                                 .ID = 0x17FC007B,
+                                 .data = {0x03, 0x22, 0x1E, 0x3D, 0x55, 0x55, 0x55, 0x55}};
+  CAN_frame MEB_1A5555A6 = {.FD = true,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1A5555A6,
+                            .data = {0x00, 0x00, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_585 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x585,
+      .data = {0xCF, 0x38, 0xAF, 0x5B, 0x25, 0x00, 0x00, 0x00}};  // CF 38 AF 5B 25 00 00 00 in start4.log
+  //                     .data = {0xCF, 0x38, 0x20, 0x02, 0x25, 0xF7, 0x30, 0x00}}; // CF 38 AF 5B 25 00 00 00 in start4.log
+  CAN_frame MEB_5F5 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5F5,
+                       .data = {0x23, 0x02, 0x39, 0xC0, 0x1B, 0x8B, 0xC8, 0x1B}};
+  CAN_frame MEB_641 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x641,
+                       .data = {0x37, 0x18, 0x00, 0x00, 0xF0, 0x00, 0xAA, 0x70}};
+  CAN_frame MEB_3C0 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 4,
+                       .ID = 0x3C0,
+                       .data = {0x66, 0x00, 0x00, 0x00}};  // Klemmen_status_01
+  CAN_frame MEB_0FD = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x0FD,  //CRC and counter, otherwise static
+                       .data = {0x5F, 0xD0, 0x1F, 0x81, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_16A954FB = {.FD = true,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x16A954FB,
+                            .data = {0x00, 0xC0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_1A555548 = {.FD = true,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1A555548,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_1A55552B = {.FD = true,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1A55552B,
+                            .data = {0x00, 0x00, 0x00, 0xA0, 0x02, 0x04, 0x00, 0x30}};
+  CAN_frame MEB_569 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x569,  //HVEM
+                       .data = {0x00, 0x00, 0x01, 0x3A, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_16A954B4 = {.FD = true,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x16A954B4,  //eTM
+                            .data = {0xFE, 0xB6, 0x0D, 0x00, 0x00, 0xD5, 0x48, 0xFD}};
+  CAN_frame MEB_1B000046 = {.FD = false,  // Not FD
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1B000046,  // Klima
+                            .data = {0x00, 0x40, 0x08, 0x01, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_1B000010 = {.FD = false,  // Not FD
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1B000010,  // Gateway
+                            .data = {0x00, 0x50, 0x08, 0x50, 0x01, 0xFF, 0x30, 0x00}};
+  CAN_frame MEB_1B0000B9 = {.FD = false,  // Not FD
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x1B0000B9,  //DC/DC converter
+                            .data = {0x00, 0x40, 0x08, 0x08, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_153 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x153,  // content
+                       .data = {0x00, 0x00, 0x00, 0xFF, 0xEF, 0xFE, 0xFF, 0xFF}};
+  CAN_frame MEB_5E1 = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5E1,  // content
+                       .data = {0x7F, 0x2A, 0x00, 0x60, 0xFE, 0x00, 0x00, 0x00}};
+  CAN_frame MEB_3BE = {.FD = true,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3BE,  // CRC, otherwise content
+                       .data = {0x57, 0x0D, 0x00, 0x00, 0x00, 0x02, 0x04, 0x40}};
+  CAN_frame MEB_272 = {.FD = true,  //HVLM_14
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x272,  // content
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x48, 0x08, 0x00, 0x94}};
+  CAN_frame MEB_503 = {.FD = true,  //HVK_01
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x503,  // Content varies. Frame1 & 3 has HV req
+                       .data = {0x5D, 0x61, 0x00, 0xFF, 0x7F, 0x80, 0xE3, 0x03}};
+  CAN_frame MEB_14C = {
+      .FD = true,  //Motor message
+      .ext_ID = false,
+      .DLC = 32,
+      .ID = 0x14C,  //CRC needed, content otherwise
+      .data = {0x38, 0x0A, 0xFF, 0x01, 0x01, 0xFF, 0x01, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE,
+               0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0x25, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFE}};
+
+  uint32_t can_msg_received = 0;
+#define RX_0x17F0007B 0x0001
+#define RX_0x12DD54D0 0x0002
+#define RX_0x12DD54D1 0x0004
+#define RX_0x12DD54D2 0x0008
+#define RX_0x1A555550 0x0010
+#define RX_0x1A555551 0x0020
+#define RX_0x1A5555B2 0x0040
+#define RX_0x16A954A6 0x0080
+#define RX_0x1A5555B0 0x0100
+#define RX_0x1A5555B1 0x0200
+#define RX_0x5A2 0x0400
+#define RX_0x5CA 0x0800
+#define RX_0x0CF 0x1000
+#define RX_DEFAULT 0xE000
+};
 
 #endif

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -10,7 +10,16 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class MG5Battery : public CanBattery {
+ public:
+  MG5Battery() : CanBattery(Mg5) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "MG 5 battery";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -10,262 +10,80 @@
 #include "../devboard/utils/events.h"
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
-static uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
-static uint8_t mprun10 = 0;                  //counter 0-3
-static uint8_t mprun100 = 0;                 //counter 0-3
 
-// These CAN messages need to be sent towards the battery to keep it alive
-CAN_frame LEAF_1F2 = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 8,
-                      .ID = 0x1F2,
-                      .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
-CAN_frame LEAF_50B = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 7,
-                      .ID = 0x50B,
-                      .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
-CAN_frame LEAF_50C = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 6,
-                      .ID = 0x50C,
-                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame LEAF_1D4 = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 8,
-                      .ID = 0x1D4,
-                      .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
-// Active polling messages
-uint8_t PIDgroups[] = {0x01, 0x02, 0x04, 0x83, 0x84, 0x90};
-uint8_t PIDindex = 0;
-CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
-                                .ext_ID = false,
-                                .DLC = 8,
-                                .ID = 0x79B,
-                                .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
-CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
-                                    .ext_ID = false,
-                                    .DLC = 8,
-                                    .ID = 0x79B,
-                                    .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-
-// The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
-// groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second
-// replies with all the battery’s cells voltages in millivolt, the third and the fifth one are still unknown, the
-// fourth contains the four battery packs temperatures, and the last one tells which cell has the shunt active.
-// There are also two more groups: group 61, which replies with lots of CAN messages (up to 48); here we
-// found the SOH value, and group 84 that replies with the HV battery production serial.
-
-static uint8_t crctable[256] = {
-    0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,
-    247, 114, 80,  213, 223, 90,  203, 78,  68,  193, 67,  198, 204, 73,  216, 93,  87,  210, 240, 117, 127, 250,
-    107, 238, 228, 97,  160, 37,  47,  170, 59,  190, 180, 49,  19,  150, 156, 25,  136, 13,  7,   130, 134, 3,
-    9,   140, 29,  152, 146, 23,  53,  176, 186, 63,  174, 43,  33,  164, 101, 224, 234, 111, 254, 123, 113, 244,
-    214, 83,  89,  220, 77,  200, 194, 71,  197, 64,  74,  207, 94,  219, 209, 84,  118, 243, 249, 124, 237, 104,
-    98,  231, 38,  163, 169, 44,  189, 56,  50,  183, 149, 16,  26,  159, 14,  139, 129, 4,   137, 12,  6,   131,
-    18,  151, 157, 24,  58,  191, 181, 48,  161, 36,  46,  171, 106, 239, 229, 96,  241, 116, 126, 251, 217, 92,
-    86,  211, 66,  199, 205, 72,  202, 79,  69,  192, 81,  212, 222, 91,  121, 252, 246, 115, 226, 103, 109, 232,
-    41,  172, 166, 35,  178, 55,  61,  184, 154, 31,  21,  144, 1,   132, 142, 11,  15,  138, 128, 5,   148, 17,
-    27,  158, 188, 57,  51,  182, 39,  162, 168, 45,  236, 105, 99,  230, 119, 242, 248, 125, 95,  218, 208, 85,
-    196, 65,  75,  206, 76,  201, 195, 70,  215, 82,  88,  221, 255, 122, 112, 245, 100, 225, 235, 110, 175, 42,
-    32,  165, 52,  177, 187, 62,  28,  153, 147, 22,  135, 2,   8,   141};
-
-//Nissan LEAF battery parameters from constantly sent CAN
-#define ZE0_BATTERY 0
-#define AZE0_BATTERY 1
-#define ZE1_BATTERY 2
-static uint8_t LEAF_battery_Type = ZE0_BATTERY;
-static bool battery_can_alive = false;
-#define WH_PER_GID 77                               //One GID is this amount of Watt hours
-static uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
-static uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW
-static int16_t battery_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
-static int16_t battery_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
-static uint16_t battery_TEMP = 0;                   //Temporary value used in status checks
-static uint16_t battery_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
-static uint16_t battery_GIDS = 273;                 //Startup in 24kWh mode
-static uint16_t battery_MAX = 0;
-static uint16_t battery_Max_GIDS = 273;               //Startup in 24kWh mode
-static uint16_t battery_StateOfHealth = 99;           //State of health %
-static uint16_t battery_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-static int16_t battery_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
-static int16_t battery_HistData_Temperature_MAX = 6;  //-40 to 86*C
-static int16_t battery_HistData_Temperature_MIN = 5;  //-40 to 86*C
-static int16_t battery_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
-static uint8_t battery_Relay_Cut_Request = 0;         //battery_FAIL
-static uint8_t battery_Failsafe_Status = 0;           //battery_STATUS
-static bool battery_Interlock =
-    true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
-static bool battery_Full_CHARGE_flag = false;  //battery_FCHGEND , Goes to 1 if battery is fully charged
-static bool battery_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
-static bool battery_Capacity_Empty = false;    //battery_EMPTY, , Goes to 1 if battery is empty
-static bool battery_HeatExist = false;  //battery_HEATEXIST, Specifies if battery pack is equipped with heating elements
-static bool battery_Heating_Stop = false;                   //When transitioning from 0->1, signals a STOP heat request
-static bool battery_Heating_Start = false;                  //When transitioning from 1->0, signals a START heat request
-static bool battery_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
-
-// Nissan LEAF battery data from polled CAN messages
-static uint8_t battery_request_idx = 0;
-static uint8_t group_7bb = 0;
-static bool stop_battery_query = true;
-static uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
-static uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
-static uint8_t battery_cellcounter = 0;
-static uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint16_t battery_HX = 0;              //Internal resistance
-static uint16_t battery_insulation = 0;      //Insulation resistance
-static uint16_t battery_temp_raw_1 = 0;
-static uint8_t battery_temp_raw_2_highnibble = 0;
-static uint16_t battery_temp_raw_2 = 0;
-static uint16_t battery_temp_raw_3 = 0;
-static uint16_t battery_temp_raw_4 = 0;
-static uint16_t battery_temp_raw_max = 0;
-static uint16_t battery_temp_raw_min = 0;
-static int16_t battery_temp_polled_max = 0;
-static int16_t battery_temp_polled_min = 0;
-static uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
-static uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
-static uint8_t BMSIDcode[8] = {0};
-#ifdef DOUBLE_BATTERY
-static uint8_t LEAF_battery2_Type = ZE0_BATTERY;
-static bool battery2_can_alive = false;
-static uint16_t battery2_Discharge_Power_Limit = 0;  //Limit in kW
-static uint16_t battery2_Charge_Power_Limit = 0;     //Limit in kW
-static int16_t battery2_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
-static int16_t battery2_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
-static uint16_t battery2_TEMP = 0;                   //Temporary value used in status checks
-static uint16_t battery2_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
-static uint16_t battery2_GIDS = 273;                 //Startup in 24kWh mode
-static uint16_t battery2_MAX = 0;
-static uint16_t battery2_Max_GIDS = 273;      //Startup in 24kWh mode
-static uint16_t battery2_StateOfHealth = 99;  //State of health %
-static uint16_t battery2_Total_Voltage2 = 0;  //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-static int16_t battery2_Current2 = 0;         //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
-static int16_t battery2_HistData_Temperature_MAX = 6;  //-40 to 86*C
-static int16_t battery2_HistData_Temperature_MIN = 5;  //-40 to 86*C
-static int16_t battery2_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
-static uint8_t battery2_Relay_Cut_Request = 0;         //battery2_FAIL
-static uint8_t battery2_Failsafe_Status = 0;           //battery2_STATUS
-static bool battery2_Interlock =
-    true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
-static bool battery2_Full_CHARGE_flag = false;  //battery2_FCHGEND , Goes to 1 if battery is fully charged
-static bool battery2_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
-static bool battery2_Capacity_Empty = false;    //battery2_EMPTY, , Goes to 1 if battery is empty
-static bool battery2_HeatExist =
-    false;  //battery2_HEATEXIST, Specifies if battery pack is equipped with heating elements
-static bool battery2_Heating_Stop = false;   //When transitioning from 0->1, signals a STOP heat request
-static bool battery2_Heating_Start = false;  //When transitioning from 1->0, signals a START heat request
-static bool battery2_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
-// Polled values
-static uint8_t battery2_group_7bb = 0;
-static uint8_t battery2_request_idx = 0;
-static uint16_t battery2_cell_voltages[97];  //array with all the cellvoltages
-static uint8_t battery2_cellcounter = 0;
-static uint16_t battery2_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint16_t battery2_HX = 0;              //Internal resistance
-static uint16_t battery2_insulation = 0;      //Insulation resistance
-static uint16_t battery2_temp_raw_1 = 0;
-static uint8_t battery2_temp_raw_2_highnibble = 0;
-static uint16_t battery2_temp_raw_2 = 0;
-static uint16_t battery2_temp_raw_3 = 0;
-static uint16_t battery2_temp_raw_4 = 0;
-static uint16_t battery2_temp_raw_max = 0;
-static uint16_t battery2_temp_raw_min = 0;
-static int16_t battery2_temp_polled_max = 0;
-static int16_t battery2_temp_polled_min = 0;
-#endif  // DOUBLE_BATTERY
-
-// Clear SOH values
-static uint8_t stateMachineClearSOH = 0xFF;
-static uint32_t incomingChallenge = 0xFFFFFFFF;
-static uint8_t solvedChallenge[8];
-static bool challengeFailed = false;
-
-CAN_frame LEAF_CLEAR_SOH = {.FD = false,
-                            .ext_ID = false,
-                            .DLC = 8,
-                            .ID = 0x79B,
-                            .data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-
-static void
-update_values_battery() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
+void NissanLeafBattery::
+    update_values() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
   /* Start with mapping all values */
 
-  datalayer.battery.status.soh_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
+  m_target->status.soh_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
 
-  datalayer.battery.status.real_soc = (battery_SOC * 10);
+  m_target->status.real_soc = (battery_SOC * 10);
 
-  datalayer.battery.status.voltage_dV =
+  m_target->status.voltage_dV =
       (battery_Total_Voltage2 * 5);  //0.5V/bit, multiply by 5 to get Voltage+1decimal (350.5V = 701)
 
-  datalayer.battery.status.current_dA =
-      (battery_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
+  m_target->status.current_dA = (battery_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
 
   if (battery_Max_GIDS == 273) {  //battery_Max_GIDS is stuck at 273 on ZE0
-    datalayer.battery.info.total_capacity_Wh = ((battery_Max_GIDS * WH_PER_GID * battery_StateOfHealth) / 100);
+    m_target->info.total_capacity_Wh = ((battery_Max_GIDS * WH_PER_GID * battery_StateOfHealth) / 100);
   } else {  //battery_Max_GIDS updates on newer generations, making for a total_capacity_Wh value that makes sense
-    datalayer.battery.info.total_capacity_Wh = (battery_Max_GIDS * WH_PER_GID);
+    m_target->info.total_capacity_Wh = (battery_Max_GIDS * WH_PER_GID);
   }
 
-  datalayer.battery.status.remaining_capacity_Wh = battery_Wh_Remaining;
+  m_target->status.remaining_capacity_Wh = battery_Wh_Remaining;
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
   if (LEAF_battery_Type == ZE0_BATTERY) {
     //Since we only have average value, send the minimum as -1.0 degrees below average
-    datalayer.battery.status.temperature_min_dC =
+    m_target->status.temperature_min_dC =
         ((battery_AverageTemperature * 10) - 10);  //Increase range from C to C+1, remove 1.0C
-    datalayer.battery.status.temperature_max_dC = (battery_AverageTemperature * 10);  //Increase range from C to C+1
+    m_target->status.temperature_max_dC = (battery_AverageTemperature * 10);  //Increase range from C to C+1
   } else if (LEAF_battery_Type == AZE0_BATTERY) {
     //Use the value sent constantly via CAN in 5C0 (only available on AZE0)
-    datalayer.battery.status.temperature_min_dC =
-        (battery_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
-    datalayer.battery.status.temperature_max_dC =
-        (battery_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
+    m_target->status.temperature_min_dC = (battery_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
+    m_target->status.temperature_max_dC = (battery_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
   } else {  // ZE1 (TODO: Once the muxed value in 5C0 becomes known, switch to using that instead of this complicated polled value)
     if (battery_temp_raw_min != 0)  //We have a polled value available
     {
       battery_temp_polled_min = ((Temp_fromRAW_to_F(battery_temp_raw_min) - 320) * 5) / 9;  //Convert from F to C
       battery_temp_polled_max = ((Temp_fromRAW_to_F(battery_temp_raw_max) - 320) * 5) / 9;  //Convert from F to C
       if (battery_temp_polled_min < battery_temp_polled_max) {  //Catch any edge cases from Temp_fromRAW_to_F function
-        datalayer.battery.status.temperature_min_dC = battery_temp_polled_min;
-        datalayer.battery.status.temperature_max_dC = battery_temp_polled_max;
+        m_target->status.temperature_min_dC = battery_temp_polled_min;
+        m_target->status.temperature_max_dC = battery_temp_polled_max;
       } else {
-        datalayer.battery.status.temperature_min_dC = battery_temp_polled_max;
-        datalayer.battery.status.temperature_max_dC = battery_temp_polled_min;
+        m_target->status.temperature_min_dC = battery_temp_polled_max;
+        m_target->status.temperature_max_dC = battery_temp_polled_min;
       }
     }
   }
 
-  datalayer.battery.status.max_discharge_power_W = (battery_Discharge_Power_Limit * 1000);  //kW to W
+  m_target->status.max_discharge_power_W = (battery_Discharge_Power_Limit * 1000);  //kW to W
 
-  datalayer.battery.status.max_charge_power_W = (battery_Charge_Power_Limit * 1000);  //kW to W
+  m_target->status.max_charge_power_W = (battery_Charge_Power_Limit * 1000);  //kW to W
 
   //Allow contactors to close
   if (battery_can_alive) {
-    datalayer.system.status.battery_allows_contactor_closing = true;
+    allow_contactor_closing();
   }
 
   /*Extra safety functions below*/
   if (battery_GIDS < 10)  //700Wh left in battery!
   {                       //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
     set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery.status.real_soc = 0;
-    datalayer.battery.status.max_discharge_power_W = 0;
+    m_target->status.real_soc = 0;
+    m_target->status.max_discharge_power_W = 0;
   }
 
   if (battery_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
     set_event(EVENT_BATTERY_FULL, 0);
-    datalayer.battery.status.max_charge_power_W = 0;
+    m_target->status.max_charge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_FULL);
   }
 
   if (battery_Capacity_Empty) {  //Battery reports that it is fully discharged. Stop all further discharging incase it hasn't already
     set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery.status.max_discharge_power_W = 0;
+    m_target->status.max_discharge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_EMPTY);
   }
@@ -278,8 +96,8 @@ update_values_battery() { /* This function maps all the values fetched via CAN t
 
   if (battery_Relay_Cut_Request) {  //battery_FAIL, BMS requesting shutdown and contactors to be opened
     //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
-    datalayer.battery.status.max_discharge_power_W = 0;
-    datalayer.battery.status.max_charge_power_W = 0;
+    m_target->status.max_discharge_power_W = 0;
+    m_target->status.max_charge_power_W = 0;
   }
 
   if (battery_Failsafe_Status > 0)  // 0 is normal, start charging/discharging
@@ -372,398 +190,11 @@ update_values_battery() { /* This function maps all the values fetched via CAN t
   }
 }
 
-#ifdef DOUBLE_BATTERY
-
-void update_values_battery2() {  // Handle the values coming in from battery #2
-  /* Start with mapping all values */
-
-  datalayer.battery2.status.soh_pptt = (battery2_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
-
-  datalayer.battery2.status.real_soc = (battery2_SOC * 10);
-
-  datalayer.battery2.status.voltage_dV =
-      (battery2_Total_Voltage2 * 5);  //0.5V/bit, multiply by 5 to get Voltage+1decimal (350.5V = 701)
-
-  datalayer.battery2.status.current_dA =
-      (battery2_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
-
-  if (battery2_Max_GIDS == 273) {  //battery2_Max_GIDS is stuck at 273 on 24kWh packs
-    datalayer.battery2.info.total_capacity_Wh = ((battery2_Max_GIDS * WH_PER_GID * battery2_StateOfHealth) / 100);
-  } else {  //battery_Max_GIDS updates on newer generations, making for a total_capacity_Wh value that makes sense
-    datalayer.battery2.info.total_capacity_Wh = (battery2_Max_GIDS * WH_PER_GID);
-  }
-
-  datalayer.battery2.status.remaining_capacity_Wh = battery2_Wh_Remaining;
-
-  //Update temperature readings. Method depends on which generation LEAF battery is used
-  if (LEAF_battery2_Type == ZE0_BATTERY) {
-    //Since we only have average value, send the minimum as -1.0 degrees below average
-    datalayer.battery2.status.temperature_min_dC =
-        ((battery2_AverageTemperature * 10) - 10);  //Increase range from C to C+1, remove 1.0C
-    datalayer.battery2.status.temperature_max_dC = (battery2_AverageTemperature * 10);  //Increase range from C to C+1
-  } else if (LEAF_battery2_Type == AZE0_BATTERY) {
-    //Use the value sent constantly via CAN in 5C0 (only available on AZE0)
-    datalayer.battery2.status.temperature_min_dC =
-        (battery2_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
-    datalayer.battery2.status.temperature_max_dC =
-        (battery2_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
-  } else {  // ZE1 (TODO: Once the muxed value in 5C0 becomes known, switch to using that instead of this complicated polled value)
-    if (battery2_temp_raw_min != 0)  //We have a polled value available
-    {
-      battery2_temp_polled_min = ((Temp_fromRAW_to_F(battery2_temp_raw_min) - 320) * 5) / 9;  //Convert from F to C
-      battery2_temp_polled_max = ((Temp_fromRAW_to_F(battery2_temp_raw_max) - 320) * 5) / 9;  //Convert from F to C
-      if (battery2_temp_polled_min < battery2_temp_polled_max) {  //Catch any edge cases from Temp_fromRAW_to_F function
-        datalayer.battery2.status.temperature_min_dC = battery2_temp_polled_min;
-        datalayer.battery2.status.temperature_max_dC = battery2_temp_polled_max;
-      } else {
-        datalayer.battery2.status.temperature_min_dC = battery2_temp_polled_max;
-        datalayer.battery2.status.temperature_max_dC = battery2_temp_polled_min;
-      }
-    }
-  }
-
-  datalayer.battery2.status.max_discharge_power_W = (battery2_Discharge_Power_Limit * 1000);  //kW to W
-
-  datalayer.battery2.status.max_charge_power_W = (battery2_Charge_Power_Limit * 1000);  //kW to W
-
-  /*Extra safety functions below*/
-  if (battery2_GIDS < 10)  //700Wh left in battery!
-  {                        //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
-    set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery2.status.real_soc = 0;
-    datalayer.battery2.status.max_discharge_power_W = 0;
-  }
-
-  if (battery2_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
-    set_event(EVENT_BATTERY_FULL, 0);
-    datalayer.battery2.status.max_charge_power_W = 0;
-  } else {
-    clear_event(EVENT_BATTERY_FULL);
-  }
-
-  if (battery2_Capacity_Empty) {  //Battery reports that it is fully discharged. Stop all further discharging incase it hasn't already
-    set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery2.status.max_discharge_power_W = 0;
-  } else {
-    clear_event(EVENT_BATTERY_EMPTY);
-  }
-
-  if (battery2_Total_Voltage2 == 0x3FF) {  //Battery reports critical measurement unavailable
-    set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
-  } else {
-    clear_event(EVENT_BATTERY_VALUE_UNAVAILABLE);
-  }
-
-  if (battery2_Relay_Cut_Request) {  //battery2_FAIL, BMS requesting shutdown and contactors to be opened
-    //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
-    datalayer.battery2.status.max_discharge_power_W = 0;
-    datalayer.battery2.status.max_charge_power_W = 0;
-  }
-
-  if (battery2_Failsafe_Status > 0)  // 0 is normal, start charging/discharging
-  {
-    switch (battery2_Failsafe_Status) {
-      case (1):
-        //Normal Stop Request
-        //This means that battery is fully discharged and it's OK to stop the session. For stationary storage we don't disconnect contactors, so we do nothing here.
-        break;
-      case (2):
-        //Charging Mode Stop Request
-        //This means that battery is fully charged and it's OK to stop the session. For stationary storage we don't disconnect contactors, so we do nothing here.
-        break;
-      case (3):
-        //Charging Mode Stop Request & Normal Stop Request
-        //Normal stop request. For stationary storage we don't disconnect contactors, so we ignore this.
-        break;
-      case (4):
-        //Caution Lamp Request
-        set_event(EVENT_BATTERY_CAUTION, 2);
-        break;
-      case (5):
-        //Caution Lamp Request & Normal Stop Request
-        set_event(EVENT_BATTERY_DISCHG_STOP_REQ, 2);
-        break;
-      case (6):
-        //Caution Lamp Request & Charging Mode Stop Request
-        set_event(EVENT_BATTERY_CHG_STOP_REQ, 2);
-        break;
-      case (7):
-        //Caution Lamp Request & Charging Mode Stop Request & Normal Stop Request
-        set_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, 2);
-        break;
-      default:
-        break;
-    }
-  } else {  //battery2_Failsafe_Status == 0
-    clear_event(EVENT_BATTERY_DISCHG_STOP_REQ);
-    clear_event(EVENT_BATTERY_CHG_STOP_REQ);
-    clear_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ);
-  }
-
-#ifdef INTERLOCK_REQUIRED
-  if (!battery2_Interlock) {
-    set_event(EVENT_HVIL_FAILURE, 2);
-  } else {
-    clear_event(EVENT_HVIL_FAILURE);
-  }
-#endif
-
-  if (battery2_HeatExist) {
-    if (battery2_Heating_Stop) {
-      set_event(EVENT_BATTERY_WARMED_UP, 2);
-    }
-    if (battery2_Heating_Start) {
-      set_event(EVENT_BATTERY_REQUESTS_HEAT, 2);
-    }
-  }
-}
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
+void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_Current2 = (rx_frame.data.u8[0] << 3) | (rx_frame.data.u8[1] & 0xe0) >> 5;
-      if (battery2_Current2 & 0x0400) {
-        // negative so extend the sign bit
-        battery2_Current2 |= 0xf800;
-      }  //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
-
-      battery2_TEMP = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
-      if (battery2_TEMP != 0x3ff) {  //3FF is unavailable value. Can happen directly on reboot.
-        battery2_Total_Voltage2 = battery2_TEMP;
-      }
-
-      //Collect various data from the BMS
-      battery2_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);
-      battery2_Failsafe_Status = (rx_frame.data.u8[1] & 0x07);
-      battery2_MainRelayOn_flag = (bool)((rx_frame.data.u8[3] & 0x20) >> 5);
-      //battery2_allows_contactor_closing written by check_interconnect_available();
-      battery2_Full_CHARGE_flag = (bool)((rx_frame.data.u8[3] & 0x10) >> 4);
-      battery2_Interlock = (bool)((rx_frame.data.u8[3] & 0x08) >> 3);
-      break;
-    case 0x1DC:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_Discharge_Power_Limit = ((rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6) / 4.0);
-      battery2_Charge_Power_Limit = (((rx_frame.data.u8[1] & 0x3F) << 4 | rx_frame.data.u8[2] >> 4) / 4.0);
-      battery2_MAX_POWER_FOR_CHARGER = ((((rx_frame.data.u8[2] & 0x0F) << 6 | rx_frame.data.u8[3] >> 2) / 10.0) - 10);
-      break;
-    case 0x55B:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_TEMP = (rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6);
-      if (battery2_TEMP != 0x3ff) {  //3FF is unavailable value
-        battery2_SOC = battery2_TEMP;
-      }
-      battery2_Capacity_Empty = (bool)((rx_frame.data.u8[6] & 0x80) >> 7);
-      break;
-    case 0x5BC:
-      battery2_can_alive = true;
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
-
-      battery2_MAX = ((rx_frame.data.u8[5] & 0x10) >> 4);
-      if (battery2_MAX) {
-        battery2_Max_GIDS = (rx_frame.data.u8[0] << 2) | ((rx_frame.data.u8[1] & 0xC0) >> 6);
-        //Max gids active, do nothing
-        //Only the 30/40/62kWh packs have this mux
-      } else {  //Normal current GIDS value is transmitted
-        battery2_GIDS = (rx_frame.data.u8[0] << 2) | ((rx_frame.data.u8[1] & 0xC0) >> 6);
-        battery2_Wh_Remaining = (battery2_GIDS * WH_PER_GID);
-      }
-
-      if (LEAF_battery2_Type == ZE0_BATTERY) {
-        battery2_AverageTemperature = (rx_frame.data.u8[3] - 40);  //In celcius, -40 to +55
-      }
-
-      battery2_TEMP = (rx_frame.data.u8[4] >> 1);
-      if (battery2_TEMP != 0) {
-        battery2_StateOfHealth = battery2_TEMP;  //Collect state of health from battery
-      }
-      break;
-    case 0x5C0:
-      //This temperature only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
-      if (LEAF_battery2_Type == AZE0_BATTERY) {
-        if ((rx_frame.data.u8[0] >> 6) ==
-            1) {  // Battery MAX temperature. Effectively has only 7-bit precision, as the bottom bit is always 0.
-          battery2_HistData_Temperature_MAX = ((rx_frame.data.u8[2] / 2) - 40);
-        }
-        if ((rx_frame.data.u8[0] >> 6) ==
-            3) {  // Battery MIN temperature. Effectively has only 7-bit precision, as the bottom bit is always 0.
-          battery2_HistData_Temperature_MIN = ((rx_frame.data.u8[2] / 2) - 40);
-        }
-      }
-
-      battery2_HeatExist = (rx_frame.data.u8[4] & 0x01);
-      battery2_Heating_Stop = ((rx_frame.data.u8[0] & 0x10) >> 4);
-      battery2_Heating_Start = ((rx_frame.data.u8[0] & 0x20) >> 5);
-      battery2_Batt_Heater_Mail_Send_Request = (rx_frame.data.u8[1] & 0x01);
-
-      break;
-    case 0x59E:
-      //AZE0 2013-2017 or ZE1 2018-2023 battery detected
-      //Only detect as AZE0 if not already set as ZE1
-      if (LEAF_battery2_Type != ZE1_BATTERY) {
-        LEAF_battery2_Type = AZE0_BATTERY;
-      }
-      break;
-    case 0x1ED:
-    case 0x1C2:
-      //ZE1 2018-2023 battery detected!
-      LEAF_battery2_Type = ZE1_BATTERY;
-      break;
-    case 0x79B:
-      stop_battery_query = true;             //Someone is trying to read data with Leafspy, stop our own polling!
-      hold_off_with_polling_10seconds = 10;  //Polling is paused for 100s
-      break;
-    case 0x7BB:
-
-      if (stop_battery_query) {  //Leafspy/Service request is active, stop our own polling
-        break;
-      }
-
-      //First check which group data we are getting
-      if (rx_frame.data.u8[0] == 0x10) {  //First message of a group
-        battery2_group_7bb = rx_frame.data.u8[3];
-      }
-
-      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery_double);
-
-      if (battery2_group_7bb == 0x01)  //High precision SOC, Current, voltages etc.
-      {
-        if (rx_frame.data.u8[0] == 0x10) {  //First frame
-          //High precision battery2_current_1 resides here, but has been deemed unusable by 62kWh owners
-        }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second frame
-          //High precision battery2_current_2 resides here, but has been deemed unusable by 62kWh owners
-        }
-
-        if (rx_frame.data.u8[0] == 0x23) {  // Fourth frame
-          battery2_insulation = (uint16_t)((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-        }
-
-        if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame
-          battery2_HX = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 102.4;
-        }
-      }
-
-      if (battery2_group_7bb == 0x02)  //Cell Voltages
-      {
-        if (rx_frame.data.u8[0] == 0x10) {  //first frame is anomalous
-          battery2_request_idx = 0;
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-          break;
-        }
-        if (rx_frame.data.u8[6] == 0xFF && rx_frame.data.u8[0] == 0x2C) {  //Last frame
-          //Last frame does not contain any cell data, calculate the result
-
-          //Map all cell voltages to the global array
-          memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cell_voltages, 96 * sizeof(uint16_t));
-
-          //calculate min/max voltages
-          battery2_min_max_voltage[0] = 9999;
-          battery2_min_max_voltage[1] = 0;
-          for (battery2_cellcounter = 0; battery2_cellcounter < 96; battery2_cellcounter++) {
-            if (battery2_min_max_voltage[0] > battery2_cell_voltages[battery2_cellcounter])
-              battery2_min_max_voltage[0] = battery2_cell_voltages[battery2_cellcounter];
-            if (battery2_min_max_voltage[1] < battery2_cell_voltages[battery2_cellcounter])
-              battery2_min_max_voltage[1] = battery2_cell_voltages[battery2_cellcounter];
-          }
-
-          datalayer.battery2.status.cell_max_voltage_mV = battery2_min_max_voltage[1];
-          datalayer.battery2.status.cell_min_voltage_mV = battery2_min_max_voltage[0];
-
-          break;
-        }
-
-        if ((rx_frame.data.u8[0] % 2) == 0) {  //even frames
-          battery2_cell_voltages[battery2_request_idx++] |= rx_frame.data.u8[1];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-        } else {  //odd frames
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6];
-          battery2_cell_voltages[battery2_request_idx] = (rx_frame.data.u8[7] << 8);
-        }
-      }
-
-      if (battery2_group_7bb == 0x04) {     //Temperatures
-        if (rx_frame.data.u8[0] == 0x10) {  //First message
-          battery2_temp_raw_1 = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_temp_raw_2_highnibble = rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second message
-          battery2_temp_raw_2 = (battery2_temp_raw_2_highnibble << 8) | rx_frame.data.u8[1];
-          battery2_temp_raw_3 = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
-          battery2_temp_raw_4 = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x22) {  //Third message
-          //All values read, let's figure out the min/max!
-
-          if (battery2_temp_raw_3 == 65535) {  //We are on a 2013+ pack that only has three temp sensors.
-            //Start with finding max value
-            battery2_temp_raw_max = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_4;
-            }
-            //Then find min
-            battery2_temp_raw_min = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_4;
-            }
-          } else {  //All 4 temp sensors available on 2011-2012
-            //Start with finding max value
-            battery2_temp_raw_max = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_3 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_3;
-            }
-            if (battery2_temp_raw_4 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_4;
-            }
-            //Then find min
-            battery2_temp_raw_min = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_3 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_4;
-            }
-          }
-        }
-      }
-
-      break;
-    default:
-      break;
-  }
-}
-#endif  // DOUBLE_BATTERY
-
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x1DB:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        m_target->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_Current2 = (rx_frame.data.u8[0] << 3) | (rx_frame.data.u8[1] & 0xe0) >> 5;
@@ -786,7 +217,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
     case 0x1DC:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        m_target->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_Discharge_Power_Limit = ((rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6) / 4.0);
@@ -795,7 +226,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
     case 0x55B:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        m_target->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_TEMP = (rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6);
@@ -806,7 +237,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
     case 0x5BC:
       battery_can_alive = true;
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
 
       battery_MAX = ((rx_frame.data.u8[5] & 0x10) >> 4);
       if (battery_MAX) {
@@ -888,7 +319,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
         group_7bb = rx_frame.data.u8[3];
       }
 
-      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery);  //Request the next frame for the group
+      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, m_can_interface);  //Request the next frame for the group
 
       if (group_7bb == 0x01)  //High precision SOC, Current, voltages etc.
       {
@@ -920,7 +351,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
           //Last frame does not contain any cell data, calculate the result
 
           //Map all cell voltages to the global array
-          memcpy(datalayer.battery.status.cell_voltages_mV, battery_cell_voltages, 96 * sizeof(uint16_t));
+          memcpy(m_target->status.cell_voltages_mV, battery_cell_voltages, 96 * sizeof(uint16_t));
 
           //calculate min/max voltages
           battery_min_max_voltage[0] = 9999;
@@ -932,8 +363,8 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
               battery_min_max_voltage[1] = battery_cell_voltages[battery_cellcounter];
           }
 
-          datalayer.battery.status.cell_max_voltage_mV = battery_min_max_voltage[1];
-          datalayer.battery.status.cell_min_voltage_mV = battery_min_max_voltage[0];
+          m_target->status.cell_max_voltage_mV = battery_min_max_voltage[1];
+          m_target->status.cell_min_voltage_mV = battery_min_max_voltage[0];
 
           break;
         }
@@ -1074,7 +505,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-static void transmit_can_battery() {
+void NissanLeafBattery::transmit_can() {
 
   unsigned long currentMillis = millis();
 
@@ -1117,10 +548,7 @@ static void transmit_can_battery() {
           LEAF_1D4.data.u8[7] = 0xDE;
           break;
       }
-      transmit_can_frame(&LEAF_1D4, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_1D4, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_1D4, m_can_interface);
 
       switch (mprun10r) {
         case (0):
@@ -1211,13 +639,10 @@ static void transmit_can_battery() {
           break;
       }
 
-//Only send this message when NISSANLEAF_CHARGER is not defined (otherwise it will collide!)
-#ifndef NISSANLEAF_CHARGER
-      transmit_can_frame(&LEAF_1F2, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_1F2, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
-#endif
+      //Only send this message when NISSANLEAF_CHARGER is not defined (otherwise it will collide!)
+      if (charger == nullptr || charger->type() != ChargerType::NissanLeaf) {
+        transmit_can_frame(&LEAF_1F2, m_can_interface);
+      }
 
       mprun10r = (mprun10r + 1) % 20;  // 0x1F2 patter repeats after 20 messages. 0-1..19-0
 
@@ -1240,10 +665,7 @@ static void transmit_can_battery() {
       }
 
       // VCM message, containing info if battery should sleep or stay awake
-      transmit_can_frame(&LEAF_50B, can_config.battery);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_50B, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_50B, m_can_interface);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 
       LEAF_50C.data.u8[3] = mprun100;
       switch (mprun100) {
@@ -1264,10 +686,7 @@ static void transmit_can_battery() {
           LEAF_50C.data.u8[5] = 0x9A;
           break;
       }
-      transmit_can_frame(&LEAF_50C, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_50C, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_50C, m_can_interface);
 
       mprun100 = (mprun100 + 1) % 4;  // mprun100 cycles between 0-1-2-3-0-1...
     }
@@ -1283,10 +702,7 @@ static void transmit_can_battery() {
         PIDindex = (PIDindex + 1) % 6;  // 6 = amount of elements in the PIDgroups[]
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
-        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery);
-#ifdef DOUBLE_BATTERY
-        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+        transmit_can_frame(&LEAF_GROUP_REQUEST, m_can_interface);
       }
 
       if (hold_off_with_polling_10seconds > 0) {
@@ -1298,7 +714,7 @@ static void transmit_can_battery() {
   }
 }
 
-bool is_message_corrupt(CAN_frame rx_frame) {
+bool NissanLeafBattery::is_message_corrupt(CAN_frame rx_frame) {
   uint8_t crc = 0;
   for (uint8_t j = 0; j < 7; j++) {
     crc = crctable[(crc ^ static_cast<uint8_t>(rx_frame.data.u8[j])) % 256];
@@ -1337,7 +753,7 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
   return static_cast<uint16_t>(1094 + (309 - temperature) * 2.5714285714285715);
 }
 
-void clearSOH(void) {
+void NissanLeafBattery::clearSOH() {
   stop_battery_query = true;
   hold_off_with_polling_10seconds = 10;  // Active battery polling is paused for 100 seconds
 
@@ -1518,38 +934,13 @@ void decodeChallengeData(unsigned int incomingChallenge, unsigned char* solvedCh
   return;
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-
-#ifdef DOUBLE_BATTERY
-  datalayer.battery2.info.number_of_cells = datalayer.battery.info.number_of_cells;
-  datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
-  datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
-  datalayer.battery2.info.max_cell_voltage_mV = datalayer.battery.info.max_cell_voltage_mV;
-  datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
-  datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
-#endif  //DOUBLE_BATTERY
-}
-
-void NissanLeafBattery::setup() {
-  setup_battery();
-}
-
-void NissanLeafBattery::update_values() {
-  update_values_battery();
-}
-
-void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  ::handle_incoming_can_frame_battery(rx_frame);
-}
-
-void NissanLeafBattery::transmit_can() {
-  transmit_can_battery();
+void NissanLeafBattery::setup(void) {  // Performs one time setup at startup
+  m_target->info.number_of_cells = 96;
+  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif  //NISSAN_LEAF_BATTERY

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -2,6 +2,7 @@
 #define NISSAN_LEAF_BATTERY_H
 
 #include "../include.h"
+#include "Battery.h"
 
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
@@ -12,8 +13,7 @@
 
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame rx_frame);
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 void clearSOH(void);
 //Cryptographic functions
 void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);
@@ -22,5 +22,17 @@ unsigned int ComputeMaskedXorProduct(unsigned int param_1, unsigned int param_2,
 short ShortMaskedSumAndProduct(short param_1, short param_2);
 unsigned int MaskedBitwiseRotateMultiply(unsigned int param_1, unsigned int param_2);
 unsigned int CryptAlgo(unsigned int param_1, unsigned int param_2, unsigned int param_3);
+
+class NissanLeafBattery : public CanBattery {
+ public:
+  NissanLeafBattery() : CanBattery(NissanLeaf) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Nissan LEAF battery";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -1,7 +1,9 @@
 #ifndef NISSAN_LEAF_BATTERY_H
 #define NISSAN_LEAF_BATTERY_H
 
+#include "../datalayer/datalayer.h"
 #include "../include.h"
+
 #include "Battery.h"
 
 #define BATTERY_SELECTED
@@ -25,14 +27,158 @@ unsigned int CryptAlgo(unsigned int param_1, unsigned int param_2, unsigned int 
 
 class NissanLeafBattery : public CanBattery {
  public:
-  NissanLeafBattery() : CanBattery(NissanLeaf) {}
+  NissanLeafBattery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(NissanLeaf) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Nissan LEAF battery";
+
+  virtual bool supportsDoubleBattery() { return true; };
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  void clearSOH();
+  bool is_message_corrupt(CAN_frame rx_frame);
+
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
+
+  unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
+  uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
+  uint8_t mprun10 = 0;                  //counter 0-3
+  uint8_t mprun100 = 0;                 //counter 0-3
+
+  // These CAN messages need to be sent towards the battery to keep it alive
+  CAN_frame LEAF_1F2 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1F2,
+                        .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
+  CAN_frame LEAF_50B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 7,
+                        .ID = 0x50B,
+                        .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_50C = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 6,
+                        .ID = 0x50C,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_1D4 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1D4,
+                        .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
+  // Active polling messages
+  uint8_t PIDgroups[6] = {0x01, 0x02, 0x04, 0x83, 0x84, 0x90};
+  uint8_t PIDindex = 0;
+  CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
+                                  .ext_ID = false,
+                                  .DLC = 8,
+                                  .ID = 0x79B,
+                                  .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
+  CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
+                                      .ext_ID = false,
+                                      .DLC = 8,
+                                      .ID = 0x79B,
+                                      .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+
+  // The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
+  // groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second
+  // replies with all the battery’s cells voltages in millivolt, the third and the fifth one are still unknown, the
+  // fourth contains the four battery packs temperatures, and the last one tells which cell has the shunt active.
+  // There are also two more groups: group 61, which replies with lots of CAN messages (up to 48); here we
+  // found the SOH value, and group 84 that replies with the HV battery production serial.
+
+  uint8_t crctable[256] = {
+      0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,
+      247, 114, 80,  213, 223, 90,  203, 78,  68,  193, 67,  198, 204, 73,  216, 93,  87,  210, 240, 117, 127, 250,
+      107, 238, 228, 97,  160, 37,  47,  170, 59,  190, 180, 49,  19,  150, 156, 25,  136, 13,  7,   130, 134, 3,
+      9,   140, 29,  152, 146, 23,  53,  176, 186, 63,  174, 43,  33,  164, 101, 224, 234, 111, 254, 123, 113, 244,
+      214, 83,  89,  220, 77,  200, 194, 71,  197, 64,  74,  207, 94,  219, 209, 84,  118, 243, 249, 124, 237, 104,
+      98,  231, 38,  163, 169, 44,  189, 56,  50,  183, 149, 16,  26,  159, 14,  139, 129, 4,   137, 12,  6,   131,
+      18,  151, 157, 24,  58,  191, 181, 48,  161, 36,  46,  171, 106, 239, 229, 96,  241, 116, 126, 251, 217, 92,
+      86,  211, 66,  199, 205, 72,  202, 79,  69,  192, 81,  212, 222, 91,  121, 252, 246, 115, 226, 103, 109, 232,
+      41,  172, 166, 35,  178, 55,  61,  184, 154, 31,  21,  144, 1,   132, 142, 11,  15,  138, 128, 5,   148, 17,
+      27,  158, 188, 57,  51,  182, 39,  162, 168, 45,  236, 105, 99,  230, 119, 242, 248, 125, 95,  218, 208, 85,
+      196, 65,  75,  206, 76,  201, 195, 70,  215, 82,  88,  221, 255, 122, 112, 245, 100, 225, 235, 110, 175, 42,
+      32,  165, 52,  177, 187, 62,  28,  153, 147, 22,  135, 2,   8,   141};
+
+//Nissan LEAF battery parameters from constantly sent CAN
+#define ZE0_BATTERY 0
+#define AZE0_BATTERY 1
+#define ZE1_BATTERY 2
+  uint8_t LEAF_battery_Type = ZE0_BATTERY;
+  bool battery_can_alive = false;
+#define WH_PER_GID 77                          //One GID is this amount of Watt hours
+  uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
+  uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW
+  int16_t battery_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
+  int16_t battery_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
+  uint16_t battery_TEMP = 0;                   //Temporary value used in status checks
+  uint16_t battery_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
+  uint16_t battery_GIDS = 273;                 //Startup in 24kWh mode
+  uint16_t battery_MAX = 0;
+  uint16_t battery_Max_GIDS = 273;               //Startup in 24kWh mode
+  uint16_t battery_StateOfHealth = 99;           //State of health %
+  uint16_t battery_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
+  int16_t battery_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
+  int16_t battery_HistData_Temperature_MAX = 6;  //-40 to 86*C
+  int16_t battery_HistData_Temperature_MIN = 5;  //-40 to 86*C
+  int16_t battery_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
+  uint8_t battery_Relay_Cut_Request = 0;         //battery_FAIL
+  uint8_t battery_Failsafe_Status = 0;           //battery_STATUS
+  bool battery_Interlock =
+      true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
+  bool battery_Full_CHARGE_flag = false;  //battery_FCHGEND , Goes to 1 if battery is fully charged
+  bool battery_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
+  bool battery_Capacity_Empty = false;    //battery_EMPTY, , Goes to 1 if battery is empty
+  bool battery_HeatExist = false;      //battery_HEATEXIST, Specifies if battery pack is equipped with heating elements
+  bool battery_Heating_Stop = false;   //When transitioning from 0->1, signals a STOP heat request
+  bool battery_Heating_Start = false;  //When transitioning from 1->0, signals a START heat request
+  bool battery_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
+
+  // Nissan LEAF battery data from polled CAN messages
+  uint8_t battery_request_idx = 0;
+  uint8_t group_7bb = 0;
+  bool stop_battery_query = true;
+  uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
+  uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
+  uint8_t battery_cellcounter = 0;
+  uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
+  uint16_t battery_HX = 0;              //Internal resistance
+  uint16_t battery_insulation = 0;      //Insulation resistance
+  uint16_t battery_temp_raw_1 = 0;
+  uint8_t battery_temp_raw_2_highnibble = 0;
+  uint16_t battery_temp_raw_2 = 0;
+  uint16_t battery_temp_raw_3 = 0;
+  uint16_t battery_temp_raw_4 = 0;
+  uint16_t battery_temp_raw_max = 0;
+  uint16_t battery_temp_raw_min = 0;
+  int16_t battery_temp_polled_max = 0;
+  int16_t battery_temp_polled_min = 0;
+  uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
+  uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
+  uint8_t BMSIDcode[8] = {0};
+
+  // Clear SOH values
+  uint8_t stateMachineClearSOH = 0xFF;
+  uint32_t incomingChallenge = 0xFFFFFFFF;
+  uint8_t solvedChallenge[8];
+  bool challengeFailed = false;
+
+  CAN_frame LEAF_CLEAR_SOH = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x79B,
+                              .data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 };
 
 #endif

--- a/Software/src/battery/ORION-BMS.cpp
+++ b/Software/src/battery/ORION-BMS.cpp
@@ -50,7 +50,7 @@ void findMinMaxCellvoltages(const uint16_t arr[], size_t size, uint16_t& Minimum
   }
 }
 
-void update_values_battery() {
+static void update_values_battery() {
 
   datalayer.battery.status.real_soc = Pack_SOC_ppt * 10;
 
@@ -87,7 +87,7 @@ void update_values_battery() {
   }
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x356:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -132,12 +132,12 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // No transmission needed for this integration
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+static void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "DIY battery with Orion BMS (Victron setting)", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = NUMBER_OF_CELLS;

--- a/Software/src/battery/ORION-BMS.cpp
+++ b/Software/src/battery/ORION-BMS.cpp
@@ -145,7 +145,7 @@ static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/ORION-BMS.h
+++ b/Software/src/battery/ORION-BMS.h
@@ -13,7 +13,4 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_MV 150
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-
 #endif

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef PYLON_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "PYLON-BATTERY.h"
@@ -29,28 +30,7 @@ CAN_frame PYLON_4200 = {.FD = false,
                         .ID = 0x4200,
                         .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-static int16_t celltemperature_max_dC = 0;
-static int16_t celltemperature_min_dC = 0;
-static int16_t current_dA = 0;
-static uint16_t voltage_dV = 0;
-static uint16_t cellvoltage_max_mV = 3700;
-static uint16_t cellvoltage_min_mV = 3700;
-static uint16_t charge_cutoff_voltage = 0;
-static uint16_t discharge_cutoff_voltage = 0;
-static int16_t max_charge_current = 0;
-static int16_t max_discharge_current = 0;
-static uint8_t ensemble_info_ack = 0;
-static uint8_t battery_module_quantity = 0;
-static uint8_t battery_modules_in_series = 0;
-static uint8_t cell_quantity_in_module = 0;
-static uint8_t voltage_level = 0;
-static uint8_t ah_number = 0;
-static uint8_t SOC = 0;
-static uint8_t SOH = 0;
-static uint8_t charge_forbidden = 0;
-static uint8_t discharge_forbidden = 0;
-
-void update_values_battery() {
+void PylonBattery::update_values() {
 
   datalayer.battery.status.real_soc = (SOC * 100);  //increase SOC range from 0-100 -> 100.00
 
@@ -82,7 +62,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = discharge_cutoff_voltage;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void PylonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x7310:
@@ -158,7 +138,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void PylonBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
@@ -317,9 +297,7 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 }
 #endif  //DOUBLE_BATTERY
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void PylonBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 2;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef PYLON_BATTERY_H
 #define PYLON_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define BATTERY_SELECTED
@@ -14,9 +15,13 @@
 
 class PylonBattery : public CanBattery {
  public:
-  PylonBattery() : CanBattery(Pylon) {}
+  PylonBattery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(Pylon) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Pylon compatible battery";
+  virtual bool supportsDoubleBattery() { return true; };
 
   virtual void setup();
   virtual void update_values();
@@ -24,6 +29,9 @@ class PylonBattery : public CanBattery {
   virtual void transmit_can();
 
  private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
+
   int16_t celltemperature_max_dC = 0;
   int16_t celltemperature_min_dC = 0;
   int16_t current_dA = 0;

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -12,7 +12,38 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_MV 150
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class PylonBattery : public CanBattery {
+ public:
+  PylonBattery() : CanBattery(Pylon) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Pylon compatible battery";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  int16_t celltemperature_max_dC = 0;
+  int16_t celltemperature_min_dC = 0;
+  int16_t current_dA = 0;
+  uint16_t voltage_dV = 0;
+  uint16_t cellvoltage_max_mV = 3700;
+  uint16_t cellvoltage_min_mV = 3700;
+  uint16_t charge_cutoff_voltage = 0;
+  uint16_t discharge_cutoff_voltage = 0;
+  int16_t max_charge_current = 0;
+  int16_t max_discharge_current = 0;
+  uint8_t ensemble_info_ack = 0;
+  uint8_t battery_module_quantity = 0;
+  uint8_t battery_modules_in_series = 0;
+  uint8_t cell_quantity_in_module = 0;
+  uint8_t voltage_level = 0;
+  uint8_t ah_number = 0;
+  uint8_t SOC = 0;
+  uint8_t SOH = 0;
+  uint8_t charge_forbidden = 0;
+  uint8_t discharge_forbidden = 0;
+};
 
 #endif

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef RANGE_ROVER_PHEV_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "RANGE-ROVER-PHEV-BATTERY.h"
@@ -47,110 +48,8 @@
 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis50ms = 0;  // will store last time a 50ms CAN Message was sent
 
-//CAN content from battery
-static bool StatusCAT5BPOChg = false;
-static bool StatusCAT4Derate = false;
-static uint8_t OCMonitorStatus = 0;
-static bool StatusCAT3 = false;
-static bool IsolationStatus = false;
-static bool HVILStatus = false;
-static bool ContactorStatus = false;
-static uint8_t StatusGpCounter = 0;
-static bool WeldCheckStatus = false;
-static bool StatusCAT7NowBPO = false;
-static bool StatusCAT6DlyBPO = false;
-static uint8_t StatusGpCS = 0;
-static uint8_t CAT6Count = 0;
-static bool EndOfCharge = false;
-static bool DerateWarning = false;
-static bool PrechargeAllowed = false;
-static uint8_t DischargeExtGpCounter = 0;    // Counter 0-15
-static uint8_t DischargeExtGpCS = 0;         // CRC
-static uint16_t DischargeVoltageLimit = 0;   //Min voltage battery allows discharging to
-static uint16_t DischargePowerLimitExt = 0;  //Momentary Discharge power limit kW*0.01 (0-655)
-static uint16_t DischargeContPwrLmt = 0;     //Longterm Discharge power limit kW*0.01 (0-655)
-static uint8_t PwrGpCS = 0;                  // CRC
-static uint8_t PwrGpCounter = 0;             // Counter 0-15
-static uint16_t VoltageExt = 370;            // Voltage of the HV Battery
-static uint16_t VoltageBus = 0;              // Voltage on the high-voltage DC bus
-static int32_t CurrentExt =
-    209715;  //Positive - discharge, Negative Charge (0 - 16777215) Scaling: 0.025 Offset: -209715.175 Units: Amps
-static bool HVIsolationTestRunning = false;
-static uint16_t VoltageOC =
-    0;  //The instantaneous equivalent open-circuit voltage of the high voltage battery. This is used by the high-voltage inverter in power prediction and derating calculations.
-static uint16_t DchCurrentLimit =
-    0;  // A, 'Maximum current that can be delivered by the HV Battery during motoring mode  i.e during discharging.
-static uint16_t ChgCurrentLimit =
-    0;  // - 1023 A, Maximum current that can be transferred into the HV Battery during generating mode i.e during charging. Charging is neagtive and discharging is positive.
-static uint16_t ChargeContPwrLmt = 0;      //Longterm charge power limit kW*0.01 (0-655)
-static uint16_t ChargePowerLimitExt = 0;   //Momentary Charge power limit kW*0.01 (0-655)
-static uint8_t ChgExtGpCS = 0;             // CRC
-static uint8_t ChgExtGpCounter = 0;        //counter 0-15
-static uint16_t ChargeVoltageLimit = 500;  //Max voltage limit during charging of the HV Battery.
-static uint8_t CurrentWarning = 0;         // 0 normal, 1 cell overcurrent, 2 cell undercurrent
-static uint8_t TempWarning = 0;            // 0 normal, 1 cell overtemp, 2 cell undertemp
-static int8_t TempUpLimit = 0;             //Upper temperature limit.
-static uint8_t CellVoltWarning = 0;        // 0 normal, 1 cell overvoltage, 2 cell undervoltage
-static bool CCCVChargeMode = false;        //0 CC, 1 = CV
-static uint16_t CellVoltUpLimit = 0;       //mV, Upper cell voltage limit
-static uint16_t SOCHighestCell = 0;        //0.01, %
-static uint16_t SOCLowestCell = 0;         //0.01, %
-static uint16_t SOCAverage = 0;            //0.01, %
-static bool WakeUpTopUpReq =
-    false;  //The HV Battery can trigger a vehicle wake-up to request its State of Charge to be increased.
-static bool WakeUpThermalReq =
-    false;  //The HV Battery can trigger a vehicle wake-up in order to be thermally managed (ie. cooled down OR warmed up).
-static bool WakeUpDchReq =
-    false;  //The HV Battery can trigger a vehicle wake-up to request its State of Charge to be reduced.
-static uint16_t StateofHealth = 0;
-static uint16_t EstimatedLossChg =
-    0;  //fact0.001, kWh Expected energy which will be lost during charging (at the rate given by VSCEstChargePower) due to resistance within the HV Battery.
-static bool CoolingRequest =
-    false;  //HV Battery cooling request to be cooled by the eAC/chiller as its cooling needs exceed the LTR cooling loop capability.
-static uint16_t EstimatedLossDch =
-    0;  //fact0.001, kWh Expected energy which will be lost during discharging (at the rate given by VSCEstDischargePower) due to resistance within the HV Battery.
-static uint8_t FanDutyRequest =
-    0;  //Request from the HV Battery cooling system to demand a change of duty for the electrical engine cooling fan speed (whilst using its LTR cooling loop).
-static bool ValveCtrlStat = false;  //0 Chiller/Heater cooling loop requested , 1 LTR cooling loop requested
-static uint16_t EstLossDchTgtSoC =
-    0;  //fact0.001, kWh Expected energy which will be lost during discharging (at the rate given by VSCEstimatedDchPower) from the target charging SoC (PHEV: HVBattEnergyUsableMax, BEV: HVBattEnergyUsableBulk) down to HVBattEnergyUsableMin, due to resistance within the Traction Battery.
-static uint8_t HeatPowerGenChg =
-    0;  //fact0.1, kW, Estimated average heat generated by battery if charged at the rate given by VSCEstimatedChgPower.
-static uint8_t HeatPowerGenDch =
-    0;  //fact0.1, kW, Estimated average heat generated by battery if discharged at the rate given by VSCEstimatedDchPower.
-static uint8_t WarmupRateChg =
-    0;  //fact0.1, C/min , Expected average rate at which the battery will self-heat if charged at the rate given by VSCEstimatedChgPower.
-static uint8_t WarmupRateDch =
-    0;  //fact0.1, C/min , Expected average rate at which the battery will self-heat if discharged at the rate given by VSCEstimatedDchPower.
-static uint16_t CellVoltageMax = 3700;
-static uint16_t CellVoltageMin = 3700;
-static int8_t CellTempAverage = 0;     //factor0.5, -40 offset
-static int8_t CellTempColdest = 0;     //factor0.5, -40 offset
-static int8_t CellTempHottest = 0;     //factor0.5, -40 offset
-static uint8_t HeaterCtrlStat = 0;     //factor1, 0 offset
-static bool ThermalOvercheck = false;  // 0 OK, 1 NOT OK
-static int8_t InletCoolantTemp = 0;    //factor0.5, -40 offset
-static bool ClntPumpDiagStat_UB = false;
-static bool InletCoolantTemp_UB = false;
-static bool CoolantLevel = false;      // Coolant level OK , 1 NOT OK
-static bool ClntPumpDiagStat = false;  // 0 Pump OK, 1 NOT OK
-static uint8_t MILRequest = 0;         //No req, 1 ON, 2 FLASHING, 3 unused
-static uint16_t EnergyAvailable = 0;   //fac0.05 , The total energy available from the HV Battery
-static uint16_t EnergyUsableMax = 0;   //fac0.05 , The total energy available from the HV Battery at its maximum SOC
-static uint16_t EnergyUsableMin = 0;   //fac0.05 , The total energy available from the HV Battery at its minimum SOC
-static uint16_t TotalCapacity =
-    0;  //fac0.1 , Total Battery capacity in Kwh. This will reduce over the lifetime of the HV Battery.
-
-//CAN messages needed by battery (LOG needed!)
-CAN_frame RANGE_ROVER_18B = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x18B,  //CONTENT??? TODO
-                             .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-void update_values_battery() {
+void RangeRoverPhevBattery::update_values() {
 
   datalayer.battery.status.real_soc = SOCAverage;
 
@@ -180,7 +79,7 @@ void update_values_battery() {
   datalayer.battery.info.min_design_voltage_dV = DischargeVoltageLimit * 10;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void RangeRoverPhevBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x080:  // 15ms
@@ -301,7 +200,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void RangeRoverPhevBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50ms >= INTERVAL_50_MS) {
@@ -312,9 +211,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Range Rover 13kWh PHEV battery (L494/L405)", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+void RangeRoverPhevBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -12,7 +12,120 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CELL_DEVIATION_MV 150
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class RangeRoverPhevBattery : public CanBattery {
+ public:
+  RangeRoverPhevBattery() : CanBattery(RangeRoverPhev) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Range Rover 13kWh PHEV battery (L494/L405)";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  unsigned long previousMillis50ms = 0;  // will store last time a 50ms CAN Message was sent
+
+  //CAN content from battery
+  bool StatusCAT5BPOChg = false;
+  bool StatusCAT4Derate = false;
+  uint8_t OCMonitorStatus = 0;
+  bool StatusCAT3 = false;
+  bool IsolationStatus = false;
+  bool HVILStatus = false;
+  bool ContactorStatus = false;
+  uint8_t StatusGpCounter = 0;
+  bool WeldCheckStatus = false;
+  bool StatusCAT7NowBPO = false;
+  bool StatusCAT6DlyBPO = false;
+  uint8_t StatusGpCS = 0;
+  uint8_t CAT6Count = 0;
+  bool EndOfCharge = false;
+  bool DerateWarning = false;
+  bool PrechargeAllowed = false;
+  uint8_t DischargeExtGpCounter = 0;    // Counter 0-15
+  uint8_t DischargeExtGpCS = 0;         // CRC
+  uint16_t DischargeVoltageLimit = 0;   //Min voltage battery allows discharging to
+  uint16_t DischargePowerLimitExt = 0;  //Momentary Discharge power limit kW*0.01 (0-655)
+  uint16_t DischargeContPwrLmt = 0;     //Longterm Discharge power limit kW*0.01 (0-655)
+  uint8_t PwrGpCS = 0;                  // CRC
+  uint8_t PwrGpCounter = 0;             // Counter 0-15
+  uint16_t VoltageExt = 370;            // Voltage of the HV Battery
+  uint16_t VoltageBus = 0;              // Voltage on the high-voltage DC bus
+  int32_t CurrentExt =
+      209715;  //Positive - discharge, Negative Charge (0 - 16777215) Scaling: 0.025 Offset: -209715.175 Units: Amps
+  bool HVIsolationTestRunning = false;
+  uint16_t VoltageOC =
+      0;  //The instantaneous equivalent open-circuit voltage of the high voltage battery. This is used by the high-voltage inverter in power prediction and derating calculations.
+  uint16_t DchCurrentLimit =
+      0;  // A, 'Maximum current that can be delivered by the HV Battery during motoring mode  i.e during discharging.
+  uint16_t ChgCurrentLimit =
+      0;  // - 1023 A, Maximum current that can be transferred into the HV Battery during generating mode i.e during charging. Charging is neagtive and discharging is positive.
+  uint16_t ChargeContPwrLmt = 0;      //Longterm charge power limit kW*0.01 (0-655)
+  uint16_t ChargePowerLimitExt = 0;   //Momentary Charge power limit kW*0.01 (0-655)
+  uint8_t ChgExtGpCS = 0;             // CRC
+  uint8_t ChgExtGpCounter = 0;        //counter 0-15
+  uint16_t ChargeVoltageLimit = 500;  //Max voltage limit during charging of the HV Battery.
+  uint8_t CurrentWarning = 0;         // 0 normal, 1 cell overcurrent, 2 cell undercurrent
+  uint8_t TempWarning = 0;            // 0 normal, 1 cell overtemp, 2 cell undertemp
+  int8_t TempUpLimit = 0;             //Upper temperature limit.
+  uint8_t CellVoltWarning = 0;        // 0 normal, 1 cell overvoltage, 2 cell undervoltage
+  bool CCCVChargeMode = false;        //0 CC, 1 = CV
+  uint16_t CellVoltUpLimit = 0;       //mV, Upper cell voltage limit
+  uint16_t SOCHighestCell = 0;        //0.01, %
+  uint16_t SOCLowestCell = 0;         //0.01, %
+  uint16_t SOCAverage = 0;            //0.01, %
+  bool WakeUpTopUpReq =
+      false;  //The HV Battery can trigger a vehicle wake-up to request its State of Charge to be increased.
+  bool WakeUpThermalReq =
+      false;  //The HV Battery can trigger a vehicle wake-up in order to be thermally managed (ie. cooled down OR warmed up).
+  bool WakeUpDchReq =
+      false;  //The HV Battery can trigger a vehicle wake-up to request its State of Charge to be reduced.
+  uint16_t StateofHealth = 0;
+  uint16_t EstimatedLossChg =
+      0;  //fact0.001, kWh Expected energy which will be lost during charging (at the rate given by VSCEstChargePower) due to resistance within the HV Battery.
+  bool CoolingRequest =
+      false;  //HV Battery cooling request to be cooled by the eAC/chiller as its cooling needs exceed the LTR cooling loop capability.
+  uint16_t EstimatedLossDch =
+      0;  //fact0.001, kWh Expected energy which will be lost during discharging (at the rate given by VSCEstDischargePower) due to resistance within the HV Battery.
+  uint8_t FanDutyRequest =
+      0;  //Request from the HV Battery cooling system to demand a change of duty for the electrical engine cooling fan speed (whilst using its LTR cooling loop).
+  bool ValveCtrlStat = false;  //0 Chiller/Heater cooling loop requested , 1 LTR cooling loop requested
+  uint16_t EstLossDchTgtSoC =
+      0;  //fact0.001, kWh Expected energy which will be lost during discharging (at the rate given by VSCEstimatedDchPower) from the target charging SoC (PHEV: HVBattEnergyUsableMax, BEV: HVBattEnergyUsableBulk) down to HVBattEnergyUsableMin, due to resistance within the Traction Battery.
+  uint8_t HeatPowerGenChg =
+      0;  //fact0.1, kW, Estimated average heat generated by battery if charged at the rate given by VSCEstimatedChgPower.
+  uint8_t HeatPowerGenDch =
+      0;  //fact0.1, kW, Estimated average heat generated by battery if discharged at the rate given by VSCEstimatedDchPower.
+  uint8_t WarmupRateChg =
+      0;  //fact0.1, C/min , Expected average rate at which the battery will self-heat if charged at the rate given by VSCEstimatedChgPower.
+  uint8_t WarmupRateDch =
+      0;  //fact0.1, C/min , Expected average rate at which the battery will self-heat if discharged at the rate given by VSCEstimatedDchPower.
+  uint16_t CellVoltageMax = 3700;
+  uint16_t CellVoltageMin = 3700;
+  int8_t CellTempAverage = 0;     //factor0.5, -40 offset
+  int8_t CellTempColdest = 0;     //factor0.5, -40 offset
+  int8_t CellTempHottest = 0;     //factor0.5, -40 offset
+  uint8_t HeaterCtrlStat = 0;     //factor1, 0 offset
+  bool ThermalOvercheck = false;  // 0 OK, 1 NOT OK
+  int8_t InletCoolantTemp = 0;    //factor0.5, -40 offset
+  bool ClntPumpDiagStat_UB = false;
+  bool InletCoolantTemp_UB = false;
+  bool CoolantLevel = false;      // Coolant level OK , 1 NOT OK
+  bool ClntPumpDiagStat = false;  // 0 Pump OK, 1 NOT OK
+  uint8_t MILRequest = 0;         //No req, 1 ON, 2 FLASHING, 3 unused
+  uint16_t EnergyAvailable = 0;   //fac0.05 , The total energy available from the HV Battery
+  uint16_t EnergyUsableMax = 0;   //fac0.05 , The total energy available from the HV Battery at its maximum SOC
+  uint16_t EnergyUsableMin = 0;   //fac0.05 , The total energy available from the HV Battery at its minimum SOC
+  uint16_t TotalCapacity =
+      0;  //fac0.1 , Total Battery capacity in Kwh. This will reduce over the lifetime of the HV Battery.
+
+  //CAN messages needed by battery (LOG needed!)
+  CAN_frame RANGE_ROVER_18B = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x18B,  //CONTENT??? TODO
+                               .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+};
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef RENAULT_KANGOO_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "RENAULT-KANGOO-BATTERY.h"
@@ -71,7 +72,8 @@ static unsigned long previousMillis100 = 0;   // will store last time a 100ms CA
 static unsigned long previousMillis1000 = 0;  // will store last time a 1000ms CAN Message was sent
 static unsigned long GVL_pause = 0;
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters
+void RenaultKangooBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters
 
   datalayer.battery.status.real_soc = (LB_SOC * 100);  //increase LB_SOC range from 0-100 -> 100.00
 
@@ -137,7 +139,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void RenaultKangooBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x155:  //BMS1
@@ -210,7 +212,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void RenaultKangooBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message (for 2.4s, then pause 10s)
   if ((currentMillis - previousMillis100) >= (INTERVAL_100_MS + GVL_pause)) {
@@ -233,11 +235,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-
-  strncpy(datalayer.system.info.battery_protocol, "Renault Kangoo", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
-
+void RenaultKangooBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -20,57 +20,6 @@ This page has info on the larger 33kWh pack: https://openinverter.org/wiki/Renau
 */
 
 /* Do not change code below unless you are sure what you are doing */
-static uint32_t LB_Battery_Voltage = 3700;
-static uint32_t LB_Charge_Power_Limit_Watts = 0;
-static int32_t LB_Current = 0;
-static int16_t LB_MAX_TEMPERATURE = 0;
-static int16_t LB_MIN_TEMPERATURE = 0;
-static uint16_t LB_SOC = 0;
-static uint16_t LB_SOH = 0;
-static uint16_t LB_Discharge_Power_Limit = 0;
-static uint16_t LB_Charge_Power_Limit = 0;
-static uint16_t LB_kWh_Remaining = 0;
-static uint16_t LB_Cell_Max_Voltage = 3700;
-static uint16_t LB_Cell_Min_Voltage = 3700;
-static uint16_t LB_MaxChargeAllowed_W = 0;
-static uint8_t LB_Discharge_Power_Limit_Byte1 = 0;
-static uint8_t GVI_Pollcounter = 0;
-static uint8_t LB_EOCR = 0;
-static uint8_t LB_HVBUV = 0;
-static uint8_t LB_HVBIR = 0;
-static uint8_t LB_CUV = 0;
-static uint8_t LB_COV = 0;
-static uint8_t LB_HVBOV = 0;
-static uint8_t LB_HVBOT = 0;
-static uint8_t LB_HVBOC = 0;
-static uint8_t LB_MaxInput_kW = 0;
-static uint8_t LB_MaxOutput_kW = 0;
-static bool GVB_79B_Continue = false;
-
-CAN_frame KANGOO_423 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x423,
-                        .data = {0x0B, 0x1D, 0x00, 0x02, 0xB2, 0x20, 0xB2, 0xD9}};  // Charging
-// Driving: 0x07  0x1D  0x00  0x02  0x5D  0x80  0x5D  0xD8
-// Charging: 0x0B   0x1D  0x00  0x02  0xB2  0x20  0xB2  0xD9
-// Fastcharging: 0x07   0x1E  0x00  0x01  0x5D  0x20  0xB2  0xC7
-// Old hardcoded message: .data = {0x33, 0x00, 0xFF, 0xFF, 0x00, 0xE0, 0x00, 0x00}};
-CAN_frame KANGOO_79B = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x79B,
-                        .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0xE0, 0x00, 0x00}};
-CAN_frame KANGOO_79B_Continue = {.FD = false,
-                                 .ext_ID = false,
-                                 .DLC = 8,
-                                 .ID = 0x79B,
-                                 .data = {0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static unsigned long previousMillis10 = 0;    // will store last time a 10ms CAN Message was sent
-static unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent
-static unsigned long previousMillis1000 = 0;  // will store last time a 1000ms CAN Message was sent
-static unsigned long GVL_pause = 0;
 
 void RenaultKangooBattery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -22,6 +22,59 @@ class RenaultKangooBattery : public CanBattery {
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  uint32_t LB_Battery_Voltage = 3700;
+  uint32_t LB_Charge_Power_Limit_Watts = 0;
+  int32_t LB_Current = 0;
+  int16_t LB_MAX_TEMPERATURE = 0;
+  int16_t LB_MIN_TEMPERATURE = 0;
+  uint16_t LB_SOC = 0;
+  uint16_t LB_SOH = 0;
+  uint16_t LB_Discharge_Power_Limit = 0;
+  uint16_t LB_Charge_Power_Limit = 0;
+  uint16_t LB_kWh_Remaining = 0;
+  uint16_t LB_Cell_Max_Voltage = 3700;
+  uint16_t LB_Cell_Min_Voltage = 3700;
+  uint16_t LB_MaxChargeAllowed_W = 0;
+  uint8_t LB_Discharge_Power_Limit_Byte1 = 0;
+  uint8_t GVI_Pollcounter = 0;
+  uint8_t LB_EOCR = 0;
+  uint8_t LB_HVBUV = 0;
+  uint8_t LB_HVBIR = 0;
+  uint8_t LB_CUV = 0;
+  uint8_t LB_COV = 0;
+  uint8_t LB_HVBOV = 0;
+  uint8_t LB_HVBOT = 0;
+  uint8_t LB_HVBOC = 0;
+  uint8_t LB_MaxInput_kW = 0;
+  uint8_t LB_MaxOutput_kW = 0;
+  bool GVB_79B_Continue = false;
+
+  CAN_frame KANGOO_423 = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x423,
+                          .data = {0x0B, 0x1D, 0x00, 0x02, 0xB2, 0x20, 0xB2, 0xD9}};  // Charging
+  // Driving: 0x07  0x1D  0x00  0x02  0x5D  0x80  0x5D  0xD8
+  // Charging: 0x0B   0x1D  0x00  0x02  0xB2  0x20  0xB2  0xD9
+  // Fastcharging: 0x07   0x1E  0x00  0x01  0x5D  0x20  0xB2  0xC7
+  // Old hardcoded message: .data = {0x33, 0x00, 0xFF, 0xFF, 0x00, 0xE0, 0x00, 0x00}};
+  CAN_frame KANGOO_79B = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x79B,
+                          .data = {0x02, 0x21, 0x01, 0x00, 0x00, 0xE0, 0x00, 0x00}};
+  CAN_frame KANGOO_79B_Continue = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 8,
+                                   .ID = 0x79B,
+                                   .data = {0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  unsigned long previousMillis10 = 0;    // will store last time a 10ms CAN Message was sent
+  unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent
+  unsigned long previousMillis1000 = 0;  // will store last time a 1000ms CAN Message was sent
+  unsigned long GVL_pause = 0;
 };
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -11,7 +11,17 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class RenaultKangooBattery : public CanBattery {
+ public:
+  RenaultKangooBattery() : CanBattery(RenaultKangoo) {}
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Renault Kangoo";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include "../include.h"
 #ifdef RENAULT_TWIZY_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "RENAULT-TWIZY.h"
@@ -38,7 +39,7 @@ int16_t min_value(int16_t* entries, size_t len) {
   return result;
 }
 
-void update_values_battery() {
+static void update_values_battery() {
 
   datalayer.battery.status.real_soc = SOC;
   datalayer.battery.status.soh_pptt = SOH;
@@ -65,7 +66,7 @@ void update_values_battery() {
       max_value(cell_temperatures_dC, sizeof(cell_temperatures_dC) / sizeof(*cell_temperatures_dC));
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x155:
@@ -127,13 +128,11 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   // we do not need to send anything to the battery for now
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Renault Twizy", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 14;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -9,7 +9,16 @@
 #define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 3400  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class RenaultTwizyBattery : public CanBattery {
+ public:
+  RenaultTwizyBattery() : CanBattery(RenaultTwizy) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Renault Twizy";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -482,18 +482,14 @@ void RenaultZoeBattery::transmit_can() {
   }
 }
 
-static void setup_battery_zoe1(void) {  // Performs one time setup at startup
-  datalayer.system.status.battery_allows_contactor_closing = true;
+void RenaultZoeBattery::setup() {  // Performs one time setup at startup
+  allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-}
-
-void RenaultZoeBattery::setup() {
-  setup_battery_zoe1();
 }
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -9,7 +9,80 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class RenaultZoeBattery : public CanBattery {
+ public:
+  RenaultZoeBattery() : CanBattery(RenaultZoeGen1) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Renault Zoe Gen1";
+
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ private:
+  uint16_t LB_SOC = 50;
+  uint16_t LB_Display_SOC = 50;
+  uint16_t LB_SOH = 99;
+  int16_t LB_Average_Temperature = 0;
+  uint32_t LB_Charging_Power_W = 0;
+  uint32_t LB_Regen_allowed_W = 0;
+  uint32_t LB_Discharge_allowed_W = 0;
+  int16_t LB_Current = 0;
+  int16_t LB_Cell_minimum_temperature = 0;
+  int16_t LB_Cell_maximum_temperature = 0;
+  uint16_t LB_kWh_Remaining = 0;
+  uint16_t LB_Battery_Voltage = 3700;
+  uint8_t LB_Heartbeat = 0;
+  uint8_t frame0 = 0;
+  uint8_t current_poll = 0;
+  uint8_t requested_poll = 0;
+  uint8_t group = 0;
+  uint16_t cellvoltages[96];
+  uint32_t calculated_total_pack_voltage_mV = 370000;
+  uint8_t highbyte_cell_next_frame = 0;
+  uint16_t SOC_polled = 50;
+  int16_t cell_1_temperature_polled = 0;
+  int16_t cell_2_temperature_polled = 0;
+  int16_t cell_3_temperature_polled = 0;
+  int16_t cell_4_temperature_polled = 0;
+  int16_t cell_5_temperature_polled = 0;
+  int16_t cell_6_temperature_polled = 0;
+  int16_t cell_7_temperature_polled = 0;
+  int16_t cell_8_temperature_polled = 0;
+  int16_t cell_9_temperature_polled = 0;
+  int16_t cell_10_temperature_polled = 0;
+  int16_t cell_11_temperature_polled = 0;
+  int16_t cell_12_temperature_polled = 0;
+  uint16_t battery_mileage_in_km = 0;
+  uint16_t kWh_from_beginning_of_battery_life = 0;
+  bool looping_over_20 = false;
+
+  CAN_frame ZOE_423 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x423,
+                       .data = {0x07, 0x1d, 0x00, 0x02, 0x5d, 0x80, 0x5d, 0xc8}};
+  CAN_frame ZOE_POLL_79B = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x79B,
+                            .data = {0x02, 0x21, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ZOE_ACK_79B = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x79B,
+                           .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+#define GROUP1_CELLVOLTAGES_1_POLL 0x41
+#define GROUP2_CELLVOLTAGES_2_POLL 0x42
+#define GROUP3_METRICS 0x61
+#define GROUP4_SOC 0x03
+#define GROUP5_TEMPERATURE_POLL 0x04
+
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
+  unsigned long previousMillis250 = 0;  // will store last time a 250ms CAN Message was sent
+  uint8_t counter_423 = 0;
+};
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -24,139 +24,9 @@ https://github.com/fesch/CanZE/tree/master/app/src/main/assets/ZOE_Ph2
 /*
 
 /* Do not change code below unless you are sure what you are doing */
-static uint16_t battery_soc = 0;
-static uint16_t battery_usable_soc = 5000;
-static uint16_t battery_soh = 10000;
-static uint16_t battery_pack_voltage = 370;
-static uint16_t battery_max_cell_voltage = 3700;
-static uint16_t battery_min_cell_voltage = 3700;
-static uint16_t battery_12v = 12000;
-static uint16_t battery_avg_temp = 920;
-static uint16_t battery_min_temp = 920;
-static uint16_t battery_max_temp = 920;
-static uint16_t battery_max_power = 0;
-static uint16_t battery_interlock = 0;
-static uint16_t battery_kwh = 0;
-static int32_t battery_current = 32640;
-static uint16_t battery_current_offset = 0;
-static uint16_t battery_max_generated = 0;
-static uint16_t battery_max_available = 0;
-static uint16_t battery_current_voltage = 0;
-static uint16_t battery_charging_status = 0;
-static uint16_t battery_remaining_charge = 0;
-static uint16_t battery_balance_capacity_total = 0;
-static uint16_t battery_balance_time_total = 0;
-static uint16_t battery_balance_capacity_sleep = 0;
-static uint16_t battery_balance_time_sleep = 0;
-static uint16_t battery_balance_capacity_wake = 0;
-static uint16_t battery_balance_time_wake = 0;
-static uint16_t battery_bms_state = 0;
-static uint16_t battery_balance_switches = 0;
-static uint16_t battery_energy_complete = 0;
-static uint16_t battery_energy_partial = 0;
-static uint16_t battery_slave_failures = 0;
-static uint16_t battery_mileage = 0;
-static uint16_t battery_fan_speed = 0;
-static uint16_t battery_fan_period = 0;
-static uint16_t battery_fan_control = 0;
-static uint16_t battery_fan_duty = 0;
-static uint16_t battery_temporisation = 0;
-static uint16_t battery_time = 0;
-static uint16_t battery_pack_time = 0;
-static uint16_t battery_soc_min = 0;
-static uint16_t battery_soc_max = 0;
 
-CAN_frame ZOE_373 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x373,
-                     .data = {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
-CAN_frame ZOE_POLL_18DADBF1 = {.FD = false,
-                               .ext_ID = true,
-                               .DLC = 8,
-                               .ID = 0x18DADBF1,
-                               .data = {0x03, 0x22, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00}};
-//NVROL Reset
-CAN_frame ZOE_NVROL_1_18DADBF1 = {.FD = false,
-                                  .ext_ID = true,
-                                  .DLC = 8,
-                                  .ID = 0x18DADBF1,
-                                  .data = {0x02, 0x10, 0x03, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
-CAN_frame ZOE_NVROL_2_18DADBF1 = {.FD = false,
-                                  .ext_ID = true,
-                                  .DLC = 8,
-                                  .ID = 0x18DADBF1,
-                                  .data = {0x04, 0x31, 0x01, 0xB0, 0x09, 0x00, 0xAA, 0xAA}};
-//Enable temporisation before sleep
-CAN_frame ZOE_SLEEP_1_18DADBF1 = {.FD = false,
-                                  .ext_ID = true,
-                                  .DLC = 8,
-                                  .ID = 0x18DADBF1,
-                                  .data = {0x02, 0x10, 0x03, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
-CAN_frame ZOE_SLEEP_2_18DADBF1 = {.FD = false,
-                                  .ext_ID = true,
-                                  .DLC = 8,
-                                  .ID = 0x18DADBF1,
-                                  .data = {0x04, 0x2E, 0x92, 0x81, 0x01, 0xAA, 0xAA, 0xAA}};
-
-const uint16_t poll_commands[48] = {POLL_SOC,
-                                    POLL_USABLE_SOC,
-                                    POLL_SOH,
-                                    POLL_PACK_VOLTAGE,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_MAX_CELL_VOLTAGE,
-                                    POLL_MIN_CELL_VOLTAGE,
-                                    POLL_12V,
-                                    POLL_AVG_TEMP,
-                                    POLL_MIN_TEMP,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_MAX_TEMP,
-                                    POLL_MAX_POWER,
-                                    POLL_INTERLOCK,
-                                    POLL_KWH,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_CURRENT_OFFSET,
-                                    POLL_MAX_GENERATED,
-                                    POLL_MAX_AVAILABLE,
-                                    POLL_CURRENT_VOLTAGE,
-                                    POLL_CHARGING_STATUS,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_REMAINING_CHARGE,
-                                    POLL_BALANCE_CAPACITY_TOTAL,
-                                    POLL_BALANCE_TIME_TOTAL,
-                                    POLL_BALANCE_CAPACITY_SLEEP,
-                                    POLL_BALANCE_TIME_SLEEP,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_BALANCE_CAPACITY_WAKE,
-                                    POLL_BALANCE_TIME_WAKE,
-                                    POLL_BMS_STATE,
-                                    POLL_BALANCE_SWITCHES,
-                                    POLL_ENERGY_COMPLETE,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_ENERGY_PARTIAL,
-                                    POLL_SLAVE_FAILURES,
-                                    POLL_MILEAGE,
-                                    POLL_FAN_SPEED,
-                                    POLL_FAN_PERIOD,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_FAN_CONTROL,
-                                    POLL_FAN_DUTY,
-                                    POLL_TEMPORISATION,
-                                    POLL_TIME,
-                                    POLL_PACK_TIME,
-                                    POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
-                                    POLL_SOC_MIN,
-                                    POLL_SOC_MAX};
-static uint8_t counter_373 = 0;
-static uint8_t poll_index = 0;
-static uint16_t currentpoll = POLL_SOC;
-static uint16_t reply_poll = 0;
-
-static unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was sent
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
-
-static void
-update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void RenaultZoeGen2Battery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   datalayer.battery.status.soh_pptt = battery_soh;
 
   if (battery_soc >= 300) {
@@ -233,7 +103,7 @@ update_values_battery() {  //This function maps all the values fetched via CAN t
   datalayer_extended.zoePH2.battery_soc_max = battery_soc_max;
 }
 
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18DAF1DB:  // LBC Reply from active polling
@@ -373,7 +243,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-static void transmit_can_battery() {
+void RenaultZoeGen2Battery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -410,8 +280,8 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  datalayer.system.status.battery_allows_contactor_closing = true;
+void RenaultZoeGen2Battery::setup(void) {  // Performs one time setup at startup
+  allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef RENAULT_ZOE_GEN2_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For "More battery info" webpage
 #include "../devboard/utils/events.h"
@@ -154,7 +155,8 @@ static uint16_t reply_poll = 0;
 static unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was sent
 static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+static void
+update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   datalayer.battery.status.soh_pptt = battery_soh;
 
   if (battery_soc >= 300) {
@@ -231,7 +233,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer_extended.zoePH2.battery_soc_max = battery_soc_max;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18DAF1DB:  // LBC Reply from active polling
@@ -371,7 +373,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -408,9 +410,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen2 50kWh", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -60,6 +60,138 @@ class RenaultZoeGen2Battery : public CanBattery {
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  uint16_t battery_soc = 0;
+  uint16_t battery_usable_soc = 5000;
+  uint16_t battery_soh = 10000;
+  uint16_t battery_pack_voltage = 370;
+  uint16_t battery_max_cell_voltage = 3700;
+  uint16_t battery_min_cell_voltage = 3700;
+  uint16_t battery_12v = 12000;
+  uint16_t battery_avg_temp = 920;
+  uint16_t battery_min_temp = 920;
+  uint16_t battery_max_temp = 920;
+  uint16_t battery_max_power = 0;
+  uint16_t battery_interlock = 0;
+  uint16_t battery_kwh = 0;
+  int32_t battery_current = 32640;
+  uint16_t battery_current_offset = 0;
+  uint16_t battery_max_generated = 0;
+  uint16_t battery_max_available = 0;
+  uint16_t battery_current_voltage = 0;
+  uint16_t battery_charging_status = 0;
+  uint16_t battery_remaining_charge = 0;
+  uint16_t battery_balance_capacity_total = 0;
+  uint16_t battery_balance_time_total = 0;
+  uint16_t battery_balance_capacity_sleep = 0;
+  uint16_t battery_balance_time_sleep = 0;
+  uint16_t battery_balance_capacity_wake = 0;
+  uint16_t battery_balance_time_wake = 0;
+  uint16_t battery_bms_state = 0;
+  uint16_t battery_balance_switches = 0;
+  uint16_t battery_energy_complete = 0;
+  uint16_t battery_energy_partial = 0;
+  uint16_t battery_slave_failures = 0;
+  uint16_t battery_mileage = 0;
+  uint16_t battery_fan_speed = 0;
+  uint16_t battery_fan_period = 0;
+  uint16_t battery_fan_control = 0;
+  uint16_t battery_fan_duty = 0;
+  uint16_t battery_temporisation = 0;
+  uint16_t battery_time = 0;
+  uint16_t battery_pack_time = 0;
+  uint16_t battery_soc_min = 0;
+  uint16_t battery_soc_max = 0;
+
+  CAN_frame ZOE_373 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x373,
+                       .data = {0xC1, 0x80, 0x5D, 0x5D, 0x00, 0x00, 0xff, 0xcb}};
+  CAN_frame ZOE_POLL_18DADBF1 = {.FD = false,
+                                 .ext_ID = true,
+                                 .DLC = 8,
+                                 .ID = 0x18DADBF1,
+                                 .data = {0x03, 0x22, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  //NVROL Reset
+  CAN_frame ZOE_NVROL_1_18DADBF1 = {.FD = false,
+                                    .ext_ID = true,
+                                    .DLC = 8,
+                                    .ID = 0x18DADBF1,
+                                    .data = {0x02, 0x10, 0x03, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
+  CAN_frame ZOE_NVROL_2_18DADBF1 = {.FD = false,
+                                    .ext_ID = true,
+                                    .DLC = 8,
+                                    .ID = 0x18DADBF1,
+                                    .data = {0x04, 0x31, 0x01, 0xB0, 0x09, 0x00, 0xAA, 0xAA}};
+  //Enable temporisation before sleep
+  CAN_frame ZOE_SLEEP_1_18DADBF1 = {.FD = false,
+                                    .ext_ID = true,
+                                    .DLC = 8,
+                                    .ID = 0x18DADBF1,
+                                    .data = {0x02, 0x10, 0x03, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
+  CAN_frame ZOE_SLEEP_2_18DADBF1 = {.FD = false,
+                                    .ext_ID = true,
+                                    .DLC = 8,
+                                    .ID = 0x18DADBF1,
+                                    .data = {0x04, 0x2E, 0x92, 0x81, 0x01, 0xAA, 0xAA, 0xAA}};
+
+  const uint16_t poll_commands[48] = {POLL_SOC,
+                                      POLL_USABLE_SOC,
+                                      POLL_SOH,
+                                      POLL_PACK_VOLTAGE,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_MAX_CELL_VOLTAGE,
+                                      POLL_MIN_CELL_VOLTAGE,
+                                      POLL_12V,
+                                      POLL_AVG_TEMP,
+                                      POLL_MIN_TEMP,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_MAX_TEMP,
+                                      POLL_MAX_POWER,
+                                      POLL_INTERLOCK,
+                                      POLL_KWH,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_CURRENT_OFFSET,
+                                      POLL_MAX_GENERATED,
+                                      POLL_MAX_AVAILABLE,
+                                      POLL_CURRENT_VOLTAGE,
+                                      POLL_CHARGING_STATUS,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_REMAINING_CHARGE,
+                                      POLL_BALANCE_CAPACITY_TOTAL,
+                                      POLL_BALANCE_TIME_TOTAL,
+                                      POLL_BALANCE_CAPACITY_SLEEP,
+                                      POLL_BALANCE_TIME_SLEEP,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_BALANCE_CAPACITY_WAKE,
+                                      POLL_BALANCE_TIME_WAKE,
+                                      POLL_BMS_STATE,
+                                      POLL_BALANCE_SWITCHES,
+                                      POLL_ENERGY_COMPLETE,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_ENERGY_PARTIAL,
+                                      POLL_SLAVE_FAILURES,
+                                      POLL_MILEAGE,
+                                      POLL_FAN_SPEED,
+                                      POLL_FAN_PERIOD,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_FAN_CONTROL,
+                                      POLL_FAN_DUTY,
+                                      POLL_TEMPORISATION,
+                                      POLL_TIME,
+                                      POLL_PACK_TIME,
+                                      POLL_CURRENT,  //Repeated to speed up update rate on this critical measurement
+                                      POLL_SOC_MIN,
+                                      POLL_SOC_MAX};
+  uint8_t counter_373 = 0;
+  uint8_t poll_index = 0;
+  uint16_t currentpoll = POLL_SOC;
+  uint16_t reply_poll = 0;
+
+  unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was sent
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
 };
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -9,9 +9,6 @@
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-
 #define POLL_SOC 0x9001
 #define POLL_USABLE_SOC 0x9002
 #define POLL_SOH 0x9003
@@ -53,5 +50,16 @@ void transmit_can_frame(CAN_frame* tx_frame, int interface);
 #define POLL_PACK_TIME 0x91C1
 #define POLL_SOC_MIN 0x91B9
 #define POLL_SOC_MAX 0x91BA
+
+class RenaultZoeGen2Battery : public CanBattery {
+ public:
+  RenaultZoeGen2Battery() : CanBattery(RenaultZoeGen2) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Renault Zoe Gen2 50kWh";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef RJXZS_BMS
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "RJXZS-BMS.h"
@@ -77,7 +78,7 @@ static uint8_t timespent_without_soc = 0;
 static bool charging_active = false;
 static bool discharging_active = false;
 
-void update_values_battery() {
+static void update_values_battery() {
 
   datalayer.battery.status.real_soc = battery_capacity_percentage * 100;
   if (battery_capacity_percentage == 0) {
@@ -166,7 +167,7 @@ void update_values_battery() {
   datalayer.battery.status.cell_min_voltage_mV = minimum_cell_voltage;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
 
   /*
   // All CAN messages recieved will be logged via serial
@@ -571,7 +572,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
@@ -590,7 +591,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+static void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "RJXZS BMS, DIY battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -18,7 +18,4 @@
 #define BATTERY_SELECTED
 #define NATIVECAN_250KBPS
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -15,113 +15,42 @@ TODO: Check if CRC function works like it should. This enables checking for corr
 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
-static uint8_t poll_data_pid = 0;
-static uint8_t counter_200 = 0;
-static uint8_t checksum_200 = 0;
 
-static uint16_t SOC_Display = 0;
-static uint16_t batterySOH = 100;
-static uint16_t CellVoltMax_mV = 3700;
-static uint16_t CellVoltMin_mV = 3700;
-static uint8_t CellVmaxNo = 0;
-static uint8_t CellVminNo = 0;
-static uint16_t allowedDischargePower = 0;
-static uint16_t allowedChargePower = 0;
-static uint16_t batteryVoltage = 0;
-static int16_t leadAcidBatteryVoltage = 120;
-static int8_t temperatureMax = 0;
-static int8_t temperatureMin = 0;
-static int16_t batteryAmps = 0;
-static uint8_t StatusBattery = 0;
-static uint16_t cellvoltages_mv[96];
+void SantaFePhevBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
-#ifdef DOUBLE_BATTERY
-static uint16_t battery2_SOC_Display = 0;
-static uint16_t battery2_SOH = 100;
-static uint16_t battery2_CellVoltMax_mV = 3700;
-static uint16_t battery2_CellVoltMin_mV = 3700;
-static uint8_t battery2_CellVmaxNo = 0;
-static uint8_t battery2_CellVminNo = 0;
-static uint16_t battery2_allowedDischargePower = 0;
-static uint16_t battery2_allowedChargePower = 0;
-static uint16_t battery2_batteryVoltage = 0;
-static int16_t battery2_leadAcidBatteryVoltage = 120;
-static int8_t battery2_temperatureMax = 0;
-static int8_t battery2_temperatureMin = 0;
-static int16_t battery2_batteryAmps = 0;
-static uint8_t battery2_StatusBattery = 0;
-static uint16_t battery2_cellvoltages_mv[96];
-#endif  //DOUBLE_BATTERY
+  m_target->status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 
-CAN_frame SANTAFE_200 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x200,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
-CAN_frame SANTAFE_2A1 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x2A1,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x02}};
-CAN_frame SANTAFE_2F0 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x2F0,
-                         .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00}};
-CAN_frame SANTAFE_523 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x523,
-                         .data = {0x60, 0x00, 0x60, 0, 0, 0, 0, 0}};
-CAN_frame SANTAFE_7E4_poll = {.FD = false,
-                              .ext_ID = false,
-                              .DLC = 8,
-                              .ID = 0x7E4,  //Polling frame, 0x22 01 0X
-                              .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SANTAFE_7E4_ack = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
-                             .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  m_target->status.soh_pptt = (batterySOH * 100);  //Increase decimals from 100% -> 100.00%
 
-static void
-update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+  m_target->status.voltage_dV = batteryVoltage;
 
-  datalayer.battery.status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
+  m_target->status.current_dA = -batteryAmps;
 
-  datalayer.battery.status.soh_pptt = (batterySOH * 100);  //Increase decimals from 100% -> 100.00%
+  m_target->status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(m_target->status.real_soc) / 10000) * m_target->info.total_capacity_Wh);
 
-  datalayer.battery.status.voltage_dV = batteryVoltage;
+  m_target->status.max_discharge_power_W = allowedDischargePower * 10;
 
-  datalayer.battery.status.current_dA = -batteryAmps;
+  m_target->status.max_charge_power_W = allowedChargePower * 10;
 
-  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+  m_target->status.cell_max_voltage_mV = CellVoltMax_mV;
 
-  datalayer.battery.status.max_discharge_power_W = allowedDischargePower * 10;
+  m_target->status.cell_min_voltage_mV = CellVoltMin_mV;
 
-  datalayer.battery.status.max_charge_power_W = allowedChargePower * 10;
+  m_target->status.temperature_min_dC = temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 
-  datalayer.battery.status.cell_max_voltage_mV = CellVoltMax_mV;
-
-  datalayer.battery.status.cell_min_voltage_mV = CellVoltMin_mV;
-
-  datalayer.battery.status.temperature_min_dC = temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
-
-  datalayer.battery.status.temperature_max_dC = temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
+  m_target->status.temperature_max_dC = temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
 
   if (leadAcidBatteryVoltage < 110) {
     set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
   }
 }
 
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void SantaFePhevBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       StatusBattery = (rx_frame.data.u8[0] & 0x0F);
       break;
     case 0x4D5:
@@ -129,16 +58,16 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
     case 0x4DD:
       break;
     case 0x4DE:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x4E0:
       break;
     case 0x542:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       SOC_Display = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]) / 2;
       break;
     case 0x588:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       batteryVoltage = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]);
       break;
     case 0x597:
@@ -148,7 +77,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
     case 0x5A7:
       break;
     case 0x5AD:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       batteryAmps = (rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2];
       break;
     case 0x5AE:
@@ -156,25 +85,25 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
     case 0x5F1:
       break;
     case 0x620:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       leadAcidBatteryVoltage = rx_frame.data.u8[1];
       temperatureMin = rx_frame.data.u8[6];  //Lowest temp in battery
       temperatureMax = rx_frame.data.u8[7];  //Highest temp in battery
       break;
     case 0x670:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
       allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
       break;
     case 0x671:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x7EC:  //Data From polled PID group, BigEndian
       switch (rx_frame.data.u8[0]) {
         case 0x10:  //"PID Header"
           if (rx_frame.data.u8[4] == poll_data_pid) {
             transmit_can_frame(&SANTAFE_7E4_ack,
-                               can_config.battery);  //Send ack to BMS if the same frame is sent as polled
+                               m_can_interface);  //Send ack to BMS if the same frame is sent as polled
           }
           break;
         case 0x21:  //First frame in PID group
@@ -319,7 +248,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
             cellvoltages_mv[95] = (rx_frame.data.u8[5] * 20);
 
             //Map all cell voltages to the global array, we have sampled them all!
-            memcpy(datalayer.battery.status.cell_voltages_mV, cellvoltages_mv, 96 * sizeof(uint16_t));
+            memcpy(m_target->status.cell_voltages_mV, cellvoltages_mv, 96 * sizeof(uint16_t));
           } else if (poll_data_pid == 5) {
           }
           break;
@@ -335,7 +264,8 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-static void transmit_can_battery() {
+
+void SantaFePhevBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   //Send 10ms message
@@ -354,14 +284,9 @@ static void transmit_can_battery() {
 
     SANTAFE_200.data.u8[7] = checksum_200;
 
-    transmit_can_frame(&SANTAFE_200, can_config.battery);
-    transmit_can_frame(&SANTAFE_2A1, can_config.battery);
-    transmit_can_frame(&SANTAFE_2F0, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&SANTAFE_200, can_config.battery_double);
-    transmit_can_frame(&SANTAFE_2A1, can_config.battery_double);
-    transmit_can_frame(&SANTAFE_2F0, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&SANTAFE_200, m_can_interface);
+    transmit_can_frame(&SANTAFE_2A1, m_can_interface);
+    transmit_can_frame(&SANTAFE_2F0, m_can_interface);
 
     counter_200++;
     if (counter_200 > 0xF) {
@@ -373,10 +298,7 @@ static void transmit_can_battery() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    transmit_can_frame(&SANTAFE_523, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&SANTAFE_523, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&SANTAFE_523, m_can_interface);
   }
 
   // Send 500ms CAN Message
@@ -386,266 +308,9 @@ static void transmit_can_battery() {
     // PID data is polled after last message sent from battery:
     poll_data_pid = (poll_data_pid % 5) + 1;
     SANTAFE_7E4_poll.data.u8[3] = (uint8_t)poll_data_pid;
-    transmit_can_frame(&SANTAFE_7E4_poll, can_config.battery);
-#ifdef DOUBLE_BATTERY
-    transmit_can_frame(&SANTAFE_7E4_poll, can_config.battery_double);
-#endif  //DOUBLE_BATTERY
+    transmit_can_frame(&SANTAFE_7E4_poll, m_can_interface);
   }
 }
-
-#ifdef DOUBLE_BATTERY
-void update_values_battery2() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
-
-  datalayer.battery2.status.real_soc = (battery2_SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
-
-  datalayer.battery2.status.soh_pptt = (battery2_SOH * 100);  //Increase decimals from 100% -> 100.00%
-
-  datalayer.battery2.status.voltage_dV = battery2_batteryVoltage;
-
-  datalayer.battery2.status.current_dA = -battery2_batteryAmps;
-
-  datalayer.battery2.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery2.status.real_soc) / 10000) * datalayer.battery2.info.total_capacity_Wh);
-
-  datalayer.battery2.status.max_discharge_power_W = battery2_allowedDischargePower * 10;
-
-  datalayer.battery2.status.max_charge_power_W = battery2_allowedChargePower * 10;
-
-  //Power in watts, Negative = charging batt
-  datalayer.battery2.status.active_power_W =
-      ((datalayer.battery2.status.voltage_dV * datalayer.battery2.status.current_dA) / 100);
-
-  datalayer.battery2.status.cell_max_voltage_mV = battery2_CellVoltMax_mV;
-
-  datalayer.battery2.status.cell_min_voltage_mV = battery2_CellVoltMin_mV;
-
-  datalayer.battery2.status.temperature_min_dC = battery2_temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
-
-  datalayer.battery2.status.temperature_max_dC = battery2_temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
-
-  if (battery2_leadAcidBatteryVoltage < 110) {
-    set_event(EVENT_12V_LOW, battery2_leadAcidBatteryVoltage);
-  }
-}
-
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x1FF:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_StatusBattery = (rx_frame.data.u8[0] & 0x0F);
-      break;
-    case 0x4D5:
-      break;
-    case 0x4DD:
-      break;
-    case 0x4DE:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x4E0:
-      break;
-    case 0x542:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_SOC_Display = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]) / 2;
-      break;
-    case 0x588:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_batteryVoltage = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]);
-      break;
-    case 0x597:
-      break;
-    case 0x5A6:
-      break;
-    case 0x5A7:
-      break;
-    case 0x5AD:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_batteryAmps = (rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2];
-      break;
-    case 0x5AE:
-      break;
-    case 0x5F1:
-      break;
-    case 0x620:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_leadAcidBatteryVoltage = rx_frame.data.u8[1];
-      battery2_temperatureMin = rx_frame.data.u8[6];  //Lowest temp in battery
-      battery2_temperatureMax = rx_frame.data.u8[7];  //Highest temp in battery
-      break;
-    case 0x670:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery2_allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
-      battery2_allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
-      break;
-    case 0x671:
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x7EC:  //Data From polled PID group, BigEndian
-      switch (rx_frame.data.u8[0]) {
-        case 0x10:  //"PID Header"
-          if (rx_frame.data.u8[4] == poll_data_pid) {
-            transmit_can_frame(&SANTAFE_7E4_ack,
-                               can_config.battery_double);  //Send ack to BMS if the same frame is sent as polled
-          }
-          break;
-        case 0x21:  //First frame in PID group
-          if (poll_data_pid == 1) {
-          } else if (poll_data_pid == 2) {
-            battery2_cellvoltages_mv[0] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[1] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[2] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[3] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[4] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[5] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 3) {
-            battery2_cellvoltages_mv[32] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[33] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[34] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[35] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[36] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[37] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 4) {
-            battery2_cellvoltages_mv[64] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[65] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[66] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[67] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[68] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[69] = (rx_frame.data.u8[7] * 20);
-          }
-          break;
-        case 0x22:  //Second datarow in PID group
-          if (poll_data_pid == 2) {
-            battery2_cellvoltages_mv[6] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[7] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[8] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[9] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[10] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[11] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[12] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 3) {
-            battery2_cellvoltages_mv[38] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[39] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[40] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[41] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[42] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[43] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[44] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 4) {
-            battery2_cellvoltages_mv[70] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[71] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[72] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[73] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[74] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[75] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[76] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 6) {
-          }
-          break;
-        case 0x23:  //Third datarow in PID group
-          if (poll_data_pid == 1) {
-            battery2_CellVoltMax_mV = (rx_frame.data.u8[7] * 20);  //(volts *50) *20 =mV
-          } else if (poll_data_pid == 2) {
-            battery2_cellvoltages_mv[13] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[14] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[15] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[16] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[17] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[18] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[19] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 3) {
-            battery2_cellvoltages_mv[45] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[46] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[47] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[48] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[49] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[50] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[51] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 4) {
-            battery2_cellvoltages_mv[77] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[78] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[79] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[80] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[81] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[82] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[83] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 5) {
-            if (rx_frame.data.u8[6] > 0) {
-              battery2_SOH = rx_frame.data.u8[6];
-            }
-            if (battery2_SOH > 100) {
-              battery2_SOH = 100;
-            }
-          }
-          break;
-        case 0x24:  //Fourth datarow in PID group
-          if (poll_data_pid == 1) {
-            battery2_CellVmaxNo = rx_frame.data.u8[1];
-            battery2_CellVminNo = rx_frame.data.u8[3];
-            CellVoltMin_mV = (rx_frame.data.u8[2] * 20);  //(volts *50) *20 =mV
-          } else if (poll_data_pid == 2) {
-            battery2_cellvoltages_mv[20] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[21] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[22] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[23] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[24] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[25] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[26] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 3) {
-            battery2_cellvoltages_mv[52] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[53] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[54] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[55] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[56] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[57] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[58] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 4) {
-            battery2_cellvoltages_mv[84] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[85] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[86] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[87] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[88] = (rx_frame.data.u8[5] * 20);
-            battery2_cellvoltages_mv[89] = (rx_frame.data.u8[6] * 20);
-            battery2_cellvoltages_mv[90] = (rx_frame.data.u8[7] * 20);
-          } else if (poll_data_pid == 5) {
-          }
-          break;
-        case 0x25:  //Fifth datarow in PID group
-          if (poll_data_pid == 2) {
-            battery2_cellvoltages_mv[27] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[28] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[29] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[30] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[31] = (rx_frame.data.u8[5] * 20);
-          } else if (poll_data_pid == 3) {
-            battery2_cellvoltages_mv[59] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[60] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[61] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[62] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[63] = (rx_frame.data.u8[5] * 20);
-          } else if (poll_data_pid == 4) {
-            battery2_cellvoltages_mv[91] = (rx_frame.data.u8[1] * 20);
-            battery2_cellvoltages_mv[92] = (rx_frame.data.u8[2] * 20);
-            battery2_cellvoltages_mv[93] = (rx_frame.data.u8[3] * 20);
-            battery2_cellvoltages_mv[94] = (rx_frame.data.u8[4] * 20);
-            battery2_cellvoltages_mv[95] = (rx_frame.data.u8[5] * 20);
-
-            //Map all cell voltages to the global array, we have sampled them all!
-            memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cellvoltages_mv, 96 * sizeof(uint16_t));
-          } else if (poll_data_pid == 5) {
-          }
-          break;
-        case 0x26:  //Sixth datarow in PID group
-          break;
-        case 0x27:  //Seventh datarow in PID group
-          break;
-        case 0x28:  //Eighth datarow in PID group
-          break;
-      }
-      break;
-    default:
-      break;
-  }
-}
-#endif  //DOUBLE_BATTERY
 
 uint8_t CalculateCRC8(CAN_frame rx_frame) {
   int crc = 0;
@@ -664,22 +329,13 @@ uint8_t CalculateCRC8(CAN_frame rx_frame) {
   return (uint8_t)crc;
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-
-#ifdef DOUBLE_BATTERY
-  datalayer.battery2.info.number_of_cells = datalayer.battery.info.number_of_cells;
-  datalayer.battery2.info.max_design_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
-  datalayer.battery2.info.min_design_voltage_dV = datalayer.battery.info.min_design_voltage_dV;
-  datalayer.battery2.info.max_cell_voltage_mV = datalayer.battery.info.max_cell_voltage_mV;
-  datalayer.battery2.info.min_cell_voltage_mV = datalayer.battery.info.min_cell_voltage_mV;
-  datalayer.battery2.info.max_cell_voltage_deviation_mV = datalayer.battery.info.max_cell_voltage_deviation_mV;
-#endif  //DOUBLE_BATTERY
+void SantaFePhevBattery::setup(void) {  // Performs one time setup at startup
+  m_target->info.number_of_cells = 96;
+  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SANTA_FE_PHEV_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SANTA-FE-PHEV-BATTERY.h"
@@ -86,7 +87,8 @@ CAN_frame SANTAFE_7E4_ack = {.FD = false,
                              .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
                              .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+static void
+update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 
@@ -116,7 +118,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   }
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1FF:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -333,7 +335,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   //Send 10ms message
@@ -662,9 +664,7 @@ uint8_t CalculateCRC8(CAN_frame rx_frame) {
   return (uint8_t)crc;
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Santa Fe PHEV", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef SANTA_FE_PHEV_BATTERY_H
 #define SANTA_FE_PHEV_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define BATTERY_SELECTED
@@ -14,12 +15,76 @@ uint8_t CalculateCRC8(CAN_frame rx_frame);
 
 class SantaFePhevBattery : public CanBattery {
  public:
+  SantaFePhevBattery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(SantaFePhev) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
+
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Santa Fe PHEV";
+
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
+
+  unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
+  uint8_t poll_data_pid = 0;
+  uint8_t counter_200 = 0;
+  uint8_t checksum_200 = 0;
+
+  uint16_t SOC_Display = 0;
+  uint16_t batterySOH = 100;
+  uint16_t CellVoltMax_mV = 3700;
+  uint16_t CellVoltMin_mV = 3700;
+  uint8_t CellVmaxNo = 0;
+  uint8_t CellVminNo = 0;
+  uint16_t allowedDischargePower = 0;
+  uint16_t allowedChargePower = 0;
+  uint16_t batteryVoltage = 0;
+  int16_t leadAcidBatteryVoltage = 120;
+  int8_t temperatureMax = 0;
+  int8_t temperatureMin = 0;
+  int16_t batteryAmps = 0;
+  uint8_t StatusBattery = 0;
+  uint16_t cellvoltages_mv[96];
+
+  CAN_frame SANTAFE_200 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x200,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x80, 0x10, 0x00, 0x00}};
+  CAN_frame SANTAFE_2A1 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x2A1,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x02}};
+  CAN_frame SANTAFE_2F0 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x2F0,
+                           .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00}};
+  CAN_frame SANTAFE_523 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x523,
+                           .data = {0x60, 0x00, 0x60, 0, 0, 0, 0, 0}};
+  CAN_frame SANTAFE_7E4_poll = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x7E4,  //Polling frame, 0x22 01 0X
+                                .data = {0x03, 0x22, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SANTAFE_7E4_ack = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
+                               .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
 };
 
 #endif

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -11,7 +11,15 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class SantaFePhevBattery : public CanBattery {
+ public:
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Santa Fe PHEV";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SIMPBMS_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SIMPBMS-BATTERY.h"
@@ -31,7 +32,7 @@ static uint8_t charge_forbidden = 0;
 static uint8_t discharge_forbidden = 0;
 static uint16_t cellvoltages_mV[SIMPBMS_MAX_CELLS] = {0};
 
-void update_values_battery() {
+static void update_values_battery() {
 
   datalayer.battery.status.real_soc = (SOC * 100);  //increase SOC range from 0-100 -> 100.00
 
@@ -67,7 +68,7 @@ void update_values_battery() {
   datalayer.battery.info.number_of_cells = cells_in_series;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x355:
@@ -115,9 +116,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {}
+static void transmit_can_battery() {}
 
-void setup_battery(void) {  // Performs one time setup at startup
+static void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "SIMPBMS battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = CELL_COUNT;

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -126,7 +126,7 @@ static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/SIMPBMS-BATTERY.h
+++ b/Software/src/battery/SIMPBMS-BATTERY.h
@@ -13,7 +13,4 @@
 #define MAX_CELL_DEVIATION_MV 500
 #define CELL_COUNT 96
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-
 #endif

--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SONO_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SONO-BATTERY.h"
@@ -32,7 +33,8 @@ CAN_frame SONO_401 = {.FD = false,  //Message of Vehicle Date, 1000ms
                       .ID = 0x400,
                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+static void
+update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = (realSOC * 100);  //increase SOC range from 0-100 -> 100.00
 
@@ -60,7 +62,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.temperature_max_dC = temperatureMax;
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x100:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -137,7 +139,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
 
   // Send 100ms CAN Message
@@ -168,9 +170,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Sono Motors Sion 64kWh LFP ", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/SONO-BATTERY.h
+++ b/Software/src/battery/SONO-BATTERY.h
@@ -11,7 +11,16 @@
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
+class SonoBattery : public CanBattery {
+ public:
+  SonoBattery() : CanBattery(Sono) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Sono Motors Sion 64kWh LFP ";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef TESLA_BATTERY_H
 #define TESLA_BATTERY_H
 #include "../include.h"
+#include "Battery.h"
 
 #define BATTERY_SELECTED
 
@@ -33,11 +34,479 @@ void printFaultCodesIfActive();
 void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);
 void print_SOC(char* header, int SOC);
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 #ifdef DOUBLE_BATTERY
 void printFaultCodesIfActive_battery2();
 #endif  //DOUBLE_BATTERY
+
+// Base class for Tesla batteries
+class TeslaBattery : public CanBattery {
+ public:
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+
+ protected:
+  TeslaBattery(BatteryType type) : CanBattery(type) {}
+  virtual void detect_chemistry() {}
+
+ private:
+  void printFaultCodesIfActive();
+
+  unsigned long previousMillis10 = 0;    // will store last time a 50ms CAN Message was sent
+  unsigned long previousMillis50 = 0;    // will store last time a 50ms CAN Message was sent
+  unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent
+  unsigned long previousMillis1000 = 0;  // will store last time a 1000ms CAN Message was sent
+  bool alternate243 = false;
+  //0x221 545 VCFRONT_LVPowerState: "GenMsgCycleTime" 50ms
+  CAN_frame TESLA_221_1 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x221,
+      .data = {0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96}};  //Contactor frame 221 - close contactors
+  CAN_frame TESLA_221_2 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x221,
+      .data = {0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA}};  //Contactor Frame 221 - hv_up_for_drive
+  //0x241 VCFRONT_coolant 100ms
+  CAN_frame TESLA_241 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 7,
+                         .ID = 0x241,
+                         .data = {0x3C, 0x78, 0x2C, 0x0F, 0x1E, 0x5B, 0x00}};
+  //0x242 VCLEFT_LVPowerState 100ms
+  CAN_frame TESLA_242 = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x242, .data = {0x10, 0x95}};
+  //0x243 VCRIGHT_hvacStatus 50ms
+  CAN_frame TESLA_243_1 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x243,
+                           .data = {0xC9, 0x00, 0xEB, 0xD4, 0x31, 0x32, 0x02, 0x00}};
+  CAN_frame TESLA_243_2 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x243,
+                           .data = {0x08, 0x81, 0x42, 0x60, 0x92, 0x2C, 0x0E, 0x09}};
+  //0x129 SteeringAngle 10ms
+  CAN_frame TESLA_129 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x129,
+                         .data = {0x21, 0x24, 0x36, 0x5F, 0x00, 0x20, 0xFF, 0x3F}};
+  //0x612 UDS diagnostic requests - on demand
+  CAN_frame TESLA_602 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x602,
+                         .data = {0x02, 0x27, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  uint8_t stateMachineClearIsolationFault = 0xFF;
+  uint8_t stateMachineBMSReset = 0xFF;
+  uint16_t sendContactorClosingMessagesStill = 300;
+  uint16_t battery_cell_max_v = 3300;
+  uint16_t battery_cell_min_v = 3300;
+  uint16_t battery_cell_deviation_mV = 0;  //contains the deviation between highest and lowest cell in mV
+  bool cellvoltagesRead = false;
+  //0x3d2: 978 BMS_kwhCounter
+  uint32_t battery_total_discharge = 0;
+  uint32_t battery_total_charge = 0;
+  //0x352: 850 BMS_energyStatus
+  bool BMS352_mux = false;                            // variable to store when 0x352 mux is present
+  uint16_t battery_energy_buffer = 0;                 // kWh
+  uint16_t battery_energy_buffer_m1 = 0;              // kWh
+  uint16_t battery_energy_to_charge_complete = 0;     // kWh
+  uint16_t battery_energy_to_charge_complete_m1 = 0;  // kWh
+  uint16_t battery_expected_energy_remaining = 0;     // kWh
+  uint16_t battery_expected_energy_remaining_m1 = 0;  // kWh
+  bool battery_full_charge_complete = false;          // Changed to bool
+  bool battery_fully_charged = false;                 // Changed to bool
+  uint16_t battery_ideal_energy_remaining = 0;        // kWh
+  uint16_t battery_ideal_energy_remaining_m0 = 0;     // kWh
+  uint16_t battery_nominal_energy_remaining = 0;      // kWh
+  uint16_t battery_nominal_energy_remaining_m0 = 0;   // kWh
+  uint16_t battery_nominal_full_pack_energy = 0;      // Kwh
+  uint16_t battery_nominal_full_pack_energy_m0 = 0;   // Kwh
+  //0x132 306 HVBattAmpVolt
+  uint16_t battery_volts = 0;                  // V
+  int16_t battery_amps = 0;                    // A
+  int16_t battery_raw_amps = 0;                // A
+  uint16_t battery_charge_time_remaining = 0;  // Minutes
+  //0x252 594 BMS_powerAvailable
+  uint16_t BMS_maxRegenPower = 0;           //rename from battery_regenerative_limit
+  uint16_t BMS_maxDischargePower = 0;       // rename from battery_discharge_limit
+  uint16_t BMS_maxStationaryHeatPower = 0;  //rename from battery_max_heat_park
+  uint16_t BMS_hvacPowerBudget = 0;         //rename from battery_hvac_max_power
+  uint8_t BMS_notEnoughPowerForHeatPump = 0;
+  uint8_t BMS_powerLimitState = 0;
+  uint8_t BMS_inverterTQF = 0;
+  //0x2d2: 722 BMSVAlimits
+  uint16_t battery_max_discharge_current = 0;
+  uint16_t battery_max_charge_current = 0;
+  uint16_t battery_bms_max_voltage = 0;
+  uint16_t battery_bms_min_voltage = 0;
+  //0x2b4: 692 PCS_dcdcRailStatus
+  uint16_t battery_dcdcHvBusVolt = 0;        // Change name from battery_high_voltage to battery_dcdcHvBusVolt
+  uint16_t battery_dcdcLvBusVolt = 0;        // Change name from battery_low_voltage to battery_dcdcLvBusVolt
+  uint16_t battery_dcdcLvOutputCurrent = 0;  // Change name from battery_output_current to battery_dcdcLvOutputCurrent
+  //0x292: 658 BMS_socStatus
+  uint16_t battery_beginning_of_life = 0;  // kWh
+  uint16_t battery_soc_min = 0;
+  uint16_t battery_soc_max = 0;
+  uint16_t battery_soc_ui = 0;  //Change name from battery_soc_vi to reflect DBC battery_soc_ui
+  uint16_t battery_soc_ave = 0;
+  uint8_t battery_battTempPct = 0;
+  //0x392: BMS_packConfig
+  uint32_t battery_packMass = 0;
+  uint32_t battery_platformMaxBusVoltage = 0;
+  uint32_t battery_packConfigMultiplexer = 0;
+  uint32_t battery_moduleType = 0;
+  uint32_t battery_reservedConfig = 0;
+  //0x332: 818 BattBrickMinMax:BMS_bmbMinMax
+  int16_t battery_max_temp = 0;  // C*
+  int16_t battery_min_temp = 0;  // C*
+  uint16_t battery_BrickVoltageMax = 0;
+  uint16_t battery_BrickVoltageMin = 0;
+  uint8_t battery_BrickTempMaxNum = 0;
+  uint8_t battery_BrickTempMinNum = 0;
+  uint8_t battery_BrickModelTMax = 0;
+  uint8_t battery_BrickModelTMin = 0;
+  uint8_t battery_BrickVoltageMaxNum = 0;  //rename from battery_max_vno
+  uint8_t battery_BrickVoltageMinNum = 0;  //rename from battery_min_vno
+  //0x20A: 522 HVP_contactorState
+  uint8_t battery_contactor = 0;  //State of contactor
+  uint8_t battery_hvil_status = 0;
+  uint8_t battery_packContNegativeState = 0;
+  uint8_t battery_packContPositiveState = 0;
+  uint8_t battery_packContactorSetState = 0;
+  bool battery_packCtrsClosingAllowed = false;    // Change to bool
+  bool battery_pyroTestInProgress = false;        // Change to bool
+  bool battery_packCtrsOpenNowRequested = false;  // Change to bool
+  bool battery_packCtrsOpenRequested = false;     // Change to bool
+  uint8_t battery_packCtrsRequestStatus = 0;
+  bool battery_packCtrsResetRequestRequired = false;  // Change to bool
+  bool battery_dcLinkAllowedToEnergize = false;       // Change to bool
+  bool battery_fcContNegativeAuxOpen = false;         // Change to bool
+  uint8_t battery_fcContNegativeState = 0;
+  bool battery_fcContPositiveAuxOpen = false;  // Change to bool
+  uint8_t battery_fcContPositiveState = 0;
+  uint8_t battery_fcContactorSetState = 0;
+  bool battery_fcCtrsClosingAllowed = false;    // Change to bool
+  bool battery_fcCtrsOpenNowRequested = false;  // Change to bool
+  bool battery_fcCtrsOpenRequested = false;     // Change to bool
+  uint8_t battery_fcCtrsRequestStatus = 0;
+  bool battery_fcCtrsResetRequestRequired = false;  // Change to bool
+  bool battery_fcLinkAllowedToEnergize = false;     // Change to bool
+  //0x72A: BMS_serialNumber
+  uint8_t BMS_SerialNumber[14] = {0};  // Stores raw HEX values for ASCII chars
+  //0x212: 530 BMS_status
+  bool battery_BMS_hvacPowerRequest = false;          //Change to bool
+  bool battery_BMS_notEnoughPowerForDrive = false;    //Change to bool
+  bool battery_BMS_notEnoughPowerForSupport = false;  //Change to bool
+  bool battery_BMS_preconditionAllowed = false;       //Change to bool
+  bool battery_BMS_updateAllowed = false;             //Change to bool
+  bool battery_BMS_activeHeatingWorthwhile = false;   //Change to bool
+  bool battery_BMS_cpMiaOnHvs = false;                //Change to bool
+  uint8_t battery_BMS_contactorState = 0;
+  uint8_t battery_BMS_state = 0;
+  uint8_t battery_BMS_hvState = 0;
+  uint16_t battery_BMS_isolationResistance = 0;
+  bool battery_BMS_chargeRequest = false;    //Change to bool
+  bool battery_BMS_keepWarmRequest = false;  //Change to bool
+  uint8_t battery_BMS_uiChargeStatus = 0;
+  bool battery_BMS_diLimpRequest = false;   //Change to bool
+  bool battery_BMS_okToShipByAir = false;   //Change to bool
+  bool battery_BMS_okToShipByLand = false;  //Change to bool
+  uint32_t battery_BMS_chgPowerAvailable = 0;
+  uint8_t battery_BMS_chargeRetryCount = 0;
+  bool battery_BMS_pcsPwmEnabled = false;        //Change to bool
+  bool battery_BMS_ecuLogUploadRequest = false;  //Change to bool
+  uint8_t battery_BMS_minPackTemperature = 0;
+  // 0x224:548 PCS_dcdcStatus
+  uint8_t battery_PCS_dcdcPrechargeStatus = 0;
+  uint8_t battery_PCS_dcdc12VSupportStatus = 0;
+  uint8_t battery_PCS_dcdcHvBusDischargeStatus = 0;
+  uint16_t battery_PCS_dcdcMainState = 0;
+  uint8_t battery_PCS_dcdcSubState = 0;
+  bool battery_PCS_dcdcFaulted = false;          //Change to bool
+  bool battery_PCS_dcdcOutputIsLimited = false;  //Change to bool
+  uint32_t battery_PCS_dcdcMaxOutputCurrentAllowed = 0;
+  uint8_t battery_PCS_dcdcPrechargeRtyCnt = 0;
+  uint8_t battery_PCS_dcdc12VSupportRtyCnt = 0;
+  uint8_t battery_PCS_dcdcDischargeRtyCnt = 0;
+  uint8_t battery_PCS_dcdcPwmEnableLine = 0;
+  uint8_t battery_PCS_dcdcSupportingFixedLvTarget = 0;
+  uint8_t battery_PCS_ecuLogUploadRequest = 0;
+  uint8_t battery_PCS_dcdcPrechargeRestartCnt = 0;
+  uint8_t battery_PCS_dcdcInitialPrechargeSubState = 0;
+  //0x312: 786 BMS_thermalStatus
+  uint16_t BMS_powerDissipation = 0;
+  uint16_t BMS_flowRequest = 0;
+  uint16_t BMS_inletActiveCoolTargetT = 0;
+  uint16_t BMS_inletPassiveTargetT = 0;
+  uint16_t BMS_inletActiveHeatTargetT = 0;
+  uint16_t BMS_packTMin = 0;
+  uint16_t BMS_packTMax = 0;
+  bool BMS_pcsNoFlowRequest = false;
+  bool BMS_noFlowRequest = false;
+  //0x2A4; 676 PCS_thermalStatus
+  int16_t PCS_chgPhATemp = 0;
+  int16_t PCS_chgPhBTemp = 0;
+  int16_t PCS_chgPhCTemp = 0;
+  int16_t PCS_dcdcTemp = 0;
+  int16_t PCS_ambientTemp = 0;
+  //0x2C4; 708 PCS_logging
+  uint16_t PCS_logMessageSelect = 0;
+  uint16_t PCS_dcdcMaxLvOutputCurrent = 0;
+  uint16_t PCS_dcdcCurrentLimit = 0;
+  uint16_t PCS_dcdcLvOutputCurrentTempLimit = 0;
+  uint16_t PCS_dcdcUnifiedCommand = 0;
+  uint16_t PCS_dcdcCLAControllerOutput = 0;
+  int16_t PCS_dcdcTankVoltage = 0;
+  uint16_t PCS_dcdcTankVoltageTarget = 0;
+  uint16_t PCS_dcdcClaCurrentFreq = 0;
+  int16_t PCS_dcdcTCommMeasured = 0;
+  uint16_t PCS_dcdcShortTimeUs = 0;
+  uint16_t PCS_dcdcHalfPeriodUs = 0;
+  uint16_t PCS_dcdcIntervalMaxFrequency = 0;
+  uint16_t PCS_dcdcIntervalMaxHvBusVolt = 0;
+  uint16_t PCS_dcdcIntervalMaxLvBusVolt = 0;
+  uint16_t PCS_dcdcIntervalMaxLvOutputCurr = 0;
+  uint16_t PCS_dcdcIntervalMinFrequency = 0;
+  uint16_t PCS_dcdcIntervalMinHvBusVolt = 0;
+  uint16_t PCS_dcdcIntervalMinLvBusVolt = 0;
+  uint16_t PCS_dcdcIntervalMinLvOutputCurr = 0;
+  uint32_t PCS_dcdc12vSupportLifetimekWh = 0;
+  //0x7AA: //1962 HVP_debugMessage:
+  uint8_t HVP_debugMessageMultiplexer = 0;
+  bool HVP_gpioPassivePyroDepl = false;       //Change to bool
+  bool HVP_gpioPyroIsoEn = false;             //Change to bool
+  bool HVP_gpioCpFaultIn = false;             //Change to bool
+  bool HVP_gpioPackContPowerEn = false;       //Change to bool
+  bool HVP_gpioHvCablesOk = false;            //Change to bool
+  bool HVP_gpioHvpSelfEnable = false;         //Change to bool
+  bool HVP_gpioLed = false;                   //Change to bool
+  bool HVP_gpioCrashSignal = false;           //Change to bool
+  bool HVP_gpioShuntDataReady = false;        //Change to bool
+  bool HVP_gpioFcContPosAux = false;          //Change to bool
+  bool HVP_gpioFcContNegAux = false;          //Change to bool
+  bool HVP_gpioBmsEout = false;               //Change to bool
+  bool HVP_gpioCpFaultOut = false;            //Change to bool
+  bool HVP_gpioPyroPor = false;               //Change to bool
+  bool HVP_gpioShuntEn = false;               //Change to bool
+  bool HVP_gpioHvpVerEn = false;              //Change to bool
+  bool HVP_gpioPackCoontPosFlywheel = false;  //Change to bool
+  bool HVP_gpioCpLatchEnable = false;         //Change to bool
+  bool HVP_gpioPcsEnable = false;             //Change to bool
+  bool HVP_gpioPcsDcdcPwmEnable = false;      //Change to bool
+  bool HVP_gpioPcsChargePwmEnable = false;    //Change to bool
+  bool HVP_gpioFcContPowerEnable = false;     //Change to bool
+  bool HVP_gpioHvilEnable = false;            //Change to bool
+  bool HVP_gpioSecDrdy = false;               //Change to bool
+  uint16_t HVP_hvp1v5Ref = 0;
+  int16_t HVP_shuntCurrentDebug = 0;
+  bool HVP_packCurrentMia = false;           //Change to bool
+  bool HVP_auxCurrentMia = false;            //Change to bool
+  bool HVP_currentSenseMia = false;          //Change to bool
+  bool HVP_shuntRefVoltageMismatch = false;  //Change to bool
+  bool HVP_shuntThermistorMia = false;       //Change to bool
+  bool HVP_shuntHwMia = false;               //Change to bool
+  int16_t HVP_dcLinkVoltage = 0;
+  int16_t HVP_packVoltage = 0;
+  int16_t HVP_fcLinkVoltage = 0;
+  uint16_t HVP_packContVoltage = 0;
+  int16_t HVP_packNegativeV = 0;
+  int16_t HVP_packPositiveV = 0;
+  uint16_t HVP_pyroAnalog = 0;
+  int16_t HVP_dcLinkNegativeV = 0;
+  int16_t HVP_dcLinkPositiveV = 0;
+  int16_t HVP_fcLinkNegativeV = 0;
+  uint16_t HVP_fcContCoilCurrent = 0;
+  uint16_t HVP_fcContVoltage = 0;
+  uint16_t HVP_hvilInVoltage = 0;
+  uint16_t HVP_hvilOutVoltage = 0;
+  int16_t HVP_fcLinkPositiveV = 0;
+  uint16_t HVP_packContCoilCurrent = 0;
+  uint16_t HVP_battery12V = 0;
+  int16_t HVP_shuntRefVoltageDbg = 0;
+  int16_t HVP_shuntAuxCurrentDbg = 0;
+  int16_t HVP_shuntBarTempDbg = 0;
+  int16_t HVP_shuntAsicTempDbg = 0;
+  uint8_t HVP_shuntAuxCurrentStatus = 0;
+  uint8_t HVP_shuntBarTempStatus = 0;
+  uint8_t HVP_shuntAsicTempStatus = 0;
+  //0x3aa: HVP_alertMatrix1 Fault codes   // Change to bool
+  bool battery_WatchdogReset = false;           //Warns if the processor has experienced a reset due to watchdog reset.
+  bool battery_PowerLossReset = false;          //Warns if the processor has experienced a reset due to power loss.
+  bool battery_SwAssertion = false;             //An internal software assertion has failed.
+  bool battery_CrashEvent = false;              //Warns if the crash signal is detected by HVP
+  bool battery_OverDchgCurrentFault = false;    //Warns if the pack discharge is above max discharge current limit
+  bool battery_OverChargeCurrentFault = false;  //Warns if the pack discharge current is above max charge current limit
+  bool battery_OverCurrentFault = false;  //Warns if the pack current (discharge or charge) is above max current limit.
+  bool battery_OverTemperatureFault = false;  //A pack module temperature is above maximum temperature limit
+  bool battery_OverVoltageFault = false;      //A brick voltage is above maximum voltage limit
+  bool battery_UnderVoltageFault = false;     //A brick voltage is below minimum voltage limit
+  bool battery_PrimaryBmbMiaFault =
+      false;  //Warns if the voltage and temperature readings from primary BMB chain are mia
+  bool battery_SecondaryBmbMiaFault =
+      false;  //Warns if the voltage and temperature readings from secondary BMB chain are mia
+  bool battery_BmbMismatchFault =
+      false;  //Warns if the primary and secondary BMB chain readings don't match with each other
+  bool battery_BmsHviMiaFault = false;   //Warns if the BMS node is mia on HVS or HVI CAN
+  bool battery_CpMiaFault = false;       //Warns if the CP node is mia on HVS CAN
+  bool battery_PcsMiaFault = false;      //The PCS node is mia on HVS CAN
+  bool battery_BmsFault = false;         //Warns if the BMS ECU has faulted
+  bool battery_PcsFault = false;         //Warns if the PCS ECU has faulted
+  bool battery_CpFault = false;          //Warns if the CP ECU has faulted
+  bool battery_ShuntHwMiaFault = false;  //Warns if the shunt current reading is not available
+  bool battery_PyroMiaFault = false;     //Warns if the pyro squib is not connected
+  bool battery_hvsMiaFault = false;      //Warns if the pack contactor hw fault
+  bool battery_hviMiaFault = false;      //Warns if the FC contactor hw fault
+  bool battery_Supply12vFault = false;   //Warns if the low voltage (12V) battery is below minimum voltage threshold
+  bool battery_VerSupplyFault = false;   //Warns if the Energy reserve voltage supply is below minimum voltage threshold
+  bool battery_HvilFault = false;        //Warn if a High Voltage Inter Lock fault is detected
+  bool battery_BmsHvsMiaFault = false;   //Warns if the BMS node is mia on HVS or HVI CAN
+  bool battery_PackVoltMismatchFault =
+      false;                         //Warns if the pack voltage doesn't match approximately with sum of brick voltages
+  bool battery_EnsMiaFault = false;  //Warns if the ENS line is not connected to HVC
+  bool battery_PackPosCtrArcFault = false;  //Warns if the HVP detectes series arc at pack contactor
+  bool battery_packNegCtrArcFault = false;  //Warns if the HVP detectes series arc at FC contactor
+  bool battery_ShuntHwAndBmsMiaFault = false;
+  bool battery_fcContHwFault = false;
+  bool battery_robinOverVoltageFault = false;
+  bool battery_packContHwFault = false;
+  bool battery_pyroFuseBlown = false;
+  bool battery_pyroFuseFailedToBlow = false;
+  bool battery_CpilFault = false;
+  bool battery_PackContactorFellOpen = false;
+  bool battery_FcContactorFellOpen = false;
+  bool battery_packCtrCloseBlocked = false;
+  bool battery_fcCtrCloseBlocked = false;
+  bool battery_packContactorForceOpen = false;
+  bool battery_fcContactorForceOpen = false;
+  bool battery_dcLinkOverVoltage = false;
+  bool battery_shuntOverTemperature = false;
+  bool battery_passivePyroDeploy = false;
+  bool battery_logUploadRequest = false;
+  bool battery_packCtrCloseFailed = false;
+  bool battery_fcCtrCloseFailed = false;
+  bool battery_shuntThermistorMia = false;
+  //0x320: 800 BMS_alertMatrix
+  uint8_t battery_BMS_matrixIndex = 0;  // Changed to bool
+  bool battery_BMS_a061_robinBrickOverVoltage = false;
+  bool battery_BMS_a062_SW_BrickV_Imbalance = false;
+  bool battery_BMS_a063_SW_ChargePort_Fault = false;
+  bool battery_BMS_a064_SW_SOC_Imbalance = false;
+  bool battery_BMS_a127_SW_shunt_SNA = false;
+  bool battery_BMS_a128_SW_shunt_MIA = false;
+  bool battery_BMS_a069_SW_Low_Power = false;
+  bool battery_BMS_a130_IO_CAN_Error = false;
+  bool battery_BMS_a071_SW_SM_TransCon_Not_Met = false;
+  bool battery_BMS_a132_HW_BMB_OTP_Uncorrctbl = false;
+  bool battery_BMS_a134_SW_Delayed_Ctr_Off = false;
+  bool battery_BMS_a075_SW_Chg_Disable_Failure = false;
+  bool battery_BMS_a076_SW_Dch_While_Charging = false;
+  bool battery_BMS_a017_SW_Brick_OV = false;
+  bool battery_BMS_a018_SW_Brick_UV = false;
+  bool battery_BMS_a019_SW_Module_OT = false;
+  bool battery_BMS_a021_SW_Dr_Limits_Regulation = false;
+  bool battery_BMS_a022_SW_Over_Current = false;
+  bool battery_BMS_a023_SW_Stack_OV = false;
+  bool battery_BMS_a024_SW_Islanded_Brick = false;
+  bool battery_BMS_a025_SW_PwrBalance_Anomaly = false;
+  bool battery_BMS_a026_SW_HFCurrent_Anomaly = false;
+  bool battery_BMS_a087_SW_Feim_Test_Blocked = false;
+  bool battery_BMS_a088_SW_VcFront_MIA_InDrive = false;
+  bool battery_BMS_a089_SW_VcFront_MIA = false;
+  bool battery_BMS_a090_SW_Gateway_MIA = false;
+  bool battery_BMS_a091_SW_ChargePort_MIA = false;
+  bool battery_BMS_a092_SW_ChargePort_Mia_On_Hv = false;
+  bool battery_BMS_a034_SW_Passive_Isolation = false;
+  bool battery_BMS_a035_SW_Isolation = false;
+  bool battery_BMS_a036_SW_HvpHvilFault = false;
+  bool battery_BMS_a037_SW_Flood_Port_Open = false;
+  bool battery_BMS_a158_SW_HVP_HVI_Comms = false;
+  bool battery_BMS_a039_SW_DC_Link_Over_Voltage = false;
+  bool battery_BMS_a041_SW_Power_On_Reset = false;
+  bool battery_BMS_a042_SW_MPU_Error = false;
+  bool battery_BMS_a043_SW_Watch_Dog_Reset = false;
+  bool battery_BMS_a044_SW_Assertion = false;
+  bool battery_BMS_a045_SW_Exception = false;
+  bool battery_BMS_a046_SW_Task_Stack_Usage = false;
+  bool battery_BMS_a047_SW_Task_Stack_Overflow = false;
+  bool battery_BMS_a048_SW_Log_Upload_Request = false;
+  bool battery_BMS_a169_SW_FC_Pack_Weld = false;
+  bool battery_BMS_a050_SW_Brick_Voltage_MIA = false;
+  bool battery_BMS_a051_SW_HVC_Vref_Bad = false;
+  bool battery_BMS_a052_SW_PCS_MIA = false;
+  bool battery_BMS_a053_SW_ThermalModel_Sanity = false;
+  bool battery_BMS_a054_SW_Ver_Supply_Fault = false;
+  bool battery_BMS_a176_SW_GracefulPowerOff = false;
+  bool battery_BMS_a059_SW_Pack_Voltage_Sensing = false;
+  bool battery_BMS_a060_SW_Leakage_Test_Failure = false;
+  bool battery_BMS_a077_SW_Charger_Regulation = false;
+  bool battery_BMS_a081_SW_Ctr_Close_Blocked = false;
+  bool battery_BMS_a082_SW_Ctr_Force_Open = false;
+  bool battery_BMS_a083_SW_Ctr_Close_Failure = false;
+  bool battery_BMS_a084_SW_Sleep_Wake_Aborted = false;
+  bool battery_BMS_a094_SW_Drive_Inverter_MIA = false;
+  bool battery_BMS_a099_SW_BMB_Communication = false;
+  bool battery_BMS_a105_SW_One_Module_Tsense = false;
+  bool battery_BMS_a106_SW_All_Module_Tsense = false;
+  bool battery_BMS_a107_SW_Stack_Voltage_MIA = false;
+  bool battery_BMS_a121_SW_NVRAM_Config_Error = false;
+  bool battery_BMS_a122_SW_BMS_Therm_Irrational = false;
+  bool battery_BMS_a123_SW_Internal_Isolation = false;
+  bool battery_BMS_a129_SW_VSH_Failure = false;
+  bool battery_BMS_a131_Bleed_FET_Failure = false;
+  bool battery_BMS_a136_SW_Module_OT_Warning = false;
+  bool battery_BMS_a137_SW_Brick_UV_Warning = false;
+  bool battery_BMS_a138_SW_Brick_OV_Warning = false;
+  bool battery_BMS_a139_SW_DC_Link_V_Irrational = false;
+  bool battery_BMS_a141_SW_BMB_Status_Warning = false;
+  bool battery_BMS_a144_Hvp_Config_Mismatch = false;
+  bool battery_BMS_a145_SW_SOC_Change = false;
+  bool battery_BMS_a146_SW_Brick_Overdischarged = false;
+  bool battery_BMS_a149_SW_Missing_Config_Block = false;
+  bool battery_BMS_a151_SW_external_isolation = false;
+  bool battery_BMS_a156_SW_BMB_Vref_bad = false;
+  bool battery_BMS_a157_SW_HVP_HVS_Comms = false;
+  bool battery_BMS_a159_SW_HVP_ECU_Error = false;
+  bool battery_BMS_a161_SW_DI_Open_Request = false;
+  bool battery_BMS_a162_SW_No_Power_For_Support = false;
+  bool battery_BMS_a163_SW_Contactor_Mismatch = false;
+  bool battery_BMS_a164_SW_Uncontrolled_Regen = false;
+  bool battery_BMS_a165_SW_Pack_Partial_Weld = false;
+  bool battery_BMS_a166_SW_Pack_Full_Weld = false;
+  bool battery_BMS_a167_SW_FC_Partial_Weld = false;
+  bool battery_BMS_a168_SW_FC_Full_Weld = false;
+  bool battery_BMS_a170_SW_Limp_Mode = false;
+  bool battery_BMS_a171_SW_Stack_Voltage_Sense = false;
+  bool battery_BMS_a174_SW_Charge_Failure = false;
+  bool battery_BMS_a179_SW_Hvp_12V_Fault = false;
+  bool battery_BMS_a180_SW_ECU_reset_blocked = false;
+};
+
+class Tesla3YBattery : public TeslaBattery {
+ public:
+  Tesla3YBattery() : TeslaBattery(Tesla3Y) {}
+  virtual void setup();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Tesla Model 3/Y";
+
+ protected:
+  virtual void detect_chemistry();
+};
+
+class TeslaSXBattery : public TeslaBattery {
+ public:
+  TeslaSXBattery() : TeslaBattery(TeslaSX) {}
+  virtual void setup();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Tesla Model S/X";
+};
 
 #endif

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -35,10 +35,6 @@ void printDebugIfActive(uint8_t symbol, const char* message);
 void print_int_with_units(char* header, int value, char* units);
 void print_SOC(char* header, int SOC);
 
-#ifdef DOUBLE_BATTERY
-void printFaultCodesIfActive_battery2();
-#endif  //DOUBLE_BATTERY
-
 // Base class for Tesla batteries
 class TeslaBattery : public CanBattery {
  public:
@@ -49,6 +45,11 @@ class TeslaBattery : public CanBattery {
  protected:
   TeslaBattery(BatteryType type) : CanBattery(type) {}
   virtual void detect_chemistry() {}
+
+  virtual void model_specific_transmit_can() {}
+
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
 
  private:
   void printFaultCodesIfActive();
@@ -507,6 +508,9 @@ class TeslaSXBattery : public TeslaBattery {
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Tesla Model S/X";
+
+ protected:
+  virtual void model_specific_transmit_can();
 };
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -24,113 +24,56 @@ static void print_units(char* header, int value, char* units) {
 void TestFakeBattery::
     update_values() { /* This function puts fake values onto the parameters sent towards the inverter */
 
-  datalayer.battery.status.real_soc = 5000;  // 50.00%
+  m_target->status.real_soc = 5000;  // 50.00%
 
-  datalayer.battery.status.soh_pptt = 9900;  // 99.00%
+  m_target->status.soh_pptt = 9900;  // 99.00%
 
-  //datalayer.battery.status.voltage_dV = 3700;  // 370.0V , value set in startup in .ino file, editable via webUI
+  //m_target->status.voltage_dV = 3700;  // 370.0V , value set in startup in .ino file, editable via webUI
 
-  datalayer.battery.status.current_dA = 0;  // 0 A
+  m_target->status.current_dA = 0;  // 0 A
 
-  datalayer.battery.info.total_capacity_Wh = 30000;  // 30kWh
+  m_target->info.total_capacity_Wh = 30000;  // 30kWh
 
-  datalayer.battery.status.remaining_capacity_Wh = 15000;  // 15kWh
+  m_target->status.remaining_capacity_Wh = 15000;  // 15kWh
 
-  datalayer.battery.status.cell_max_voltage_mV = 3596;
+  m_target->status.cell_max_voltage_mV = 3596;
 
-  datalayer.battery.status.cell_min_voltage_mV = 3500;
+  m_target->status.cell_min_voltage_mV = 3500;
 
-  datalayer.battery.status.temperature_min_dC = 50;  // 5.0*C
+  m_target->status.temperature_min_dC = 50;  // 5.0*C
 
-  datalayer.battery.status.temperature_max_dC = 60;  // 6.0*C
+  m_target->status.temperature_max_dC = 60;  // 6.0*C
 
-  datalayer.battery.status.max_discharge_power_W = 5000;  // 5kW
+  m_target->status.max_discharge_power_W = 5000;  // 5kW
 
-  datalayer.battery.status.max_charge_power_W = 5000;  // 5kW
+  m_target->status.max_charge_power_W = 5000;  // 5kW
 
   for (int i = 0; i < 97; ++i) {
-    datalayer.battery.status.cell_voltages_mV[i] = 3700 + random(-20, 21);
+    m_target->status.cell_voltages_mV[i] = 3700 + random(-20, 21);
   }
 
   //Fake that we get CAN messages
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 
-/*Finally print out values to serial if configured to do so*/
+  /*Finally print out values to serial if configured to do so*/
+  // TODO: Should distinguish battery 1 and 2
 #ifdef DEBUG_LOG
   logging.println("FAKE Values going to inverter");
-  print_units("SOH%: ", (datalayer.battery.status.soh_pptt * 0.01), "% ");
-  print_units(", SOC%: ", (datalayer.battery.status.reported_soc * 0.01), "% ");
-  print_units(", Voltage: ", (datalayer.battery.status.voltage_dV * 0.1), "V ");
-  print_units(", Max discharge power: ", datalayer.battery.status.max_discharge_power_W, "W ");
-  print_units(", Max charge power: ", datalayer.battery.status.max_charge_power_W, "W ");
-  print_units(", Max temp: ", (datalayer.battery.status.temperature_max_dC * 0.1), "°C ");
-  print_units(", Min temp: ", (datalayer.battery.status.temperature_min_dC * 0.1), "°C ");
-  print_units(", Max cell voltage: ", datalayer.battery.status.cell_max_voltage_mV, "mV ");
-  print_units(", Min cell voltage: ", datalayer.battery.status.cell_min_voltage_mV, "mV ");
+  print_units("SOH%: ", (m_target->status.soh_pptt * 0.01), "% ");
+  print_units(", SOC%: ", (m_target->status.reported_soc * 0.01), "% ");
+  print_units(", Voltage: ", (m_target->status.voltage_dV * 0.1), "V ");
+  print_units(", Max discharge power: ", m_target->status.max_discharge_power_W, "W ");
+  print_units(", Max charge power: ", m_target->status.max_charge_power_W, "W ");
+  print_units(", Max temp: ", (m_target->status.temperature_max_dC * 0.1), "°C ");
+  print_units(", Min temp: ", (m_target->status.temperature_min_dC * 0.1), "°C ");
+  print_units(", Max cell voltage: ", m_target->status.cell_max_voltage_mV, "mV ");
+  print_units(", Min cell voltage: ", m_target->status.cell_min_voltage_mV, "mV ");
   logging.println("");
 #endif
 }
-
-#ifdef DOUBLE_BATTERY
-
-void update_values_battery2() {  // Handle the values coming in from battery #2
-
-  datalayer.battery2.info.number_of_cells = 96;
-
-  datalayer.battery2.status.real_soc = 5000;  // 50.00%
-
-  datalayer.battery2.status.soh_pptt = 9900;  // 99.00%
-
-  //datalayer.battery.status.voltage_dV = 3700;  // 370.0V , value set in startup in .ino file, editable via webUI
-
-  datalayer.battery2.status.current_dA = 0;  // 0 A
-
-  datalayer.battery2.info.total_capacity_Wh = 30000;  // 30kWh
-
-  datalayer.battery2.status.remaining_capacity_Wh = 15000;  // 15kWh
-
-  datalayer.battery2.status.cell_max_voltage_mV = 3596;
-
-  datalayer.battery2.status.cell_min_voltage_mV = 3500;
-
-  datalayer.battery2.status.temperature_min_dC = 50;  // 5.0*C
-
-  datalayer.battery2.status.temperature_max_dC = 60;  // 6.0*C
-
-  datalayer.battery2.status.max_discharge_power_W = 5000;  // 5kW
-
-  datalayer.battery2.status.max_charge_power_W = 5000;  // 5kW
-
-  for (int i = 0; i < 97; ++i) {
-    datalayer.battery2.status.cell_voltages_mV[i] = 3700 + random(-20, 21);
-  }
-
-  //Fake that we get CAN messages
-  datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-
-/*Finally print out values to serial if configured to do so*/
-#ifdef DEBUG_LOG
-  logging.println("FAKE Values  battery 2 going to inverter");
-  print_units("SOH 2 %: ", (datalayer.battery2.status.soh_pptt * 0.01), "% ");
-  print_units(", SOC 2 %: ", (datalayer.battery2.status.reported_soc * 0.01), "% ");
-  print_units(", Voltage 2: ", (datalayer.battery2.status.voltage_dV * 0.1), "V ");
-  print_units(", Max discharge power 2: ", datalayer.battery2.status.max_discharge_power_W, "W ");
-  print_units(", Max charge power 2: ", datalayer.battery2.status.max_charge_power_W, "W ");
-  print_units(", Max temp 2: ", (datalayer.battery2.status.temperature_max_dC * 0.1), "°C ");
-  print_units(", Min temp 2: ", (datalayer.battery2.status.temperature_min_dC * 0.1), "°C ");
-  print_units(", Max cell voltage 2: ", datalayer.battery2.status.cell_max_voltage_mV, "mV ");
-  print_units(", Min cell voltage 2: ", datalayer.battery2.status.cell_min_voltage_mV, "mV ");
-  logging.println("");
-#endif
-}
-
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-}
-#endif  // DOUBLE_BATTERY
 
 void TestFakeBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  m_target->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
 
 void TestFakeBattery::transmit_can() {
@@ -139,18 +82,18 @@ void TestFakeBattery::transmit_can() {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
     // Put fake messages here incase you want to test sending CAN
-    //transmit_can_frame(&TEST, can_config.battery);
+    //transmit_can_frame(&TEST, m_can_interface);
   }
 }
 
 void TestFakeBattery::setup(void) {  // Performs one time setup at startup
   randomSeed(analogRead(0));
 
-  datalayer.battery.info.max_design_voltage_dV =
+  m_target->info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)
-  datalayer.battery.info.min_design_voltage_dV = 2450;  // 245.0V under this, discharging further is disabled
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  m_target->info.min_design_voltage_dV = 2450;  // 245.0V under this, discharging further is disabled
+  m_target->info.number_of_cells = 96;
+  allow_contactor_closing();
 }
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef TEST_FAKE_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "TEST-FAKE-BATTERY.h"
 
@@ -14,13 +15,14 @@ CAN_frame TEST = {.FD = false,
                   .ID = 0x123,
                   .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
 
-void print_units(char* header, int value, char* units) {
+static void print_units(char* header, int value, char* units) {
   logging.print(header);
   logging.print(value);
   logging.print(units);
 }
 
-void update_values_battery() { /* This function puts fake values onto the parameters sent towards the inverter */
+void TestFakeBattery::
+    update_values() { /* This function puts fake values onto the parameters sent towards the inverter */
 
   datalayer.battery.status.real_soc = 5000;  // 50.00%
 
@@ -127,10 +129,11 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 }
 #endif  // DOUBLE_BATTERY
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void TestFakeBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
-void transmit_can_battery() {
+
+void TestFakeBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -140,11 +143,8 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+void TestFakeBattery::setup(void) {  // Performs one time setup at startup
   randomSeed(analogRead(0));
-
-  strncpy(datalayer.system.info.battery_protocol, "Fake battery for testing purposes", 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
 
   datalayer.battery.info.max_design_voltage_dV =
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -1,5 +1,6 @@
 #ifndef TEST_FAKE_BATTERY_H
 #define TEST_FAKE_BATTERY_H
+#include "../datalayer/datalayer.h"
 #include "../include.h"
 
 #define BATTERY_SELECTED
@@ -7,13 +8,22 @@
 
 class TestFakeBattery : public CanBattery {
  public:
-  TestFakeBattery() : CanBattery(TestFake) {}
+  TestFakeBattery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface) : CanBattery(TestFake) {
+    m_target = target;
+    m_can_interface = can_interface;
+  }
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Fake battery for testing purposes";
+
+  virtual bool supportsDoubleBattery() { return true; };
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  DATALAYER_BATTERY_TYPE* m_target;
+  CAN_Interface m_can_interface;
 };
 
 #endif

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -5,7 +5,15 @@
 #define BATTERY_SELECTED
 #define MAX_CELL_DEVIATION_MV 9999
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class TestFakeBattery : public CanBattery {
+ public:
+  TestFakeBattery() : CanBattery(TestFake) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Fake battery for testing purposes";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -7,105 +7,9 @@
 #include "VOLVO-SPA-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis1s = 0;   // will store last time a 1s CAN Message was send
-static unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
 
-static float BATT_U = 0;                 //0x3A
-static float MAX_U = 0;                  //0x3A
-static float MIN_U = 0;                  //0x3A
-static float BATT_I = 0;                 //0x3A
-static int32_t CHARGE_ENERGY = 0;        //0x1A1
-static uint8_t BATT_ERR_INDICATION = 0;  //0x413
-static float BATT_T_MAX = 0;             //0x413
-static float BATT_T_MIN = 0;             //0x413
-static float BATT_T_AVG = 0;             //0x413
-static uint16_t SOC_BMS = 0;             //0X37D
-static uint16_t SOC_CALC = 0;
-static uint16_t CELL_U_MAX = 3700;            //0x37D
-static uint16_t CELL_U_MIN = 3700;            //0x37D
-static uint8_t CELL_ID_U_MAX = 0;             //0x37D
-static uint16_t HvBattPwrLimDchaSoft = 0;     //0x369
-static uint16_t HvBattPwrLimDcha1 = 0;        //0x175
-static uint16_t HvBattPwrLimDchaSlowAgi = 0;  //0x177
-static uint16_t HvBattPwrLimChrgSlowAgi = 0;  //0x177
-static uint8_t batteryModuleNumber = 0x10;    // First battery module
-static uint8_t battery_request_idx = 0;
-static uint8_t rxConsecutiveFrames = 0;
-static uint16_t min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint8_t cellcounter = 0;
-static uint16_t cell_voltages[108];  //array with all the cellvoltages
-static bool startedUp = false;
-static uint8_t DTC_reset_counter = 0;
-
-static CAN_frame VOLVO_536 = {.FD = false,
-                              .ext_ID = false,
-                              .DLC = 8,
-                              .ID = 0x536,
-                              //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-                              .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-
-static CAN_frame VOLVO_140_CLOSE = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x140,
-    .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
-
-static CAN_frame VOLVO_140_OPEN = {.FD = false,
-                                   .ext_ID = false,
-                                   .DLC = 8,
-                                   .ID = 0x140,
-                                   .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
-
-static CAN_frame VOLVO_372 = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x372,
-    .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
-static CAN_frame VOLVO_CELL_U_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0x4B, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame
-static CAN_frame VOLVO_FlowControl = {.FD = false,
-                                      .ext_ID = false,
-                                      .DLC = 8,
-                                      .ID = 0x735,
-                                      .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
-static CAN_frame VOLVO_SOH_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
-static CAN_frame VOLVO_BECMsupplyVoltage_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0xF4, 0x42, 0x00, 0x00, 0x00, 0x00}};  //BECM supply voltage request frame
-static CAN_frame VOLVO_DTC_Erase = {.FD = false,
-                                    .ext_ID = false,
-                                    .DLC = 8,
-                                    .ID = 0x7FF,
-                                    .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
-static CAN_frame VOLVO_BECM_ECUreset = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x02, 0x11, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BECM ECU reset command (reboot/powercycle BECM)
-static CAN_frame VOLVO_DTCreadout = {.FD = false,
-                                     .ext_ID = false,
-                                     .DLC = 8,
-                                     .ID = 0x7FF,
-                                     .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
-
-static void
-update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
+void VolvoSpaBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
   uint8_t cnt = 0;
 
   // Update webserver datalayer
@@ -232,7 +136,7 @@ update_values_battery() {  //This function maps all the values fetched via CAN t
 #endif
 }
 
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void VolvoSpaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
@@ -432,7 +336,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-static void readCellVoltages() {
+void VolvoSpaBattery::readCellVoltages() {
   battery_request_idx = 0;
   batteryModuleNumber = 0x10;
   rxConsecutiveFrames = 0;
@@ -440,7 +344,7 @@ static void readCellVoltages() {
   transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-static void transmit_can_battery() {
+void VolvoSpaBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -456,10 +360,10 @@ static void transmit_can_battery() {
     transmit_can_frame(&VOLVO_372, can_config.battery);  //Send 0x372 ECMAmbientTempCalculated
 
     if ((datalayer.battery.status.bms_status == ACTIVE) && startedUp) {
-      datalayer.system.status.battery_allows_contactor_closing = true;
+      allow_contactor_closing();
       transmit_can_frame(&VOLVO_140_CLOSE, can_config.battery);  //Send 0x140 Close contactors message
     } else {  //datalayer.battery.status.bms_status == FAULT , OR inverter requested opening contactors, OR system not started yet
-      datalayer.system.status.battery_allows_contactor_closing = false;
+      disallow_contactor_closing();
       transmit_can_frame(&VOLVO_140_OPEN, can_config.battery);  //Send 0x140 Open contactors message
     }
   }
@@ -482,7 +386,7 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {                    // Performs one time setup at startup
+void VolvoSpaBattery::setup(void) {                  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 0;        // Initializes when all cells have been read
   datalayer.battery.info.total_capacity_Wh = 78200;  //Startout in 78kWh mode (This value used for SOC calc)
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_108S_DV;  //Startout with max allowed range

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -21,6 +21,102 @@ class VolvoSpaBattery : public CanBattery {
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  void readCellVoltages();
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis1s = 0;   // will store last time a 1s CAN Message was send
+  unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
+
+  float BATT_U = 0;                 //0x3A
+  float MAX_U = 0;                  //0x3A
+  float MIN_U = 0;                  //0x3A
+  float BATT_I = 0;                 //0x3A
+  int32_t CHARGE_ENERGY = 0;        //0x1A1
+  uint8_t BATT_ERR_INDICATION = 0;  //0x413
+  float BATT_T_MAX = 0;             //0x413
+  float BATT_T_MIN = 0;             //0x413
+  float BATT_T_AVG = 0;             //0x413
+  uint16_t SOC_BMS = 0;             //0X37D
+  uint16_t SOC_CALC = 0;
+  uint16_t CELL_U_MAX = 3700;            //0x37D
+  uint16_t CELL_U_MIN = 3700;            //0x37D
+  uint8_t CELL_ID_U_MAX = 0;             //0x37D
+  uint16_t HvBattPwrLimDchaSoft = 0;     //0x369
+  uint16_t HvBattPwrLimDcha1 = 0;        //0x175
+  uint16_t HvBattPwrLimDchaSlowAgi = 0;  //0x177
+  uint16_t HvBattPwrLimChrgSlowAgi = 0;  //0x177
+  uint8_t batteryModuleNumber = 0x10;    // First battery module
+  uint8_t battery_request_idx = 0;
+  uint8_t rxConsecutiveFrames = 0;
+  uint16_t min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
+  uint8_t cellcounter = 0;
+  uint16_t cell_voltages[108];  //array with all the cellvoltages
+  bool startedUp = false;
+  uint8_t DTC_reset_counter = 0;
+
+  CAN_frame VOLVO_536 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x536,
+                         //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+                         .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+
+  CAN_frame VOLVO_140_CLOSE = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x140,
+                               .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
+
+  CAN_frame VOLVO_140_OPEN = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x140,
+                              .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
+
+  CAN_frame VOLVO_372 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x372,
+      .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
+  CAN_frame VOLVO_CELL_U_Req = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x735,
+                                .data = {0x03, 0x22, 0x4B, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame
+  CAN_frame VOLVO_FlowControl = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x735,
+                                 .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
+  CAN_frame VOLVO_SOH_Req = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x735,
+                             .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
+  CAN_frame VOLVO_BECMsupplyVoltage_Req = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x735,
+      .data = {0x03, 0x22, 0xF4, 0x42, 0x00, 0x00, 0x00, 0x00}};  //BECM supply voltage request frame
+  CAN_frame VOLVO_DTC_Erase = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7FF,
+                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
+  CAN_frame VOLVO_BECM_ECUreset = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x735,
+      .data = {0x02, 0x11, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BECM ECU reset command (reboot/powercycle BECM)
+  CAN_frame VOLVO_DTCreadout = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x7FF,
+                                .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
 };
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -12,7 +12,15 @@
 #define MAX_CELL_VOLTAGE_MV 4210  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class VolvoSpaBattery : public CanBattery {
+ public:
+  VolvoSpaBattery() : CanBattery(VolvoSpa) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Volvo / Polestar 69/78kWh SPA battery";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef VOLVO_SPA_HYBRID_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For "More battery info" webpage
 #include "../devboard/utils/events.h"
@@ -38,71 +39,74 @@ static uint16_t cell_voltages[102];  //array with all the cellvoltages
 static bool startedUp = false;
 static uint8_t DTC_reset_counter = 0;
 
-CAN_frame VOLVO_536 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x536,
-                       //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-                       .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+static CAN_frame VOLVO_536 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x536,
+                              //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+                              .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
 
-CAN_frame VOLVO_140_CLOSE = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x140,
-                             .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
+static CAN_frame VOLVO_140_CLOSE = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x140,
+    .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
 
-CAN_frame VOLVO_140_OPEN = {.FD = false,
-                            .ext_ID = false,
-                            .DLC = 8,
-                            .ID = 0x140,
-                            .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
+static CAN_frame VOLVO_140_OPEN = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 8,
+                                   .ID = 0x140,
+                                   .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
 
-CAN_frame VOLVO_372 = {
+static CAN_frame VOLVO_372 = {
     .FD = false,
     .ext_ID = false,
     .DLC = 8,
     .ID = 0x372,
     .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
-CAN_frame VOLVO_CELL_U_Req = {
+static CAN_frame VOLVO_CELL_U_Req = {
     .FD = false,
     .ext_ID = false,
     .DLC = 8,
     .ID = 0x735,
     .data = {0x03, 0x22, 0x48, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame // changed
-CAN_frame VOLVO_FlowControl = {.FD = false,
-                               .ext_ID = false,
-                               .DLC = 8,
-                               .ID = 0x735,
-                               .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
-CAN_frame VOLVO_SOH_Req = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x735,
-                           .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
-CAN_frame VOLVO_BECMsupplyVoltage_Req = {
+static CAN_frame VOLVO_FlowControl = {.FD = false,
+                                      .ext_ID = false,
+                                      .DLC = 8,
+                                      .ID = 0x735,
+                                      .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
+static CAN_frame VOLVO_SOH_Req = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x735,
+    .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
+static CAN_frame VOLVO_BECMsupplyVoltage_Req = {
     .FD = false,
     .ext_ID = false,
     .DLC = 8,
     .ID = 0x735,
     .data = {0x03, 0x22, 0xF4, 0x42, 0x00, 0x00, 0x00, 0x00}};  //BECM supply voltage request frame
-CAN_frame VOLVO_DTC_Erase = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x7FF,
-                             .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
-CAN_frame VOLVO_BECM_ECUreset = {
+static CAN_frame VOLVO_DTC_Erase = {.FD = false,
+                                    .ext_ID = false,
+                                    .DLC = 8,
+                                    .ID = 0x7FF,
+                                    .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
+static CAN_frame VOLVO_BECM_ECUreset = {
     .FD = false,
     .ext_ID = false,
     .DLC = 8,
     .ID = 0x735,
     .data = {0x02, 0x11, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BECM ECU reset command (reboot/powercycle BECM)
-CAN_frame VOLVO_DTCreadout = {.FD = false,
-                              .ext_ID = false,
-                              .DLC = 8,
-                              .ID = 0x7FF,
-                              .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
+static CAN_frame VOLVO_DTCreadout = {.FD = false,
+                                     .ext_ID = false,
+                                     .DLC = 8,
+                                     .ID = 0x7FF,
+                                     .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
+static void
+update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
   uint8_t cnt = 0;
 
   // Update webserver datalayer
@@ -213,7 +217,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
 #endif
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
@@ -602,7 +606,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void readCellVoltages() {
+static void readCellVoltages() {
   battery_request_idx = 0;
   //batteryModuleNumber = 0x10;
   rxConsecutiveFrames = 0;
@@ -610,7 +614,7 @@ void readCellVoltages() {
   transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-void transmit_can_battery() {
+static void transmit_can_battery() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -655,9 +659,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {                                                    // Performs one time setup at startup
-  strncpy(datalayer.system.info.battery_protocol, "Volvo PHEV battery", 63);  //changed
-  datalayer.system.info.battery_protocol[63] = '\0';
+static void setup_battery(void) {                // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 102;  //was 108, changed
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -7,106 +7,9 @@
 #include "VOLVO-SPA-HYBRID-BATTERY.h"
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis1s = 0;   // will store last time a 1s CAN Message was send
-static unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
 
-static float BATT_U = 0;                 //0x3A
-static float MAX_U = 0;                  //0x3A
-static float MIN_U = 0;                  //0x3A
-static float BATT_I = 0;                 //0x3A
-static int32_t CHARGE_ENERGY = 0;        //0x1A1
-static uint8_t BATT_ERR_INDICATION = 0;  //0x413
-static float BATT_T_MAX = 0;             //0x413
-static float BATT_T_MIN = 0;             //0x413
-static float BATT_T_AVG = 0;             //0x413
-static uint16_t SOC_BMS = 0;             //0X37D
-static uint16_t SOC_CALC = 0;
-static uint16_t CELL_U_MAX = 3700;         //0x37D
-static uint16_t CELL_U_MIN = 3700;         //0x37D
-static uint8_t CELL_ID_U_MAX = 0;          //0x37D
-static uint16_t HvBattPwrLimDchaSoft = 0;  //0x369
-static uint16_t HvBattPwrLimDcha1 = 0;     //0x175
-//static uint16_t HvBattPwrLimDchaSlowAgi = 0;  //0x177
-//static uint16_t HvBattPwrLimChrgSlowAgi = 0;  //0x177
-//static uint8_t batteryModuleNumber = 0x10;    // First battery module
-static uint8_t battery_request_idx = 0;
-static uint8_t rxConsecutiveFrames = 0;
-static uint16_t min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint8_t cellcounter = 0;
-static uint32_t remaining_capacity = 0;
-static uint16_t cell_voltages[102];  //array with all the cellvoltages
-static bool startedUp = false;
-static uint8_t DTC_reset_counter = 0;
-
-static CAN_frame VOLVO_536 = {.FD = false,
-                              .ext_ID = false,
-                              .DLC = 8,
-                              .ID = 0x536,
-                              //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-                              .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
-
-static CAN_frame VOLVO_140_CLOSE = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x140,
-    .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
-
-static CAN_frame VOLVO_140_OPEN = {.FD = false,
-                                   .ext_ID = false,
-                                   .DLC = 8,
-                                   .ID = 0x140,
-                                   .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
-
-static CAN_frame VOLVO_372 = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x372,
-    .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
-static CAN_frame VOLVO_CELL_U_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0x48, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame // changed
-static CAN_frame VOLVO_FlowControl = {.FD = false,
-                                      .ext_ID = false,
-                                      .DLC = 8,
-                                      .ID = 0x735,
-                                      .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
-static CAN_frame VOLVO_SOH_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
-static CAN_frame VOLVO_BECMsupplyVoltage_Req = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x03, 0x22, 0xF4, 0x42, 0x00, 0x00, 0x00, 0x00}};  //BECM supply voltage request frame
-static CAN_frame VOLVO_DTC_Erase = {.FD = false,
-                                    .ext_ID = false,
-                                    .DLC = 8,
-                                    .ID = 0x7FF,
-                                    .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
-static CAN_frame VOLVO_BECM_ECUreset = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 8,
-    .ID = 0x735,
-    .data = {0x02, 0x11, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BECM ECU reset command (reboot/powercycle BECM)
-static CAN_frame VOLVO_DTCreadout = {.FD = false,
-                                     .ext_ID = false,
-                                     .DLC = 8,
-                                     .ID = 0x7FF,
-                                     .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
-
-static void
-update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
+void VolvoSpaHybridBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for the inverter
   uint8_t cnt = 0;
 
   // Update webserver datalayer
@@ -217,7 +120,7 @@ update_values_battery() {  //This function maps all the values fetched via CAN t
 #endif
 }
 
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void VolvoSpaHybridBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
@@ -606,7 +509,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-static void readCellVoltages() {
+void VolvoSpaHybridBattery::readCellVoltages() {
   battery_request_idx = 0;
   //batteryModuleNumber = 0x10;
   rxConsecutiveFrames = 0;
@@ -614,7 +517,7 @@ static void readCellVoltages() {
   transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-static void transmit_can_battery() {
+void VolvoSpaHybridBattery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -630,10 +533,10 @@ static void transmit_can_battery() {
     transmit_can_frame(&VOLVO_372, can_config.battery);  //Send 0x372 ECMAmbientTempCalculated
 
     if ((datalayer.battery.status.bms_status == ACTIVE) && startedUp) {
-      datalayer.system.status.battery_allows_contactor_closing = true;
+      allow_contactor_closing();
       //transmit_can_frame(&VOLVO_140_CLOSE, can_config.battery);  //Send 0x140 Close contactors message
     } else {  //datalayer.battery.status.bms_status == FAULT , OR inverter requested opening contactors, OR system not started yet
-      datalayer.system.status.battery_allows_contactor_closing = false;
+      disallow_contactor_closing();
       transmit_can_frame(&VOLVO_140_OPEN, can_config.battery);  //Send 0x140 Open contactors message
     }
   }
@@ -659,7 +562,7 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {                // Performs one time setup at startup
+void VolvoSpaHybridBattery::setup(void) {        // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 102;  //was 108, changed
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
@@ -19,6 +19,104 @@ class VolvoSpaHybridBattery : public CanBattery {
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+ private:
+  void readCellVoltages();
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis1s = 0;   // will store last time a 1s CAN Message was send
+  unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
+
+  float BATT_U = 0;                 //0x3A
+  float MAX_U = 0;                  //0x3A
+  float MIN_U = 0;                  //0x3A
+  float BATT_I = 0;                 //0x3A
+  int32_t CHARGE_ENERGY = 0;        //0x1A1
+  uint8_t BATT_ERR_INDICATION = 0;  //0x413
+  float BATT_T_MAX = 0;             //0x413
+  float BATT_T_MIN = 0;             //0x413
+  float BATT_T_AVG = 0;             //0x413
+  uint16_t SOC_BMS = 0;             //0X37D
+  uint16_t SOC_CALC = 0;
+  uint16_t CELL_U_MAX = 3700;         //0x37D
+  uint16_t CELL_U_MIN = 3700;         //0x37D
+  uint8_t CELL_ID_U_MAX = 0;          //0x37D
+  uint16_t HvBattPwrLimDchaSoft = 0;  //0x369
+  uint16_t HvBattPwrLimDcha1 = 0;     //0x175
+  //uint16_t HvBattPwrLimDchaSlowAgi = 0;  //0x177
+  //uint16_t HvBattPwrLimChrgSlowAgi = 0;  //0x177
+  //uint8_t batteryModuleNumber = 0x10;    // First battery module
+  uint8_t battery_request_idx = 0;
+  uint8_t rxConsecutiveFrames = 0;
+  uint16_t min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
+  uint8_t cellcounter = 0;
+  uint32_t remaining_capacity = 0;
+  uint16_t cell_voltages[102];  //array with all the cellvoltages
+  bool startedUp = false;
+  uint8_t DTC_reset_counter = 0;
+
+  CAN_frame VOLVO_536 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x536,
+                         //.data = {0x00, 0x40, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+                         .data = {0x00, 0x40, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00}};  //Network manage frame
+
+  CAN_frame VOLVO_140_CLOSE = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x140,
+                               .data = {0x00, 0x02, 0x00, 0xB7, 0xFF, 0x03, 0xFF, 0x82}};  //Close contactors message
+
+  CAN_frame VOLVO_140_OPEN = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x140,
+                              .data = {0x00, 0x02, 0x00, 0x9E, 0xFF, 0x03, 0xFF, 0x82}};  //Open contactor message
+
+  CAN_frame VOLVO_372 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x372,
+      .data = {0x00, 0xA6, 0x07, 0x14, 0x04, 0x00, 0x80, 0x00}};  //Ambient Temp -->>VERIFY this data content!!!<<--
+  CAN_frame VOLVO_CELL_U_Req = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x735,
+      .data = {0x03, 0x22, 0x48, 0x06, 0x00, 0x00, 0x00, 0x00}};  //Cell voltage request frame // changed
+  CAN_frame VOLVO_FlowControl = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x735,
+                                 .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Flowcontrol
+  CAN_frame VOLVO_SOH_Req = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x735,
+                             .data = {0x03, 0x22, 0x49, 0x6D, 0x00, 0x00, 0x00, 0x00}};  //Battery SOH request frame
+  CAN_frame VOLVO_BECMsupplyVoltage_Req = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x735,
+      .data = {0x03, 0x22, 0xF4, 0x42, 0x00, 0x00, 0x00, 0x00}};  //BECM supply voltage request frame
+  CAN_frame VOLVO_DTC_Erase = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7FF,
+                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //Global DTC erase
+  CAN_frame VOLVO_BECM_ECUreset = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x735,
+      .data = {0x02, 0x11, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BECM ECU reset command (reboot/powercycle BECM)
+  CAN_frame VOLVO_DTCreadout = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x7FF,
+                                .data = {0x02, 0x19, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Global DTC readout
 };
 
 #endif

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
@@ -10,7 +10,15 @@
 #define MAX_CELL_VOLTAGE_MV 4210  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class VolvoSpaHybridBattery : public CanBattery {
+ public:
+  VolvoSpaHybridBattery() : CanBattery(VolvoSpaHybrid) {}
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Volvo PHEV battery";
+  virtual void setup();
+  virtual void update_values();
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -2,7 +2,9 @@
 #define CHARGERS_H
 #include "../../USER_SETTINGS.h"
 
-enum class ChargerType { ChevyVolt, NissanLeaf };
+#include "../devboard/utils/types.h"
+
+enum class ChargerType { None = 0, ChevyVolt = 1, NissanLeaf = 2, HighestCharger = 3 };
 
 class Charger {
  public:
@@ -11,12 +13,19 @@ class Charger {
   ChargerType type() { return m_type; }
   virtual const char* name() = 0;
 
+  static const char* name_for_type(ChargerType type);
+
  protected:
   Charger(ChargerType type) : m_type(type) {}
   ChargerType m_type;
 };
 
 extern Charger* charger;
+
+Charger* init_charger(ChargerType type);
+
+std::vector<ChargerType> supported_charger_types();
+extern ChargerType userSelectedChargerType;
 
 #ifdef BUILD_EM_ALL
 #define CHEVYVOLT_CHARGER

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -2,6 +2,26 @@
 #define CHARGERS_H
 #include "../../USER_SETTINGS.h"
 
+enum class ChargerType { ChevyVolt, NissanLeaf };
+
+class Charger {
+ public:
+  virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame) = 0;
+  virtual void transmit_can() = 0;
+  ChargerType type() { return m_type; }
+
+ protected:
+  Charger(ChargerType type) : m_type(type) {}
+  ChargerType m_type;
+};
+
+extern Charger* charger;
+
+#ifdef BUILD_EM_ALL
+#define CHEVYVOLT_CHARGER
+#define NISSANLEAF_CHARGER
+#endif
+
 #ifdef CHEVYVOLT_CHARGER
 #include "CHEVY-VOLT-CHARGER.h"
 #endif
@@ -9,8 +29,5 @@
 #ifdef NISSANLEAF_CHARGER
 #include "NISSAN-LEAF-CHARGER.h"
 #endif
-
-void map_can_frame_to_variable_charger(CAN_frame rx_frame);
-void transmit_can_charger();
 
 #endif

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -9,6 +9,7 @@ class Charger {
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame) = 0;
   virtual void transmit_can() = 0;
   ChargerType type() { return m_type; }
+  virtual const char* name() = 0;
 
  protected:
   Charger(ChargerType type) : m_type(type) {}

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "CHEVY-VOLT-CHARGER.h"
 
+#include "../communication/can/comm_can.h"
+
 /* This implements Chevy Volt / Ampera charger support (2011-2015 model years).
  *
  * This code is intended to facilitate battery charging while repurposing inverters
@@ -41,7 +43,7 @@ static CAN_frame charger_set_targets = {
     .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a static value, meaning unknown
 
 /* We are mostly sending out not receiving */
-void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
+void ChevyVoltCharger::map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   uint16_t charger_stat_HVcur_temp = 0;
   uint16_t charger_stat_HVvol_temp = 0;
   uint16_t charger_stat_LVcur_temp = 0;
@@ -98,7 +100,7 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_charger() {
+void ChevyVoltCharger::transmit_can() {
   unsigned long currentMillis = millis();
   uint16_t Vol_temp = 0;
 

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -19,6 +19,8 @@ class ChevyVoltCharger : Charger {
  public:
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Chevy Volt Gen1 Charger";
 };
 
 #endif

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -15,8 +15,9 @@
 #define CHEVYVOLT_MAX_AMP 11.5
 #define CHEVYVOLT_MAX_POWER 3300
 
-class ChevyVoltCharger : Charger {
+class ChevyVoltCharger : public Charger {
  public:
+  ChevyVoltCharger() : Charger(ChargerType::ChevyVolt) {}
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
   virtual const char* name() { return Name; };

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -15,4 +15,10 @@
 #define CHEVYVOLT_MAX_AMP 11.5
 #define CHEVYVOLT_MAX_POWER 3300
 
+class ChevyVoltCharger : Charger {
+ public:
+  virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
+
 #endif

--- a/Software/src/charger/Chargers.cpp
+++ b/Software/src/charger/Chargers.cpp
@@ -1,0 +1,49 @@
+#include "CHARGERS.h"
+
+ChargerType userSelectedChargerType = ChargerType::None;
+
+Charger* init_charger(ChargerType type) {
+  switch (type) {
+#ifdef CHEVYVOLT_CHARGER
+    case ChargerType::ChevyVolt:
+      return new ChevyVoltCharger();
+#endif
+#ifdef NISSANLEAF_CHARGER
+    case ChargerType::NissanLeaf:
+      return new NissanLeafCharger();
+#endif
+    default:
+      return nullptr;
+  }
+}
+
+const char* Charger::name_for_type(ChargerType type) {
+  switch (type) {
+    case ChargerType::None:
+      return "None";
+#ifdef CHEVYVOLT_CHARGER
+    case ChargerType::ChevyVolt:
+      return ChevyVoltCharger::Name;
+#endif
+#ifdef NISSANLEAF_CHARGER
+    case ChargerType::NissanLeaf:
+      return NissanLeafCharger::Name;
+#endif
+    default:
+      return nullptr;
+  }
+}
+
+std::vector<ChargerType> supported_charger_types() {
+  std::vector<ChargerType> types;
+
+  // Also allow None = 0 to be selected
+  for (int i = 0; i < static_cast<int>(ChargerType::HighestCharger); i++) {
+    auto type = static_cast<ChargerType>(i);
+    if (Charger::name_for_type(type) != nullptr) {
+      types.push_back(type);
+    }
+  }
+
+  return types;
+}

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -5,8 +5,10 @@
 
 #define CHARGER_SELECTED
 
-class NissanLeafCharger : Charger {
+class NissanLeafCharger : public Charger {
  public:
+  NissanLeafCharger() : Charger(ChargerType::NissanLeaf) {}
+
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
   virtual const char* name() { return Name; };

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -5,4 +5,10 @@
 
 #define CHARGER_SELECTED
 
+class NissanLeafCharger : Charger {
+ public:
+  virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
+  virtual void transmit_can();
+};
+
 #endif

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -9,6 +9,8 @@ class NissanLeafCharger : Charger {
  public:
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Nissan LEAF 2013-2024 PDM charger";
 };
 
 #endif

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -297,13 +297,11 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
     ISA_handleFrame(rx_frame);
 #endif
   }
+  if (interface == can_config.battery_double && battery2) {
+    battery2->handle_incoming_can_frame(*rx_frame);
+  }
   if (interface == can_config.inverter && inverter) {
     inverter->map_can_frame_to_variable_inverter(*rx_frame);
-  }
-  if (interface == can_config.battery_double) {
-#ifdef DOUBLE_BATTERY
-    handle_incoming_can_frame_battery2(*rx_frame);
-#endif
   }
   if (interface == can_config.charger && charger) {
     charger->map_can_frame_to_variable_charger(*rx_frame);

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -291,13 +291,13 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
   }
 #endif
 
-  if (interface == can_config.battery) {
+  if (interface == can_config.battery && battery) {
     battery->handle_incoming_can_frame(*rx_frame);
 #ifdef CHADEMO_BATTERY
     ISA_handleFrame(rx_frame);
 #endif
   }
-  if (interface == can_config.inverter) {
+  if (interface == can_config.inverter && inverter) {
     inverter->map_can_frame_to_variable_inverter(*rx_frame);
   }
   if (interface == can_config.battery_double) {
@@ -305,10 +305,8 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
     handle_incoming_can_frame_battery2(*rx_frame);
 #endif
   }
-  if (interface == can_config.charger) {
-#ifdef CHARGER_SELECTED
-    map_can_frame_to_variable_charger(*rx_frame);
-#endif
+  if (interface == can_config.charger && charger) {
+    charger->map_can_frame_to_variable_charger(*rx_frame);
   }
   if (interface == can_config.shunt) {
 #ifdef CAN_SHUNT_SELECTED

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -1,6 +1,8 @@
 #include "comm_can.h"
 #include "../../include.h"
+#include "src/battery/Battery.h"
 #include "src/devboard/sdcard/sdcard.h"
+#include "src/inverter/Inverter.h"
 
 // Parameters
 
@@ -105,28 +107,6 @@ void init_CAN() {
 }
 
 // Transmit functions
-void transmit_can() {
-  if (!allowed_to_send_CAN) {
-    return;  //Global block of CAN messages
-  }
-
-#ifndef RS485_BATTERY_SELECTED
-  transmit_can_battery();
-#endif
-
-#ifdef CAN_INVERTER_SELECTED
-  transmit_can_inverter();
-#endif  // CAN_INVERTER_SELECTED
-
-#ifdef CHARGER_SELECTED
-  transmit_can_charger();
-#endif  // CHARGER_SELECTED
-
-#ifdef CAN_SHUNT_SELECTED
-  transmit_can_shunt();
-#endif  // CAN_SHUNT_SELECTED
-}
-
 void transmit_can_frame(CAN_frame* tx_frame, int interface) {
   if (!allowed_to_send_CAN) {
     return;
@@ -312,17 +292,13 @@ void map_can_frame_to_variable(CAN_frame* rx_frame, int interface) {
 #endif
 
   if (interface == can_config.battery) {
-#ifndef RS485_BATTERY_SELECTED
-    handle_incoming_can_frame_battery(*rx_frame);
-#endif
+    battery->handle_incoming_can_frame(*rx_frame);
 #ifdef CHADEMO_BATTERY
     ISA_handleFrame(rx_frame);
 #endif
   }
   if (interface == can_config.inverter) {
-#ifdef CAN_INVERTER_SELECTED
-    map_can_frame_to_variable_inverter(*rx_frame);
-#endif
+    inverter->map_can_frame_to_variable_inverter(*rx_frame);
   }
   if (interface == can_config.battery_double) {
 #ifdef DOUBLE_BATTERY

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -15,6 +15,8 @@
 #include "../../lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h"
 #endif  //CANFD_ADDON
 
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 void dump_can_frame(CAN_frame& frame, frameDirection msgDir);
 
 /**

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -156,8 +156,8 @@ void handle_contactors() {
     set(POSITIVE_CONTACTOR_PIN, OFF, PWM_OFF_DUTY);
     datalayer.system.status.contactors_engaged = false;
 
-    if (datalayer.system.status.battery_allows_contactor_closing &&
-        datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.settings.equipment_stop_active) {
+    if (battery->contactor_closing_allowed() && datalayer.system.status.inverter_allows_contactor_closing &&
+        !datalayer.system.settings.equipment_stop_active) {
       contactorStatus = START_PRECHARGE;
     }
   }
@@ -225,14 +225,16 @@ void handle_contactors() {
 
 #ifdef CONTACTOR_CONTROL_DOUBLE_BATTERY
 void handle_contactors_battery2() {
-  if ((contactorStatus == COMPLETED) && datalayer.system.status.battery2_allows_contactor_closing) {
-    set(SECOND_NEGATIVE_CONTACTOR_PIN, ON);
-    set(SECOND_POSITIVE_CONTACTOR_PIN, ON);
-    datalayer.system.status.contactors_battery2_engaged = true;
-  } else {  // Closing contactors on secondary battery not allowed
-    set(SECOND_NEGATIVE_CONTACTOR_PIN, OFF);
-    set(SECOND_POSITIVE_CONTACTOR_PIN, OFF);
-    datalayer.system.status.contactors_battery2_engaged = false;
+  if (battery2) {
+    if ((contactorStatus == COMPLETED) && battery2->contactor_closing_allowed()) {
+      set(SECOND_NEGATIVE_CONTACTOR_PIN, ON);
+      set(SECOND_POSITIVE_CONTACTOR_PIN, ON);
+      datalayer.system.status.contactors_battery2_engaged = true;
+    } else {  // Closing contactors on secondary battery not allowed
+      set(SECOND_NEGATIVE_CONTACTOR_PIN, OFF);
+      set(SECOND_POSITIVE_CONTACTOR_PIN, OFF);
+      datalayer.system.status.contactors_battery2_engaged = false;
+    }
   }
 }
 #endif  // CONTACTOR_CONTROL_DOUBLE_BATTERY

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -34,7 +34,7 @@ State contactorStatus = DISCONNECTED;
 #define PWM_ON_DUTY 1023
 #define PWM_Positive_Channel 0
 #define PWM_Negative_Channel 1
-unsigned long prechargeStartTime = 0;
+static unsigned long prechargeStartTime = 0;
 unsigned long negativeStartTime = 0;
 unsigned long prechargeCompletedTime = 0;
 unsigned long timeSpentInFaultedMode = 0;

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -68,6 +68,15 @@ void init_stored_settings() {
   if (temp != 0) {
     datalayer.battery.settings.max_user_set_discharge_voltage_dV = temp;
   }
+  temp = settings.getInt("Inverter", 0);
+  if (temp > 0) {
+    userSelectedInverter = (InverterProtocolType)temp;
+  }
+  temp = settings.getInt("Battery", 0);
+  if (temp > 0) {
+    userSelectedBatteryType = (BatteryType)temp;
+  }
+
   datalayer.battery.settings.user_set_voltage_limits_active = settings.getBool("USEVOLTLIMITS", false);
   settings.end();
 }
@@ -121,5 +130,9 @@ void store_settings() {
   if (!settings.putUInt("TARGETDISCHVOLT", datalayer.battery.settings.max_user_set_discharge_voltage_dV)) {
     set_event(EVENT_PERSISTENT_SAVE_INFO, 11);
   }
+
+  settings.putInt("Inverter", (int)userSelectedInverter);
+  settings.putInt("Battery", (int)userSelectedBatteryType);
+
   settings.end();  // Close preferences handle
 }

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -76,6 +76,10 @@ void init_stored_settings() {
   if (temp > 0) {
     userSelectedBatteryType = (BatteryType)temp;
   }
+  temp = settings.getInt("Charger", 0);
+  if (temp > 0) {
+    userSelectedChargerType = (ChargerType)temp;
+  }
   temp = settings.getBool("DoubleBattery", false);
   secondBatteryInUse = temp;
 
@@ -135,6 +139,7 @@ void store_settings() {
 
   settings.putInt("Inverter", (int)userSelectedInverter);
   settings.putInt("Battery", (int)userSelectedBatteryType);
+  settings.putInt("Charger", (int)userSelectedChargerType);
   settings.putBool("DoubleBattery", secondBatteryInUse);
 
   settings.end();  // Close preferences handle

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -76,6 +76,8 @@ void init_stored_settings() {
   if (temp > 0) {
     userSelectedBatteryType = (BatteryType)temp;
   }
+  temp = settings.getBool("DoubleBattery", false);
+  secondBatteryInUse = temp;
 
   datalayer.battery.settings.user_set_voltage_limits_active = settings.getBool("USEVOLTLIMITS", false);
   settings.end();
@@ -133,6 +135,7 @@ void store_settings() {
 
   settings.putInt("Inverter", (int)userSelectedInverter);
   settings.putInt("Battery", (int)userSelectedBatteryType);
+  settings.putBool("DoubleBattery", secondBatteryInUse);
 
   settings.end();  // Close preferences handle
 }

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -122,7 +122,7 @@ void handle_precharge_control() {
         set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);
 
         // Add event
-      } else if (datalayer.system.status.battery_allows_contactor_closing) {
+      } else if (battery->contactor_closing_allowed()) {
         pinMode(PRECHARGE_PIN, OUTPUT);
         digitalWrite(PRECHARGE_PIN, LOW);
         digitalWrite(POSITIVE_CONTACTOR_PIN, LOW);
@@ -143,8 +143,7 @@ void handle_precharge_control() {
       break;
 
     case AUTO_PRECHARGE_OFF:
-      if (!datalayer.system.status.battery_allows_contactor_closing ||
-          !datalayer.system.status.inverter_allows_contactor_closing ||
+      if (!battery->contactor_closing_allowed() || !datalayer.system.status.inverter_allows_contactor_closing ||
           datalayer.system.settings.equipment_stop_active || datalayer.battery.status.bms_status != FAULT) {
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_IDLE;
         pinMode(PRECHARGE_PIN, OUTPUT);

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -16,7 +16,7 @@
 #define PWM_OFF_DUTY 0
 
 #define PWM_Precharge_Channel 0
-unsigned long prechargeStartTime = 0;
+static unsigned long prechargeStartTime = 0;
 static uint32_t freq = Precharge_default_PWM_Freq;
 uint16_t delta_freq = 1;
 static int32_t prev_external_voltage = 20000;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -219,10 +219,6 @@ typedef struct {
   /** ESP32 main CPU temperature, for displaying on webserver and for safeties */
   float CPU_temperature = 0;
   /** array with type of battery used, for displaying on webserver */
-  char battery_protocol[64] = {0};
-  /** array with type of inverter protocol used, for displaying on webserver */
-  char inverter_protocol[64] = {0};
-  /** array with type of battery used, for displaying on webserver */
   char shunt_protocol[64] = {0};
   /** array with type of inverter brand used, for displaying on webserver */
   char inverter_brand[8] = {0};

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -1,7 +1,11 @@
 #ifndef _DATALAYER_H_
 #define _DATALAYER_H_
 
-#include "../include.h"
+//#include "../include.h"
+
+#include "../devboard/utils/types.h"
+#include "../system_settings.h"
+#include "USER_SETTINGS.h"
 
 typedef struct {
   /** uint32_t */
@@ -291,10 +295,6 @@ typedef struct {
    * we report the inverter as missing entirely on the CAN bus.
    */
   uint8_t CAN_inverter_still_alive = CAN_STILL_ALIVE;
-  /** True if the battery allows for the contactors to close */
-  bool battery_allows_contactor_closing = false;
-  /** True if the second battery allows for the contactors to close */
-  bool battery2_allows_contactor_closing = false;
   /** True if the inverter allows for the contactors to close */
   bool inverter_allows_contactor_closing = true;
 #ifdef CONTACTOR_CONTROL

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -281,7 +281,6 @@ typedef struct {
   uint8_t batteryManagementMode = 0;
   uint8_t BMS_ign = 0;
   uint8_t batteryRelay = 0;
-#ifdef DOUBLE_BATTERY
   uint8_t battery2_total_cell_count = 0;
   int16_t battery2_battery_12V = 0;
   uint8_t battery2_waterleakageSensor = 0;
@@ -290,7 +289,6 @@ typedef struct {
   uint8_t battery2_batteryManagementMode = 0;
   uint8_t battery2_BMS_ign = 0;
   uint8_t battery2_batteryRelay = 0;
-#endif  //DOUBLE BATTERY
 } DATALAYER_INFO_KIAHYUNDAI64;
 
 typedef struct {

--- a/Software/src/devboard/hal/hw_3LB.h
+++ b/Software/src/devboard/hal/hw_3LB.h
@@ -107,6 +107,8 @@
 #endif
 #endif
 
+// TODO: Implement the following GPIO checks at runtime
+
 #ifdef BMW_I3_BATTERY
 #if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
 #error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL

--- a/Software/src/devboard/hal/hw_3LB.h
+++ b/Software/src/devboard/hal/hw_3LB.h
@@ -75,12 +75,8 @@
 #define EQUIPMENT_STOP_PIN 35
 
 // BMW_I3_BATTERY wake up pin
-#ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
-#ifdef DOUBLE_BATTERY
 #define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
-#endif                        // DOUBLE_BATTERY
-#endif                        // BMW_I3_BATTERY
 
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED

--- a/Software/src/devboard/hal/hw_devkit.h
+++ b/Software/src/devboard/hal/hw_devkit.h
@@ -63,12 +63,8 @@ The pin layout below supports the following:
 #define EQUIPMENT_STOP_PIN GPIO_NUM_12
 
 // BMW_I3_BATTERY wake up pin
-#ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
-#ifdef DOUBLE_BATTERY
 #define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
-#endif                        // DOUBLE_BATTERY
-#endif                        // BMW_I3_BATTERY
 
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -70,12 +70,8 @@
 #define EQUIPMENT_STOP_PIN 35
 
 // BMW_I3_BATTERY wake up pin
-//#ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
-#ifdef DOUBLE_BATTERY
 #define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
-#endif                        // DOUBLE_BATTERY
-//#endif                        // BMW_I3_BATTERY
 
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -70,12 +70,12 @@
 #define EQUIPMENT_STOP_PIN 35
 
 // BMW_I3_BATTERY wake up pin
-#ifdef BMW_I3_BATTERY
+//#ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
 #ifdef DOUBLE_BATTERY
 #define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
 #endif                        // DOUBLE_BATTERY
-#endif                        // BMW_I3_BATTERY
+//#endif                        // BMW_I3_BATTERY
 
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED
@@ -107,13 +107,14 @@
 #endif
 #endif
 
-#ifdef BMW_I3_BATTERY
+// TODO: Implement the following GPIO checks at runtime
+/*#ifdef BMW_I3_BATTERY
 #if defined(CONTACTOR_CONTROL) && defined(WUP_PIN1)
 #error GPIO PIN 25 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
 #if defined(CONTACTOR_CONTROL) && defined(WUP_PIN2)
 #error GPIO PIN 32 cannot be used for both BMWi3 Wakeup and contactor control. Disable CONTACTOR_CONTROL
 #endif
-#endif
+#endif*/
 
 #endif

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -62,12 +62,8 @@ GPIOs on extra header
 #define EQUIPMENT_STOP_PIN 2
 
 // BMW_I3_BATTERY wake up pin
-#ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1
-#ifdef DOUBLE_BATTERY
 #define WUP_PIN2 GPIO_NUM_32  // Wake up pin for battery 2
-#endif                        // DOUBLE_BATTERY
-#endif                        // BMW_I3_BATTERY
 
 /* ----- Error checks below, don't change (can't be moved to separate file) ----- */
 #ifndef HW_CONFIGURED

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -471,23 +471,24 @@ String advanced_battery_processor(const String& var) {
           "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
       content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
       content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
-#ifdef DOUBLE_BATTERY
-      content += "<h4>Values from battery 2</h4>";
-      content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.battery2_total_cell_count) + "S</h4>";
-      content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery2_battery_12V / 10.0, 1) + "</h4>";
-      content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.battery2_waterleakageSensor) + "</h4>";
-      content +=
-          "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.battery2_temperature_water_inlet) +
-          "</h4>";
-      content +=
-          "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.battery2_powerRelayTemperature) +
-          "</h4>";
-      content +=
-          "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.battery2_batteryManagementMode) +
-          "</h4>";
-      content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.battery2_BMS_ign) + "</h4>";
-      content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.battery2_batteryRelay) + "</h4>";
-#endif  //DOUBLE_BATTERY
+
+      if (double_battery()) {
+        content += "<h4>Values from battery 2</h4>";
+        content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.battery2_total_cell_count) + "S</h4>";
+        content +=
+            "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery2_battery_12V / 10.0, 1) + "</h4>";
+        content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.battery2_waterleakageSensor) + "</h4>";
+        content += "<h4>Temperature, water inlet: " +
+                   String(datalayer_extended.KiaHyundai64.battery2_temperature_water_inlet) + "</h4>";
+        content +=
+            "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.battery2_powerRelayTemperature) +
+            "</h4>";
+        content +=
+            "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.battery2_batteryManagementMode) +
+            "</h4>";
+        content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.battery2_BMS_ign) + "</h4>";
+        content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.battery2_batteryRelay) + "</h4>";
+      }
     }  //KIA_HYUNDAI_64_BATTERY
 
     else if (battery->type() == BydAtto3) {

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -5,6 +5,7 @@
 
 String advanced_battery_processor(const String& var) {
   if (var == "X") {
+    char readableSerialNumber[15];  // One extra space for null terminator
     String content = "";
     //Page format
     content += "<style>";
@@ -19,1461 +20,1462 @@ String advanced_battery_processor(const String& var) {
     // Start a new block with a specific background color
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
-#ifdef BOLT_AMPERA_BATTERY
-    content += "<h4>5V Reference: " + String(datalayer_extended.boltampera.battery_5V_ref) + "</h4>";
-    content += "<h4>Module 1 temp: " + String(datalayer_extended.boltampera.battery_module_temp_1) + "</h4>";
-    content += "<h4>Module 2 temp: " + String(datalayer_extended.boltampera.battery_module_temp_2) + "</h4>";
-    content += "<h4>Module 3 temp: " + String(datalayer_extended.boltampera.battery_module_temp_3) + "</h4>";
-    content += "<h4>Module 4 temp: " + String(datalayer_extended.boltampera.battery_module_temp_4) + "</h4>";
-    content += "<h4>Module 5 temp: " + String(datalayer_extended.boltampera.battery_module_temp_5) + "</h4>";
-    content += "<h4>Module 6 temp: " + String(datalayer_extended.boltampera.battery_module_temp_6) + "</h4>";
-    content +=
-        "<h4>Cell average voltage: " + String(datalayer_extended.boltampera.battery_cell_average_voltage) + "</h4>";
-    content +=
-        "<h4>Cell average voltage 2: " + String(datalayer_extended.boltampera.battery_cell_average_voltage_2) + "</h4>";
-    content += "<h4>Terminal voltage: " + String(datalayer_extended.boltampera.battery_terminal_voltage) + "</h4>";
-    content +=
-        "<h4>Ignition power mode: " + String(datalayer_extended.boltampera.battery_ignition_power_mode) + "</h4>";
-    content += "<h4>Battery current (7E7): " + String(datalayer_extended.boltampera.battery_current_7E7) + "</h4>";
-    content += "<h4>Capacity MY17-18: " + String(datalayer_extended.boltampera.battery_capacity_my17_18) + "</h4>";
-    content += "<h4>Capacity MY19+: " + String(datalayer_extended.boltampera.battery_capacity_my19plus) + "</h4>";
-    content += "<h4>SOC Display: " + String(datalayer_extended.boltampera.battery_SOC_display) + "</h4>";
-    content += "<h4>SOC Raw highprec: " + String(datalayer_extended.boltampera.battery_SOC_raw_highprec) + "</h4>";
-    content += "<h4>Max temp: " + String(datalayer_extended.boltampera.battery_max_temperature) + "</h4>";
-    content += "<h4>Min temp: " + String(datalayer_extended.boltampera.battery_min_temperature) + "</h4>";
-    content += "<h4>Cell max mV: " + String(datalayer_extended.boltampera.battery_max_cell_voltage) + "</h4>";
-    content += "<h4>Cell min mV: " + String(datalayer_extended.boltampera.battery_min_cell_voltage) + "</h4>";
-    content += "<h4>Lowest cell: " + String(datalayer_extended.boltampera.battery_lowest_cell) + "</h4>";
-    content += "<h4>Highest cell: " + String(datalayer_extended.boltampera.battery_highest_cell) + "</h4>";
-    content +=
-        "<h4>Internal resistance: " + String(datalayer_extended.boltampera.battery_internal_resistance) + "</h4>";
-    content += "<h4>Voltage: " + String(datalayer_extended.boltampera.battery_voltage_polled) + "</h4>";
-    content += "<h4>Isolation Ohm: " + String(datalayer_extended.boltampera.battery_vehicle_isolation) + "</h4>";
-    content += "<h4>Isolation kOhm: " + String(datalayer_extended.boltampera.battery_isolation_kohm) + "</h4>";
-    content += "<h4>HV locked: " + String(datalayer_extended.boltampera.battery_HV_locked) + "</h4>";
-    content += "<h4>Crash event: " + String(datalayer_extended.boltampera.battery_crash_event) + "</h4>";
-    content += "<h4>HVIL: " + String(datalayer_extended.boltampera.battery_HVIL) + "</h4>";
-    content += "<h4>HVIL status: " + String(datalayer_extended.boltampera.battery_HVIL_status) + "</h4>";
-    content += "<h4>Current (7E4): " + String(datalayer_extended.boltampera.battery_current_7E4) + "</h4>";
-#endif  //BOLT_AMPERA_BATTERY
+    // TODO: Eliminate if-else by extracting battery specific HTML generation into separate classes with clear
+    // interface
+    if (battery->type() == BoltAmpera) {
+      content += "<h4>5V Reference: " + String(datalayer_extended.boltampera.battery_5V_ref) + "</h4>";
+      content += "<h4>Module 1 temp: " + String(datalayer_extended.boltampera.battery_module_temp_1) + "</h4>";
+      content += "<h4>Module 2 temp: " + String(datalayer_extended.boltampera.battery_module_temp_2) + "</h4>";
+      content += "<h4>Module 3 temp: " + String(datalayer_extended.boltampera.battery_module_temp_3) + "</h4>";
+      content += "<h4>Module 4 temp: " + String(datalayer_extended.boltampera.battery_module_temp_4) + "</h4>";
+      content += "<h4>Module 5 temp: " + String(datalayer_extended.boltampera.battery_module_temp_5) + "</h4>";
+      content += "<h4>Module 6 temp: " + String(datalayer_extended.boltampera.battery_module_temp_6) + "</h4>";
+      content +=
+          "<h4>Cell average voltage: " + String(datalayer_extended.boltampera.battery_cell_average_voltage) + "</h4>";
+      content += "<h4>Cell average voltage 2: " + String(datalayer_extended.boltampera.battery_cell_average_voltage_2) +
+                 "</h4>";
+      content += "<h4>Terminal voltage: " + String(datalayer_extended.boltampera.battery_terminal_voltage) + "</h4>";
+      content +=
+          "<h4>Ignition power mode: " + String(datalayer_extended.boltampera.battery_ignition_power_mode) + "</h4>";
+      content += "<h4>Battery current (7E7): " + String(datalayer_extended.boltampera.battery_current_7E7) + "</h4>";
+      content += "<h4>Capacity MY17-18: " + String(datalayer_extended.boltampera.battery_capacity_my17_18) + "</h4>";
+      content += "<h4>Capacity MY19+: " + String(datalayer_extended.boltampera.battery_capacity_my19plus) + "</h4>";
+      content += "<h4>SOC Display: " + String(datalayer_extended.boltampera.battery_SOC_display) + "</h4>";
+      content += "<h4>SOC Raw highprec: " + String(datalayer_extended.boltampera.battery_SOC_raw_highprec) + "</h4>";
+      content += "<h4>Max temp: " + String(datalayer_extended.boltampera.battery_max_temperature) + "</h4>";
+      content += "<h4>Min temp: " + String(datalayer_extended.boltampera.battery_min_temperature) + "</h4>";
+      content += "<h4>Cell max mV: " + String(datalayer_extended.boltampera.battery_max_cell_voltage) + "</h4>";
+      content += "<h4>Cell min mV: " + String(datalayer_extended.boltampera.battery_min_cell_voltage) + "</h4>";
+      content += "<h4>Lowest cell: " + String(datalayer_extended.boltampera.battery_lowest_cell) + "</h4>";
+      content += "<h4>Highest cell: " + String(datalayer_extended.boltampera.battery_highest_cell) + "</h4>";
+      content +=
+          "<h4>Internal resistance: " + String(datalayer_extended.boltampera.battery_internal_resistance) + "</h4>";
+      content += "<h4>Voltage: " + String(datalayer_extended.boltampera.battery_voltage_polled) + "</h4>";
+      content += "<h4>Isolation Ohm: " + String(datalayer_extended.boltampera.battery_vehicle_isolation) + "</h4>";
+      content += "<h4>Isolation kOhm: " + String(datalayer_extended.boltampera.battery_isolation_kohm) + "</h4>";
+      content += "<h4>HV locked: " + String(datalayer_extended.boltampera.battery_HV_locked) + "</h4>";
+      content += "<h4>Crash event: " + String(datalayer_extended.boltampera.battery_crash_event) + "</h4>";
+      content += "<h4>HVIL: " + String(datalayer_extended.boltampera.battery_HVIL) + "</h4>";
+      content += "<h4>HVIL status: " + String(datalayer_extended.boltampera.battery_HVIL_status) + "</h4>";
+      content += "<h4>Current (7E4): " + String(datalayer_extended.boltampera.battery_current_7E4) + "</h4>";
+    }  //BOLT_AMPERA_BATTERY
 
-#ifdef BMW_IX_BATTERY
-    content +=
-        "<h4>Battery Voltage after Contactor: " + String(datalayer_extended.bmwix.battery_voltage_after_contactor) +
-        " dV</h4>";
-    content += "<h4>Max Design Voltage: " + String(datalayer.battery.info.max_design_voltage_dV) + " dV</h4>";
-    content += "<h4>Min Design Voltage: " + String(datalayer.battery.info.min_design_voltage_dV) + " dV</h4>";
-    content += "<h4>Max Cell Design Voltage: " + String(datalayer.battery.info.max_cell_voltage_mV) + " mV</h4>";
-    content += "<h4>Min Cell Design Voltage: " + String(datalayer.battery.info.min_cell_voltage_mV) + " mV</h4>";
-    content +=
-        "<h4>Min Cell Voltage Data Age: " + String(datalayer_extended.bmwix.min_cell_voltage_data_age) + " ms</h4>";
-    content +=
-        "<h4>Max Cell Voltage Data Age: " + String(datalayer_extended.bmwix.max_cell_voltage_data_age) + " ms</h4>";
-    content += "<h4>Allowed Discharge Power: " + String(datalayer.battery.status.max_discharge_power_W) + " W</h4>";
-    content += "<h4>Allowed Charge Power: " + String(datalayer.battery.status.max_charge_power_W) + " W</h4>";
-    content += "<h4>T30 Terminal Voltage: " + String(datalayer_extended.bmwix.T30_Voltage) + " mV</h4>";
-    content += "<h4>Detected Cell Count: " + String(datalayer.battery.info.number_of_cells) + "</h4>";
-    static const char* balanceText[5] = {"0 No balancing mode active", "1 Voltage-Controlled Balancing Mode",
-                                         "2 Time-Controlled Balancing Mode with Demand Calculation at End of Charging",
-                                         "3 Time-Controlled Balancing Mode with Demand Calculation at Resting Voltage",
-                                         "4 No balancing mode active, qualifier invalid"};
-    content += "<h4>Balancing: " + String((balanceText[datalayer_extended.bmwix.balancing_status])) + "</h4>";
-    static const char* hvilText[2] = {"Error (Loop Open)", "OK (Loop Closed)"};
-    content += "<h4>HVIL Status: " + String(hvilText[datalayer_extended.bmwix.hvil_status]) + "</h4>";
-    content += "<h4>BMS Uptime: " + String(datalayer_extended.bmwix.bms_uptime) + " seconds</h4>";
-    content += "<h4>BMS Allowed Charge Amps: " + String(datalayer_extended.bmwix.allowable_charge_amps) + " A</h4>";
-    content +=
-        "<h4>BMS Allowed Disharge Amps: " + String(datalayer_extended.bmwix.allowable_discharge_amps) + " A</h4>";
-    content += "<br>";
-    content += "<h3>HV Isolation (2147483647kOhm = maximum/invalid)</h3>";
-    content += "<h4>Isolation Positive: " + String(datalayer_extended.bmwix.iso_safety_positive) + " kOhm</h4>";
-    content += "<h4>Isolation Negative: " + String(datalayer_extended.bmwix.iso_safety_negative) + " kOhm</h4>";
-    content += "<h4>Isolation Parallel: " + String(datalayer_extended.bmwix.iso_safety_parallel) + " kOhm</h4>";
-    static const char* pyroText[5] = {"0 Value Invalid", "1 Successfully Blown", "2 Disconnected",
-                                      "3 Not Activated - Pyro Intact", "4 Unknown"};
-    content += "<h4>Pyro Status PSS1: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss1])) + "</h4>";
-    content += "<h4>Pyro Status PSS4: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss4])) + "</h4>";
-    content += "<h4>Pyro Status PSS6: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss6])) + "</h4>";
-#endif  //BMW_IX_BATTERY
+    else if (battery->type() == BMWIX) {
+      content +=
+          "<h4>Battery Voltage after Contactor: " + String(datalayer_extended.bmwix.battery_voltage_after_contactor) +
+          " dV</h4>";
+      content += "<h4>Max Design Voltage: " + String(datalayer.battery.info.max_design_voltage_dV) + " dV</h4>";
+      content += "<h4>Min Design Voltage: " + String(datalayer.battery.info.min_design_voltage_dV) + " dV</h4>";
+      content += "<h4>Max Cell Design Voltage: " + String(datalayer.battery.info.max_cell_voltage_mV) + " mV</h4>";
+      content += "<h4>Min Cell Design Voltage: " + String(datalayer.battery.info.min_cell_voltage_mV) + " mV</h4>";
+      content +=
+          "<h4>Min Cell Voltage Data Age: " + String(datalayer_extended.bmwix.min_cell_voltage_data_age) + " ms</h4>";
+      content +=
+          "<h4>Max Cell Voltage Data Age: " + String(datalayer_extended.bmwix.max_cell_voltage_data_age) + " ms</h4>";
+      content += "<h4>Allowed Discharge Power: " + String(datalayer.battery.status.max_discharge_power_W) + " W</h4>";
+      content += "<h4>Allowed Charge Power: " + String(datalayer.battery.status.max_charge_power_W) + " W</h4>";
+      content += "<h4>T30 Terminal Voltage: " + String(datalayer_extended.bmwix.T30_Voltage) + " mV</h4>";
+      content += "<h4>Detected Cell Count: " + String(datalayer.battery.info.number_of_cells) + "</h4>";
+      static const char* balanceText[5] = {
+          "0 No balancing mode active", "1 Voltage-Controlled Balancing Mode",
+          "2 Time-Controlled Balancing Mode with Demand Calculation at End of Charging",
+          "3 Time-Controlled Balancing Mode with Demand Calculation at Resting Voltage",
+          "4 No balancing mode active, qualifier invalid"};
+      content += "<h4>Balancing: " + String((balanceText[datalayer_extended.bmwix.balancing_status])) + "</h4>";
+      static const char* hvilText[2] = {"Error (Loop Open)", "OK (Loop Closed)"};
+      content += "<h4>HVIL Status: " + String(hvilText[datalayer_extended.bmwix.hvil_status]) + "</h4>";
+      content += "<h4>BMS Uptime: " + String(datalayer_extended.bmwix.bms_uptime) + " seconds</h4>";
+      content += "<h4>BMS Allowed Charge Amps: " + String(datalayer_extended.bmwix.allowable_charge_amps) + " A</h4>";
+      content +=
+          "<h4>BMS Allowed Disharge Amps: " + String(datalayer_extended.bmwix.allowable_discharge_amps) + " A</h4>";
+      content += "<br>";
+      content += "<h3>HV Isolation (2147483647kOhm = maximum/invalid)</h3>";
+      content += "<h4>Isolation Positive: " + String(datalayer_extended.bmwix.iso_safety_positive) + " kOhm</h4>";
+      content += "<h4>Isolation Negative: " + String(datalayer_extended.bmwix.iso_safety_negative) + " kOhm</h4>";
+      content += "<h4>Isolation Parallel: " + String(datalayer_extended.bmwix.iso_safety_parallel) + " kOhm</h4>";
+      static const char* pyroText[5] = {"0 Value Invalid", "1 Successfully Blown", "2 Disconnected",
+                                        "3 Not Activated - Pyro Intact", "4 Unknown"};
+      content += "<h4>Pyro Status PSS1: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss1])) + "</h4>";
+      content += "<h4>Pyro Status PSS4: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss4])) + "</h4>";
+      content += "<h4>Pyro Status PSS6: " + String((pyroText[datalayer_extended.bmwix.pyro_status_pss6])) + "</h4>";
+    }  //BMW_IX_BATTERY
 
-#ifdef BMW_PHEV_BATTERY
-    content +=
-        "<h4>Battery Voltage after Contactor: " + String(datalayer_extended.bmwphev.battery_voltage_after_contactor) +
-        " dV</h4>";
-    content += "<h4>Allowed Discharge Power: " + String(datalayer.battery.status.max_discharge_power_W) + " W</h4>";
-    content += "<h4>Allowed Charge Power: " + String(datalayer.battery.status.max_charge_power_W) + " W</h4>";
-    static const char* balanceText[5] = {"0 Balancing Inactive - Balancing not needed", "1 Balancing Active",
-                                         "2 Balancing Inactive - Cells not in rest break wait 10mins",
-                                         "3 Balancing Inactive", "4 Unknown"};
-    content += "<h4>Balancing: " + String((balanceText[datalayer_extended.bmwphev.balancing_status])) + "</h4>";
-    static const char* pyroText[5] = {"0 Value Invalid", "1 Successfully Blown", "2 Disconnected",
-                                      "3 Not Activated - Pyro Intact", "4 Unknown"};
-    static const char* statusText[16] = {
-        "Not evaluated", "OK", "Error!", "Invalid signal", "", "", "", "", "", "", "", "", "", "", "", ""};
-    content += "<h4>Interlock: " + String(statusText[datalayer_extended.bmwphev.ST_interlock]) + "</h4>";
-    content += "<h4>Isolation external: " + String(statusText[datalayer_extended.bmwphev.ST_iso_ext]) + "</h4>";
-    content += "<h4>Isolation internal: " + String(statusText[datalayer_extended.bmwphev.ST_iso_int]) + "</h4>";
-    content += "<h4>Isolation: " + String(statusText[datalayer_extended.bmwphev.ST_isolation]) + "</h4>";
-    content += "<h4>Cooling valve: " + String(statusText[datalayer_extended.bmwphev.ST_valve_cooling]) + "</h4>";
-    content += "<h4>Emergency: " + String(statusText[datalayer_extended.bmwphev.ST_EMG]) + "</h4>";
-    static const char* prechargeText[16] = {"Not evaluated",
-                                            "Not active, closing not blocked",
-                                            "Error precharge blocked",
-                                            "Invalid signal",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            ""};
-    content += "<h4>Precharge: " + String(prechargeText[datalayer_extended.bmwphev.ST_precharge]) +
-               "</h4>";  //Still unclear of enum
-    static const char* DCSWText[16] = {"Contactors open",
-                                       "Precharge ongoing",
-                                       "Contactors engaged",
-                                       "Invalid signal",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       ""};
-    content += "<h4>Contactor status: " + String(DCSWText[datalayer_extended.bmwphev.ST_DCSW]) + "</h4>";
-    static const char* contText[16] = {"Contactors OK",
-                                       "One contactor welded!",
-                                       "Two contactors welded!",
-                                       "Invalid signal",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       ""};
-    content += "<h4>Contactor weld: " + String(contText[datalayer_extended.bmwphev.ST_WELD]) + "</h4>";
-    static const char* valveText[16] = {"OK",
-                                        "Short circuit to GND",
-                                        "Short circuit to 12V",
-                                        "Line break",
-                                        "",
-                                        "",
-                                        "Driver error",
-                                        "",
-                                        "",
-                                        "",
-                                        "",
-                                        "",
-                                        "Stuck",
-                                        "Stuck",
-                                        "",
-                                        "Invalid Signal"};
-    content +=
-        "<h4>Cold shutoff valve: " + String(valveText[datalayer_extended.bmwphev.ST_cold_shutoff_valve]) + "</h4>";
-    content +=
-        "<h4>Min Cell Voltage Data Age: " + String(datalayer_extended.bmwphev.min_cell_voltage_data_age) + " ms</h4>";
-    content +=
-        "<h4>Max Cell Voltage Data Age: " + String(datalayer_extended.bmwphev.max_cell_voltage_data_age) + " ms</h4>";
-    content += "<h4>Max Design Voltage: " + String(datalayer.battery.info.max_design_voltage_dV) + " dV</h4>";
-    content += "<h4>Min Design Voltage: " + String(datalayer.battery.info.min_design_voltage_dV) + " dV</h4>";
-    content += "<h4>BMS Allowed Charge Amps: " + String(datalayer_extended.bmwphev.allowable_charge_amps) + " A</h4>";
-    content +=
-        "<h4>BMS Allowed Disharge Amps: " + String(datalayer_extended.bmwphev.allowable_discharge_amps) + " A</h4>";
-    content += "<h4>Detected Cell Count: " + String(datalayer.battery.info.number_of_cells) + "</h4>";
-    content += "<h4>iso_safety_int_kohm: " + String(datalayer_extended.bmwphev.iso_safety_int_kohm) + "</h4>";
-    content += "<h4>iso_safety_ext_kohm: " + String(datalayer_extended.bmwphev.iso_safety_ext_kohm) + "</h4>";
-    content += "<h4>iso_safety_trg_kohm: " + String(datalayer_extended.bmwphev.iso_safety_trg_kohm) + "</h4>";
-    content += "<h4>iso_safety_ext_plausible: " + String(datalayer_extended.bmwphev.iso_safety_ext_plausible) + "</h4>";
-    content += "<h4>iso_safety_int_plausible: " + String(datalayer_extended.bmwphev.iso_safety_int_plausible) + "</h4>";
-    content += "<h4>iso_safety_trg_plausible: " + String(datalayer_extended.bmwphev.iso_safety_trg_plausible) + "</h4>";
-    content += "<h4>iso_safety_kohm: " + String(datalayer_extended.bmwphev.iso_safety_kohm) + "</h4>";
-    content += "<h4>iso_safety_kohm_quality: " + String(datalayer_extended.bmwphev.iso_safety_kohm_quality) + "</h4>";
-    content += "<br>";
-    content += "<h4>Todo";
-    content += "<br>";
-    content += "<h4>Max Cell Design Voltage: " + String(datalayer.battery.info.max_cell_voltage_mV) + " mV</h4>";
-    content += "<h4>Min Cell Design Voltage: " + String(datalayer.battery.info.min_cell_voltage_mV) + " mV</h4>";
-    content += "<h4>T30 Terminal Voltage: " + String(datalayer_extended.bmwphev.T30_Voltage) + " mV</h4>";
-    content += "<br>";
-#endif  //BMW_PHEV_BATTERY
+    else if (battery->type() == BMWPhev) {
+      content +=
+          "<h4>Battery Voltage after Contactor: " + String(datalayer_extended.bmwphev.battery_voltage_after_contactor) +
+          " dV</h4>";
+      content += "<h4>Allowed Discharge Power: " + String(datalayer.battery.status.max_discharge_power_W) + " W</h4>";
+      content += "<h4>Allowed Charge Power: " + String(datalayer.battery.status.max_charge_power_W) + " W</h4>";
+      static const char* balanceText[5] = {"0 Balancing Inactive - Balancing not needed", "1 Balancing Active",
+                                           "2 Balancing Inactive - Cells not in rest break wait 10mins",
+                                           "3 Balancing Inactive", "4 Unknown"};
+      content += "<h4>Balancing: " + String((balanceText[datalayer_extended.bmwphev.balancing_status])) + "</h4>";
+      static const char* pyroText[5] = {"0 Value Invalid", "1 Successfully Blown", "2 Disconnected",
+                                        "3 Not Activated - Pyro Intact", "4 Unknown"};
+      static const char* statusText[16] = {
+          "Not evaluated", "OK", "Error!", "Invalid signal", "", "", "", "", "", "", "", "", "", "", "", ""};
+      content += "<h4>Interlock: " + String(statusText[datalayer_extended.bmwphev.ST_interlock]) + "</h4>";
+      content += "<h4>Isolation external: " + String(statusText[datalayer_extended.bmwphev.ST_iso_ext]) + "</h4>";
+      content += "<h4>Isolation internal: " + String(statusText[datalayer_extended.bmwphev.ST_iso_int]) + "</h4>";
+      content += "<h4>Isolation: " + String(statusText[datalayer_extended.bmwphev.ST_isolation]) + "</h4>";
+      content += "<h4>Cooling valve: " + String(statusText[datalayer_extended.bmwphev.ST_valve_cooling]) + "</h4>";
+      content += "<h4>Emergency: " + String(statusText[datalayer_extended.bmwphev.ST_EMG]) + "</h4>";
+      static const char* prechargeText[16] = {"Not evaluated",
+                                              "Not active, closing not blocked",
+                                              "Error precharge blocked",
+                                              "Invalid signal",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              ""};
+      content += "<h4>Precharge: " + String(prechargeText[datalayer_extended.bmwphev.ST_precharge]) +
+                 "</h4>";  //Still unclear of enum
+      static const char* DCSWText[16] = {"Contactors open",
+                                         "Precharge ongoing",
+                                         "Contactors engaged",
+                                         "Invalid signal",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         ""};
+      content += "<h4>Contactor status: " + String(DCSWText[datalayer_extended.bmwphev.ST_DCSW]) + "</h4>";
+      static const char* contText[16] = {"Contactors OK",
+                                         "One contactor welded!",
+                                         "Two contactors welded!",
+                                         "Invalid signal",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         ""};
+      content += "<h4>Contactor weld: " + String(contText[datalayer_extended.bmwphev.ST_WELD]) + "</h4>";
+      static const char* valveText[16] = {"OK",
+                                          "Short circuit to GND",
+                                          "Short circuit to 12V",
+                                          "Line break",
+                                          "",
+                                          "",
+                                          "Driver error",
+                                          "",
+                                          "",
+                                          "",
+                                          "",
+                                          "",
+                                          "Stuck",
+                                          "Stuck",
+                                          "",
+                                          "Invalid Signal"};
+      content +=
+          "<h4>Cold shutoff valve: " + String(valveText[datalayer_extended.bmwphev.ST_cold_shutoff_valve]) + "</h4>";
+      content +=
+          "<h4>Min Cell Voltage Data Age: " + String(datalayer_extended.bmwphev.min_cell_voltage_data_age) + " ms</h4>";
+      content +=
+          "<h4>Max Cell Voltage Data Age: " + String(datalayer_extended.bmwphev.max_cell_voltage_data_age) + " ms</h4>";
+      content += "<h4>Max Design Voltage: " + String(datalayer.battery.info.max_design_voltage_dV) + " dV</h4>";
+      content += "<h4>Min Design Voltage: " + String(datalayer.battery.info.min_design_voltage_dV) + " dV</h4>";
+      content += "<h4>BMS Allowed Charge Amps: " + String(datalayer_extended.bmwphev.allowable_charge_amps) + " A</h4>";
+      content +=
+          "<h4>BMS Allowed Disharge Amps: " + String(datalayer_extended.bmwphev.allowable_discharge_amps) + " A</h4>";
+      content += "<h4>Detected Cell Count: " + String(datalayer.battery.info.number_of_cells) + "</h4>";
+      content += "<h4>iso_safety_int_kohm: " + String(datalayer_extended.bmwphev.iso_safety_int_kohm) + "</h4>";
+      content += "<h4>iso_safety_ext_kohm: " + String(datalayer_extended.bmwphev.iso_safety_ext_kohm) + "</h4>";
+      content += "<h4>iso_safety_trg_kohm: " + String(datalayer_extended.bmwphev.iso_safety_trg_kohm) + "</h4>";
+      content +=
+          "<h4>iso_safety_ext_plausible: " + String(datalayer_extended.bmwphev.iso_safety_ext_plausible) + "</h4>";
+      content +=
+          "<h4>iso_safety_int_plausible: " + String(datalayer_extended.bmwphev.iso_safety_int_plausible) + "</h4>";
+      content +=
+          "<h4>iso_safety_trg_plausible: " + String(datalayer_extended.bmwphev.iso_safety_trg_plausible) + "</h4>";
+      content += "<h4>iso_safety_kohm: " + String(datalayer_extended.bmwphev.iso_safety_kohm) + "</h4>";
+      content += "<h4>iso_safety_kohm_quality: " + String(datalayer_extended.bmwphev.iso_safety_kohm_quality) + "</h4>";
+      content += "<br>";
+      content += "<h4>Todo";
+      content += "<br>";
+      content += "<h4>Max Cell Design Voltage: " + String(datalayer.battery.info.max_cell_voltage_mV) + " mV</h4>";
+      content += "<h4>Min Cell Design Voltage: " + String(datalayer.battery.info.min_cell_voltage_mV) + " mV</h4>";
+      content += "<h4>T30 Terminal Voltage: " + String(datalayer_extended.bmwphev.T30_Voltage) + " mV</h4>";
+      content += "<br>";
+    }  //BMW_PHEV_BATTERY
 
-#ifdef BMW_I3_BATTERY
-    content += "<h4>SOC raw: " + String(datalayer_extended.bmwi3.SOC_raw) + "</h4>";
-    content += "<h4>SOC dash: " + String(datalayer_extended.bmwi3.SOC_dash) + "</h4>";
-    content += "<h4>SOC OBD2: " + String(datalayer_extended.bmwi3.SOC_OBD2) + "</h4>";
-    static const char* statusText[16] = {
-        "Not evaluated", "OK", "Error!", "Invalid signal", "", "", "", "", "", "", "", "", "", "", "", ""};
-    content += "<h4>Interlock: " + String(statusText[datalayer_extended.bmwi3.ST_interlock]) + "</h4>";
-    content += "<h4>Isolation external: " + String(statusText[datalayer_extended.bmwi3.ST_iso_ext]) + "</h4>";
-    content += "<h4>Isolation internal: " + String(statusText[datalayer_extended.bmwi3.ST_iso_int]) + "</h4>";
-    content += "<h4>Isolation: " + String(statusText[datalayer_extended.bmwi3.ST_isolation]) + "</h4>";
-    content += "<h4>Cooling valve: " + String(statusText[datalayer_extended.bmwi3.ST_valve_cooling]) + "</h4>";
-    content += "<h4>Emergency: " + String(statusText[datalayer_extended.bmwi3.ST_EMG]) + "</h4>";
-    static const char* prechargeText[16] = {"Not evaluated",
-                                            "Not active, closing not blocked",
-                                            "Error precharge blocked",
-                                            "Invalid signal",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            "",
-                                            ""};
-    content += "<h4>Precharge: " + String(prechargeText[datalayer_extended.bmwi3.ST_precharge]) +
-               "</h4>";  //Still unclear of enum
-    static const char* DCSWText[16] = {"Contactors open",
-                                       "Precharge ongoing",
-                                       "Contactors engaged",
-                                       "Invalid signal",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       ""};
-    content += "<h4>Contactor status: " + String(DCSWText[datalayer_extended.bmwi3.ST_DCSW]) + "</h4>";
-    static const char* contText[16] = {"Contactors OK",
-                                       "One contactor welded!",
-                                       "Two contactors welded!",
-                                       "Invalid signal",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       "",
-                                       ""};
-    content += "<h4>Contactor weld: " + String(contText[datalayer_extended.bmwi3.ST_WELD]) + "</h4>";
-    static const char* valveText[16] = {"OK",
-                                        "Short circuit to GND",
-                                        "Short circuit to 12V",
-                                        "Line break",
-                                        "",
-                                        "",
-                                        "Driver error",
-                                        "",
-                                        "",
-                                        "",
-                                        "",
-                                        "",
-                                        "Stuck",
-                                        "Stuck",
-                                        "",
-                                        "Invalid Signal"};
-    content += "<h4>Cold shutoff valve: " + String(contText[datalayer_extended.bmwi3.ST_cold_shutoff_valve]) + "</h4>";
+    else if (battery->type() == BMWi3) {
+      content += "<h4>SOC raw: " + String(datalayer_extended.bmwi3.SOC_raw) + "</h4>";
+      content += "<h4>SOC dash: " + String(datalayer_extended.bmwi3.SOC_dash) + "</h4>";
+      content += "<h4>SOC OBD2: " + String(datalayer_extended.bmwi3.SOC_OBD2) + "</h4>";
+      static const char* statusText[16] = {
+          "Not evaluated", "OK", "Error!", "Invalid signal", "", "", "", "", "", "", "", "", "", "", "", ""};
+      content += "<h4>Interlock: " + String(statusText[datalayer_extended.bmwi3.ST_interlock]) + "</h4>";
+      content += "<h4>Isolation external: " + String(statusText[datalayer_extended.bmwi3.ST_iso_ext]) + "</h4>";
+      content += "<h4>Isolation internal: " + String(statusText[datalayer_extended.bmwi3.ST_iso_int]) + "</h4>";
+      content += "<h4>Isolation: " + String(statusText[datalayer_extended.bmwi3.ST_isolation]) + "</h4>";
+      content += "<h4>Cooling valve: " + String(statusText[datalayer_extended.bmwi3.ST_valve_cooling]) + "</h4>";
+      content += "<h4>Emergency: " + String(statusText[datalayer_extended.bmwi3.ST_EMG]) + "</h4>";
+      static const char* prechargeText[16] = {"Not evaluated",
+                                              "Not active, closing not blocked",
+                                              "Error precharge blocked",
+                                              "Invalid signal",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              "",
+                                              ""};
+      content += "<h4>Precharge: " + String(prechargeText[datalayer_extended.bmwi3.ST_precharge]) +
+                 "</h4>";  //Still unclear of enum
+      static const char* DCSWText[16] = {"Contactors open",
+                                         "Precharge ongoing",
+                                         "Contactors engaged",
+                                         "Invalid signal",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         ""};
+      content += "<h4>Contactor status: " + String(DCSWText[datalayer_extended.bmwi3.ST_DCSW]) + "</h4>";
+      static const char* contText[16] = {"Contactors OK",
+                                         "One contactor welded!",
+                                         "Two contactors welded!",
+                                         "Invalid signal",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         ""};
+      content += "<h4>Contactor weld: " + String(contText[datalayer_extended.bmwi3.ST_WELD]) + "</h4>";
+      static const char* valveText[16] = {"OK",
+                                          "Short circuit to GND",
+                                          "Short circuit to 12V",
+                                          "Line break",
+                                          "",
+                                          "",
+                                          "Driver error",
+                                          "",
+                                          "",
+                                          "",
+                                          "",
+                                          "",
+                                          "Stuck",
+                                          "Stuck",
+                                          "",
+                                          "Invalid Signal"};
+      content +=
+          "<h4>Cold shutoff valve: " + String(contText[datalayer_extended.bmwi3.ST_cold_shutoff_valve]) + "</h4>";
 
-#endif  //BMW_I3_BATTERY
+    }  //BMW_I3_BATTERY
 
-#ifdef CELLPOWER_BMS
-    static const char* falseTrue[2] = {"False", "True"};
-    content += "<h3>States:</h3>";
-    content += "<h4>Discharge: " + String(falseTrue[datalayer_extended.cellpower.system_state_discharge]) + "</h4>";
-    content += "<h4>Charge: " + String(falseTrue[datalayer_extended.cellpower.system_state_charge]) + "</h4>";
-    content +=
-        "<h4>Cellbalancing: " + String(falseTrue[datalayer_extended.cellpower.system_state_cellbalancing]) + "</h4>";
-    content +=
-        "<h4>Tricklecharging: " + String(falseTrue[datalayer_extended.cellpower.system_state_tricklecharge]) + "</h4>";
-    content += "<h4>Idle: " + String(falseTrue[datalayer_extended.cellpower.system_state_idle]) + "</h4>";
-    content += "<h4>Charge completed: " + String(falseTrue[datalayer_extended.cellpower.system_state_chargecompleted]) +
-               "</h4>";
-    content +=
-        "<h4>Maintenance charge: " + String(falseTrue[datalayer_extended.cellpower.system_state_maintenancecharge]) +
-        "</h4>";
-    content += "<h3>IO:</h3>";
-    content +=
-        "<h4>Main positive relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_main_positive_relay]) +
-        "</h4>";
-    content +=
-        "<h4>Main negative relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_main_negative_relay]) +
-        "</h4>";
-    content +=
-        "<h4>Charge enabled: " + String(falseTrue[datalayer_extended.cellpower.IO_state_charge_enable]) + "</h4>";
-    content +=
-        "<h4>Precharge relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_precharge_relay]) + "</h4>";
-    content +=
-        "<h4>Discharge enable: " + String(falseTrue[datalayer_extended.cellpower.IO_state_discharge_enable]) + "</h4>";
-    content += "<h4>IO 6: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_6]) + "</h4>";
-    content += "<h4>IO 7: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_7]) + "</h4>";
-    content += "<h4>IO 8: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_8]) + "</h4>";
-    content += "<h3>Errors:</h3>";
-    content +=
-        "<h4>Cell overvoltage: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_overvoltage]) + "</h4>";
-    content +=
-        "<h4>Cell undervoltage: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_undervoltage]) + "</h4>";
-    content += "<h4>Cell end of life voltage: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Cell_end_of_life_voltage]) + "</h4>";
-    content +=
-        "<h4>Cell voltage misread: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_voltage_misread]) +
-        "</h4>";
-    content +=
-        "<h4>Cell over temperature: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_over_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>Cell under temperature: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_under_temperature]) +
-        "</h4>";
-    content += "<h4>Cell unmanaged: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_unmanaged]) + "</h4>";
-    content +=
-        "<h4>LMU over temperature: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_over_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>LMU under temperature: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_under_temperature]) +
-        "</h4>";
-    content += "<h4>Temp sensor open circuit: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Temp_sensor_open_circuit]) + "</h4>";
-    content += "<h4>Temp sensor short circuit: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Temp_sensor_short_circuit]) + "</h4>";
-    content += "<h4>SUB comm: " + String(falseTrue[datalayer_extended.cellpower.error_SUB_communication]) + "</h4>";
-    content += "<h4>LMU comm: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_communication]) + "</h4>";
-    content +=
-        "<h4>Over current In: " + String(falseTrue[datalayer_extended.cellpower.error_Over_current_IN]) + "</h4>";
-    content +=
-        "<h4>Over current Out: " + String(falseTrue[datalayer_extended.cellpower.error_Over_current_OUT]) + "</h4>";
-    content += "<h4>Short circuit: " + String(falseTrue[datalayer_extended.cellpower.error_Short_circuit]) + "</h4>";
-    content += "<h4>Leak detected: " + String(falseTrue[datalayer_extended.cellpower.error_Leak_detected]) + "</h4>";
-    content +=
-        "<h4>Leak detection failed: " + String(falseTrue[datalayer_extended.cellpower.error_Leak_detection_failed]) +
-        "</h4>";
-    content +=
-        "<h4>Voltage diff: " + String(falseTrue[datalayer_extended.cellpower.error_Voltage_difference]) + "</h4>";
-    content += "<h4>BMCU supply overvoltage: " +
-               String(falseTrue[datalayer_extended.cellpower.error_BMCU_supply_over_voltage]) + "</h4>";
-    content += "<h4>BMCU supply undervoltage: " +
-               String(falseTrue[datalayer_extended.cellpower.error_BMCU_supply_under_voltage]) + "</h4>";
-    content += "<h4>Main positive contactor: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Main_positive_contactor]) + "</h4>";
-    content += "<h4>Main negative contactor: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Main_negative_contactor]) + "</h4>";
-    content += "<h4>Precharge contactor: " + String(falseTrue[datalayer_extended.cellpower.error_Precharge_contactor]) +
-               "</h4>";
-    content +=
-        "<h4>Midpack contactor: " + String(falseTrue[datalayer_extended.cellpower.error_Midpack_contactor]) + "</h4>";
-    content +=
-        "<h4>Precharge timeout: " + String(falseTrue[datalayer_extended.cellpower.error_Precharge_timeout]) + "</h4>";
-    content += "<h4>EMG connector override: " +
-               String(falseTrue[datalayer_extended.cellpower.error_Emergency_connector_override]) + "</h4>";
-    content += "<h3>Warnings:</h3>";
-    content +=
-        "<h4>High cell voltage: " + String(falseTrue[datalayer_extended.cellpower.warning_High_cell_voltage]) + "</h4>";
-    content +=
-        "<h4>Low cell voltage: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_cell_voltage]) + "</h4>";
-    content +=
-        "<h4>High cell temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_High_cell_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>Low cell temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_cell_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>High LMU temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_High_LMU_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>Low LMU temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_LMU_temperature]) +
-        "</h4>";
-    content +=
-        "<h4>SUB comm interf: " + String(falseTrue[datalayer_extended.cellpower.warning_SUB_communication_interfered]) +
-        "</h4>";
-    content +=
-        "<h4>LMU comm interf: " + String(falseTrue[datalayer_extended.cellpower.warning_LMU_communication_interfered]) +
-        "</h4>";
-    content +=
-        "<h4>High current In: " + String(falseTrue[datalayer_extended.cellpower.warning_High_current_IN]) + "</h4>";
-    content +=
-        "<h4>High current Out: " + String(falseTrue[datalayer_extended.cellpower.warning_High_current_OUT]) + "</h4>";
-    content += "<h4>Pack resistance diff: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_Pack_resistance_difference]) + "</h4>";
-    content +=
-        "<h4>High pack resistance: " + String(falseTrue[datalayer_extended.cellpower.warning_High_pack_resistance]) +
-        "</h4>";
-    content += "<h4>Cell resistance diff: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_Cell_resistance_difference]) + "</h4>";
-    content +=
-        "<h4>High cell resistance: " + String(falseTrue[datalayer_extended.cellpower.warning_High_cell_resistance]) +
-        "</h4>";
-    content += "<h4>High BMCU supply voltage: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_High_BMCU_supply_voltage]) + "</h4>";
-    content += "<h4>Low BMCU supply voltage: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_Low_BMCU_supply_voltage]) + "</h4>";
-    content += "<h4>Low SOC: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_SOC]) + "</h4>";
-    content += "<h4>Balancing required: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_Balancing_required_OCV_model]) + "</h4>";
-    content += "<h4>Charger not responding: " +
-               String(falseTrue[datalayer_extended.cellpower.warning_Charger_not_responding]) + "</h4>";
-#endif  //CELLPOWER_BMS
-
-#ifdef CMFA_EV_BATTERY
-    content += "<h4>SOC U: " + String(datalayer_extended.CMFAEV.soc_u) + "percent</h4>";
-    content += "<h4>SOC Z: " + String(datalayer_extended.CMFAEV.soc_z) + "percent</h4>";
-    content += "<h4>SOH Average: " + String(datalayer_extended.CMFAEV.soh_average) + "pptt</h4>";
-    content += "<h4>12V voltage: " + String(datalayer_extended.CMFAEV.lead_acid_voltage) + "mV</h4>";
-    content += "<h4>Highest cell number: " + String(datalayer_extended.CMFAEV.highest_cell_voltage_number) + "</h4>";
-    content += "<h4>Lowest cell number: " + String(datalayer_extended.CMFAEV.lowest_cell_voltage_number) + "</h4>";
-    content += "<h4>Max regen power: " + String(datalayer_extended.CMFAEV.max_regen_power) + "</h4>";
-    content += "<h4>Max discharge power: " + String(datalayer_extended.CMFAEV.max_discharge_power) + "</h4>";
-    content += "<h4>Max charge power: " + String(datalayer_extended.CMFAEV.maximum_charge_power) + "</h4>";
-    content += "<h4>SOH available power: " + String(datalayer_extended.CMFAEV.SOH_available_power) + "</h4>";
-    content += "<h4>SOH generated power: " + String(datalayer_extended.CMFAEV.SOH_generated_power) + "</h4>";
-    content += "<h4>Average temperature: " + String(datalayer_extended.CMFAEV.average_temperature) + "dC</h4>";
-    content += "<h4>Maximum temperature: " + String(datalayer_extended.CMFAEV.maximum_temperature) + "dC</h4>";
-    content += "<h4>Minimum temperature: " + String(datalayer_extended.CMFAEV.minimum_temperature) + "dC</h4>";
-    content +=
-        "<h4>Cumulative energy discharged: " + String(datalayer_extended.CMFAEV.cumulative_energy_when_discharging) +
-        "Wh</h4>";
-    content += "<h4>Cumulative energy charged: " + String(datalayer_extended.CMFAEV.cumulative_energy_when_charging) +
-               "Wh</h4>";
-    content +=
-        "<h4>Cumulative energy regen: " + String(datalayer_extended.CMFAEV.cumulative_energy_in_regen) + "Wh</h4>";
-#endif  //CMFA_EV_BATTERY
-
-#ifdef KIA_HYUNDAI_64_BATTERY
-    content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.total_cell_count) + "S</h4>";
-    content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery_12V / 10.0, 1) + "</h4>";
-    content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.waterleakageSensor) + "</h4>";
-    content +=
-        "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.temperature_water_inlet) + "</h4>";
-    content +=
-        "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.powerRelayTemperature) + "</h4>";
-    content += "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
-    content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
-    content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
+    else if (battery->type() == CellPower) {
+      static const char* falseTrue[2] = {"False", "True"};
+      content += "<h3>States:</h3>";
+      content += "<h4>Discharge: " + String(falseTrue[datalayer_extended.cellpower.system_state_discharge]) + "</h4>";
+      content += "<h4>Charge: " + String(falseTrue[datalayer_extended.cellpower.system_state_charge]) + "</h4>";
+      content +=
+          "<h4>Cellbalancing: " + String(falseTrue[datalayer_extended.cellpower.system_state_cellbalancing]) + "</h4>";
+      content += "<h4>Tricklecharging: " + String(falseTrue[datalayer_extended.cellpower.system_state_tricklecharge]) +
+                 "</h4>";
+      content += "<h4>Idle: " + String(falseTrue[datalayer_extended.cellpower.system_state_idle]) + "</h4>";
+      content +=
+          "<h4>Charge completed: " + String(falseTrue[datalayer_extended.cellpower.system_state_chargecompleted]) +
+          "</h4>";
+      content +=
+          "<h4>Maintenance charge: " + String(falseTrue[datalayer_extended.cellpower.system_state_maintenancecharge]) +
+          "</h4>";
+      content += "<h3>IO:</h3>";
+      content +=
+          "<h4>Main positive relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_main_positive_relay]) +
+          "</h4>";
+      content +=
+          "<h4>Main negative relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_main_negative_relay]) +
+          "</h4>";
+      content +=
+          "<h4>Charge enabled: " + String(falseTrue[datalayer_extended.cellpower.IO_state_charge_enable]) + "</h4>";
+      content +=
+          "<h4>Precharge relay: " + String(falseTrue[datalayer_extended.cellpower.IO_state_precharge_relay]) + "</h4>";
+      content += "<h4>Discharge enable: " + String(falseTrue[datalayer_extended.cellpower.IO_state_discharge_enable]) +
+                 "</h4>";
+      content += "<h4>IO 6: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_6]) + "</h4>";
+      content += "<h4>IO 7: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_7]) + "</h4>";
+      content += "<h4>IO 8: " + String(falseTrue[datalayer_extended.cellpower.IO_state_IO_8]) + "</h4>";
+      content += "<h3>Errors:</h3>";
+      content +=
+          "<h4>Cell overvoltage: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_overvoltage]) + "</h4>";
+      content +=
+          "<h4>Cell undervoltage: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_undervoltage]) + "</h4>";
+      content += "<h4>Cell end of life voltage: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Cell_end_of_life_voltage]) + "</h4>";
+      content +=
+          "<h4>Cell voltage misread: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_voltage_misread]) +
+          "</h4>";
+      content +=
+          "<h4>Cell over temperature: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_over_temperature]) +
+          "</h4>";
+      content += "<h4>Cell under temperature: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Cell_under_temperature]) + "</h4>";
+      content +=
+          "<h4>Cell unmanaged: " + String(falseTrue[datalayer_extended.cellpower.error_Cell_unmanaged]) + "</h4>";
+      content +=
+          "<h4>LMU over temperature: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_over_temperature]) +
+          "</h4>";
+      content +=
+          "<h4>LMU under temperature: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_under_temperature]) +
+          "</h4>";
+      content += "<h4>Temp sensor open circuit: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Temp_sensor_open_circuit]) + "</h4>";
+      content += "<h4>Temp sensor short circuit: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Temp_sensor_short_circuit]) + "</h4>";
+      content += "<h4>SUB comm: " + String(falseTrue[datalayer_extended.cellpower.error_SUB_communication]) + "</h4>";
+      content += "<h4>LMU comm: " + String(falseTrue[datalayer_extended.cellpower.error_LMU_communication]) + "</h4>";
+      content +=
+          "<h4>Over current In: " + String(falseTrue[datalayer_extended.cellpower.error_Over_current_IN]) + "</h4>";
+      content +=
+          "<h4>Over current Out: " + String(falseTrue[datalayer_extended.cellpower.error_Over_current_OUT]) + "</h4>";
+      content += "<h4>Short circuit: " + String(falseTrue[datalayer_extended.cellpower.error_Short_circuit]) + "</h4>";
+      content += "<h4>Leak detected: " + String(falseTrue[datalayer_extended.cellpower.error_Leak_detected]) + "</h4>";
+      content +=
+          "<h4>Leak detection failed: " + String(falseTrue[datalayer_extended.cellpower.error_Leak_detection_failed]) +
+          "</h4>";
+      content +=
+          "<h4>Voltage diff: " + String(falseTrue[datalayer_extended.cellpower.error_Voltage_difference]) + "</h4>";
+      content += "<h4>BMCU supply overvoltage: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_BMCU_supply_over_voltage]) + "</h4>";
+      content += "<h4>BMCU supply undervoltage: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_BMCU_supply_under_voltage]) + "</h4>";
+      content += "<h4>Main positive contactor: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Main_positive_contactor]) + "</h4>";
+      content += "<h4>Main negative contactor: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Main_negative_contactor]) + "</h4>";
+      content +=
+          "<h4>Precharge contactor: " + String(falseTrue[datalayer_extended.cellpower.error_Precharge_contactor]) +
+          "</h4>";
+      content +=
+          "<h4>Midpack contactor: " + String(falseTrue[datalayer_extended.cellpower.error_Midpack_contactor]) + "</h4>";
+      content +=
+          "<h4>Precharge timeout: " + String(falseTrue[datalayer_extended.cellpower.error_Precharge_timeout]) + "</h4>";
+      content += "<h4>EMG connector override: " +
+                 String(falseTrue[datalayer_extended.cellpower.error_Emergency_connector_override]) + "</h4>";
+      content += "<h3>Warnings:</h3>";
+      content += "<h4>High cell voltage: " + String(falseTrue[datalayer_extended.cellpower.warning_High_cell_voltage]) +
+                 "</h4>";
+      content +=
+          "<h4>Low cell voltage: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_cell_voltage]) + "</h4>";
+      content += "<h4>High cell temperature: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_High_cell_temperature]) + "</h4>";
+      content +=
+          "<h4>Low cell temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_cell_temperature]) +
+          "</h4>";
+      content +=
+          "<h4>High LMU temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_High_LMU_temperature]) +
+          "</h4>";
+      content +=
+          "<h4>Low LMU temperature: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_LMU_temperature]) +
+          "</h4>";
+      content += "<h4>SUB comm interf: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_SUB_communication_interfered]) + "</h4>";
+      content += "<h4>LMU comm interf: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_LMU_communication_interfered]) + "</h4>";
+      content +=
+          "<h4>High current In: " + String(falseTrue[datalayer_extended.cellpower.warning_High_current_IN]) + "</h4>";
+      content +=
+          "<h4>High current Out: " + String(falseTrue[datalayer_extended.cellpower.warning_High_current_OUT]) + "</h4>";
+      content += "<h4>Pack resistance diff: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_Pack_resistance_difference]) + "</h4>";
+      content +=
+          "<h4>High pack resistance: " + String(falseTrue[datalayer_extended.cellpower.warning_High_pack_resistance]) +
+          "</h4>";
+      content += "<h4>Cell resistance diff: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_Cell_resistance_difference]) + "</h4>";
+      content +=
+          "<h4>High cell resistance: " + String(falseTrue[datalayer_extended.cellpower.warning_High_cell_resistance]) +
+          "</h4>";
+      content += "<h4>High BMCU supply voltage: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_High_BMCU_supply_voltage]) + "</h4>";
+      content += "<h4>Low BMCU supply voltage: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_Low_BMCU_supply_voltage]) + "</h4>";
+      content += "<h4>Low SOC: " + String(falseTrue[datalayer_extended.cellpower.warning_Low_SOC]) + "</h4>";
+      content += "<h4>Balancing required: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_Balancing_required_OCV_model]) + "</h4>";
+      content += "<h4>Charger not responding: " +
+                 String(falseTrue[datalayer_extended.cellpower.warning_Charger_not_responding]) + "</h4>";
+    } else if (battery->type() == CmfaEv) {
+      content += "<h4>SOC U: " + String(datalayer_extended.CMFAEV.soc_u) + "percent</h4>";
+      content += "<h4>SOC Z: " + String(datalayer_extended.CMFAEV.soc_z) + "percent</h4>";
+      content += "<h4>SOH Average: " + String(datalayer_extended.CMFAEV.soh_average) + "pptt</h4>";
+      content += "<h4>12V voltage: " + String(datalayer_extended.CMFAEV.lead_acid_voltage) + "mV</h4>";
+      content += "<h4>Highest cell number: " + String(datalayer_extended.CMFAEV.highest_cell_voltage_number) + "</h4>";
+      content += "<h4>Lowest cell number: " + String(datalayer_extended.CMFAEV.lowest_cell_voltage_number) + "</h4>";
+      content += "<h4>Max regen power: " + String(datalayer_extended.CMFAEV.max_regen_power) + "</h4>";
+      content += "<h4>Max discharge power: " + String(datalayer_extended.CMFAEV.max_discharge_power) + "</h4>";
+      content += "<h4>Max charge power: " + String(datalayer_extended.CMFAEV.maximum_charge_power) + "</h4>";
+      content += "<h4>SOH available power: " + String(datalayer_extended.CMFAEV.SOH_available_power) + "</h4>";
+      content += "<h4>SOH generated power: " + String(datalayer_extended.CMFAEV.SOH_generated_power) + "</h4>";
+      content += "<h4>Average temperature: " + String(datalayer_extended.CMFAEV.average_temperature) + "dC</h4>";
+      content += "<h4>Maximum temperature: " + String(datalayer_extended.CMFAEV.maximum_temperature) + "dC</h4>";
+      content += "<h4>Minimum temperature: " + String(datalayer_extended.CMFAEV.minimum_temperature) + "dC</h4>";
+      content +=
+          "<h4>Cumulative energy discharged: " + String(datalayer_extended.CMFAEV.cumulative_energy_when_discharging) +
+          "Wh</h4>";
+      content += "<h4>Cumulative energy charged: " + String(datalayer_extended.CMFAEV.cumulative_energy_when_charging) +
+                 "Wh</h4>";
+      content +=
+          "<h4>Cumulative energy regen: " + String(datalayer_extended.CMFAEV.cumulative_energy_in_regen) + "Wh</h4>";
+    } else if (battery->type() == KiaHyundai64) {
+      content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.total_cell_count) + "S</h4>";
+      content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery_12V / 10.0, 1) + "</h4>";
+      content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.waterleakageSensor) + "</h4>";
+      content +=
+          "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.temperature_water_inlet) + "</h4>";
+      content +=
+          "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.powerRelayTemperature) + "</h4>";
+      content +=
+          "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.batteryManagementMode) + "</h4>";
+      content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.BMS_ign) + "</h4>";
+      content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.batteryRelay) + "</h4>";
 #ifdef DOUBLE_BATTERY
-    content += "<h4>Values from battery 2</h4>";
-    content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.battery2_total_cell_count) + "S</h4>";
-    content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery2_battery_12V / 10.0, 1) + "</h4>";
-    content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.battery2_waterleakageSensor) + "</h4>";
-    content +=
-        "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.battery2_temperature_water_inlet) +
-        "</h4>";
-    content +=
-        "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.battery2_powerRelayTemperature) +
-        "</h4>";
-    content += "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.battery2_batteryManagementMode) +
-               "</h4>";
-    content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.battery2_BMS_ign) + "</h4>";
-    content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.battery2_batteryRelay) + "</h4>";
+      content += "<h4>Values from battery 2</h4>";
+      content += "<h4>Cells: " + String(datalayer_extended.KiaHyundai64.battery2_total_cell_count) + "S</h4>";
+      content += "<h4>12V voltage: " + String(datalayer_extended.KiaHyundai64.battery2_battery_12V / 10.0, 1) + "</h4>";
+      content += "<h4>Waterleakage: " + String(datalayer_extended.KiaHyundai64.battery2_waterleakageSensor) + "</h4>";
+      content +=
+          "<h4>Temperature, water inlet: " + String(datalayer_extended.KiaHyundai64.battery2_temperature_water_inlet) +
+          "</h4>";
+      content +=
+          "<h4>Temperature, power relay: " + String(datalayer_extended.KiaHyundai64.battery2_powerRelayTemperature) +
+          "</h4>";
+      content +=
+          "<h4>Batterymanagement mode: " + String(datalayer_extended.KiaHyundai64.battery2_batteryManagementMode) +
+          "</h4>";
+      content += "<h4>BMS ignition: " + String(datalayer_extended.KiaHyundai64.battery2_BMS_ign) + "</h4>";
+      content += "<h4>Battery relay: " + String(datalayer_extended.KiaHyundai64.battery2_batteryRelay) + "</h4>";
 #endif  //DOUBLE_BATTERY
-#endif  //KIA_HYUNDAI_64_BATTERY
+    }  //KIA_HYUNDAI_64_BATTERY
 
-#ifdef BYD_ATTO_3_BATTERY
-    static const char* SOCmethod[2] = {"Estimated from voltage", "Measured by BMS"};
-    content += "<h4>SOC method used: " + String(SOCmethod[datalayer_extended.bydAtto3.SOC_method]) + "</h4>";
-    content += "<h4>SOC estimated: " + String(datalayer_extended.bydAtto3.SOC_estimated) + "</h4>";
-    content += "<h4>SOC highprec: " + String(datalayer_extended.bydAtto3.SOC_highprec) + "</h4>";
-    content += "<h4>SOC OBD2: " + String(datalayer_extended.bydAtto3.SOC_polled) + "</h4>";
-    content += "<h4>Voltage periodic: " + String(datalayer_extended.bydAtto3.voltage_periodic) + "</h4>";
-    content += "<h4>Voltage OBD2: " + String(datalayer_extended.bydAtto3.voltage_polled) + "</h4>";
-    content += "<h4>Temperature sensor 1: " + String(datalayer_extended.bydAtto3.battery_temperatures[0]) + "</h4>";
-    content += "<h4>Temperature sensor 2: " + String(datalayer_extended.bydAtto3.battery_temperatures[1]) + "</h4>";
-    content += "<h4>Temperature sensor 3: " + String(datalayer_extended.bydAtto3.battery_temperatures[2]) + "</h4>";
-    content += "<h4>Temperature sensor 4: " + String(datalayer_extended.bydAtto3.battery_temperatures[3]) + "</h4>";
-    content += "<h4>Temperature sensor 5: " + String(datalayer_extended.bydAtto3.battery_temperatures[4]) + "</h4>";
-    content += "<h4>Temperature sensor 6: " + String(datalayer_extended.bydAtto3.battery_temperatures[5]) + "</h4>";
-    content += "<h4>Temperature sensor 7: " + String(datalayer_extended.bydAtto3.battery_temperatures[6]) + "</h4>";
-    content += "<h4>Temperature sensor 8: " + String(datalayer_extended.bydAtto3.battery_temperatures[7]) + "</h4>";
-    content += "<h4>Temperature sensor 9: " + String(datalayer_extended.bydAtto3.battery_temperatures[8]) + "</h4>";
-    content += "<h4>Temperature sensor 10: " + String(datalayer_extended.bydAtto3.battery_temperatures[9]) + "</h4>";
-#endif  //BYD_ATTO_3_BATTERY
+    else if (battery->type() == BydAtto3) {
+      static const char* SOCmethod[2] = {"Estimated from voltage", "Measured by BMS"};
+      content += "<h4>SOC method used: " + String(SOCmethod[datalayer_extended.bydAtto3.SOC_method]) + "</h4>";
+      content += "<h4>SOC estimated: " + String(datalayer_extended.bydAtto3.SOC_estimated) + "</h4>";
+      content += "<h4>SOC highprec: " + String(datalayer_extended.bydAtto3.SOC_highprec) + "</h4>";
+      content += "<h4>SOC OBD2: " + String(datalayer_extended.bydAtto3.SOC_polled) + "</h4>";
+      content += "<h4>Voltage periodic: " + String(datalayer_extended.bydAtto3.voltage_periodic) + "</h4>";
+      content += "<h4>Voltage OBD2: " + String(datalayer_extended.bydAtto3.voltage_polled) + "</h4>";
+      content += "<h4>Temperature sensor 1: " + String(datalayer_extended.bydAtto3.battery_temperatures[0]) + "</h4>";
+      content += "<h4>Temperature sensor 2: " + String(datalayer_extended.bydAtto3.battery_temperatures[1]) + "</h4>";
+      content += "<h4>Temperature sensor 3: " + String(datalayer_extended.bydAtto3.battery_temperatures[2]) + "</h4>";
+      content += "<h4>Temperature sensor 4: " + String(datalayer_extended.bydAtto3.battery_temperatures[3]) + "</h4>";
+      content += "<h4>Temperature sensor 5: " + String(datalayer_extended.bydAtto3.battery_temperatures[4]) + "</h4>";
+      content += "<h4>Temperature sensor 6: " + String(datalayer_extended.bydAtto3.battery_temperatures[5]) + "</h4>";
+      content += "<h4>Temperature sensor 7: " + String(datalayer_extended.bydAtto3.battery_temperatures[6]) + "</h4>";
+      content += "<h4>Temperature sensor 8: " + String(datalayer_extended.bydAtto3.battery_temperatures[7]) + "</h4>";
+      content += "<h4>Temperature sensor 9: " + String(datalayer_extended.bydAtto3.battery_temperatures[8]) + "</h4>";
+      content += "<h4>Temperature sensor 10: " + String(datalayer_extended.bydAtto3.battery_temperatures[9]) + "</h4>";
+    }  //BYD_ATTO_3_BATTERY
 
-#ifdef TESLA_BATTERY
-    float beginning_of_life = static_cast<float>(datalayer_extended.tesla.battery_beginning_of_life);
-    float battTempPct = static_cast<float>(datalayer_extended.tesla.battery_battTempPct) * 0.4;
-    float dcdcLvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625;
-    float dcdcHvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcHvBusVolt) * 0.146484;
-    float dcdcLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1;
-    float nominal_full_pack_energy =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy) * 0.1;
-    float nominal_full_pack_energy_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy_m0) * 0.02;
-    float nominal_energy_remaining =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining) * 0.1;
-    float nominal_energy_remaining_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining_m0) * 0.02;
-    float ideal_energy_remaining = static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining) * 0.1;
-    float ideal_energy_remaining_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining_m0) * 0.02;
-    float energy_to_charge_complete =
-        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete) * 0.1;
-    float energy_to_charge_complete_m1 =
-        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete_m1) * 0.02;
-    float energy_buffer = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer) * 0.1;
-    float energy_buffer_m1 = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer_m1) * 0.01;
-    float expected_energy_remaining_m1 =
-        static_cast<float>(datalayer_extended.tesla.battery_expected_energy_remaining_m1) * 0.02;
-    float total_discharge = static_cast<float>(datalayer.battery.status.total_discharged_battery_Wh) * 0.001;
-    float total_charge = static_cast<float>(datalayer.battery.status.total_charged_battery_Wh) * 0.001;
-    float packMass = static_cast<float>(datalayer_extended.tesla.battery_packMass);
-    float platformMaxBusVoltage =
-        static_cast<float>(datalayer_extended.tesla.battery_platformMaxBusVoltage) * 0.1 + 375;
-    float bms_min_voltage = static_cast<float>(datalayer_extended.tesla.battery_bms_min_voltage) * 0.01 * 2;
-    float bms_max_voltage = static_cast<float>(datalayer_extended.tesla.battery_bms_max_voltage) * 0.01 * 2;
-    float max_charge_current = static_cast<float>(datalayer_extended.tesla.battery_max_charge_current);
-    float max_discharge_current = static_cast<float>(datalayer_extended.tesla.battery_max_discharge_current);
-    float soc_ave = static_cast<float>(datalayer_extended.tesla.battery_soc_ave) * 0.1;
-    float soc_max = static_cast<float>(datalayer_extended.tesla.battery_soc_max) * 0.1;
-    float soc_min = static_cast<float>(datalayer_extended.tesla.battery_soc_min) * 0.1;
-    float soc_ui = static_cast<float>(datalayer_extended.tesla.battery_soc_ui) * 0.1;
-    float BrickVoltageMax = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMax) * 0.002;
-    float BrickVoltageMin = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMin) * 0.002;
-    float BrickModelTMax = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMax) * 0.5 - 40;
-    float BrickModelTMin = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMin) * 0.5 - 40;
-    float isolationResistance = static_cast<float>(datalayer_extended.tesla.battery_BMS_isolationResistance) * 10;
-    float PCS_dcdcMaxOutputCurrentAllowed =
-        static_cast<float>(datalayer_extended.tesla.battery_PCS_dcdcMaxOutputCurrentAllowed) * 0.1;
-    float PCS_dcdcTemp = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTemp) * 0.1 + 40;
-    float PCS_ambientTemp = static_cast<float>(datalayer_extended.tesla.PCS_ambientTemp) * 0.1 + 40;
-    float PCS_chgPhATemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhATemp) * 0.1 + 40;
-    float PCS_chgPhBTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhBTemp) * 0.1 + 40;
-    float PCS_chgPhCTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhCTemp) * 0.1 + 40;
-    float BMS_maxRegenPower = static_cast<float>(datalayer_extended.tesla.BMS_maxRegenPower) * 0.01;
-    float BMS_maxDischargePower = static_cast<float>(datalayer_extended.tesla.BMS_maxDischargePower) * 0.013;
-    float BMS_maxStationaryHeatPower = static_cast<float>(datalayer_extended.tesla.BMS_maxStationaryHeatPower) * 0.01;
-    float BMS_hvacPowerBudget = static_cast<float>(datalayer_extended.tesla.BMS_hvacPowerBudget) * 0.02;
-    float BMS_powerDissipation = static_cast<float>(datalayer_extended.tesla.BMS_powerDissipation) * 0.02;
-    float BMS_flowRequest = static_cast<float>(datalayer_extended.tesla.BMS_flowRequest) * 0.3;
-    float BMS_inletActiveCoolTargetT =
-        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveCoolTargetT) * 0.25 - 25;
-    float BMS_inletPassiveTargetT = static_cast<float>(datalayer_extended.tesla.BMS_inletPassiveTargetT) * 0.25 - 25;
-    float BMS_inletActiveHeatTargetT =
-        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveHeatTargetT) * 0.25 - 25;
-    float BMS_packTMin = static_cast<float>(datalayer_extended.tesla.BMS_packTMin) * 0.25 - 25;
-    float BMS_packTMax = static_cast<float>(datalayer_extended.tesla.BMS_packTMax) * 0.25 - 25;
-    float PCS_dcdcMaxLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxLvOutputCurrent) * 0.1;
-    float PCS_dcdcCurrentLimit = static_cast<float>(datalayer_extended.tesla.PCS_dcdcCurrentLimit) * 0.1;
-    float PCS_dcdcLvOutputCurrentTempLimit =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcLvOutputCurrentTempLimit) * 0.1;
-    float PCS_dcdcUnifiedCommand = static_cast<float>(datalayer_extended.tesla.PCS_dcdcUnifiedCommand) * 0.001;
-    float PCS_dcdcCLAControllerOutput =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcCLAControllerOutput * 0.001);
-    float PCS_dcdcTankVoltage = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltage);
-    float PCS_dcdcTankVoltageTarget = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltageTarget);
-    float PCS_dcdcClaCurrentFreq = static_cast<float>(datalayer_extended.tesla.PCS_dcdcClaCurrentFreq) * 0.0976563;
-    float PCS_dcdcTCommMeasured = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTCommMeasured) * 0.00195313;
-    float PCS_dcdcShortTimeUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcShortTimeUs) * 0.000488281;
-    float PCS_dcdcHalfPeriodUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcHalfPeriodUs) * 0.000488281;
-    float PCS_dcdcIntervalMaxFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxFrequency);
-    float PCS_dcdcIntervalMaxHvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxHvBusVolt) * 0.1;
-    float PCS_dcdcIntervalMaxLvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvBusVolt) * 0.1;
-    float PCS_dcdcIntervalMaxLvOutputCurr =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvOutputCurr);
-    float PCS_dcdcIntervalMinFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinFrequency);
-    float PCS_dcdcIntervalMinHvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinHvBusVolt) * 0.1;
-    float PCS_dcdcIntervalMinLvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvBusVolt) * 0.1;
-    float PCS_dcdcIntervalMinLvOutputCurr =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvOutputCurr);
-    float PCS_dcdc12vSupportLifetimekWh =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdc12vSupportLifetimekWh) * 0.01;
-    float HVP_hvp1v5Ref = static_cast<float>(datalayer_extended.tesla.HVP_hvp1v5Ref) * 0.1;
-    float HVP_shuntCurrentDebug = static_cast<float>(datalayer_extended.tesla.HVP_shuntCurrentDebug) * 0.1;
-    float HVP_dcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkVoltage) * 0.1;
-    float HVP_packVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packVoltage) * 0.1;
-    float HVP_fcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkVoltage) * 0.1;
-    float HVP_packContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packContVoltage) * 0.1;
-    float HVP_packNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_packNegativeV) * 0.1;
-    float HVP_packPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_packPositiveV) * 0.1;
-    float HVP_pyroAnalog = static_cast<float>(datalayer_extended.tesla.HVP_pyroAnalog) * 0.1;
-    float HVP_dcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkNegativeV) * 0.1;
-    float HVP_dcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkPositiveV) * 0.1;
-    float HVP_fcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkNegativeV) * 0.1;
-    float HVP_fcContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_fcContCoilCurrent) * 0.1;
-    float HVP_fcContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcContVoltage) * 0.1;
-    float HVP_hvilInVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilInVoltage) * 0.1;
-    float HVP_hvilOutVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilOutVoltage) * 0.1;
-    float HVP_fcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkPositiveV) * 0.1;
-    float HVP_packContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_packContCoilCurrent) * 0.1;
-    float HVP_battery12V = static_cast<float>(datalayer_extended.tesla.HVP_battery12V) * 0.1;
-    float HVP_shuntRefVoltageDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntRefVoltageDbg) * 0.001;
-    float HVP_shuntAuxCurrentDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAuxCurrentDbg) * 0.1;
-    float HVP_shuntBarTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntBarTempDbg) * 0.01;
-    float HVP_shuntAsicTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAsicTempDbg) * 0.01;
+    else if (battery->type() == Tesla3Y || battery->type() == TeslaSX) {
+      float beginning_of_life = static_cast<float>(datalayer_extended.tesla.battery_beginning_of_life);
+      float battTempPct = static_cast<float>(datalayer_extended.tesla.battery_battTempPct) * 0.4;
+      float dcdcLvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625;
+      float dcdcHvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcHvBusVolt) * 0.146484;
+      float dcdcLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1;
+      float nominal_full_pack_energy =
+          static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy) * 0.1;
+      float nominal_full_pack_energy_m0 =
+          static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy_m0) * 0.02;
+      float nominal_energy_remaining =
+          static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining) * 0.1;
+      float nominal_energy_remaining_m0 =
+          static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining_m0) * 0.02;
+      float ideal_energy_remaining = static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining) * 0.1;
+      float ideal_energy_remaining_m0 =
+          static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining_m0) * 0.02;
+      float energy_to_charge_complete =
+          static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete) * 0.1;
+      float energy_to_charge_complete_m1 =
+          static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete_m1) * 0.02;
+      float energy_buffer = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer) * 0.1;
+      float energy_buffer_m1 = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer_m1) * 0.01;
+      float expected_energy_remaining_m1 =
+          static_cast<float>(datalayer_extended.tesla.battery_expected_energy_remaining_m1) * 0.02;
+      float total_discharge = static_cast<float>(datalayer.battery.status.total_discharged_battery_Wh) * 0.001;
+      float total_charge = static_cast<float>(datalayer.battery.status.total_charged_battery_Wh) * 0.001;
+      float packMass = static_cast<float>(datalayer_extended.tesla.battery_packMass);
+      float platformMaxBusVoltage =
+          static_cast<float>(datalayer_extended.tesla.battery_platformMaxBusVoltage) * 0.1 + 375;
+      float bms_min_voltage = static_cast<float>(datalayer_extended.tesla.battery_bms_min_voltage) * 0.01 * 2;
+      float bms_max_voltage = static_cast<float>(datalayer_extended.tesla.battery_bms_max_voltage) * 0.01 * 2;
+      float max_charge_current = static_cast<float>(datalayer_extended.tesla.battery_max_charge_current);
+      float max_discharge_current = static_cast<float>(datalayer_extended.tesla.battery_max_discharge_current);
+      float soc_ave = static_cast<float>(datalayer_extended.tesla.battery_soc_ave) * 0.1;
+      float soc_max = static_cast<float>(datalayer_extended.tesla.battery_soc_max) * 0.1;
+      float soc_min = static_cast<float>(datalayer_extended.tesla.battery_soc_min) * 0.1;
+      float soc_ui = static_cast<float>(datalayer_extended.tesla.battery_soc_ui) * 0.1;
+      float BrickVoltageMax = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMax) * 0.002;
+      float BrickVoltageMin = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMin) * 0.002;
+      float BrickModelTMax = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMax) * 0.5 - 40;
+      float BrickModelTMin = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMin) * 0.5 - 40;
+      float isolationResistance = static_cast<float>(datalayer_extended.tesla.battery_BMS_isolationResistance) * 10;
+      float PCS_dcdcMaxOutputCurrentAllowed =
+          static_cast<float>(datalayer_extended.tesla.battery_PCS_dcdcMaxOutputCurrentAllowed) * 0.1;
+      float PCS_dcdcTemp = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTemp) * 0.1 + 40;
+      float PCS_ambientTemp = static_cast<float>(datalayer_extended.tesla.PCS_ambientTemp) * 0.1 + 40;
+      float PCS_chgPhATemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhATemp) * 0.1 + 40;
+      float PCS_chgPhBTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhBTemp) * 0.1 + 40;
+      float PCS_chgPhCTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhCTemp) * 0.1 + 40;
+      float BMS_maxRegenPower = static_cast<float>(datalayer_extended.tesla.BMS_maxRegenPower) * 0.01;
+      float BMS_maxDischargePower = static_cast<float>(datalayer_extended.tesla.BMS_maxDischargePower) * 0.013;
+      float BMS_maxStationaryHeatPower = static_cast<float>(datalayer_extended.tesla.BMS_maxStationaryHeatPower) * 0.01;
+      float BMS_hvacPowerBudget = static_cast<float>(datalayer_extended.tesla.BMS_hvacPowerBudget) * 0.02;
+      float BMS_powerDissipation = static_cast<float>(datalayer_extended.tesla.BMS_powerDissipation) * 0.02;
+      float BMS_flowRequest = static_cast<float>(datalayer_extended.tesla.BMS_flowRequest) * 0.3;
+      float BMS_inletActiveCoolTargetT =
+          static_cast<float>(datalayer_extended.tesla.BMS_inletActiveCoolTargetT) * 0.25 - 25;
+      float BMS_inletPassiveTargetT = static_cast<float>(datalayer_extended.tesla.BMS_inletPassiveTargetT) * 0.25 - 25;
+      float BMS_inletActiveHeatTargetT =
+          static_cast<float>(datalayer_extended.tesla.BMS_inletActiveHeatTargetT) * 0.25 - 25;
+      float BMS_packTMin = static_cast<float>(datalayer_extended.tesla.BMS_packTMin) * 0.25 - 25;
+      float BMS_packTMax = static_cast<float>(datalayer_extended.tesla.BMS_packTMax) * 0.25 - 25;
+      float PCS_dcdcMaxLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxLvOutputCurrent) * 0.1;
+      float PCS_dcdcCurrentLimit = static_cast<float>(datalayer_extended.tesla.PCS_dcdcCurrentLimit) * 0.1;
+      float PCS_dcdcLvOutputCurrentTempLimit =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcLvOutputCurrentTempLimit) * 0.1;
+      float PCS_dcdcUnifiedCommand = static_cast<float>(datalayer_extended.tesla.PCS_dcdcUnifiedCommand) * 0.001;
+      float PCS_dcdcCLAControllerOutput =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcCLAControllerOutput * 0.001);
+      float PCS_dcdcTankVoltage = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltage);
+      float PCS_dcdcTankVoltageTarget = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltageTarget);
+      float PCS_dcdcClaCurrentFreq = static_cast<float>(datalayer_extended.tesla.PCS_dcdcClaCurrentFreq) * 0.0976563;
+      float PCS_dcdcTCommMeasured = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTCommMeasured) * 0.00195313;
+      float PCS_dcdcShortTimeUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcShortTimeUs) * 0.000488281;
+      float PCS_dcdcHalfPeriodUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcHalfPeriodUs) * 0.000488281;
+      float PCS_dcdcIntervalMaxFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxFrequency);
+      float PCS_dcdcIntervalMaxHvBusVolt =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxHvBusVolt) * 0.1;
+      float PCS_dcdcIntervalMaxLvBusVolt =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvBusVolt) * 0.1;
+      float PCS_dcdcIntervalMaxLvOutputCurr =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvOutputCurr);
+      float PCS_dcdcIntervalMinFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinFrequency);
+      float PCS_dcdcIntervalMinHvBusVolt =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinHvBusVolt) * 0.1;
+      float PCS_dcdcIntervalMinLvBusVolt =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvBusVolt) * 0.1;
+      float PCS_dcdcIntervalMinLvOutputCurr =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvOutputCurr);
+      float PCS_dcdc12vSupportLifetimekWh =
+          static_cast<float>(datalayer_extended.tesla.PCS_dcdc12vSupportLifetimekWh) * 0.01;
+      float HVP_hvp1v5Ref = static_cast<float>(datalayer_extended.tesla.HVP_hvp1v5Ref) * 0.1;
+      float HVP_shuntCurrentDebug = static_cast<float>(datalayer_extended.tesla.HVP_shuntCurrentDebug) * 0.1;
+      float HVP_dcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkVoltage) * 0.1;
+      float HVP_packVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packVoltage) * 0.1;
+      float HVP_fcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkVoltage) * 0.1;
+      float HVP_packContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packContVoltage) * 0.1;
+      float HVP_packNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_packNegativeV) * 0.1;
+      float HVP_packPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_packPositiveV) * 0.1;
+      float HVP_pyroAnalog = static_cast<float>(datalayer_extended.tesla.HVP_pyroAnalog) * 0.1;
+      float HVP_dcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkNegativeV) * 0.1;
+      float HVP_dcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkPositiveV) * 0.1;
+      float HVP_fcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkNegativeV) * 0.1;
+      float HVP_fcContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_fcContCoilCurrent) * 0.1;
+      float HVP_fcContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcContVoltage) * 0.1;
+      float HVP_hvilInVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilInVoltage) * 0.1;
+      float HVP_hvilOutVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilOutVoltage) * 0.1;
+      float HVP_fcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkPositiveV) * 0.1;
+      float HVP_packContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_packContCoilCurrent) * 0.1;
+      float HVP_battery12V = static_cast<float>(datalayer_extended.tesla.HVP_battery12V) * 0.1;
+      float HVP_shuntRefVoltageDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntRefVoltageDbg) * 0.001;
+      float HVP_shuntAuxCurrentDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAuxCurrentDbg) * 0.1;
+      float HVP_shuntBarTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntBarTempDbg) * 0.01;
+      float HVP_shuntAsicTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAsicTempDbg) * 0.01;
 
-    static const char* contactorText[] = {"UNKNOWN(0)",  "OPEN",        "CLOSING",    "BLOCKED", "OPENING",
-                                          "CLOSED",      "UNKNOWN(6)",  "WELDED",     "POS_CL",  "NEG_CL",
-                                          "UNKNOWN(10)", "UNKNOWN(11)", "UNKNOWN(12)"};
-    static const char* hvilStatusState[] = {"NOT Ok",
-                                            "STATUS_OK",
-                                            "CURRENT_SOURCE_FAULT",
-                                            "INTERNAL_OPEN_FAULT",
-                                            "VEHICLE_OPEN_FAULT",
-                                            "PENTHOUSE_LID_OPEN_FAULT",
-                                            "UNKNOWN_LOCATION_OPEN_FAULT",
-                                            "VEHICLE_NODE_FAULT",
-                                            "NO_12V_SUPPLY",
-                                            "VEHICLE_OR_PENTHOUSE_LID_OPENFAULT",
-                                            "UNKNOWN(10)",
-                                            "UNKNOWN(11)",
-                                            "UNKNOWN(12)",
-                                            "UNKNOWN(13)",
-                                            "UNKNOWN(14)",
-                                            "UNKNOWN(15)"};
-    static const char* contactorState[] = {"SNA",        "OPEN",       "PRECHARGE",   "BLOCKED",
-                                           "PULLED_IN",  "OPENING",    "ECONOMIZED",  "WELDED",
-                                           "UNKNOWN(8)", "UNKNOWN(9)", "UNKNOWN(10)", "UNKNOWN(11)"};
-    static const char* BMS_state[] = {"STANDBY",     "DRIVE", "SUPPORT", "CHARGE", "FEIM",
-                                      "CLEAR_FAULT", "FAULT", "WELD",    "TEST",   "SNA"};
-    static const char* BMS_contactorState[] = {"SNA", "OPEN", "OPENING", "CLOSING", "CLOSED", "WELDED", "BLOCKED"};
-    static const char* BMS_hvState[] = {"DOWN",          "COMING_UP",        "GOING_DOWN", "UP_FOR_DRIVE",
-                                        "UP_FOR_CHARGE", "UP_FOR_DC_CHARGE", "UP"};
-    static const char* BMS_uiChargeStatus[] = {"DISCONNECTED", "NO_POWER",        "ABOUT_TO_CHARGE",
-                                               "CHARGING",     "CHARGE_COMPLETE", "CHARGE_STOPPED"};
-    static const char* PCS_dcdcStatus[] = {"IDLE", "ACTIVE", "FAULTED"};
-    static const char* PCS_dcdcMainState[] = {"STANDBY",          "12V_SUPPORT_ACTIVE", "PRECHARGE_STARTUP",
-                                              "PRECHARGE_ACTIVE", "DIS_HVBUS_ACTIVE",   "SHUTDOWN",
-                                              "FAULTED"};
-    static const char* PCS_dcdcSubState[] = {"PWR_UP_INIT",
-                                             "STANDBY",
-                                             "12V_SUPPORT_ACTIVE",
-                                             "DIS_HVBUS",
-                                             "PCHG_FAST_DIS_HVBUS",
-                                             "PCHG_SLOW_DIS_HVBUS",
-                                             "PCHG_DWELL_CHARGE",
-                                             "PCHG_DWELL_WAIT",
-                                             "PCHG_DI_RECOVERY_WAIT",
-                                             "PCHG_ACTIVE",
-                                             "PCHG_FLT_FAST_DIS_HVBUS",
-                                             "SHUTDOWN",
-                                             "12V_SUPPORT_FAULTED",
-                                             "DIS_HVBUS_FAULTED",
-                                             "PCHG_FAULTED",
-                                             "CLEAR_FAULTS",
-                                             "FAULTED",
-                                             "NUM"};
-    static const char* BMS_powerLimitState[] = {"NOT_CALCULATED_FOR_DRIVE", "CALCULATED_FOR_DRIVE"};
-    static const char* HVP_status[] = {"INVALID", "NOT_AVAILABLE", "STALE", "VALID"};
-    static const char* HVP_contactor[] = {"NOT_ACTIVE", "ACTIVE", "COMPLETED"};
-    static const char* falseTrue[] = {"False", "True"};
-    static const char* noYes[] = {"No", "Yes"};
-    static const char* Fault[] = {"NOT_ACTIVE", "ACTIVE"};
+      static const char* contactorText[] = {"UNKNOWN(0)",  "OPEN",        "CLOSING",    "BLOCKED", "OPENING",
+                                            "CLOSED",      "UNKNOWN(6)",  "WELDED",     "POS_CL",  "NEG_CL",
+                                            "UNKNOWN(10)", "UNKNOWN(11)", "UNKNOWN(12)"};
+      static const char* hvilStatusState[] = {"NOT Ok",
+                                              "STATUS_OK",
+                                              "CURRENT_SOURCE_FAULT",
+                                              "INTERNAL_OPEN_FAULT",
+                                              "VEHICLE_OPEN_FAULT",
+                                              "PENTHOUSE_LID_OPEN_FAULT",
+                                              "UNKNOWN_LOCATION_OPEN_FAULT",
+                                              "VEHICLE_NODE_FAULT",
+                                              "NO_12V_SUPPLY",
+                                              "VEHICLE_OR_PENTHOUSE_LID_OPENFAULT",
+                                              "UNKNOWN(10)",
+                                              "UNKNOWN(11)",
+                                              "UNKNOWN(12)",
+                                              "UNKNOWN(13)",
+                                              "UNKNOWN(14)",
+                                              "UNKNOWN(15)"};
+      static const char* contactorState[] = {"SNA",        "OPEN",       "PRECHARGE",   "BLOCKED",
+                                             "PULLED_IN",  "OPENING",    "ECONOMIZED",  "WELDED",
+                                             "UNKNOWN(8)", "UNKNOWN(9)", "UNKNOWN(10)", "UNKNOWN(11)"};
+      static const char* BMS_state[] = {"STANDBY",     "DRIVE", "SUPPORT", "CHARGE", "FEIM",
+                                        "CLEAR_FAULT", "FAULT", "WELD",    "TEST",   "SNA"};
+      static const char* BMS_contactorState[] = {"SNA", "OPEN", "OPENING", "CLOSING", "CLOSED", "WELDED", "BLOCKED"};
+      static const char* BMS_hvState[] = {"DOWN",          "COMING_UP",        "GOING_DOWN", "UP_FOR_DRIVE",
+                                          "UP_FOR_CHARGE", "UP_FOR_DC_CHARGE", "UP"};
+      static const char* BMS_uiChargeStatus[] = {"DISCONNECTED", "NO_POWER",        "ABOUT_TO_CHARGE",
+                                                 "CHARGING",     "CHARGE_COMPLETE", "CHARGE_STOPPED"};
+      static const char* PCS_dcdcStatus[] = {"IDLE", "ACTIVE", "FAULTED"};
+      static const char* PCS_dcdcMainState[] = {"STANDBY",          "12V_SUPPORT_ACTIVE", "PRECHARGE_STARTUP",
+                                                "PRECHARGE_ACTIVE", "DIS_HVBUS_ACTIVE",   "SHUTDOWN",
+                                                "FAULTED"};
+      static const char* PCS_dcdcSubState[] = {"PWR_UP_INIT",
+                                               "STANDBY",
+                                               "12V_SUPPORT_ACTIVE",
+                                               "DIS_HVBUS",
+                                               "PCHG_FAST_DIS_HVBUS",
+                                               "PCHG_SLOW_DIS_HVBUS",
+                                               "PCHG_DWELL_CHARGE",
+                                               "PCHG_DWELL_WAIT",
+                                               "PCHG_DI_RECOVERY_WAIT",
+                                               "PCHG_ACTIVE",
+                                               "PCHG_FLT_FAST_DIS_HVBUS",
+                                               "SHUTDOWN",
+                                               "12V_SUPPORT_FAULTED",
+                                               "DIS_HVBUS_FAULTED",
+                                               "PCHG_FAULTED",
+                                               "CLEAR_FAULTS",
+                                               "FAULTED",
+                                               "NUM"};
+      static const char* BMS_powerLimitState[] = {"NOT_CALCULATED_FOR_DRIVE", "CALCULATED_FOR_DRIVE"};
+      static const char* HVP_status[] = {"INVALID", "NOT_AVAILABLE", "STALE", "VALID"};
+      static const char* HVP_contactor[] = {"NOT_ACTIVE", "ACTIVE", "COMPLETED"};
+      static const char* falseTrue[] = {"False", "True"};
+      static const char* noYes[] = {"No", "Yes"};
+      static const char* Fault[] = {"NOT_ACTIVE", "ACTIVE"};
 
-    //Buttons for user action
-    content += "<button onclick='askTeslaClearIsolation()'>Clear isolation fault</button>";
-    content += "<button onclick='askTeslaResetBMS()'>BMS reset</button>";
-    //0x20A 522 HVP_contatorState
-    content += "<h4>Contactor Status: " + String(contactorText[datalayer_extended.tesla.status_contactor]) + "</h4>";
-    content += "<h4>HVIL: " + String(hvilStatusState[datalayer_extended.tesla.hvil_status]) + "</h4>";
-    content +=
-        "<h4>Negative contactor: " + String(contactorState[datalayer_extended.tesla.packContNegativeState]) + "</h4>";
-    content +=
-        "<h4>Positive contactor: " + String(contactorState[datalayer_extended.tesla.packContPositiveState]) + "</h4>";
-    content += "<h4>Closing allowed?: " + String(noYes[datalayer_extended.tesla.packCtrsClosingAllowed]) + "</h4>";
-    content += "<h4>Pyrotest in Progress: " + String(noYes[datalayer_extended.tesla.pyroTestInProgress]) + "</h4>";
-    content += "<h4>Contactors Open Now Requested: " +
-               String(noYes[datalayer_extended.tesla.battery_packCtrsOpenNowRequested]) + "</h4>";
-    content +=
-        "<h4>Contactors Open Requested: " + String(noYes[datalayer_extended.tesla.battery_packCtrsOpenRequested]) +
-        "</h4>";
-    content += "<h4>Contactors Request Status: " +
-               String(HVP_contactor[datalayer_extended.tesla.battery_packCtrsRequestStatus]) + "</h4>";
-    content += "<h4>Contactors Reset Request Required: " +
-               String(noYes[datalayer_extended.tesla.battery_packCtrsResetRequestRequired]) + "</h4>";
-    content +=
-        "<h4>DC Link Allowed to Energize: " + String(noYes[datalayer_extended.tesla.battery_dcLinkAllowedToEnergize]) +
-        "</h4>";
-    char readableSerialNumber[15];  // One extra space for null terminator
-    memcpy(readableSerialNumber, datalayer_extended.tesla.BMS_SerialNumber,
-           sizeof(datalayer_extended.tesla.BMS_SerialNumber));
-    readableSerialNumber[14] = '\0';  // Null terminate the string
-    content += "<h4>BMS Serial number: " + String(readableSerialNumber) + "</h4>";
-    // Comment what data you would like to display, order can be changed.
-    //0x352 850 BMS_energyStatus
-    if (datalayer_extended.tesla.BMS352_mux == false) {
-      content += "<h3>BMS 0x352 w/o mux</h3>";  //if using older BMS <2021 and comment 0x352 without MUX
-      content += "<h4>Calculated SOH: " + String(nominal_full_pack_energy * 100 / beginning_of_life) + "</h4>";
-      content += "<h4>Nominal Full Pack Energy: " + String(nominal_full_pack_energy) + " KWh</h4>";
-      content += "<h4>Nominal Energy Remaining: " + String(nominal_energy_remaining) + " KWh</h4>";
-      content += "<h4>Ideal Energy Remaining: " + String(ideal_energy_remaining) + " KWh</h4>";
-      content += "<h4>Energy to Charge Complete: " + String(energy_to_charge_complete) + " KWh</h4>";
-      content += "<h4>Energy Buffer: " + String(energy_buffer) + " KWh</h4>";
-      content += "<h4>Full Charge Complete: " + String(noYes[datalayer_extended.tesla.battery_full_charge_complete]) +
-                 "</h4>";  //bool
-    }
-    //0x352 850 BMS_energyStatus
-    if (datalayer_extended.tesla.BMS352_mux == true) {
-      content += "<h3>BMS 0x352 w/ mux</h3>";  //if using newer BMS >2021 and comment 0x352 with MUX
-      content += "<h4>Calculated SOH: " + String(nominal_full_pack_energy_m0 * 100 / beginning_of_life) + "</h4>";
-      content += "<h4>Nominal Full Pack Energy: " + String(nominal_full_pack_energy_m0) + " KWh</h4>";
-      content += "<h4>Nominal Energy Remaining: " + String(nominal_energy_remaining_m0) + " KWh</h4>";
-      content += "<h4>Ideal Energy Remaining: " + String(ideal_energy_remaining_m0) + " KWh</h4>";
-      content += "<h4>Energy to Charge Complete: " + String(energy_to_charge_complete_m1) + " KWh</h4>";
-      content += "<h4>Energy Buffer: " + String(energy_buffer_m1) + " KWh</h4>";
-      content += "<h4>Expected Energy Remaining: " + String(expected_energy_remaining_m1) + " KWh</h4>";
-      content += "<h4>Fully Charged: " + String(noYes[datalayer_extended.tesla.battery_fully_charged]) + "</h4>";
-    }
-    //0x3D2 978 BMS_kwhCounter
-    content += "<h4>Total Discharge: " + String(total_discharge) + " KWh</h4>";
-    content += "<h4>Total Charge: " + String(total_charge) + " KWh</h4>";
-    //0x292 658 BMS_socStates
-    content += "<h4>Battery Beginning of Life: " + String(beginning_of_life) + " KWh</h4>";
-    content += "<h4>Battery SOC UI: " + String(soc_ui) + " </h4>";
-    content += "<h4>Battery SOC Ave: " + String(soc_ave) + " </h4>";
-    content += "<h4>Battery SOC Max: " + String(soc_max) + " </h4>";
-    content += "<h4>Battery SOC Min: " + String(soc_min) + " </h4>";
-    content += "<h4>Battery Temp Percent: " + String(battTempPct) + " </h4>";
-    //0x2B4 PCS_dcdcRailStatus
-    content += "<h4>PCS Lv Output: " + String(dcdcLvOutputCurrent) + " A</h4>";
-    content += "<h4>PCS Lv Bus: " + String(dcdcLvBusVolt) + " V</h4>";
-    content += "<h4>PCS Hv Bus: " + String(dcdcHvBusVolt) + " V</h4>";
-    //0x392 BMS_packConfig
-    //content += "<h4>packConfigMultiplexer: " + String(datalayer_extended.tesla.battery_packConfigMultiplexer) + "</h4>"; // Not giving useable data
-    //content += "<h4>moduleType: " + String(datalayer_extended.tesla.battery_moduleType) + "</h4>";  // Not giving useable data
-    //content += "<h4>reserveConfig: " + String(datalayer_extended.tesla.battery_reservedConfig) + "</h4>";  // Not giving useable data
-    content += "<h4>Battery Pack Mass: " + String(packMass) + " KG</h4>";
-    content += "<h4>Platform Max Bus Voltage: " + String(platformMaxBusVoltage) + " V</h4>";
-    //0x2D2 722 BMSVAlimits
-    content += "<h4>BMS Min Voltage: " + String(bms_min_voltage) + " V</h4>";
-    content += "<h4>BMS Max Voltage: " + String(bms_max_voltage) + " V</h4>";
-    content += "<h4>Max Charge Current: " + String(max_charge_current) + " A</h4>";
-    content += "<h4>Max Discharge Current: " + String(max_discharge_current) + " A</h4>";
-    //0x332 818 BMS_bmbMinMax
-    content += "<h4>Brick Voltage Max: " + String(BrickVoltageMax) + " V</h4>";
-    content += "<h4>Brick Voltage Min: " + String(BrickVoltageMin) + " V</h4>";
-    content += "<h4>Brick Temp Max Num: " + String(datalayer_extended.tesla.battery_BrickTempMaxNum) + " </h4>";
-    content += "<h4>Brick Temp Min Num: " + String(datalayer_extended.tesla.battery_BrickTempMinNum) + " </h4>";
-    //content += "<h4>Brick Model Temp Max: " + String(BrickModelTMax) + " C</h4>";// Not giving useable data
-    //content += "<h4>Brick Model Temp Min: " + String(BrickModelTMin) + " C</h4>";// Not giving useable data
-    //0x2A4 676 PCS_thermalStatus
-    content += "<h4>PCS dcdc Temp: " + String(PCS_dcdcTemp) + " DegC</h4>";
-    content += "<h4>PCS Ambient Temp: " + String(PCS_ambientTemp) + " DegC</h4>";
-    content += "<h4>PCS Chg PhA Temp: " + String(PCS_chgPhATemp) + " DegC</h4>";
-    content += "<h4>PCS Chg PhB Temp: " + String(PCS_chgPhBTemp) + " DegC</h4>";
-    content += "<h4>PCS Chg PhC Temp: " + String(PCS_chgPhCTemp) + " DegC</h4>";
-    //0x252 594 BMS_powerAvailable
-    content += "<h4>Max Regen Power: " + String(BMS_maxRegenPower) + " KW</h4>";
-    content += "<h4>Max Discharge Power: " + String(BMS_maxDischargePower) + " KW</h4>";
-    //content += "<h4>Max Stationary Heat Power: " + String(BMS_maxStationaryHeatPower) + " KWh</h4>"; // Not giving useable data
-    //content += "<h4>HVAC Power Budget: " + String(BMS_hvacPowerBudget) + " KW</h4>"; // Not giving useable data
-    //content += "<h4>Not Enough Power For Heat Pump: " + String(noYes[datalayer_extended.tesla.BMS_notEnoughPowerForHeatPump]) + "</h4>"; // Not giving useable data
-    content +=
-        "<h4>Power Limit State: " + String(BMS_powerLimitState[datalayer_extended.tesla.BMS_powerLimitState]) + "</h4>";
-    //content += "<h4>Inverter TQF: " + String(datalayer_extended.tesla.BMS_inverterTQF) + "</h4>"; // Not giving useable data
-    //0x212 530 BMS_status
-    content += "<h4>Isolation Resistance: " + String(isolationResistance) + " kOhms</h4>";
-    content +=
-        "<h4>BMS Contactor State: " + String(BMS_contactorState[datalayer_extended.tesla.battery_BMS_contactorState]) +
-        "</h4>";
-    content += "<h4>BMS State: " + String(BMS_state[datalayer_extended.tesla.battery_BMS_state]) + "</h4>";
-    content += "<h4>BMS HV State: " + String(BMS_hvState[datalayer_extended.tesla.battery_BMS_hvState]) + "</h4>";
-    content += "<h4>BMS UI Charge Status: " + String(BMS_uiChargeStatus[datalayer_extended.tesla.battery_BMS_hvState]) +
-               "</h4>";
-    content +=
-        "<h4>BMS PCS PWM Enabled: " + String(Fault[datalayer_extended.tesla.battery_BMS_pcsPwmEnabled]) + "</h4>";
-    //0x312 786 BMS_thermalStatus
-    content += "<h4>Power Dissipation: " + String(BMS_powerDissipation) + " kW</h4>";
-    content += "<h4>Flow Request: " + String(BMS_flowRequest) + " LPM</h4>";
-    content += "<h4>Inlet Active Cool Target Temp: " + String(BMS_inletActiveCoolTargetT) + " DegC</h4>";
-    content += "<h4>Inlet Passive Target Temp: " + String(BMS_inletPassiveTargetT) + " DegC</h4>";
-    content += "<h4>Inlet Active Heat Target Temp: " + String(BMS_inletActiveHeatTargetT) + " DegC</h4>";
-    content += "<h4>Pack Temp Min: " + String(BMS_packTMin) + " DegC</h4>";
-    content += "<h4>Pack Temp Max: " + String(BMS_packTMax) + " DegC</h4>";
-    content += "<h4>PCS No Flow Request: " + String(Fault[datalayer_extended.tesla.BMS_pcsNoFlowRequest]) + "</h4>";
-    content += "<h4>BMS No Flow Request: " + String(Fault[datalayer_extended.tesla.BMS_noFlowRequest]) + "</h4>";
-    //0x224 548 PCS_dcdcStatus
-    content +=
-        "<h4>Precharge Status: " + String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdcPrechargeStatus]) +
-        "</h4>";
-    content +=
-        "<h4>12V Support Status: " + String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdc12VSupportStatus]) +
-        "</h4>";
-    content += "<h4>HV Bus Discharge Status: " +
-               String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdcHvBusDischargeStatus]) + "</h4>";
-    content +=
-        "<h4>Main State: " + String(PCS_dcdcMainState[datalayer_extended.tesla.battery_PCS_dcdcMainState]) + "</h4>";
-    content +=
-        "<h4>Sub State: " + String(PCS_dcdcSubState[datalayer_extended.tesla.battery_PCS_dcdcSubState]) + "</h4>";
-    content += "<h4>PCS Faulted: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcFaulted]) + "</h4>";
-    content +=
-        "<h4>Output Is Limited: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcOutputIsLimited]) + "</h4>";
-    content += "<h4>Max Output Current Allowed: " + String(PCS_dcdcMaxOutputCurrentAllowed) + " A</h4>";
-    content += "<h4>Precharge Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcPrechargeRtyCnt]) +
-               "</h4>";
-    content +=
-        "<h4>12V Support Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdc12VSupportRtyCnt]) +
-        "</h4>";
-    content += "<h4>Discharge Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcDischargeRtyCnt]) +
-               "</h4>";
-    content +=
-        "<h4>PWM Enable Line: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcPwmEnableLine]) + "</h4>";
-    content += "<h4>Supporting Fixed LV Target: " +
-               String(Fault[datalayer_extended.tesla.battery_PCS_dcdcSupportingFixedLvTarget]) + "</h4>";
-    content += "<h4>Precharge Restart Cnt: " +
-               String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcPrechargeRestartCnt]) + "</h4>";
-    content += "<h4>Initial Precharge Substate: " +
-               String(PCS_dcdcSubState[datalayer_extended.tesla.battery_PCS_dcdcInitialPrechargeSubState]) + "</h4>";
-    //0x2C4 708 PCS_logging
-    content += "<h4>PCS_dcdcMaxLvOutputCurrent: " + String(PCS_dcdcMaxLvOutputCurrent) + " A</h4>";
-    content += "<h4>PCS_dcdcCurrentLimit: " + String(PCS_dcdcCurrentLimit) + " A</h4>";
-    content += "<h4>PCS_dcdcLvOutputCurrentTempLimit: " + String(PCS_dcdcLvOutputCurrentTempLimit) + " A</h4>";
-    content += "<h4>PCS_dcdcUnifiedCommand: " + String(PCS_dcdcUnifiedCommand) + "</h4>";
-    content += "<h4>PCS_dcdcCLAControllerOutput: " + String(PCS_dcdcCLAControllerOutput) + "</h4>";
-    content += "<h4>PCS_dcdcTankVoltage: " + String(PCS_dcdcTankVoltage) + " V</h4>";
-    content += "<h4>PCS_dcdcTankVoltageTarget: " + String(PCS_dcdcTankVoltageTarget) + " V</h4>";
-    content += "<h4>PCS_dcdcClaCurrentFreq: " + String(PCS_dcdcClaCurrentFreq) + " kHz</h4>";
-    content += "<h4>PCS_dcdcTCommMeasured: " + String(PCS_dcdcTCommMeasured) + " us</h4>";
-    content += "<h4>PCS_dcdcShortTimeUs: " + String(PCS_dcdcShortTimeUs) + " us</h4>";
-    content += "<h4>PCS_dcdcHalfPeriodUs: " + String(PCS_dcdcHalfPeriodUs) + " us</h4>";
-    content += "<h4>PCS_dcdcIntervalMaxFrequency: " + String(PCS_dcdcIntervalMaxFrequency) + " kHz</h4>";
-    content += "<h4>PCS_dcdcIntervalMaxHvBusVolt: " + String(PCS_dcdcIntervalMaxHvBusVolt) + " V</h4>";
-    content += "<h4>PCS_dcdcIntervalMaxLvBusVolt: " + String(PCS_dcdcIntervalMaxLvBusVolt) + " V</h4>";
-    content += "<h4>PCS_dcdcIntervalMaxLvOutputCurr: " + String(PCS_dcdcIntervalMaxLvOutputCurr) + " A</h4>";
-    content += "<h4>PCS_dcdcIntervalMinFrequency: " + String(PCS_dcdcIntervalMinFrequency) + " kHz</h4>";
-    content += "<h4>PCS_dcdcIntervalMinHvBusVolt: " + String(PCS_dcdcIntervalMinHvBusVolt) + " V</h4>";
-    content += "<h4>PCS_dcdcIntervalMinLvBusVolt: " + String(PCS_dcdcIntervalMinLvBusVolt) + " V</h4>";
-    content += "<h4>PCS_dcdcIntervalMinLvOutputCurr: " + String(PCS_dcdcIntervalMinLvOutputCurr) + " A</h4>";
-    content += "<h4>PCS_dcdc12vSupportLifetimekWh: " + String(PCS_dcdc12vSupportLifetimekWh) + " kWh</h4>";
-    //0x7AA 1962 HVP_debugMessage
-    content += "<h4>HVP_battery12V: " + String(HVP_battery12V) + " V</h4>";
-    content += "<h4>HVP_dcLinkVoltage: " + String(HVP_dcLinkVoltage) + " V</h4>";
-    content += "<h4>HVP_packVoltage: " + String(HVP_packVoltage) + " V</h4>";
-    content += "<h4>HVP_packContVoltage: " + String(HVP_packContVoltage) + " V</h4>";
-    content += "<h4>HVP_packContCoilCurrent: " + String(HVP_packContCoilCurrent) + " A</h4>";
-    content += "<h4>HVP_pyroAnalog: " + String(HVP_pyroAnalog) + " V</h4>";
-    content += "<h4>HVP_hvp1v5Ref: " + String(HVP_hvp1v5Ref) + " V</h4>";
-    content += "<h4>HVP_hvilInVoltage: " + String(HVP_hvilInVoltage) + " V</h4>";
-    content += "<h4>HVP_hvilOutVoltage: " + String(HVP_hvilOutVoltage) + " V</h4>";
-    content +=
-        "<h4>HVP_gpioPassivePyroDepl: " + String(Fault[datalayer_extended.tesla.HVP_gpioPassivePyroDepl]) + "</h4>";
-    content += "<h4>HVP_gpioPyroIsoEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioPyroIsoEn]) + "</h4>";
-    content += "<h4>HVP_gpioCpFaultIn: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpFaultIn]) + "</h4>";
-    content +=
-        "<h4>HVP_gpioPackContPowerEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioPackContPowerEn]) + "</h4>";
-    content += "<h4>HVP_gpioHvCablesOk: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvCablesOk]) + "</h4>";
-    content += "<h4>HVP_gpioHvpSelfEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvpSelfEnable]) + "</h4>";
-    content += "<h4>HVP_gpioLed: " + String(Fault[datalayer_extended.tesla.HVP_gpioLed]) + "</h4>";
-    content += "<h4>HVP_gpioCrashSignal: " + String(Fault[datalayer_extended.tesla.HVP_gpioCrashSignal]) + "</h4>";
-    content +=
-        "<h4>HVP_gpioShuntDataReady: " + String(Fault[datalayer_extended.tesla.HVP_gpioShuntDataReady]) + "</h4>";
-    content += "<h4>HVP_gpioFcContPosAux: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContPosAux]) + "</h4>";
-    content += "<h4>HVP_gpioFcContNegAux: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContNegAux]) + "</h4>";
-    content += "<h4>HVP_gpioBmsEout: " + String(Fault[datalayer_extended.tesla.HVP_gpioBmsEout]) + "</h4>";
-    content += "<h4>HVP_gpioCpFaultOut: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpFaultOut]) + "</h4>";
-    content += "<h4>HVP_gpioPyroPor: " + String(Fault[datalayer_extended.tesla.HVP_gpioPyroPor]) + "</h4>";
-    content += "<h4>HVP_gpioShuntEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioShuntEn]) + "</h4>";
-    content += "<h4>HVP_gpioHvpVerEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvpVerEn]) + "</h4>";
-    content +=
-        "<h4>HVP_gpioPackCoontPosFlywheel: " + String(Fault[datalayer_extended.tesla.HVP_gpioPackCoontPosFlywheel]) +
-        "</h4>";
-    content += "<h4>HVP_gpioCpLatchEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpLatchEnable]) + "</h4>";
-    content += "<h4>HVP_gpioPcsEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsEnable]) + "</h4>";
-    content +=
-        "<h4>HVP_gpioPcsDcdcPwmEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsDcdcPwmEnable]) + "</h4>";
-    content += "<h4>HVP_gpioPcsChargePwmEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsChargePwmEnable]) +
-               "</h4>";
-    content +=
-        "<h4>HVP_gpioFcContPowerEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContPowerEnable]) + "</h4>";
-    content += "<h4>HVP_gpioHvilEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvilEnable]) + "</h4>";
-    content += "<h4>HVP_gpioSecDrdy: " + String(Fault[datalayer_extended.tesla.HVP_gpioSecDrdy]) + "</h4>";
-    content += "<h4>HVP_shuntCurrentDebug: " + String(HVP_shuntCurrentDebug) + " A</h4>";
-    content += "<h4>HVP_packCurrentMia: " + String(noYes[datalayer_extended.tesla.HVP_packCurrentMia]) + "</h4>";
-    content += "<h4>HVP_auxCurrentMia: " + String(noYes[datalayer_extended.tesla.HVP_auxCurrentMia]) + "</h4>";
-    content += "<h4>HVP_currentSenseMia: " + String(noYes[datalayer_extended.tesla.HVP_currentSenseMia]) + "</h4>";
-    content +=
-        "<h4>HVP_shuntRefVoltageMismatch: " + String(noYes[datalayer_extended.tesla.HVP_shuntRefVoltageMismatch]) +
-        "</h4>";
-    content +=
-        "<h4>HVP_shuntThermistorMia: " + String(noYes[datalayer_extended.tesla.HVP_shuntThermistorMia]) + "</h4>";
-    content += "<h4>HVP_shuntHwMia: " + String(noYes[datalayer_extended.tesla.HVP_shuntHwMia]) + "</h4>";
-    //content += "<h4>HVP_fcLinkVoltage: " + String(HVP_fcLinkVoltage) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_packNegativeV: " + String(HVP_packNegativeV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_packPositiveV: " + String(HVP_packPositiveV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_dcLinkNegativeV: " + String(HVP_dcLinkNegativeV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_dcLinkPositiveV: " + String(HVP_dcLinkPositiveV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_fcLinkNegativeV: " + String(HVP_fcLinkNegativeV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_fcContCoilCurrent: " + String(HVP_fcContCoilCurrent) + " A</h4>"; // Not giving useable data
-    //content += "<h4>HVP_fcContVoltage: " + String(HVP_fcContVoltage) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_fcLinkPositiveV: " + String(HVP_fcLinkPositiveV) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntRefVoltageDbg: " + String(HVP_shuntRefVoltageDbg) + " V</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntAuxCurrentDbg: " + String(HVP_shuntAuxCurrentDbg) + " A</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntBarTempDbg: " + String(HVP_shuntBarTempDbg) + " DegC</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntAsicTempDbg: " + String(HVP_shuntAsicTempDbg) + " DegC</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntAuxCurrentStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntAuxCurrentStatus]) + "</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntBarTempStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntBarTempStatus]) + "</h4>"; // Not giving useable data
-    //content += "<h4>HVP_shuntAsicTempStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntAsicTempStatus]) + "</h4>"; // Not giving useable data
-#endif
-
-#ifdef NISSAN_LEAF_BATTERY
-    static const char* LEAFgen[] = {"ZE0", "AZE0", "ZE1"};
-    content += "<h4>LEAF generation: " + String(LEAFgen[datalayer_extended.nissanleaf.LEAF_gen]) + "</h4>";
-    char readableSerialNumber[16];  // One extra space for null terminator
-    memcpy(readableSerialNumber, datalayer_extended.nissanleaf.BatterySerialNumber,
-           sizeof(datalayer_extended.nissanleaf.BatterySerialNumber));
-    readableSerialNumber[15] = '\0';  // Null terminate the string
-    content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
-    char readablePartNumber[8];  // One extra space for null terminator
-    memcpy(readablePartNumber, datalayer_extended.nissanleaf.BatteryPartNumber,
-           sizeof(datalayer_extended.nissanleaf.BatteryPartNumber));
-    readablePartNumber[7] = '\0';  // Null terminate the string
-    content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
-    char readableBMSID[9];  // One extra space for null terminator
-    memcpy(readableBMSID, datalayer_extended.nissanleaf.BMSIDcode, sizeof(datalayer_extended.nissanleaf.BMSIDcode));
-    readableBMSID[8] = '\0';  // Null terminate the string
-    content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
-    content += "<h4>GIDS: " + String(datalayer_extended.nissanleaf.GIDS) + "</h4>";
-    content += "<h4>Regen kW: " + String(datalayer_extended.nissanleaf.ChargePowerLimit) + "</h4>";
-    content += "<h4>Charge kW: " + String(datalayer_extended.nissanleaf.MaxPowerForCharger) + "</h4>";
-    content += "<h4>Interlock: " + String(datalayer_extended.nissanleaf.Interlock) + "</h4>";
-    content += "<h4>Insulation: " + String(datalayer_extended.nissanleaf.Insulation) + "</h4>";
-    content += "<h4>Relay cut request: " + String(datalayer_extended.nissanleaf.RelayCutRequest) + "</h4>";
-    content += "<h4>Failsafe status: " + String(datalayer_extended.nissanleaf.FailsafeStatus) + "</h4>";
-    content += "<h4>Fully charged: " + String(datalayer_extended.nissanleaf.Full) + "</h4>";
-    content += "<h4>Battery empty: " + String(datalayer_extended.nissanleaf.Empty) + "</h4>";
-    content += "<h4>Main relay ON: " + String(datalayer_extended.nissanleaf.MainRelayOn) + "</h4>";
-    content += "<h4>Heater present: " + String(datalayer_extended.nissanleaf.HeatExist) + "</h4>";
-    content += "<h4>Heating stopped: " + String(datalayer_extended.nissanleaf.HeatingStop) + "</h4>";
-    content += "<h4>Heating started: " + String(datalayer_extended.nissanleaf.HeatingStart) + "</h4>";
-    content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
-    content += "<button onclick='askResetSOH()'>Reset degradation data</button>";
-    content += "<h4>CryptoChallenge: " + String(datalayer_extended.nissanleaf.CryptoChallenge) + "</h4>";
-    content += "<h4>SolvedChallenge: " + String(datalayer_extended.nissanleaf.SolvedChallengeMSB) +
-               String(datalayer_extended.nissanleaf.SolvedChallengeLSB) + "</h4>";
-    content += "<h4>Challenge failed: " + String(datalayer_extended.nissanleaf.challengeFailed) + "</h4>";
-#endif
-
-#ifdef MEB_BATTERY
-    content += datalayer_extended.meb.SDSW ? "<h4>Service disconnect switch: Missing!</h4>"
-                                           : "<h4>Service disconnect switch: OK</h4>";
-    content += datalayer_extended.meb.pilotline ? "<h4>Pilotline: Open!</h4>" : "<h4>Pilotline: OK</h4>";
-    content += datalayer_extended.meb.transportmode ? "<h4>Transportmode: Locked!</h4>" : "<h4>Transportmode: OK</h4>";
-    content += datalayer_extended.meb.shutdown_active ? "<h4>Shutdown: Active!</h4>" : "<h4>Shutdown: No</h4>";
-    content += datalayer_extended.meb.componentprotection ? "<h4>Component protection: Active!</h4>"
-                                                          : "<h4>Component protection: No</h4>";
-    content += "<h4>HVIL status: ";
-    switch (datalayer_extended.meb.HVIL) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("Open!");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>KL30C status: ";
-    switch (datalayer_extended.meb.BMS_Kl30c_Status) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("Open!");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>BMS mode: ";
-    switch (datalayer_extended.meb.BMS_mode) {
-      case 0:
-        content += String("HV inactive");
-        break;
-      case 1:
-        content += String("HV active");
-        break;
-      case 2:
-        content += String("Balancing");
-        break;
-      case 3:
-        content += String("Extern charging");
-        break;
-      case 4:
-        content += String("AC charging");
-        break;
-      case 5:
-        content += String("Battery error");
-        break;
-      case 6:
-        content += String("DC charging");
-        break;
-      case 7:
-        content += String("Init");
-        break;
-      default:
-        content += String("?");
-    }
-    content += String("</h4><h4>Charging: ") + (datalayer_extended.meb.charging_active ? "active" : "not active");
-    content += String("</h4><h4>Balancing: ");
-    switch (datalayer_extended.meb.balancing_active) {
-      case 0:
-        content += String("init");
-        break;
-      case 1:
-        content += String("active");
-        break;
-      case 2:
-        content += String("inactive");
-        break;
-      default:
-        content += String("?");
-    }
-    content +=
-        String("</h4><h4>Slow charging: ") + (datalayer_extended.meb.balancing_request ? "requested" : "not requested");
-    content += "</h4><h4>Diagnostic: ";
-    switch (datalayer_extended.meb.battery_diagnostic) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("Battery display");
-        break;
-      case 4:
-        content += String("Battery display OK");
-        break;
-      case 6:
-        content += String("Battery display check");
-        break;
-      case 7:
-        content += String("Fault");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>HV line status: ";
-    switch (datalayer_extended.meb.status_HV_line) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("No open HV line detected");
-        break;
-      case 2:
-        content += String("Open HV line");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("? ") + String(datalayer_extended.meb.status_HV_line);
-    }
-    content += "</h4>";
-    content += datalayer_extended.meb.BMS_fault_performance ? "<h4>BMS fault performance: Active!</h4>"
-                                                            : "<h4>BMS fault performance: Off</h4>";
-    content += datalayer_extended.meb.BMS_fault_emergency_shutdown_crash
-                   ? "<h4>BMS fault emergency shutdown crash: Active!</h4>"
-                   : "<h4>BMS fault emergency shutdown crash: Off</h4>";
-    content += datalayer_extended.meb.BMS_error_shutdown_request ? "<h4>BMS error shutdown request: Active!</h4>"
-                                                                 : "<h4>BMS error shutdown request: Inactive</h4>";
-    content += datalayer_extended.meb.BMS_error_shutdown ? "<h4>BMS error shutdown: Active!</h4>"
-                                                         : "<h4>BMS error shutdown: Off</h4>";
-    content += "<h4>Welded contactors: ";
-    switch (datalayer_extended.meb.BMS_welded_contactors_status) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("No contactor welded");
-        break;
-      case 2:
-        content += String("At least 1 contactor welded");
-        break;
-      case 3:
-        content += String("Protection status detection error");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>Warning support: ";
-    switch (datalayer_extended.meb.warning_support) {
-      case 0:
-        content += String("OK");
-        break;
-      case 1:
-        content += String("Not OK");
-        break;
-      case 6:
-        content += String("Init");
-        break;
-      case 7:
-        content += String("Fault");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>Interm. Voltage (" + String(datalayer_extended.meb.BMS_voltage_intermediate_dV / 10.0, 1) +
-               "V) status: ";
-    switch (datalayer_extended.meb.BMS_status_voltage_free) {
-      case 0:
-        content += String("Init");
-        break;
-      case 1:
-        content += String("BMS interm circuit voltage free (U<20V)");
-        break;
-      case 2:
-        content += String("BMS interm circuit not voltage free (U >= 25V)");
-        break;
-      case 3:
-        content += String("Error");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>BMS error status: ";
-    switch (datalayer_extended.meb.BMS_error_status) {
-      case 0:
-        content += String("Component IO");
-        break;
-      case 1:
-        content += String("Iso Error 1");
-        break;
-      case 2:
-        content += String("Iso Error 2");
-        break;
-      case 3:
-        content += String("Interlock");
-        break;
-      case 4:
-        content += String("SD");
-        break;
-      case 5:
-        content += String("Performance red");
-        break;
-      case 6:
-        content += String("No component function");
-        break;
-      case 7:
-        content += String("Init");
-        break;
-      default:
-        content += String("?");
-    }
-    content += "</h4><h4>BMS voltage: " + String(datalayer_extended.meb.BMS_voltage_dV / 10.0, 1) + "</h4>";
-    content += datalayer_extended.meb.BMS_OBD_MIL ? "<h4>OBD MIL: ON!</h4>" : "<h4>OBD MIL: Off</h4>";
-    content +=
-        datalayer_extended.meb.BMS_error_lamp_req ? "<h4>Red error lamp: ON!</h4>" : "<h4>Red error lamp: Off</h4>";
-    content += datalayer_extended.meb.BMS_warning_lamp_req ? "<h4>Yellow warning lamp: ON!</h4>"
-                                                           : "<h4>Yellow warning lamp: Off</h4>";
-    content += "<h4>Isolation resistance: " + String(datalayer_extended.meb.isolation_resistance) + " kOhm</h4>";
-    content +=
-        datalayer_extended.meb.battery_heating ? "<h4>Battery heating: Active!</h4>" : "<h4>Battery heating: Off</h4>";
-    const char* rt_enum[] = {"No", "Error level 1", "Error level 2", "Error level 3"};
-    content += "<h4>Overcurrent: " + String(rt_enum[datalayer_extended.meb.rt_overcurrent & 0x03]) + "</h4>";
-    content += "<h4>CAN fault: " + String(rt_enum[datalayer_extended.meb.rt_CAN_fault & 0x03]) + "</h4>";
-    content += "<h4>Overcharged: " + String(rt_enum[datalayer_extended.meb.rt_overcharge & 0x03]) + "</h4>";
-    content += "<h4>SOC too high: " + String(rt_enum[datalayer_extended.meb.rt_SOC_high & 0x03]) + "</h4>";
-    content += "<h4>SOC too low: " + String(rt_enum[datalayer_extended.meb.rt_SOC_low & 0x03]) + "</h4>";
-    content += "<h4>SOC jumping: " + String(rt_enum[datalayer_extended.meb.rt_SOC_jumping & 0x03]) + "</h4>";
-    content += "<h4>Temp difference: " + String(rt_enum[datalayer_extended.meb.rt_temp_difference & 0x03]) + "</h4>";
-    content += "<h4>Cell overtemp: " + String(rt_enum[datalayer_extended.meb.rt_cell_overtemp & 0x03]) + "</h4>";
-    content += "<h4>Cell undertemp: " + String(rt_enum[datalayer_extended.meb.rt_cell_undertemp & 0x03]) + "</h4>";
-    content +=
-        "<h4>Battery overvoltage: " + String(rt_enum[datalayer_extended.meb.rt_battery_overvolt & 0x03]) + "</h4>";
-    content +=
-        "<h4>Battery undervoltage: " + String(rt_enum[datalayer_extended.meb.rt_battery_undervol & 0x03]) + "</h4>";
-    content += "<h4>Cell overvoltage: " + String(rt_enum[datalayer_extended.meb.rt_cell_overvolt & 0x03]) + "</h4>";
-    content += "<h4>Cell undervoltage: " + String(rt_enum[datalayer_extended.meb.rt_cell_undervol & 0x03]) + "</h4>";
-    content += "<h4>Cell imbalance: " + String(rt_enum[datalayer_extended.meb.rt_cell_imbalance & 0x03]) + "</h4>";
-    content +=
-        "<h4>Battery unathorized: " + String(rt_enum[datalayer_extended.meb.rt_battery_unathorized & 0x03]) + "</h4>";
-    content +=
-        "<h4>Battery temperature: " + String(datalayer_extended.meb.battery_temperature_dC / 10.f, 1) + " &deg;C</h4>";
-    for (int i = 0; i < 3; i++) {
-      content += "<h4>Temperature points " + String(i * 6 + 1) + "-" + String(i * 6 + 6) + " :";
-      for (int j = 0; j < 6; j++)
-        content += " &nbsp;" + String(datalayer_extended.meb.temp_points[i * 6 + j], 1);
-      content += " &deg;C</h4>";
-    }
-    bool temps_done = false;
-    for (int i = 0; i < 7 && !temps_done; i++) {
-      content += "<h4>Cell temperatures " + String(i * 8 + 1) + "-" + String(i * 8 + 8) + " :";
-      for (int j = 0; j < 8; j++) {
-        if (datalayer_extended.meb.celltemperature_dC[i * 8 + j] == 865) {
-          temps_done = true;
-          break;
-        } else {
-          content += " &nbsp;" + String(datalayer_extended.meb.celltemperature_dC[i * 8 + j] / 10.f, 1);
-        }
+      //Buttons for user action
+      content += "<button onclick='askTeslaClearIsolation()'>Clear isolation fault</button>";
+      content += "<button onclick='askTeslaResetBMS()'>BMS reset</button>";
+      //0x20A 522 HVP_contatorState
+      content += "<h4>Contactor Status: " + String(contactorText[datalayer_extended.tesla.status_contactor]) + "</h4>";
+      content += "<h4>HVIL: " + String(hvilStatusState[datalayer_extended.tesla.hvil_status]) + "</h4>";
+      content +=
+          "<h4>Negative contactor: " + String(contactorState[datalayer_extended.tesla.packContNegativeState]) + "</h4>";
+      content +=
+          "<h4>Positive contactor: " + String(contactorState[datalayer_extended.tesla.packContPositiveState]) + "</h4>";
+      content += "<h4>Closing allowed?: " + String(noYes[datalayer_extended.tesla.packCtrsClosingAllowed]) + "</h4>";
+      content += "<h4>Pyrotest in Progress: " + String(noYes[datalayer_extended.tesla.pyroTestInProgress]) + "</h4>";
+      content += "<h4>Contactors Open Now Requested: " +
+                 String(noYes[datalayer_extended.tesla.battery_packCtrsOpenNowRequested]) + "</h4>";
+      content +=
+          "<h4>Contactors Open Requested: " + String(noYes[datalayer_extended.tesla.battery_packCtrsOpenRequested]) +
+          "</h4>";
+      content += "<h4>Contactors Request Status: " +
+                 String(HVP_contactor[datalayer_extended.tesla.battery_packCtrsRequestStatus]) + "</h4>";
+      content += "<h4>Contactors Reset Request Required: " +
+                 String(noYes[datalayer_extended.tesla.battery_packCtrsResetRequestRequired]) + "</h4>";
+      content += "<h4>DC Link Allowed to Energize: " +
+                 String(noYes[datalayer_extended.tesla.battery_dcLinkAllowedToEnergize]) + "</h4>";
+      memcpy(readableSerialNumber, datalayer_extended.tesla.BMS_SerialNumber,
+             sizeof(datalayer_extended.tesla.BMS_SerialNumber));
+      readableSerialNumber[14] = '\0';  // Null terminate the string
+      content += "<h4>BMS Serial number: " + String(readableSerialNumber) + "</h4>";
+      // Comment what data you would like to display, order can be changed.
+      //0x352 850 BMS_energyStatus
+      if (datalayer_extended.tesla.BMS352_mux == false) {
+        content += "<h3>BMS 0x352 w/o mux</h3>";  //if using older BMS <2021 and comment 0x352 without MUX
+        content += "<h4>Calculated SOH: " + String(nominal_full_pack_energy * 100 / beginning_of_life) + "</h4>";
+        content += "<h4>Nominal Full Pack Energy: " + String(nominal_full_pack_energy) + " KWh</h4>";
+        content += "<h4>Nominal Energy Remaining: " + String(nominal_energy_remaining) + " KWh</h4>";
+        content += "<h4>Ideal Energy Remaining: " + String(ideal_energy_remaining) + " KWh</h4>";
+        content += "<h4>Energy to Charge Complete: " + String(energy_to_charge_complete) + " KWh</h4>";
+        content += "<h4>Energy Buffer: " + String(energy_buffer) + " KWh</h4>";
+        content += "<h4>Full Charge Complete: " + String(noYes[datalayer_extended.tesla.battery_full_charge_complete]) +
+                   "</h4>";  //bool
       }
-      content += " &deg;C</h4>";
-    }
-    content +=
-        "<h4>Total charged: " + String(datalayer.battery.status.total_charged_battery_Wh / 1000.0, 1) + " kWh</h4>";
-    content += "<h4>Total discharged: " + String(datalayer.battery.status.total_discharged_battery_Wh / 1000.0, 1) +
-               " kWh</h4>";
-#endif  //MEB_BATTERY
-
-#ifdef RENAULT_ZOE_GEN2_BATTERY
-    content += "<h4>soc: " + String(datalayer_extended.zoePH2.battery_soc) + "</h4>";
-    content += "<h4>usable soc: " + String(datalayer_extended.zoePH2.battery_usable_soc) + "</h4>";
-    content += "<h4>soh: " + String(datalayer_extended.zoePH2.battery_soh) + "</h4>";
-    content += "<h4>pack voltage: " + String(datalayer_extended.zoePH2.battery_pack_voltage) + "</h4>";
-    content += "<h4>max cell voltage: " + String(datalayer_extended.zoePH2.battery_max_cell_voltage) + "</h4>";
-    content += "<h4>min cell voltage: " + String(datalayer_extended.zoePH2.battery_min_cell_voltage) + "</h4>";
-    content += "<h4>12v: " + String(datalayer_extended.zoePH2.battery_12v) + "</h4>";
-    content += "<h4>avg temp: " + String(datalayer_extended.zoePH2.battery_avg_temp) + "</h4>";
-    content += "<h4>min temp: " + String(datalayer_extended.zoePH2.battery_min_temp) + "</h4>";
-    content += "<h4>max temp: " + String(datalayer_extended.zoePH2.battery_max_temp) + "</h4>";
-    content += "<h4>max power: " + String(datalayer_extended.zoePH2.battery_max_power) + "</h4>";
-    content += "<h4>interlock: " + String(datalayer_extended.zoePH2.battery_interlock) + "</h4>";
-    content += "<h4>kwh: " + String(datalayer_extended.zoePH2.battery_kwh) + "</h4>";
-    content += "<h4>current: " + String(datalayer_extended.zoePH2.battery_current) + "</h4>";
-    content += "<h4>current offset: " + String(datalayer_extended.zoePH2.battery_current_offset) + "</h4>";
-    content += "<h4>max generated: " + String(datalayer_extended.zoePH2.battery_max_generated) + "</h4>";
-    content += "<h4>max available: " + String(datalayer_extended.zoePH2.battery_max_available) + "</h4>";
-    content += "<h4>current voltage: " + String(datalayer_extended.zoePH2.battery_current_voltage) + "</h4>";
-    content += "<h4>charging status: " + String(datalayer_extended.zoePH2.battery_charging_status) + "</h4>";
-    content += "<h4>remaining charge: " + String(datalayer_extended.zoePH2.battery_remaining_charge) + "</h4>";
-    content +=
-        "<h4>balance capacity total: " + String(datalayer_extended.zoePH2.battery_balance_capacity_total) + "</h4>";
-    content += "<h4>balance time total: " + String(datalayer_extended.zoePH2.battery_balance_time_total) + "</h4>";
-    content +=
-        "<h4>balance capacity sleep: " + String(datalayer_extended.zoePH2.battery_balance_capacity_sleep) + "</h4>";
-    content += "<h4>balance time sleep: " + String(datalayer_extended.zoePH2.battery_balance_time_sleep) + "</h4>";
-    content +=
-        "<h4>balance capacity wake: " + String(datalayer_extended.zoePH2.battery_balance_capacity_wake) + "</h4>";
-    content += "<h4>balance time wake: " + String(datalayer_extended.zoePH2.battery_balance_time_wake) + "</h4>";
-    content += "<h4>bms state: " + String(datalayer_extended.zoePH2.battery_bms_state) + "</h4>";
-    content += "<h4>balance switches: " + String(datalayer_extended.zoePH2.battery_balance_switches) + "</h4>";
-    content += "<h4>energy complete: " + String(datalayer_extended.zoePH2.battery_energy_complete) + "</h4>";
-    content += "<h4>energy partial: " + String(datalayer_extended.zoePH2.battery_energy_partial) + "</h4>";
-    content += "<h4>slave failures: " + String(datalayer_extended.zoePH2.battery_slave_failures) + "</h4>";
-    content += "<h4>mileage: " + String(datalayer_extended.zoePH2.battery_mileage) + "</h4>";
-    content += "<h4>fan speed: " + String(datalayer_extended.zoePH2.battery_fan_speed) + "</h4>";
-    content += "<h4>fan period: " + String(datalayer_extended.zoePH2.battery_fan_period) + "</h4>";
-    content += "<h4>fan control: " + String(datalayer_extended.zoePH2.battery_fan_control) + "</h4>";
-    content += "<h4>fan duty: " + String(datalayer_extended.zoePH2.battery_fan_duty) + "</h4>";
-    content += "<h4>temporisation: " + String(datalayer_extended.zoePH2.battery_temporisation) + "</h4>";
-    content += "<h4>time: " + String(datalayer_extended.zoePH2.battery_time) + "</h4>";
-    content += "<h4>pack time: " + String(datalayer_extended.zoePH2.battery_pack_time) + "</h4>";
-    content += "<h4>soc min: " + String(datalayer_extended.zoePH2.battery_soc_min) + "</h4>";
-    content += "<h4>soc max: " + String(datalayer_extended.zoePH2.battery_soc_max) + "</h4>";
-#endif  //RENAULT_ZOE_GEN2_BATTERY
-
-#ifdef VOLVO_SPA_BATTERY
-    content += "<h4>BECM reported SOC: " + String(datalayer_extended.VolvoPolestar.soc_bms) + "</h4>";
-    content += "<h4>Calculated SOC: " + String(datalayer_extended.VolvoPolestar.soc_calc) + "</h4>";
-    content += "<h4>Rescaled SOC: " + String(datalayer_extended.VolvoPolestar.soc_rescaled / 10) + "</h4>";
-    content += "<h4>BECM reported SOH: " + String(datalayer_extended.VolvoPolestar.soh_bms) + "</h4>";
-    content += "<h4>BECM supply voltage: " + String(datalayer_extended.VolvoPolestar.BECMsupplyVoltage) + " mV</h4>";
-
-    content += "<h4>HV voltage: " + String(datalayer_extended.VolvoPolestar.BECMBatteryVoltage) + " V</h4>";
-    content += "<h4>HV current: " + String(datalayer_extended.VolvoPolestar.BECMBatteryCurrent) + " A</h4>";
-    content += "<h4>Dynamic max voltage: " + String(datalayer_extended.VolvoPolestar.BECMUDynMaxLim) + " V</h4>";
-    content += "<h4>Dynamic min voltage: " + String(datalayer_extended.VolvoPolestar.BECMUDynMinLim) + " V</h4>";
-
-    content +=
-        "<h4>Discharge power limit 1: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDcha1) + " kW</h4>";
-    content +=
-        "<h4>Discharge soft power limit: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDchaSoft) + " kW</h4>";
-    content +=
-        "<h4>Discharge power limit slow aging: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDchaSlowAgi) +
-        " kW</h4>";
-    content +=
-        "<h4>Charge power limit slow aging: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimChrgSlowAgi) +
-        " kW</h4>";
-
-    content += "<h4>HV system relay status: ";
-    switch (datalayer_extended.VolvoPolestar.HVSysRlySts) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("OpenAndRequestActiveDischarge");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system relay status 1: ";
-    switch (datalayer_extended.VolvoPolestar.HVSysDCRlySts1) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system relay status 2: ";
-    switch (datalayer_extended.VolvoPolestar.HVSysDCRlySts2) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system isolation resistance monitoring status: ";
-    switch (datalayer_extended.VolvoPolestar.HVSysIsoRMonrSts) {
-      case 0:
-        content += String("Not valid 1");
-        break;
-      case 1:
-        content += String("False");
-        break;
-      case 2:
-        content += String("True");
-        break;
-      case 3:
-        content += String("Not valid 2");
-        break;
-      default:
-        content += String("Not valid");
-    }
-
-    content += "<br><br><button onclick='Volvo_askEraseDTC()'>Erase DTC</button><br>";
-    content += "<button onclick='Volvo_askReadDTC()'>Read DTC (result must be checked in CANlog)</button><br>";
-    content += "<button onclick='Volvo_BECMecuReset()'>Restart BECM module</button>";
-#endif  // VOLVO_SPA_BATTERY
-
-#ifdef VOLVO_SPA_HYBRID_BATTERY
-    content += "<h4>BECM reported SOC: " + String(datalayer_extended.VolvoHybrid.soc_bms) + "</h4>";
-    content += "<h4>Calculated SOC: " + String(datalayer_extended.VolvoHybrid.soc_calc) + "</h4>";
-    content += "<h4>Rescaled SOC: " + String(datalayer_extended.VolvoHybrid.soc_rescaled / 10) + "</h4>";
-    content += "<h4>BECM reported SOH: " + String(datalayer_extended.VolvoHybrid.soh_bms) + "</h4>";
-    content += "<h4>BECM supply voltage: " + String(datalayer_extended.VolvoHybrid.BECMsupplyVoltage) + " mV</h4>";
-
-    content += "<h4>HV voltage: " + String(datalayer_extended.VolvoHybrid.BECMBatteryVoltage) + " V</h4>";
-    content += "<h4>HV current: " + String(datalayer_extended.VolvoHybrid.BECMBatteryCurrent) + " A</h4>";
-    content += "<h4>Dynamic max voltage: " + String(datalayer_extended.VolvoHybrid.BECMUDynMaxLim) + " V</h4>";
-    content += "<h4>Dynamic min voltage: " + String(datalayer_extended.VolvoHybrid.BECMUDynMinLim) + " V</h4>";
-
-    content += "<h4>Discharge power limit 1: " + String(datalayer_extended.VolvoHybrid.HvBattPwrLimDcha1) + " kW</h4>";
-    content +=
-        "<h4>Discharge soft power limit: " + String(datalayer_extended.VolvoHybrid.HvBattPwrLimDchaSoft) + " kW</h4>";
-
-    content += "<h4>HV system relay status: ";
-    switch (datalayer_extended.VolvoHybrid.HVSysRlySts) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("OpenAndRequestActiveDischarge");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system relay status 1: ";
-    switch (datalayer_extended.VolvoHybrid.HVSysDCRlySts1) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system relay status 2: ";
-    switch (datalayer_extended.VolvoHybrid.HVSysDCRlySts2) {
-      case 0:
-        content += String("Open");
-        break;
-      case 1:
-        content += String("Closed");
-        break;
-      case 2:
-        content += String("KeepStatus");
-        break;
-      case 3:
-        content += String("Fault");
-        break;
-      default:
-        content += String("Not valid");
-    }
-    content += "</h4><h4>HV system isolation resistance monitoring status: ";
-    switch (datalayer_extended.VolvoHybrid.HVSysIsoRMonrSts) {
-      case 0:
-        content += String("Not valid 1");
-        break;
-      case 1:
-        content += String("False");
-        break;
-      case 2:
-        content += String("True");
-        break;
-      case 3:
-        content += String("Not valid 2");
-        break;
-      default:
-        content += String("Not valid");
+      //0x352 850 BMS_energyStatus
+      if (datalayer_extended.tesla.BMS352_mux == true) {
+        content += "<h3>BMS 0x352 w/ mux</h3>";  //if using newer BMS >2021 and comment 0x352 with MUX
+        content += "<h4>Calculated SOH: " + String(nominal_full_pack_energy_m0 * 100 / beginning_of_life) + "</h4>";
+        content += "<h4>Nominal Full Pack Energy: " + String(nominal_full_pack_energy_m0) + " KWh</h4>";
+        content += "<h4>Nominal Energy Remaining: " + String(nominal_energy_remaining_m0) + " KWh</h4>";
+        content += "<h4>Ideal Energy Remaining: " + String(ideal_energy_remaining_m0) + " KWh</h4>";
+        content += "<h4>Energy to Charge Complete: " + String(energy_to_charge_complete_m1) + " KWh</h4>";
+        content += "<h4>Energy Buffer: " + String(energy_buffer_m1) + " KWh</h4>";
+        content += "<h4>Expected Energy Remaining: " + String(expected_energy_remaining_m1) + " KWh</h4>";
+        content += "<h4>Fully Charged: " + String(noYes[datalayer_extended.tesla.battery_fully_charged]) + "</h4>";
+      }
+      //0x3D2 978 BMS_kwhCounter
+      content += "<h4>Total Discharge: " + String(total_discharge) + " KWh</h4>";
+      content += "<h4>Total Charge: " + String(total_charge) + " KWh</h4>";
+      //0x292 658 BMS_socStates
+      content += "<h4>Battery Beginning of Life: " + String(beginning_of_life) + " KWh</h4>";
+      content += "<h4>Battery SOC UI: " + String(soc_ui) + " </h4>";
+      content += "<h4>Battery SOC Ave: " + String(soc_ave) + " </h4>";
+      content += "<h4>Battery SOC Max: " + String(soc_max) + " </h4>";
+      content += "<h4>Battery SOC Min: " + String(soc_min) + " </h4>";
+      content += "<h4>Battery Temp Percent: " + String(battTempPct) + " </h4>";
+      //0x2B4 PCS_dcdcRailStatus
+      content += "<h4>PCS Lv Output: " + String(dcdcLvOutputCurrent) + " A</h4>";
+      content += "<h4>PCS Lv Bus: " + String(dcdcLvBusVolt) + " V</h4>";
+      content += "<h4>PCS Hv Bus: " + String(dcdcHvBusVolt) + " V</h4>";
+      //0x392 BMS_packConfig
+      //content += "<h4>packConfigMultiplexer: " + String(datalayer_extended.tesla.battery_packConfigMultiplexer) + "</h4>"; // Not giving useable data
+      //content += "<h4>moduleType: " + String(datalayer_extended.tesla.battery_moduleType) + "</h4>";  // Not giving useable data
+      //content += "<h4>reserveConfig: " + String(datalayer_extended.tesla.battery_reservedConfig) + "</h4>";  // Not giving useable data
+      content += "<h4>Battery Pack Mass: " + String(packMass) + " KG</h4>";
+      content += "<h4>Platform Max Bus Voltage: " + String(platformMaxBusVoltage) + " V</h4>";
+      //0x2D2 722 BMSVAlimits
+      content += "<h4>BMS Min Voltage: " + String(bms_min_voltage) + " V</h4>";
+      content += "<h4>BMS Max Voltage: " + String(bms_max_voltage) + " V</h4>";
+      content += "<h4>Max Charge Current: " + String(max_charge_current) + " A</h4>";
+      content += "<h4>Max Discharge Current: " + String(max_discharge_current) + " A</h4>";
+      //0x332 818 BMS_bmbMinMax
+      content += "<h4>Brick Voltage Max: " + String(BrickVoltageMax) + " V</h4>";
+      content += "<h4>Brick Voltage Min: " + String(BrickVoltageMin) + " V</h4>";
+      content += "<h4>Brick Temp Max Num: " + String(datalayer_extended.tesla.battery_BrickTempMaxNum) + " </h4>";
+      content += "<h4>Brick Temp Min Num: " + String(datalayer_extended.tesla.battery_BrickTempMinNum) + " </h4>";
+      //content += "<h4>Brick Model Temp Max: " + String(BrickModelTMax) + " C</h4>";// Not giving useable data
+      //content += "<h4>Brick Model Temp Min: " + String(BrickModelTMin) + " C</h4>";// Not giving useable data
+      //0x2A4 676 PCS_thermalStatus
+      content += "<h4>PCS dcdc Temp: " + String(PCS_dcdcTemp) + " DegC</h4>";
+      content += "<h4>PCS Ambient Temp: " + String(PCS_ambientTemp) + " DegC</h4>";
+      content += "<h4>PCS Chg PhA Temp: " + String(PCS_chgPhATemp) + " DegC</h4>";
+      content += "<h4>PCS Chg PhB Temp: " + String(PCS_chgPhBTemp) + " DegC</h4>";
+      content += "<h4>PCS Chg PhC Temp: " + String(PCS_chgPhCTemp) + " DegC</h4>";
+      //0x252 594 BMS_powerAvailable
+      content += "<h4>Max Regen Power: " + String(BMS_maxRegenPower) + " KW</h4>";
+      content += "<h4>Max Discharge Power: " + String(BMS_maxDischargePower) + " KW</h4>";
+      //content += "<h4>Max Stationary Heat Power: " + String(BMS_maxStationaryHeatPower) + " KWh</h4>"; // Not giving useable data
+      //content += "<h4>HVAC Power Budget: " + String(BMS_hvacPowerBudget) + " KW</h4>"; // Not giving useable data
+      //content += "<h4>Not Enough Power For Heat Pump: " + String(noYes[datalayer_extended.tesla.BMS_notEnoughPowerForHeatPump]) + "</h4>"; // Not giving useable data
+      content += "<h4>Power Limit State: " + String(BMS_powerLimitState[datalayer_extended.tesla.BMS_powerLimitState]) +
+                 "</h4>";
+      //content += "<h4>Inverter TQF: " + String(datalayer_extended.tesla.BMS_inverterTQF) + "</h4>"; // Not giving useable data
+      //0x212 530 BMS_status
+      content += "<h4>Isolation Resistance: " + String(isolationResistance) + " kOhms</h4>";
+      content += "<h4>BMS Contactor State: " +
+                 String(BMS_contactorState[datalayer_extended.tesla.battery_BMS_contactorState]) + "</h4>";
+      content += "<h4>BMS State: " + String(BMS_state[datalayer_extended.tesla.battery_BMS_state]) + "</h4>";
+      content += "<h4>BMS HV State: " + String(BMS_hvState[datalayer_extended.tesla.battery_BMS_hvState]) + "</h4>";
+      content +=
+          "<h4>BMS UI Charge Status: " + String(BMS_uiChargeStatus[datalayer_extended.tesla.battery_BMS_hvState]) +
+          "</h4>";
+      content +=
+          "<h4>BMS PCS PWM Enabled: " + String(Fault[datalayer_extended.tesla.battery_BMS_pcsPwmEnabled]) + "</h4>";
+      //0x312 786 BMS_thermalStatus
+      content += "<h4>Power Dissipation: " + String(BMS_powerDissipation) + " kW</h4>";
+      content += "<h4>Flow Request: " + String(BMS_flowRequest) + " LPM</h4>";
+      content += "<h4>Inlet Active Cool Target Temp: " + String(BMS_inletActiveCoolTargetT) + " DegC</h4>";
+      content += "<h4>Inlet Passive Target Temp: " + String(BMS_inletPassiveTargetT) + " DegC</h4>";
+      content += "<h4>Inlet Active Heat Target Temp: " + String(BMS_inletActiveHeatTargetT) + " DegC</h4>";
+      content += "<h4>Pack Temp Min: " + String(BMS_packTMin) + " DegC</h4>";
+      content += "<h4>Pack Temp Max: " + String(BMS_packTMax) + " DegC</h4>";
+      content += "<h4>PCS No Flow Request: " + String(Fault[datalayer_extended.tesla.BMS_pcsNoFlowRequest]) + "</h4>";
+      content += "<h4>BMS No Flow Request: " + String(Fault[datalayer_extended.tesla.BMS_noFlowRequest]) + "</h4>";
+      //0x224 548 PCS_dcdcStatus
+      content +=
+          "<h4>Precharge Status: " + String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdcPrechargeStatus]) +
+          "</h4>";
+      content += "<h4>12V Support Status: " +
+                 String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdc12VSupportStatus]) + "</h4>";
+      content += "<h4>HV Bus Discharge Status: " +
+                 String(PCS_dcdcStatus[datalayer_extended.tesla.battery_PCS_dcdcHvBusDischargeStatus]) + "</h4>";
+      content +=
+          "<h4>Main State: " + String(PCS_dcdcMainState[datalayer_extended.tesla.battery_PCS_dcdcMainState]) + "</h4>";
+      content +=
+          "<h4>Sub State: " + String(PCS_dcdcSubState[datalayer_extended.tesla.battery_PCS_dcdcSubState]) + "</h4>";
+      content += "<h4>PCS Faulted: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcFaulted]) + "</h4>";
+      content +=
+          "<h4>Output Is Limited: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcOutputIsLimited]) + "</h4>";
+      content += "<h4>Max Output Current Allowed: " + String(PCS_dcdcMaxOutputCurrentAllowed) + " A</h4>";
+      content +=
+          "<h4>Precharge Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcPrechargeRtyCnt]) +
+          "</h4>";
+      content +=
+          "<h4>12V Support Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdc12VSupportRtyCnt]) +
+          "</h4>";
+      content +=
+          "<h4>Discharge Rty Cnt: " + String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcDischargeRtyCnt]) +
+          "</h4>";
+      content +=
+          "<h4>PWM Enable Line: " + String(Fault[datalayer_extended.tesla.battery_PCS_dcdcPwmEnableLine]) + "</h4>";
+      content += "<h4>Supporting Fixed LV Target: " +
+                 String(Fault[datalayer_extended.tesla.battery_PCS_dcdcSupportingFixedLvTarget]) + "</h4>";
+      content += "<h4>Precharge Restart Cnt: " +
+                 String(falseTrue[datalayer_extended.tesla.battery_PCS_dcdcPrechargeRestartCnt]) + "</h4>";
+      content += "<h4>Initial Precharge Substate: " +
+                 String(PCS_dcdcSubState[datalayer_extended.tesla.battery_PCS_dcdcInitialPrechargeSubState]) + "</h4>";
+      //0x2C4 708 PCS_logging
+      content += "<h4>PCS_dcdcMaxLvOutputCurrent: " + String(PCS_dcdcMaxLvOutputCurrent) + " A</h4>";
+      content += "<h4>PCS_dcdcCurrentLimit: " + String(PCS_dcdcCurrentLimit) + " A</h4>";
+      content += "<h4>PCS_dcdcLvOutputCurrentTempLimit: " + String(PCS_dcdcLvOutputCurrentTempLimit) + " A</h4>";
+      content += "<h4>PCS_dcdcUnifiedCommand: " + String(PCS_dcdcUnifiedCommand) + "</h4>";
+      content += "<h4>PCS_dcdcCLAControllerOutput: " + String(PCS_dcdcCLAControllerOutput) + "</h4>";
+      content += "<h4>PCS_dcdcTankVoltage: " + String(PCS_dcdcTankVoltage) + " V</h4>";
+      content += "<h4>PCS_dcdcTankVoltageTarget: " + String(PCS_dcdcTankVoltageTarget) + " V</h4>";
+      content += "<h4>PCS_dcdcClaCurrentFreq: " + String(PCS_dcdcClaCurrentFreq) + " kHz</h4>";
+      content += "<h4>PCS_dcdcTCommMeasured: " + String(PCS_dcdcTCommMeasured) + " us</h4>";
+      content += "<h4>PCS_dcdcShortTimeUs: " + String(PCS_dcdcShortTimeUs) + " us</h4>";
+      content += "<h4>PCS_dcdcHalfPeriodUs: " + String(PCS_dcdcHalfPeriodUs) + " us</h4>";
+      content += "<h4>PCS_dcdcIntervalMaxFrequency: " + String(PCS_dcdcIntervalMaxFrequency) + " kHz</h4>";
+      content += "<h4>PCS_dcdcIntervalMaxHvBusVolt: " + String(PCS_dcdcIntervalMaxHvBusVolt) + " V</h4>";
+      content += "<h4>PCS_dcdcIntervalMaxLvBusVolt: " + String(PCS_dcdcIntervalMaxLvBusVolt) + " V</h4>";
+      content += "<h4>PCS_dcdcIntervalMaxLvOutputCurr: " + String(PCS_dcdcIntervalMaxLvOutputCurr) + " A</h4>";
+      content += "<h4>PCS_dcdcIntervalMinFrequency: " + String(PCS_dcdcIntervalMinFrequency) + " kHz</h4>";
+      content += "<h4>PCS_dcdcIntervalMinHvBusVolt: " + String(PCS_dcdcIntervalMinHvBusVolt) + " V</h4>";
+      content += "<h4>PCS_dcdcIntervalMinLvBusVolt: " + String(PCS_dcdcIntervalMinLvBusVolt) + " V</h4>";
+      content += "<h4>PCS_dcdcIntervalMinLvOutputCurr: " + String(PCS_dcdcIntervalMinLvOutputCurr) + " A</h4>";
+      content += "<h4>PCS_dcdc12vSupportLifetimekWh: " + String(PCS_dcdc12vSupportLifetimekWh) + " kWh</h4>";
+      //0x7AA 1962 HVP_debugMessage
+      content += "<h4>HVP_battery12V: " + String(HVP_battery12V) + " V</h4>";
+      content += "<h4>HVP_dcLinkVoltage: " + String(HVP_dcLinkVoltage) + " V</h4>";
+      content += "<h4>HVP_packVoltage: " + String(HVP_packVoltage) + " V</h4>";
+      content += "<h4>HVP_packContVoltage: " + String(HVP_packContVoltage) + " V</h4>";
+      content += "<h4>HVP_packContCoilCurrent: " + String(HVP_packContCoilCurrent) + " A</h4>";
+      content += "<h4>HVP_pyroAnalog: " + String(HVP_pyroAnalog) + " V</h4>";
+      content += "<h4>HVP_hvp1v5Ref: " + String(HVP_hvp1v5Ref) + " V</h4>";
+      content += "<h4>HVP_hvilInVoltage: " + String(HVP_hvilInVoltage) + " V</h4>";
+      content += "<h4>HVP_hvilOutVoltage: " + String(HVP_hvilOutVoltage) + " V</h4>";
+      content +=
+          "<h4>HVP_gpioPassivePyroDepl: " + String(Fault[datalayer_extended.tesla.HVP_gpioPassivePyroDepl]) + "</h4>";
+      content += "<h4>HVP_gpioPyroIsoEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioPyroIsoEn]) + "</h4>";
+      content += "<h4>HVP_gpioCpFaultIn: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpFaultIn]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioPackContPowerEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioPackContPowerEn]) + "</h4>";
+      content += "<h4>HVP_gpioHvCablesOk: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvCablesOk]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioHvpSelfEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvpSelfEnable]) + "</h4>";
+      content += "<h4>HVP_gpioLed: " + String(Fault[datalayer_extended.tesla.HVP_gpioLed]) + "</h4>";
+      content += "<h4>HVP_gpioCrashSignal: " + String(Fault[datalayer_extended.tesla.HVP_gpioCrashSignal]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioShuntDataReady: " + String(Fault[datalayer_extended.tesla.HVP_gpioShuntDataReady]) + "</h4>";
+      content += "<h4>HVP_gpioFcContPosAux: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContPosAux]) + "</h4>";
+      content += "<h4>HVP_gpioFcContNegAux: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContNegAux]) + "</h4>";
+      content += "<h4>HVP_gpioBmsEout: " + String(Fault[datalayer_extended.tesla.HVP_gpioBmsEout]) + "</h4>";
+      content += "<h4>HVP_gpioCpFaultOut: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpFaultOut]) + "</h4>";
+      content += "<h4>HVP_gpioPyroPor: " + String(Fault[datalayer_extended.tesla.HVP_gpioPyroPor]) + "</h4>";
+      content += "<h4>HVP_gpioShuntEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioShuntEn]) + "</h4>";
+      content += "<h4>HVP_gpioHvpVerEn: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvpVerEn]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioPackCoontPosFlywheel: " + String(Fault[datalayer_extended.tesla.HVP_gpioPackCoontPosFlywheel]) +
+          "</h4>";
+      content +=
+          "<h4>HVP_gpioCpLatchEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioCpLatchEnable]) + "</h4>";
+      content += "<h4>HVP_gpioPcsEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsEnable]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioPcsDcdcPwmEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsDcdcPwmEnable]) + "</h4>";
+      content +=
+          "<h4>HVP_gpioPcsChargePwmEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioPcsChargePwmEnable]) +
+          "</h4>";
+      content += "<h4>HVP_gpioFcContPowerEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioFcContPowerEnable]) +
+                 "</h4>";
+      content += "<h4>HVP_gpioHvilEnable: " + String(Fault[datalayer_extended.tesla.HVP_gpioHvilEnable]) + "</h4>";
+      content += "<h4>HVP_gpioSecDrdy: " + String(Fault[datalayer_extended.tesla.HVP_gpioSecDrdy]) + "</h4>";
+      content += "<h4>HVP_shuntCurrentDebug: " + String(HVP_shuntCurrentDebug) + " A</h4>";
+      content += "<h4>HVP_packCurrentMia: " + String(noYes[datalayer_extended.tesla.HVP_packCurrentMia]) + "</h4>";
+      content += "<h4>HVP_auxCurrentMia: " + String(noYes[datalayer_extended.tesla.HVP_auxCurrentMia]) + "</h4>";
+      content += "<h4>HVP_currentSenseMia: " + String(noYes[datalayer_extended.tesla.HVP_currentSenseMia]) + "</h4>";
+      content +=
+          "<h4>HVP_shuntRefVoltageMismatch: " + String(noYes[datalayer_extended.tesla.HVP_shuntRefVoltageMismatch]) +
+          "</h4>";
+      content +=
+          "<h4>HVP_shuntThermistorMia: " + String(noYes[datalayer_extended.tesla.HVP_shuntThermistorMia]) + "</h4>";
+      content += "<h4>HVP_shuntHwMia: " + String(noYes[datalayer_extended.tesla.HVP_shuntHwMia]) + "</h4>";
+      //content += "<h4>HVP_fcLinkVoltage: " + String(HVP_fcLinkVoltage) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_packNegativeV: " + String(HVP_packNegativeV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_packPositiveV: " + String(HVP_packPositiveV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_dcLinkNegativeV: " + String(HVP_dcLinkNegativeV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_dcLinkPositiveV: " + String(HVP_dcLinkPositiveV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_fcLinkNegativeV: " + String(HVP_fcLinkNegativeV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_fcContCoilCurrent: " + String(HVP_fcContCoilCurrent) + " A</h4>"; // Not giving useable data
+      //content += "<h4>HVP_fcContVoltage: " + String(HVP_fcContVoltage) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_fcLinkPositiveV: " + String(HVP_fcLinkPositiveV) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntRefVoltageDbg: " + String(HVP_shuntRefVoltageDbg) + " V</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntAuxCurrentDbg: " + String(HVP_shuntAuxCurrentDbg) + " A</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntBarTempDbg: " + String(HVP_shuntBarTempDbg) + " DegC</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntAsicTempDbg: " + String(HVP_shuntAsicTempDbg) + " DegC</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntAuxCurrentStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntAuxCurrentStatus]) + "</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntBarTempStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntBarTempStatus]) + "</h4>"; // Not giving useable data
+      //content += "<h4>HVP_shuntAsicTempStatus: " + String(HVP_status[datalayer_extended.tesla.HVP_shuntAsicTempStatus]) + "</h4>"; // Not giving useable data
     }
 
-    content += "<br><br><button onclick='Volvo_askEraseDTC()'>Erase DTC</button><br>";
-    content += "<button onclick='Volvo_askReadDTC()'>Read DTC (result must be checked in CANlog)</button><br>";
-    content += "<button onclick='Volvo_BECMecuReset()'>Restart BECM module</button>";
-#endif  // VOLVO_SPA_HYBRID_BATTERY
+    if (battery->type() == NissanLeaf) {
+      static const char* LEAFgen[] = {"ZE0", "AZE0", "ZE1"};
+      content += "<h4>LEAF generation: " + String(LEAFgen[datalayer_extended.nissanleaf.LEAF_gen]) + "</h4>";
+      memcpy(readableSerialNumber, datalayer_extended.nissanleaf.BatterySerialNumber,
+             sizeof(datalayer_extended.nissanleaf.BatterySerialNumber));
+      readableSerialNumber[15] = '\0';  // Null terminate the string
+      content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
+      char readablePartNumber[8];  // One extra space for null terminator
+      memcpy(readablePartNumber, datalayer_extended.nissanleaf.BatteryPartNumber,
+             sizeof(datalayer_extended.nissanleaf.BatteryPartNumber));
+      readablePartNumber[7] = '\0';  // Null terminate the string
+      content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
+      char readableBMSID[9];  // One extra space for null terminator
+      memcpy(readableBMSID, datalayer_extended.nissanleaf.BMSIDcode, sizeof(datalayer_extended.nissanleaf.BMSIDcode));
+      readableBMSID[8] = '\0';  // Null terminate the string
+      content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
+      content += "<h4>GIDS: " + String(datalayer_extended.nissanleaf.GIDS) + "</h4>";
+      content += "<h4>Regen kW: " + String(datalayer_extended.nissanleaf.ChargePowerLimit) + "</h4>";
+      content += "<h4>Charge kW: " + String(datalayer_extended.nissanleaf.MaxPowerForCharger) + "</h4>";
+      content += "<h4>Interlock: " + String(datalayer_extended.nissanleaf.Interlock) + "</h4>";
+      content += "<h4>Insulation: " + String(datalayer_extended.nissanleaf.Insulation) + "</h4>";
+      content += "<h4>Relay cut request: " + String(datalayer_extended.nissanleaf.RelayCutRequest) + "</h4>";
+      content += "<h4>Failsafe status: " + String(datalayer_extended.nissanleaf.FailsafeStatus) + "</h4>";
+      content += "<h4>Fully charged: " + String(datalayer_extended.nissanleaf.Full) + "</h4>";
+      content += "<h4>Battery empty: " + String(datalayer_extended.nissanleaf.Empty) + "</h4>";
+      content += "<h4>Main relay ON: " + String(datalayer_extended.nissanleaf.MainRelayOn) + "</h4>";
+      content += "<h4>Heater present: " + String(datalayer_extended.nissanleaf.HeatExist) + "</h4>";
+      content += "<h4>Heating stopped: " + String(datalayer_extended.nissanleaf.HeatingStop) + "</h4>";
+      content += "<h4>Heating started: " + String(datalayer_extended.nissanleaf.HeatingStart) + "</h4>";
+      content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
+      content += "<button onclick='askResetSOH()'>Reset degradation data</button>";
+      content += "<h4>CryptoChallenge: " + String(datalayer_extended.nissanleaf.CryptoChallenge) + "</h4>";
+      content += "<h4>SolvedChallenge: " + String(datalayer_extended.nissanleaf.SolvedChallengeMSB) +
+                 String(datalayer_extended.nissanleaf.SolvedChallengeLSB) + "</h4>";
+      content += "<h4>Challenge failed: " + String(datalayer_extended.nissanleaf.challengeFailed) + "</h4>";
+    }
 
-#if !defined(BMW_PHEV_BATTERY) && !defined(BMW_IX_BATTERY) && !defined(BOLT_AMPERA_BATTERY) &&       \
-    !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY) && !defined(BMW_I3_BATTERY) &&          \
-    !defined(BYD_ATTO_3_BATTERY) && !defined(RENAULT_ZOE_GEN2_BATTERY) && !defined(CELLPOWER_BMS) && \
-    !defined(MEB_BATTERY) && !defined(VOLVO_SPA_BATTERY) && !defined(VOLVO_SPA_HYBRID_BATTERY) &&    \
-    !defined(KIA_HYUNDAI_64_BATTERY) && !defined(CMFA_EV_BATTERY)  //Only the listed types have extra info
-    content += "No extra information available for this battery type";
-#endif
+    else if (battery->type() == Meb) {
+      content += datalayer_extended.meb.SDSW ? "<h4>Service disconnect switch: Missing!</h4>"
+                                             : "<h4>Service disconnect switch: OK</h4>";
+      content += datalayer_extended.meb.pilotline ? "<h4>Pilotline: Open!</h4>" : "<h4>Pilotline: OK</h4>";
+      content +=
+          datalayer_extended.meb.transportmode ? "<h4>Transportmode: Locked!</h4>" : "<h4>Transportmode: OK</h4>";
+      content += datalayer_extended.meb.shutdown_active ? "<h4>Shutdown: Active!</h4>" : "<h4>Shutdown: No</h4>";
+      content += datalayer_extended.meb.componentprotection ? "<h4>Component protection: Active!</h4>"
+                                                            : "<h4>Component protection: No</h4>";
+      content += "<h4>HVIL status: ";
+      switch (datalayer_extended.meb.HVIL) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("Open!");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>KL30C status: ";
+      switch (datalayer_extended.meb.BMS_Kl30c_Status) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("Open!");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>BMS mode: ";
+      switch (datalayer_extended.meb.BMS_mode) {
+        case 0:
+          content += String("HV inactive");
+          break;
+        case 1:
+          content += String("HV active");
+          break;
+        case 2:
+          content += String("Balancing");
+          break;
+        case 3:
+          content += String("Extern charging");
+          break;
+        case 4:
+          content += String("AC charging");
+          break;
+        case 5:
+          content += String("Battery error");
+          break;
+        case 6:
+          content += String("DC charging");
+          break;
+        case 7:
+          content += String("Init");
+          break;
+        default:
+          content += String("?");
+      }
+      content += String("</h4><h4>Charging: ") + (datalayer_extended.meb.charging_active ? "active" : "not active");
+      content += String("</h4><h4>Balancing: ");
+      switch (datalayer_extended.meb.balancing_active) {
+        case 0:
+          content += String("init");
+          break;
+        case 1:
+          content += String("active");
+          break;
+        case 2:
+          content += String("inactive");
+          break;
+        default:
+          content += String("?");
+      }
+      content += String("</h4><h4>Slow charging: ") +
+                 (datalayer_extended.meb.balancing_request ? "requested" : "not requested");
+      content += "</h4><h4>Diagnostic: ";
+      switch (datalayer_extended.meb.battery_diagnostic) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("Battery display");
+          break;
+        case 4:
+          content += String("Battery display OK");
+          break;
+        case 6:
+          content += String("Battery display check");
+          break;
+        case 7:
+          content += String("Fault");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>HV line status: ";
+      switch (datalayer_extended.meb.status_HV_line) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("No open HV line detected");
+          break;
+        case 2:
+          content += String("Open HV line");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("? ") + String(datalayer_extended.meb.status_HV_line);
+      }
+      content += "</h4>";
+      content += datalayer_extended.meb.BMS_fault_performance ? "<h4>BMS fault performance: Active!</h4>"
+                                                              : "<h4>BMS fault performance: Off</h4>";
+      content += datalayer_extended.meb.BMS_fault_emergency_shutdown_crash
+                     ? "<h4>BMS fault emergency shutdown crash: Active!</h4>"
+                     : "<h4>BMS fault emergency shutdown crash: Off</h4>";
+      content += datalayer_extended.meb.BMS_error_shutdown_request ? "<h4>BMS error shutdown request: Active!</h4>"
+                                                                   : "<h4>BMS error shutdown request: Inactive</h4>";
+      content += datalayer_extended.meb.BMS_error_shutdown ? "<h4>BMS error shutdown: Active!</h4>"
+                                                           : "<h4>BMS error shutdown: Off</h4>";
+      content += "<h4>Welded contactors: ";
+      switch (datalayer_extended.meb.BMS_welded_contactors_status) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("No contactor welded");
+          break;
+        case 2:
+          content += String("At least 1 contactor welded");
+          break;
+        case 3:
+          content += String("Protection status detection error");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>Warning support: ";
+      switch (datalayer_extended.meb.warning_support) {
+        case 0:
+          content += String("OK");
+          break;
+        case 1:
+          content += String("Not OK");
+          break;
+        case 6:
+          content += String("Init");
+          break;
+        case 7:
+          content += String("Fault");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>Interm. Voltage (" + String(datalayer_extended.meb.BMS_voltage_intermediate_dV / 10.0, 1) +
+                 "V) status: ";
+      switch (datalayer_extended.meb.BMS_status_voltage_free) {
+        case 0:
+          content += String("Init");
+          break;
+        case 1:
+          content += String("BMS interm circuit voltage free (U<20V)");
+          break;
+        case 2:
+          content += String("BMS interm circuit not voltage free (U >= 25V)");
+          break;
+        case 3:
+          content += String("Error");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>BMS error status: ";
+      switch (datalayer_extended.meb.BMS_error_status) {
+        case 0:
+          content += String("Component IO");
+          break;
+        case 1:
+          content += String("Iso Error 1");
+          break;
+        case 2:
+          content += String("Iso Error 2");
+          break;
+        case 3:
+          content += String("Interlock");
+          break;
+        case 4:
+          content += String("SD");
+          break;
+        case 5:
+          content += String("Performance red");
+          break;
+        case 6:
+          content += String("No component function");
+          break;
+        case 7:
+          content += String("Init");
+          break;
+        default:
+          content += String("?");
+      }
+      content += "</h4><h4>BMS voltage: " + String(datalayer_extended.meb.BMS_voltage_dV / 10.0, 1) + "</h4>";
+      content += datalayer_extended.meb.BMS_OBD_MIL ? "<h4>OBD MIL: ON!</h4>" : "<h4>OBD MIL: Off</h4>";
+      content +=
+          datalayer_extended.meb.BMS_error_lamp_req ? "<h4>Red error lamp: ON!</h4>" : "<h4>Red error lamp: Off</h4>";
+      content += datalayer_extended.meb.BMS_warning_lamp_req ? "<h4>Yellow warning lamp: ON!</h4>"
+                                                             : "<h4>Yellow warning lamp: Off</h4>";
+      content += "<h4>Isolation resistance: " + String(datalayer_extended.meb.isolation_resistance) + " kOhm</h4>";
+      content += datalayer_extended.meb.battery_heating ? "<h4>Battery heating: Active!</h4>"
+                                                        : "<h4>Battery heating: Off</h4>";
+      const char* rt_enum[] = {"No", "Error level 1", "Error level 2", "Error level 3"};
+      content += "<h4>Overcurrent: " + String(rt_enum[datalayer_extended.meb.rt_overcurrent & 0x03]) + "</h4>";
+      content += "<h4>CAN fault: " + String(rt_enum[datalayer_extended.meb.rt_CAN_fault & 0x03]) + "</h4>";
+      content += "<h4>Overcharged: " + String(rt_enum[datalayer_extended.meb.rt_overcharge & 0x03]) + "</h4>";
+      content += "<h4>SOC too high: " + String(rt_enum[datalayer_extended.meb.rt_SOC_high & 0x03]) + "</h4>";
+      content += "<h4>SOC too low: " + String(rt_enum[datalayer_extended.meb.rt_SOC_low & 0x03]) + "</h4>";
+      content += "<h4>SOC jumping: " + String(rt_enum[datalayer_extended.meb.rt_SOC_jumping & 0x03]) + "</h4>";
+      content += "<h4>Temp difference: " + String(rt_enum[datalayer_extended.meb.rt_temp_difference & 0x03]) + "</h4>";
+      content += "<h4>Cell overtemp: " + String(rt_enum[datalayer_extended.meb.rt_cell_overtemp & 0x03]) + "</h4>";
+      content += "<h4>Cell undertemp: " + String(rt_enum[datalayer_extended.meb.rt_cell_undertemp & 0x03]) + "</h4>";
+      content +=
+          "<h4>Battery overvoltage: " + String(rt_enum[datalayer_extended.meb.rt_battery_overvolt & 0x03]) + "</h4>";
+      content +=
+          "<h4>Battery undervoltage: " + String(rt_enum[datalayer_extended.meb.rt_battery_undervol & 0x03]) + "</h4>";
+      content += "<h4>Cell overvoltage: " + String(rt_enum[datalayer_extended.meb.rt_cell_overvolt & 0x03]) + "</h4>";
+      content += "<h4>Cell undervoltage: " + String(rt_enum[datalayer_extended.meb.rt_cell_undervol & 0x03]) + "</h4>";
+      content += "<h4>Cell imbalance: " + String(rt_enum[datalayer_extended.meb.rt_cell_imbalance & 0x03]) + "</h4>";
+      content +=
+          "<h4>Battery unathorized: " + String(rt_enum[datalayer_extended.meb.rt_battery_unathorized & 0x03]) + "</h4>";
+      content += "<h4>Battery temperature: " + String(datalayer_extended.meb.battery_temperature_dC / 10.f, 1) +
+                 " &deg;C</h4>";
+      for (int i = 0; i < 3; i++) {
+        content += "<h4>Temperature points " + String(i * 6 + 1) + "-" + String(i * 6 + 6) + " :";
+        for (int j = 0; j < 6; j++)
+          content += " &nbsp;" + String(datalayer_extended.meb.temp_points[i * 6 + j], 1);
+        content += " &deg;C</h4>";
+      }
+      bool temps_done = false;
+      for (int i = 0; i < 7 && !temps_done; i++) {
+        content += "<h4>Cell temperatures " + String(i * 8 + 1) + "-" + String(i * 8 + 8) + " :";
+        for (int j = 0; j < 8; j++) {
+          if (datalayer_extended.meb.celltemperature_dC[i * 8 + j] == 865) {
+            temps_done = true;
+            break;
+          } else {
+            content += " &nbsp;" + String(datalayer_extended.meb.celltemperature_dC[i * 8 + j] / 10.f, 1);
+          }
+        }
+        content += " &deg;C</h4>";
+      }
+      content +=
+          "<h4>Total charged: " + String(datalayer.battery.status.total_charged_battery_Wh / 1000.0, 1) + " kWh</h4>";
+      content += "<h4>Total discharged: " + String(datalayer.battery.status.total_discharged_battery_Wh / 1000.0, 1) +
+                 " kWh</h4>";
+    }  //MEB_BATTERY
+
+    else if (battery->type() == RenaultZoeGen2) {
+      content += "<h4>soc: " + String(datalayer_extended.zoePH2.battery_soc) + "</h4>";
+      content += "<h4>usable soc: " + String(datalayer_extended.zoePH2.battery_usable_soc) + "</h4>";
+      content += "<h4>soh: " + String(datalayer_extended.zoePH2.battery_soh) + "</h4>";
+      content += "<h4>pack voltage: " + String(datalayer_extended.zoePH2.battery_pack_voltage) + "</h4>";
+      content += "<h4>max cell voltage: " + String(datalayer_extended.zoePH2.battery_max_cell_voltage) + "</h4>";
+      content += "<h4>min cell voltage: " + String(datalayer_extended.zoePH2.battery_min_cell_voltage) + "</h4>";
+      content += "<h4>12v: " + String(datalayer_extended.zoePH2.battery_12v) + "</h4>";
+      content += "<h4>avg temp: " + String(datalayer_extended.zoePH2.battery_avg_temp) + "</h4>";
+      content += "<h4>min temp: " + String(datalayer_extended.zoePH2.battery_min_temp) + "</h4>";
+      content += "<h4>max temp: " + String(datalayer_extended.zoePH2.battery_max_temp) + "</h4>";
+      content += "<h4>max power: " + String(datalayer_extended.zoePH2.battery_max_power) + "</h4>";
+      content += "<h4>interlock: " + String(datalayer_extended.zoePH2.battery_interlock) + "</h4>";
+      content += "<h4>kwh: " + String(datalayer_extended.zoePH2.battery_kwh) + "</h4>";
+      content += "<h4>current: " + String(datalayer_extended.zoePH2.battery_current) + "</h4>";
+      content += "<h4>current offset: " + String(datalayer_extended.zoePH2.battery_current_offset) + "</h4>";
+      content += "<h4>max generated: " + String(datalayer_extended.zoePH2.battery_max_generated) + "</h4>";
+      content += "<h4>max available: " + String(datalayer_extended.zoePH2.battery_max_available) + "</h4>";
+      content += "<h4>current voltage: " + String(datalayer_extended.zoePH2.battery_current_voltage) + "</h4>";
+      content += "<h4>charging status: " + String(datalayer_extended.zoePH2.battery_charging_status) + "</h4>";
+      content += "<h4>remaining charge: " + String(datalayer_extended.zoePH2.battery_remaining_charge) + "</h4>";
+      content +=
+          "<h4>balance capacity total: " + String(datalayer_extended.zoePH2.battery_balance_capacity_total) + "</h4>";
+      content += "<h4>balance time total: " + String(datalayer_extended.zoePH2.battery_balance_time_total) + "</h4>";
+      content +=
+          "<h4>balance capacity sleep: " + String(datalayer_extended.zoePH2.battery_balance_capacity_sleep) + "</h4>";
+      content += "<h4>balance time sleep: " + String(datalayer_extended.zoePH2.battery_balance_time_sleep) + "</h4>";
+      content +=
+          "<h4>balance capacity wake: " + String(datalayer_extended.zoePH2.battery_balance_capacity_wake) + "</h4>";
+      content += "<h4>balance time wake: " + String(datalayer_extended.zoePH2.battery_balance_time_wake) + "</h4>";
+      content += "<h4>bms state: " + String(datalayer_extended.zoePH2.battery_bms_state) + "</h4>";
+      content += "<h4>balance switches: " + String(datalayer_extended.zoePH2.battery_balance_switches) + "</h4>";
+      content += "<h4>energy complete: " + String(datalayer_extended.zoePH2.battery_energy_complete) + "</h4>";
+      content += "<h4>energy partial: " + String(datalayer_extended.zoePH2.battery_energy_partial) + "</h4>";
+      content += "<h4>slave failures: " + String(datalayer_extended.zoePH2.battery_slave_failures) + "</h4>";
+      content += "<h4>mileage: " + String(datalayer_extended.zoePH2.battery_mileage) + "</h4>";
+      content += "<h4>fan speed: " + String(datalayer_extended.zoePH2.battery_fan_speed) + "</h4>";
+      content += "<h4>fan period: " + String(datalayer_extended.zoePH2.battery_fan_period) + "</h4>";
+      content += "<h4>fan control: " + String(datalayer_extended.zoePH2.battery_fan_control) + "</h4>";
+      content += "<h4>fan duty: " + String(datalayer_extended.zoePH2.battery_fan_duty) + "</h4>";
+      content += "<h4>temporisation: " + String(datalayer_extended.zoePH2.battery_temporisation) + "</h4>";
+      content += "<h4>time: " + String(datalayer_extended.zoePH2.battery_time) + "</h4>";
+      content += "<h4>pack time: " + String(datalayer_extended.zoePH2.battery_pack_time) + "</h4>";
+      content += "<h4>soc min: " + String(datalayer_extended.zoePH2.battery_soc_min) + "</h4>";
+      content += "<h4>soc max: " + String(datalayer_extended.zoePH2.battery_soc_max) + "</h4>";
+    }  //RENAULT_ZOE_GEN2_BATTERY
+
+    else if (battery->type() == VolvoSpa) {
+      content += "<h4>BECM reported SOC: " + String(datalayer_extended.VolvoPolestar.soc_bms) + "</h4>";
+      content += "<h4>Calculated SOC: " + String(datalayer_extended.VolvoPolestar.soc_calc) + "</h4>";
+      content += "<h4>Rescaled SOC: " + String(datalayer_extended.VolvoPolestar.soc_rescaled / 10) + "</h4>";
+      content += "<h4>BECM reported SOH: " + String(datalayer_extended.VolvoPolestar.soh_bms) + "</h4>";
+      content += "<h4>BECM supply voltage: " + String(datalayer_extended.VolvoPolestar.BECMsupplyVoltage) + " mV</h4>";
+
+      content += "<h4>HV voltage: " + String(datalayer_extended.VolvoPolestar.BECMBatteryVoltage) + " V</h4>";
+      content += "<h4>HV current: " + String(datalayer_extended.VolvoPolestar.BECMBatteryCurrent) + " A</h4>";
+      content += "<h4>Dynamic max voltage: " + String(datalayer_extended.VolvoPolestar.BECMUDynMaxLim) + " V</h4>";
+      content += "<h4>Dynamic min voltage: " + String(datalayer_extended.VolvoPolestar.BECMUDynMinLim) + " V</h4>";
+
+      content +=
+          "<h4>Discharge power limit 1: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDcha1) + " kW</h4>";
+      content += "<h4>Discharge soft power limit: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDchaSoft) +
+                 " kW</h4>";
+      content +=
+          "<h4>Discharge power limit slow aging: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimDchaSlowAgi) +
+          " kW</h4>";
+      content +=
+          "<h4>Charge power limit slow aging: " + String(datalayer_extended.VolvoPolestar.HvBattPwrLimChrgSlowAgi) +
+          " kW</h4>";
+
+      content += "<h4>HV system relay status: ";
+      switch (datalayer_extended.VolvoPolestar.HVSysRlySts) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("OpenAndRequestActiveDischarge");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system relay status 1: ";
+      switch (datalayer_extended.VolvoPolestar.HVSysDCRlySts1) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system relay status 2: ";
+      switch (datalayer_extended.VolvoPolestar.HVSysDCRlySts2) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system isolation resistance monitoring status: ";
+      switch (datalayer_extended.VolvoPolestar.HVSysIsoRMonrSts) {
+        case 0:
+          content += String("Not valid 1");
+          break;
+        case 1:
+          content += String("False");
+          break;
+        case 2:
+          content += String("True");
+          break;
+        case 3:
+          content += String("Not valid 2");
+          break;
+        default:
+          content += String("Not valid");
+      }
+
+      content += "<br><br><button onclick='Volvo_askEraseDTC()'>Erase DTC</button><br>";
+      content += "<button onclick='Volvo_askReadDTC()'>Read DTC (result must be checked in CANlog)</button><br>";
+      content += "<button onclick='Volvo_BECMecuReset()'>Restart BECM module</button>";
+    }  // VOLVO_SPA_BATTERY
+
+    else if (battery->type() == VolvoSpaHybrid) {
+      content += "<h4>BECM reported SOC: " + String(datalayer_extended.VolvoHybrid.soc_bms) + "</h4>";
+      content += "<h4>Calculated SOC: " + String(datalayer_extended.VolvoHybrid.soc_calc) + "</h4>";
+      content += "<h4>Rescaled SOC: " + String(datalayer_extended.VolvoHybrid.soc_rescaled / 10) + "</h4>";
+      content += "<h4>BECM reported SOH: " + String(datalayer_extended.VolvoHybrid.soh_bms) + "</h4>";
+      content += "<h4>BECM supply voltage: " + String(datalayer_extended.VolvoHybrid.BECMsupplyVoltage) + " mV</h4>";
+
+      content += "<h4>HV voltage: " + String(datalayer_extended.VolvoHybrid.BECMBatteryVoltage) + " V</h4>";
+      content += "<h4>HV current: " + String(datalayer_extended.VolvoHybrid.BECMBatteryCurrent) + " A</h4>";
+      content += "<h4>Dynamic max voltage: " + String(datalayer_extended.VolvoHybrid.BECMUDynMaxLim) + " V</h4>";
+      content += "<h4>Dynamic min voltage: " + String(datalayer_extended.VolvoHybrid.BECMUDynMinLim) + " V</h4>";
+
+      content +=
+          "<h4>Discharge power limit 1: " + String(datalayer_extended.VolvoHybrid.HvBattPwrLimDcha1) + " kW</h4>";
+      content +=
+          "<h4>Discharge soft power limit: " + String(datalayer_extended.VolvoHybrid.HvBattPwrLimDchaSoft) + " kW</h4>";
+
+      content += "<h4>HV system relay status: ";
+      switch (datalayer_extended.VolvoHybrid.HVSysRlySts) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("OpenAndRequestActiveDischarge");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system relay status 1: ";
+      switch (datalayer_extended.VolvoHybrid.HVSysDCRlySts1) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system relay status 2: ";
+      switch (datalayer_extended.VolvoHybrid.HVSysDCRlySts2) {
+        case 0:
+          content += String("Open");
+          break;
+        case 1:
+          content += String("Closed");
+          break;
+        case 2:
+          content += String("KeepStatus");
+          break;
+        case 3:
+          content += String("Fault");
+          break;
+        default:
+          content += String("Not valid");
+      }
+      content += "</h4><h4>HV system isolation resistance monitoring status: ";
+      switch (datalayer_extended.VolvoHybrid.HVSysIsoRMonrSts) {
+        case 0:
+          content += String("Not valid 1");
+          break;
+        case 1:
+          content += String("False");
+          break;
+        case 2:
+          content += String("True");
+          break;
+        case 3:
+          content += String("Not valid 2");
+          break;
+        default:
+          content += String("Not valid");
+      }
+
+      content += "<br><br><button onclick='Volvo_askEraseDTC()'>Erase DTC</button><br>";
+      content += "<button onclick='Volvo_askReadDTC()'>Read DTC (result must be checked in CANlog)</button><br>";
+      content += "<button onclick='Volvo_BECMecuReset()'>Restart BECM module</button>";
+    } else {
+      content += "No extra information available for this battery type";
+    }
 
     content += "</div>";
     content += "<script>";

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -16,21 +16,22 @@ String cellmonitor_processor(const String& var) {
     content += ".cell { width: 48%; margin: 1%; padding: 10px; border: 1px solid white; text-align: center; }";
     content += ".low-voltage { color: red; }";              // Style for low voltage text
     content += ".voltage-values { margin-bottom: 10px; }";  // Style for voltage values section
-#ifdef DOUBLE_BATTERY
-    content +=
-        "#graph, #graph2 {display: flex;align-items: flex-end;height: 200px;border: 1px solid #ccc;position: "
-        "relative;}";
-#else
-    content += "#graph {display: flex;align-items: flex-end;height: 200px;border: 1px solid #ccc;position: relative;}";
-#endif
+    if (battery2) {
+      content +=
+          "#graph, #graph2 {display: flex;align-items: flex-end;height: 200px;border: 1px solid #ccc;position: "
+          "relative;}";
+    } else {
+      content +=
+          "#graph {display: flex;align-items: flex-end;height: 200px;border: 1px solid #ccc;position: relative;}";
+    }
     content +=
         ".bar {margin: 0 0px;background-color: blue;display: inline-block;position: relative;cursor: pointer;border: "
         "1px solid white; /* Add this line */}";
-#ifdef DOUBLE_BATTERY
-    content += "#valueDisplay, #valueDisplay2 {text-align: left;font-weight: bold;margin-top: 10px;}";
-#else
-    content += "#valueDisplay {text-align: left;font-weight: bold;margin-top: 10px;}";
-#endif
+    if (battery2) {
+      content += "#valueDisplay, #valueDisplay2 {text-align: left;font-weight: bold;margin-top: 10px;}";
+    } else {
+      content += "#valueDisplay {text-align: left;font-weight: bold;margin-top: 10px;}";
+    }
     content += "</style>";
 
     content += "<button onclick='home()'>Back to main page</button>";
@@ -50,24 +51,24 @@ String cellmonitor_processor(const String& var) {
     // Close the block
     content += "</div>";
 
-#ifdef DOUBLE_BATTERY
-    // Start a new block with a specific background color
-    content += "<div style='background-color: #303E41; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+    if (battery2) {
+      // Start a new block with a specific background color
+      content += "<div style='background-color: #303E41; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
 
-    // Display max, min, and deviation voltage values
-    content += "<div id='voltageValues2' class='voltage-values'></div>";
-    // Display cells
-    content += "<div id='cellContainer2' class='container'></div>";
-    // Display bars
-    content += "<div id='graph2'></div>";
-    // Display single hovered value
-    content += "<div id='valueDisplay2'>Value: ...</div>";
+      // Display max, min, and deviation voltage values
+      content += "<div id='voltageValues2' class='voltage-values'></div>";
+      // Display cells
+      content += "<div id='cellContainer2' class='container'></div>";
+      // Display bars
+      content += "<div id='graph2'></div>";
+      // Display single hovered value
+      content += "<div id='valueDisplay2'>Value: ...</div>";
 
-    // Close the block
-    content += "</div>";
+      // Close the block
+      content += "</div>";
 
-    content += "<button onclick='home()'>Back to main page</button>";
-#endif  // DOUBLE_BATTERY
+      content += "<button onclick='home()'>Back to main page</button>";
+    }
 
     content += "<script>";
     // Populate cell data
@@ -184,120 +185,120 @@ String cellmonitor_processor(const String& var) {
         "available';";
     content += "}";
 
-#ifdef DOUBLE_BATTERY
-    // Populate cell data
-    content += "const data2 = [";
-    for (uint8_t i = 0u; i < datalayer.battery2.info.number_of_cells; i++) {
-      if (datalayer.battery2.status.cell_voltages_mV[i] == 0) {
-        continue;
+    if (battery2) {
+      // Populate cell data
+      content += "const data2 = [";
+      for (uint8_t i = 0u; i < datalayer.battery2.info.number_of_cells; i++) {
+        if (datalayer.battery2.status.cell_voltages_mV[i] == 0) {
+          continue;
+        }
+        content += String(datalayer.battery2.status.cell_voltages_mV[i]) + ",";
       }
-      content += String(datalayer.battery2.status.cell_voltages_mV[i]) + ",";
+      content += "];";
+
+      content += "const min_mv2 = Math.min(...data2) - 20;";
+      content += "const max_mv2 = Math.max(...data2) + 20;";
+      content += "const min_index2 = data2.indexOf(Math.min(...data2));";
+      content += "const max_index2 = data2.indexOf(Math.max(...data2));";
+      content += "const graphContainer2 = document.getElementById('graph2');";
+      content += "const valueDisplay2 = document.getElementById('valueDisplay2');";
+      content += "const cellContainer2 = document.getElementById('cellContainer2');";
+
+      // Arduino-style map() function
+      content +=
+          "function map2(value, fromLow, fromHigh, toLow, toHigh) {return (value - fromLow) * (toHigh - toLow) / "
+          "(fromHigh - fromLow) + toLow;}";
+
+      // Mark cell and bar with highest/lowest values
+      content +=
+          "function checkMinMax2(cell2, bar2, index2) {if ((index2 == min_index2) || (index2 == max_index2)) "
+          "{cell2.style.borderColor = 'red';bar2.style.borderColor = 'red';}}";
+
+      // Bar function. Basically get the mV, scale the height and add a bar div to its container
+      content +=
+          "function createBars2(data2) {"
+          "data2.forEach((mV, index2) => {"
+          "const bar2 = document.createElement('div');"
+          "const mV_limited2 = map2(mV, min_mv2, max_mv2, 20, 200);"
+          "bar2.className = 'bar';"
+          "bar2.id = `barIndex2${index2}`;"
+          "bar2.style.height = `${mV_limited2}px`;"
+          "bar2.style.width = `${750/data2.length}px`;"
+
+          "const cell2 = document.getElementById(`cellIndex2${index2}`);"
+
+          "checkMinMax2(cell2, bar2, index2);"
+
+          "bar2.addEventListener('mouseenter', () => {"
+          "valueDisplay2.textContent = `Value: ${mV}`;"
+          "bar2.style.backgroundColor = `lightblue`;"
+          "cell2.style.backgroundColor = `blue`;"
+          "});"
+
+          "bar2.addEventListener('mouseleave', () => {"
+          "valueDisplay2.textContent = 'Value: ...';"
+          "bar2.style.backgroundColor = `blue`;"
+          "cell2.style.removeProperty('background-color');"
+          "});"
+
+          "graphContainer2.appendChild(bar2);"
+          "});"
+          "}";
+
+      // Cell population function. For each value, add a cell block with its value
+      content +=
+          "function createCells2(data2) {"
+          "data2.forEach((mV, index2) => {"
+          "const cell2 = document.createElement('div');"
+          "cell2.className = 'cell';"
+          "cell2.id = `cellIndex2${index2}`;"
+          "let cellContent2 = `Cell ${index2 + 1}<br>${mV} mV`;"
+          "if (mV < 3000) {"
+          "cellContent2 = `<span class='low-voltage'>${cellContent2}</span>`;"
+          "}"
+          "cell2.innerHTML = cellContent2;"
+
+          "cell2.addEventListener('mouseenter', () => {"
+          "let bar2 = document.getElementById(`barIndex2${index2}`);"
+          "valueDisplay2.textContent = `Value: ${mV}`;"
+          "bar2.style.backgroundColor = `lightblue`;"
+          "cell2.style.backgroundColor = `blue`;"
+          "});"
+
+          "cell2.addEventListener('mouseleave', () => {"
+          "let bar2 = document.getElementById(`barIndex2${index2}`);"
+          "bar2.style.backgroundColor = `blue`;"
+          "cell2.style.removeProperty('background-color');"
+          "});"
+
+          "cellContainer2.appendChild(cell2);"
+          "});"
+          "}";
+
+      // On fetch, update the header of max/min/deviation client-side for consistency
+      content +=
+          "function updateVoltageValues2(data2) {"
+          "const min_mv2 = Math.min(...data2);"
+          "const max_mv2 = Math.max(...data2);"
+          "const cell_dev2 = max_mv2 - min_mv2;"
+          "const voltVal2 = document.getElementById('voltageValues2');"
+          "voltVal2.innerHTML = `Max Voltage : ${max_mv2} mV<br>Min Voltage: ${min_mv2} mV<br>Voltage Deviation: "
+          "${cell_dev2} mV`"
+          "}";
+
+      // If we have values, do the thing. Otherwise, display friendly message and wait
+      content += "if (data2.length != 0) {";
+      content += "createCells2(data2);";
+      content += "createBars2(data2);";
+      content += "updateVoltageValues2(data2);";
+      content += "}";
+      content += "else {";
+      content +=
+          "document.getElementById('voltageValues2').textContent = 'Cell information not yet fetched, or information "
+          "not "
+          "available';";
+      content += "}";
     }
-    content += "];";
-
-    content += "const min_mv2 = Math.min(...data2) - 20;";
-    content += "const max_mv2 = Math.max(...data2) + 20;";
-    content += "const min_index2 = data2.indexOf(Math.min(...data2));";
-    content += "const max_index2 = data2.indexOf(Math.max(...data2));";
-    content += "const graphContainer2 = document.getElementById('graph2');";
-    content += "const valueDisplay2 = document.getElementById('valueDisplay2');";
-    content += "const cellContainer2 = document.getElementById('cellContainer2');";
-
-    // Arduino-style map() function
-    content +=
-        "function map2(value, fromLow, fromHigh, toLow, toHigh) {return (value - fromLow) * (toHigh - toLow) / "
-        "(fromHigh - fromLow) + toLow;}";
-
-    // Mark cell and bar with highest/lowest values
-    content +=
-        "function checkMinMax2(cell2, bar2, index2) {if ((index2 == min_index2) || (index2 == max_index2)) "
-        "{cell2.style.borderColor = 'red';bar2.style.borderColor = 'red';}}";
-
-    // Bar function. Basically get the mV, scale the height and add a bar div to its container
-    content +=
-        "function createBars2(data2) {"
-        "data2.forEach((mV, index2) => {"
-        "const bar2 = document.createElement('div');"
-        "const mV_limited2 = map2(mV, min_mv2, max_mv2, 20, 200);"
-        "bar2.className = 'bar';"
-        "bar2.id = `barIndex2${index2}`;"
-        "bar2.style.height = `${mV_limited2}px`;"
-        "bar2.style.width = `${750/data2.length}px`;"
-
-        "const cell2 = document.getElementById(`cellIndex2${index2}`);"
-
-        "checkMinMax2(cell2, bar2, index2);"
-
-        "bar2.addEventListener('mouseenter', () => {"
-        "valueDisplay2.textContent = `Value: ${mV}`;"
-        "bar2.style.backgroundColor = `lightblue`;"
-        "cell2.style.backgroundColor = `blue`;"
-        "});"
-
-        "bar2.addEventListener('mouseleave', () => {"
-        "valueDisplay2.textContent = 'Value: ...';"
-        "bar2.style.backgroundColor = `blue`;"
-        "cell2.style.removeProperty('background-color');"
-        "});"
-
-        "graphContainer2.appendChild(bar2);"
-        "});"
-        "}";
-
-    // Cell population function. For each value, add a cell block with its value
-    content +=
-        "function createCells2(data2) {"
-        "data2.forEach((mV, index2) => {"
-        "const cell2 = document.createElement('div');"
-        "cell2.className = 'cell';"
-        "cell2.id = `cellIndex2${index2}`;"
-        "let cellContent2 = `Cell ${index2 + 1}<br>${mV} mV`;"
-        "if (mV < 3000) {"
-        "cellContent2 = `<span class='low-voltage'>${cellContent2}</span>`;"
-        "}"
-        "cell2.innerHTML = cellContent2;"
-
-        "cell2.addEventListener('mouseenter', () => {"
-        "let bar2 = document.getElementById(`barIndex2${index2}`);"
-        "valueDisplay2.textContent = `Value: ${mV}`;"
-        "bar2.style.backgroundColor = `lightblue`;"
-        "cell2.style.backgroundColor = `blue`;"
-        "});"
-
-        "cell2.addEventListener('mouseleave', () => {"
-        "let bar2 = document.getElementById(`barIndex2${index2}`);"
-        "bar2.style.backgroundColor = `blue`;"
-        "cell2.style.removeProperty('background-color');"
-        "});"
-
-        "cellContainer2.appendChild(cell2);"
-        "});"
-        "}";
-
-    // On fetch, update the header of max/min/deviation client-side for consistency
-    content +=
-        "function updateVoltageValues2(data2) {"
-        "const min_mv2 = Math.min(...data2);"
-        "const max_mv2 = Math.max(...data2);"
-        "const cell_dev2 = max_mv2 - min_mv2;"
-        "const voltVal2 = document.getElementById('voltageValues2');"
-        "voltVal2.innerHTML = `Max Voltage : ${max_mv2} mV<br>Min Voltage: ${min_mv2} mV<br>Voltage Deviation: "
-        "${cell_dev2} mV`"
-        "}";
-
-    // If we have values, do the thing. Otherwise, display friendly message and wait
-    content += "if (data2.length != 0) {";
-    content += "createCells2(data2);";
-    content += "createBars2(data2);";
-    content += "updateVoltageValues2(data2);";
-    content += "}";
-    content += "else {";
-    content +=
-        "document.getElementById('voltageValues2').textContent = 'Cell information not yet fetched, or information not "
-        "available';";
-    content += "}";
-
-#endif  //DOUBLE_BATTERY
 
     // Automatic refresh is nice
     content += "setTimeout(function(){ location.reload(true); }, 20000);";

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -193,37 +193,36 @@ String settings_processor(const String& var) {
       content += "</div>";
     }
 
-#if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
+    if (charger) {
+      // Start a new block with orange background color
+      content += "<div style='background-color: #FF6E00; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
-    // Start a new block with orange background color
-    content += "<div style='background-color: #FF6E00; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+      content += "<h4 style='color: white;'>Charger HVDC Enabled: ";
+      if (datalayer.charger.charger_HV_enabled) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
+      content += " <button onclick='editChargerHVDCEnabled()'>Edit</button></h4>";
 
-    content += "<h4 style='color: white;'>Charger HVDC Enabled: ";
-    if (datalayer.charger.charger_HV_enabled) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
+      content += "<h4 style='color: white;'>Charger Aux12VDC Enabled: ";
+      if (datalayer.charger.charger_aux12V_enabled) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
+      content += " <button onclick='editChargerAux12vEnabled()'>Edit</button></h4>";
+
+      content += "<h4 style='color: white;'>Charger Voltage Setpoint: " +
+                 String(datalayer.charger.charger_setpoint_HV_VDC, 1) +
+                 " V </span> <button onclick='editChargerSetpointVDC()'>Edit</button></h4>";
+      content += "<h4 style='color: white;'>Charger Current Setpoint: " +
+                 String(datalayer.charger.charger_setpoint_HV_IDC, 1) +
+                 " A </span> <button onclick='editChargerSetpointIDC()'>Edit</button></h4>";
+
+      // Close the block
+      content += "</div>";
     }
-    content += " <button onclick='editChargerHVDCEnabled()'>Edit</button></h4>";
-
-    content += "<h4 style='color: white;'>Charger Aux12VDC Enabled: ";
-    if (datalayer.charger.charger_aux12V_enabled) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
-    content += " <button onclick='editChargerAux12vEnabled()'>Edit</button></h4>";
-
-    content +=
-        "<h4 style='color: white;'>Charger Voltage Setpoint: " + String(datalayer.charger.charger_setpoint_HV_VDC, 1) +
-        " V </span> <button onclick='editChargerSetpointVDC()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: white;'>Charger Current Setpoint: " + String(datalayer.charger.charger_setpoint_HV_IDC, 1) +
-        " A </span> <button onclick='editChargerSetpointIDC()'>Edit</button></h4>";
-
-    // Close the block
-    content += "</div>";
-#endif
 
     content += "<script>";  // Note, this section is minified to improve performance
     content += "function editComplete(){if(this.status==200){window.location.reload();}}";
@@ -358,40 +357,44 @@ String settings_processor(const String& var) {
           "between 0 and 1000');}}}";
     }
 
-#if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
-    content +=
-        "function editChargerHVDCEnabled(){var value=prompt('Enable or disable HV DC output. Enter 1 for enabled, 0 "
-        "for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateChargerHvEnabled?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}";
-    content +=
-        "function editChargerAux12vEnabled(){var value=prompt('Enable or disable low voltage 12v auxiliary DC output. "
-        "Enter 1 for enabled, 0 for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateChargerAux12vEnabled?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter 1 or "
-        "0');}}}";
-    content +=
-        "function editChargerSetpointVDC(){var value=prompt('Set charging voltage. Input will be validated against "
-        "inverter and/or charger configuration parameters, but use sensible values like 200 to "
-        "420.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateChargeSetpointV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between "
-        "0 and 1000');}}}";
-    content +=
-        "function editChargerSetpointIDC(){var value=prompt('Set charging amperage. Input will be validated against "
-        "inverter and/or charger configuration parameters, but use sensible values like 6 to "
-        "48.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateChargeSetpointA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between "
-        "0 and 100');}}}";
-    content +=
-        "function editChargerSetpointEndI(){var value=prompt('Set amperage that terminates charge as being "
-        "sufficiently complete. Input will be validated against inverter and/or charger configuration parameters, but "
-        "use sensible values like 1-5.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateChargeEndA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
-        "and 100');}}}";
-#endif
+    if (charger) {
+      content +=
+          "function editChargerHVDCEnabled(){var value=prompt('Enable or disable HV DC output. Enter 1 for enabled, 0 "
+          "for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateChargerHvEnabled?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}";
+      content +=
+          "function editChargerAux12vEnabled(){var value=prompt('Enable or disable low voltage 12v auxiliary DC "
+          "output. "
+          "Enter 1 for enabled, 0 for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateChargerAux12vEnabled?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter 1 or "
+          "0');}}}";
+      content +=
+          "function editChargerSetpointVDC(){var value=prompt('Set charging voltage. Input will be validated against "
+          "inverter and/or charger configuration parameters, but use sensible values like 200 to "
+          "420.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateChargeSetpointV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between "
+          "0 and 1000');}}}";
+      content +=
+          "function editChargerSetpointIDC(){var value=prompt('Set charging amperage. Input will be validated against "
+          "inverter and/or charger configuration parameters, but use sensible values like 6 to "
+          "48.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateChargeSetpointA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between "
+          "0 and 100');}}}";
+      content +=
+          "function editChargerSetpointEndI(){var value=prompt('Set amperage that terminates charge as being "
+          "sufficiently complete. Input will be validated against inverter and/or charger configuration parameters, "
+          "but "
+          "use sensible values like 1-5.');if(value!==null){if(value>=0&&value<=1000){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateChargeEndA?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 "
+          "and 100');}}}";
+    }
     content += "</script>";
 
     content += "<script>";

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -49,6 +49,25 @@ String inverter_options(InverterProtocolType selected) {
 
   return options;
 }
+
+String charger_options(ChargerType selected) {
+  String options;
+
+  auto chargers = supported_charger_types();
+
+  for (ChargerType type : chargers) {
+    auto name = Charger::name_for_type(type);
+    if (name != nullptr) {
+      options +=
+          ("<option value=\"" + String(static_cast<int>(type)) + "\"" + (selected == type ? "selected" : "") + ">");
+      options += name;
+      options += "</option>";
+    }
+  }
+
+  return options;
+}
+
 #endif
 
 String settings_processor(const String& var) {
@@ -79,6 +98,9 @@ String settings_processor(const String& var) {
     content += "</select>";
     content += "<label>Inverter protocol: </label><select style='max-width: 250px;' name='inverter'>";
     content += inverter_options(userSelectedInverter);
+    content += "</select>";
+    content += "<label>Charger: </label><select style='max-width: 250px;' name='charger'>";
+    content += charger_options(userSelectedChargerType);
     content += "</select>";
     content += "<label>Double battery:</label>";
     content +=

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -2,6 +2,43 @@
 #include <Arduino.h>
 #include "../../datalayer/datalayer.h"
 
+#ifdef BUILD_EM_ALL
+String battery_options(BatteryType selected) {
+  String options;
+
+  auto batteries = supported_battery_types();
+  for (BatteryType type : batteries) {
+    auto name = CanBattery::name_for_type(type);
+    if (name != nullptr) {
+      options +=
+          ("<option value=\"" + String(static_cast<int>(type)) + "\"" + (selected == type ? " selected" : "") + ">");
+      options += name;
+      options += "</option>";
+    }
+  }
+
+  return options;
+}
+
+String inverter_options(InverterProtocolType selected) {
+  String options;
+
+  auto inverters = supported_inverter_protocols();
+
+  for (InverterProtocolType type : inverters) {
+    auto name = InverterProtocol::name_for_type(type);
+    if (name != nullptr) {
+      options +=
+          ("<option value=\"" + String(static_cast<int>(type)) + "\"" + (selected == type ? "selected" : "") + ">");
+      options += name;
+      options += "</option>";
+    }
+  }
+
+  return options;
+}
+#endif
+
 String settings_processor(const String& var) {
   if (var == "X") {
     String content = "";
@@ -16,6 +53,20 @@ String settings_processor(const String& var) {
 
     content += "<button onclick='goToMainPage()'>Back to main page</button>";
 
+#ifdef BUILD_EM_ALL
+    // Battery and inverter settings form
+    content += "<div style='background-color: #404E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+    content += "<form action='saveSettings' method='post'>";
+    content += "<label style='display: block;'>Battery: </label><select name='battery'>";
+    content += battery_options(userSelectedBatteryType);
+    content += "</select>";
+    content += "<label style='display: block;'>Inverter protocol: </label><select name='inverter'>";
+    content += inverter_options(userSelectedInverter);
+    content += "</select>";
+    content += "<button type='submit'>Save</button>";
+    content += "</form></div>";
+#endif
+
     // Start a new block with a specific background color
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
@@ -25,26 +76,26 @@ String settings_processor(const String& var) {
         "<h4 style='color: white;'>Password: ######## <span id='Password'></span> <button "
         "onclick='editPassword()'>Edit</button></h4>";
 
-#ifndef RS485_BATTERY_SELECTED
-    content += "<h4 style='color: white;'>Battery interface: <span id='Battery'>" +
-               String(getCANInterfaceName(can_config.battery)) + "</span></h4>";
-#endif
-#ifdef RS485_BATTERY_SELECTED
-    content += "<h4 style='color: white;'>Battery interface: RS485<span id='Battery'></span></h4>";
-#endif
+    if (!battery->usesRS485()) {
+      content += "<h4 style='color: white;'>Battery interface: <span id='Battery'>" +
+                 String(getCANInterfaceName(can_config.battery)) + "</span></h4>";
+    }
+    if (battery->usesRS485()) {
+      content += "<h4 style='color: white;'>Battery interface: RS485<span id='Battery'></span></h4>";
+    }
 
 #ifdef DOUBLE_BATTERY
     content += "<h4 style='color: white;'>Battery #2 interface: <span id='Battery'>" +
                String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
 #endif  // DOUBLE_BATTERY
 
-#ifdef CAN_INVERTER_SELECTED
-    content += "<h4 style='color: white;'>Inverter interface: <span id='Inverter'>" +
-               String(getCANInterfaceName(can_config.inverter)) + "</span></h4>";
-#endif  //CAN_INVERTER_SELECTED
-#ifdef MODBUS_INVERTER_SELECTED
-    content += "<h4 style='color: white;'>Inverter interface: RS485<span id='Inverter'></span></h4>";
-#endif
+    if (inverter->usesCAN()) {
+      content += "<h4 style='color: white;'>Inverter interface: <span id='Inverter'>" +
+                 String(getCANInterfaceName(can_config.inverter)) + "</span></h4>";
+    }
+    if (inverter->usesMODBUS()) {
+      content += "<h4 style='color: white;'>Inverter interface: RS485<span id='Inverter'></span></h4>";
+    }
 
 #ifdef CAN_SHUNT_SELECTED
     content += "<h4 style='color: white;'>Shunt Interface: <span id='Shunt'>" +
@@ -95,53 +146,52 @@ String settings_processor(const String& var) {
     // Close the block
     content += "</div>";
 
-#ifdef TEST_FAKE_BATTERY
-    // Start a new block with blue background color
-    content += "<div style='background-color: #2E37AD; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
-    float voltageFloat =
-        static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
-    content += "<h4 style='color: white;'>Fake battery voltage: " + String(voltageFloat, 1) +
-               " V </span> <button onclick='editFakeBatteryVoltage()'>Edit</button></h4>";
+    if (battery->type() == TestFake) {
+      // Start a new block with blue background color
+      content += "<div style='background-color: #2E37AD; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+      float voltageFloat =
+          static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
+      content += "<h4 style='color: white;'>Fake battery voltage: " + String(voltageFloat, 1) +
+                 " V </span> <button onclick='editFakeBatteryVoltage()'>Edit</button></h4>";
 
-    // Close the block
-    content += "</div>";
-#endif
+      // Close the block
+      content += "</div>";
+    }
 
-#ifdef TESLA_MODEL_3Y_BATTERY
+    if (battery->type() == Tesla3Y) {
+      // Start a new block with grey background color
+      content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
-    // Start a new block with grey background color
-    content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+      content +=
+          "<h4 style='color: white;'>Manual LFP balancing: <span id='TSL_BAL_ACT'>" +
+          String(datalayer.battery.settings.user_requests_balancing ? "<span>&#10003;</span>"
+                                                                    : "<span style='color: red;'>&#10005;</span>") +
+          "</span> <button onclick='editTeslaBalAct()'>Edit</button></h4>";
+      content +=
+          "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
+          ";'>Balancing max time: " + String(datalayer.battery.settings.balancing_time_ms / 60000.0, 1) +
+          " Minutes </span> <button onclick='editBalTime()'>Edit</button></h4>";
+      content +=
+          "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
+          ";'>Balancing float power: " + String(datalayer.battery.settings.balancing_float_power_W / 1.0, 0) +
+          " W </span> <button onclick='editBalFloatPower()'>Edit</button></h4>";
+      content +=
+          "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
+          ";'>Max battery voltage: " + String(datalayer.battery.settings.balancing_max_pack_voltage_dV / 10.0, 0) +
+          " V </span> <button onclick='editBalMaxPackV()'>Edit</button></h4>";
+      content +=
+          "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
+          ";'>Max cell voltage: " + String(datalayer.battery.settings.balancing_max_cell_voltage_mV / 1.0, 0) +
+          " mV </span> <button onclick='editBalMaxCellV()'>Edit</button></h4>";
+      content +=
+          "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
+          ";'>Max cell voltage deviation: " +
+          String(datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV / 1.0, 0) +
+          " mV </span> <button onclick='editBalMaxDevCellV()'>Edit</button></h4>";
 
-    content +=
-        "<h4 style='color: white;'>Manual LFP balancing: <span id='TSL_BAL_ACT'>" +
-        String(datalayer.battery.settings.user_requests_balancing ? "<span>&#10003;</span>"
-                                                                  : "<span style='color: red;'>&#10005;</span>") +
-        "</span> <button onclick='editTeslaBalAct()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
-        ";'>Balancing max time: " + String(datalayer.battery.settings.balancing_time_ms / 60000.0, 1) +
-        " Minutes </span> <button onclick='editBalTime()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
-        ";'>Balancing float power: " + String(datalayer.battery.settings.balancing_float_power_W / 1.0, 0) +
-        " W </span> <button onclick='editBalFloatPower()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
-        ";'>Max battery voltage: " + String(datalayer.battery.settings.balancing_max_pack_voltage_dV / 10.0, 0) +
-        " V </span> <button onclick='editBalMaxPackV()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
-        ";'>Max cell voltage: " + String(datalayer.battery.settings.balancing_max_cell_voltage_mV / 1.0, 0) +
-        " mV </span> <button onclick='editBalMaxCellV()'>Edit</button></h4>";
-    content +=
-        "<h4 style='color: " + String(datalayer.battery.settings.user_requests_balancing ? "white" : "darkgrey") +
-        ";'>Max cell voltage deviation: " +
-        String(datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV / 1.0, 0) +
-        " mV </span> <button onclick='editBalMaxDevCellV()'>Edit</button></h4>";
-
-    // Close the block
-    content += "</div>";
-#endif
+      // Close the block
+      content += "</div>";
+    }
 
 #if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
 
@@ -255,55 +305,58 @@ String settings_processor(const String& var) {
         "between 0 "
         "and 1000.0');}}}";
 
-#ifdef TESLA_MODEL_3Y_BATTERY
-    content +=
-        "function editTeslaBalAct(){var value=prompt('Enable or disable forced LFP balancing. Makes the battery charge "
-        "to 101percent. This should be performed once every month, to keep LFP batteries balanced. Ensure battery is "
-        "fully charged before enabling, and also that you have enough sun or grid power to feed power into the battery "
-        "while balancing is active. Enter 1 for enabled, 0 "
-        "for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "TeslaBalAct?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}";
-    content +=
-        "function editBalTime(){var value=prompt('Enter new max balancing time in "
-        "minutes');if(value!==null){if(value>=1&&value<=300){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "BalTime?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 1 and 300');}}}";
-    content +=
-        "function editBalFloatPower(){var value=prompt('Power level in Watt to float charge during forced "
-        "balancing');if(value!==null){if(value>=100&&value<=2000){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "BalFloatPower?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 100 and 2000');}}}";
-    content +=
-        "function editBalMaxPackV(){var value=prompt('Battery pack max voltage temporarily raised to this value during "
-        "forced balancing. Value in V');if(value!==null){if(value>=380&&value<=410){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "BalMaxPackV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 380 and 410');}}}";
-    content +=
-        "function editBalMaxCellV(){var value=prompt('Cellvoltage max temporarily raised to this value during forced "
-        "balancing. Value in mV');if(value!==null){if(value>=3400&&value<=3750){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "BalMaxCellV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 3400 and 3750');}}}";
-    content +=
-        "function editBalMaxDevCellV(){var value=prompt('Cellvoltage max deviation temporarily raised to this value "
-        "during forced balancing. Value in mV');if(value!==null){if(value>=300&&value<=600){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "BalMaxDevCellV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 300 and 600');}}}";
-#endif
+    if (battery->type() == Tesla3Y) {
+      content +=
+          "function editTeslaBalAct(){var value=prompt('Enable or disable forced LFP balancing. Makes the battery "
+          "charge "
+          "to 101percent. This should be performed once every month, to keep LFP batteries balanced. Ensure battery is "
+          "fully charged before enabling, and also that you have enough sun or grid power to feed power into the "
+          "battery "
+          "while balancing is active. Enter 1 for enabled, 0 "
+          "for disabled');if(value!==null){if(value==0||value==1){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "TeslaBalAct?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}";
+      content +=
+          "function editBalTime(){var value=prompt('Enter new max balancing time in "
+          "minutes');if(value!==null){if(value>=1&&value<=300){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "BalTime?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 1 and 300');}}}";
+      content +=
+          "function editBalFloatPower(){var value=prompt('Power level in Watt to float charge during forced "
+          "balancing');if(value!==null){if(value>=100&&value<=2000){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "BalFloatPower?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 100 and 2000');}}}";
+      content +=
+          "function editBalMaxPackV(){var value=prompt('Battery pack max voltage temporarily raised to this value "
+          "during "
+          "forced balancing. Value in V');if(value!==null){if(value>=380&&value<=410){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "BalMaxPackV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 380 and 410');}}}";
+      content +=
+          "function editBalMaxCellV(){var value=prompt('Cellvoltage max temporarily raised to this value during forced "
+          "balancing. Value in mV');if(value!==null){if(value>=3400&&value<=3750){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "BalMaxCellV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 3400 and 3750');}}}";
+      content +=
+          "function editBalMaxDevCellV(){var value=prompt('Cellvoltage max deviation temporarily raised to this value "
+          "during forced balancing. Value in mV');if(value!==null){if(value>=300&&value<=600){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "BalMaxDevCellV?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 300 and 600');}}}";
+    }
 
-#ifdef TEST_FAKE_BATTERY
-    content +=
-        "function editFakeBatteryVoltage(){var value=prompt('Enter new fake battery "
-        "voltage');if(value!==null){if(value>=0&&value<=5000){var xhr=new "
-        "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
-        "updateFakeBatteryVoltage?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
-        "between 0 and 1000');}}}";
-#endif
+    if (battery->type() == Tesla3Y) {
+      content +=
+          "function editFakeBatteryVoltage(){var value=prompt('Enter new fake battery "
+          "voltage');if(value!==null){if(value>=0&&value<=5000){var xhr=new "
+          "XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/"
+          "updateFakeBatteryVoltage?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value "
+          "between 0 and 1000');}}}";
+    }
 
 #if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
     content +=

--- a/Software/src/devboard/webserver/settings_html.h
+++ b/Software/src/devboard/webserver/settings_html.h
@@ -17,13 +17,5 @@ extern std::string password;
  * @return String
  */
 String settings_processor(const String& var);
-/**
- * @brief Maps the value to a string of characters
- *
- * @param[in] char
- *
- * @return String
- */
-const char* getCANInterfaceName(CAN_Interface interface);
 
 #endif

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1446,39 +1446,41 @@ String processor(const String& var) {
       content += "<span style='color: red;'>&#10005;</span>";
     }
     content += "</h4>";
-#ifdef CHEVYVOLT_CHARGER
-    float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * datalayer.charger.charger_stat_HVvol);
-    float chgPwrAC = static_cast<float>(datalayer.charger.charger_stat_ACcur * datalayer.charger.charger_stat_ACvol);
-    float chgEff = chgPwrDC / chgPwrAC * 100;
-    float ACcur = datalayer.charger.charger_stat_ACcur;
-    float ACvol = datalayer.charger.charger_stat_ACvol;
-    float HVvol = datalayer.charger.charger_stat_HVvol;
-    float HVcur = datalayer.charger.charger_stat_HVcur;
-    float LVvol = datalayer.charger.charger_stat_LVvol;
-    float LVcur = datalayer.charger.charger_stat_LVcur;
 
-    content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
-    content += "<h4 style='color: white;'>Charger Efficiency: " + String(chgEff) + "%</h4>";
-    content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
-    content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
-    content += "<h4 style='color: white;'>Charger LVDC Output I: " + String(LVcur, 2) + "</h4>";
-    content += "<h4 style='color: white;'>Charger LVDC Output V: " + String(LVvol, 2) + "</h4>";
-    content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
-    content += "<h4 style='color: white;'>Charger AC Input I: " + String(ACcur, 2) + " A</h4>";
-#endif  // CHEVYVOLT_CHARGER
-#ifdef NISSANLEAF_CHARGER
-    float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * 100);
-    datalayer.charger.charger_stat_HVcur = chgPwrDC / (datalayer.battery.status.voltage_dV / 10);  // P/U=I
-    datalayer.charger.charger_stat_HVvol = static_cast<float>(datalayer.battery.status.voltage_dV / 10);
-    float ACvol = datalayer.charger.charger_stat_ACvol;
-    float HVvol = datalayer.charger.charger_stat_HVvol;
-    float HVcur = datalayer.charger.charger_stat_HVcur;
+    if (charger && charger->type() == ChargerType::ChevyVolt) {
+      float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * datalayer.charger.charger_stat_HVvol);
+      float chgPwrAC = static_cast<float>(datalayer.charger.charger_stat_ACcur * datalayer.charger.charger_stat_ACvol);
+      float chgEff = chgPwrDC / chgPwrAC * 100;
+      float ACcur = datalayer.charger.charger_stat_ACcur;
+      float ACvol = datalayer.charger.charger_stat_ACvol;
+      float HVvol = datalayer.charger.charger_stat_HVvol;
+      float HVcur = datalayer.charger.charger_stat_HVcur;
+      float LVvol = datalayer.charger.charger_stat_LVvol;
+      float LVcur = datalayer.charger.charger_stat_LVcur;
 
-    content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
-    content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
-    content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
-    content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
-#endif  // NISSANLEAF_CHARGER
+      content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
+      content += "<h4 style='color: white;'>Charger Efficiency: " + String(chgEff) + "%</h4>";
+      content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
+      content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
+      content += "<h4 style='color: white;'>Charger LVDC Output I: " + String(LVcur, 2) + "</h4>";
+      content += "<h4 style='color: white;'>Charger LVDC Output V: " + String(LVvol, 2) + "</h4>";
+      content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
+      content += "<h4 style='color: white;'>Charger AC Input I: " + String(ACcur, 2) + " A</h4>";
+    }
+
+    if (charger && charger->type() == ChargerType::NissanLeaf) {
+      float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * 100);
+      datalayer.charger.charger_stat_HVcur = chgPwrDC / (datalayer.battery.status.voltage_dV / 10);  // P/U=I
+      datalayer.charger.charger_stat_HVvol = static_cast<float>(datalayer.battery.status.voltage_dV / 10);
+      float ACvol = datalayer.charger.charger_stat_ACvol;
+      float HVvol = datalayer.charger.charger_stat_HVvol;
+      float HVcur = datalayer.charger.charger_stat_HVcur;
+
+      content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
+      content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
+      content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
+      content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
+    }
     // Close the block
     content += "</div>";
 #endif  // defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -392,6 +392,9 @@ void init_webserver() {
       } else if (p->name() == "battery") {
         auto type = static_cast<BatteryType>(atoi(p->value().c_str()));
         userSelectedBatteryType = type;
+      } else if (p->name() == "charger") {
+        auto type = static_cast<ChargerType>(atoi(p->value().c_str()));
+        userSelectedChargerType = type;
       } else if (p->name() == "dblbtr") {
         secondBattery = p->value() == "on";
       }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -379,19 +379,24 @@ void init_webserver() {
   });
 
 #ifdef BUILD_EM_ALL
+  // Handles the form POST from UI to save certain settings: battery/inverter type and double battery on/off
   server.on("/saveSettings", HTTP_POST, [](AsyncWebServerRequest* request) {
     int params = request->params();
+    // dblbtr not present in form content if not checked.
+    bool secondBattery = false;
     for (int i = 0; i < params; i++) {
       auto p = request->getParam(i);
       if (p->name() == "inverter") {
         auto type = static_cast<InverterProtocolType>(atoi(p->value().c_str()));
         userSelectedInverter = type;
-      }
-      if (p->name() == "battery") {
+      } else if (p->name() == "battery") {
         auto type = static_cast<BatteryType>(atoi(p->value().c_str()));
         userSelectedBatteryType = type;
+      } else if (p->name() == "dblbtr") {
+        secondBattery = p->value() == "on";
       }
     }
+    secondBatteryInUse = secondBattery;
     store_settings();
     request->redirect("/settings");
   });
@@ -751,94 +756,94 @@ void init_webserver() {
   });
 #endif
 
-#if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
-  // Route for editing ChargerTargetV
-  server.on("/updateChargeSetpointV", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
-      return request->requestAuthentication();
-    if (!request->hasParam("value")) {
-      request->send(400, "text/plain", "Bad Request");
-    }
+  if (charger) {
+    // Route for editing ChargerTargetV
+    server.on("/updateChargeSetpointV", HTTP_GET, [](AsyncWebServerRequest* request) {
+      if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
+        return request->requestAuthentication();
+      if (!request->hasParam("value")) {
+        request->send(400, "text/plain", "Bad Request");
+      }
 
-    String value = request->getParam("value")->value();
-    float val = value.toFloat();
-
-    if (!(val <= CHARGER_MAX_HV && val >= CHARGER_MIN_HV)) {
-      request->send(400, "text/plain", "Bad Request");
-    }
-
-    if (!(val * datalayer.charger.charger_setpoint_HV_IDC <= CHARGER_MAX_POWER)) {
-      request->send(400, "text/plain", "Bad Request");
-    }
-
-    datalayer.charger.charger_setpoint_HV_VDC = val;
-
-    request->send(200, "text/plain", "Updated successfully");
-  });
-
-  // Route for editing ChargerTargetA
-  server.on("/updateChargeSetpointA", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
-      return request->requestAuthentication();
-    if (!request->hasParam("value")) {
-      request->send(400, "text/plain", "Bad Request");
-    }
-
-    String value = request->getParam("value")->value();
-    float val = value.toFloat();
-
-    if (!(val <= datalayer.battery.settings.max_user_set_charge_dA && val <= CHARGER_MAX_A)) {
-      request->send(400, "text/plain", "Bad Request");
-    }
-
-    if (!(val * datalayer.charger.charger_setpoint_HV_VDC <= CHARGER_MAX_POWER)) {
-      request->send(400, "text/plain", "Bad Request");
-    }
-
-    datalayer.charger.charger_setpoint_HV_IDC = value.toFloat();
-
-    request->send(200, "text/plain", "Updated successfully");
-  });
-
-  // Route for editing ChargerEndA
-  server.on("/updateChargeEndA", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
-      return request->requestAuthentication();
-    if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
-      datalayer.charger.charger_setpoint_HV_IDC_END = value.toFloat();
-      request->send(200, "text/plain", "Updated successfully");
-    } else {
-      request->send(400, "text/plain", "Bad Request");
-    }
-  });
+      float val = value.toFloat();
 
-  // Route for enabling/disabling HV charger
-  server.on("/updateChargerHvEnabled", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
-      return request->requestAuthentication();
-    if (request->hasParam("value")) {
-      String value = request->getParam("value")->value();
-      datalayer.charger.charger_HV_enabled = (bool)value.toInt();
-      request->send(200, "text/plain", "Updated successfully");
-    } else {
-      request->send(400, "text/plain", "Bad Request");
-    }
-  });
+      if (!(val <= CHARGER_MAX_HV && val >= CHARGER_MIN_HV)) {
+        request->send(400, "text/plain", "Bad Request");
+      }
 
-  // Route for enabling/disabling aux12v charger
-  server.on("/updateChargerAux12vEnabled", HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
-      return request->requestAuthentication();
-    if (request->hasParam("value")) {
-      String value = request->getParam("value")->value();
-      datalayer.charger.charger_aux12V_enabled = (bool)value.toInt();
+      if (!(val * datalayer.charger.charger_setpoint_HV_IDC <= CHARGER_MAX_POWER)) {
+        request->send(400, "text/plain", "Bad Request");
+      }
+
+      datalayer.charger.charger_setpoint_HV_VDC = val;
+
       request->send(200, "text/plain", "Updated successfully");
-    } else {
-      request->send(400, "text/plain", "Bad Request");
-    }
-  });
-#endif  // defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
+    });
+
+    // Route for editing ChargerTargetA
+    server.on("/updateChargeSetpointA", HTTP_GET, [](AsyncWebServerRequest* request) {
+      if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
+        return request->requestAuthentication();
+      if (!request->hasParam("value")) {
+        request->send(400, "text/plain", "Bad Request");
+      }
+
+      String value = request->getParam("value")->value();
+      float val = value.toFloat();
+
+      if (!(val <= datalayer.battery.settings.max_user_set_charge_dA && val <= CHARGER_MAX_A)) {
+        request->send(400, "text/plain", "Bad Request");
+      }
+
+      if (!(val * datalayer.charger.charger_setpoint_HV_VDC <= CHARGER_MAX_POWER)) {
+        request->send(400, "text/plain", "Bad Request");
+      }
+
+      datalayer.charger.charger_setpoint_HV_IDC = value.toFloat();
+
+      request->send(200, "text/plain", "Updated successfully");
+    });
+
+    // Route for editing ChargerEndA
+    server.on("/updateChargeEndA", HTTP_GET, [](AsyncWebServerRequest* request) {
+      if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
+        return request->requestAuthentication();
+      if (request->hasParam("value")) {
+        String value = request->getParam("value")->value();
+        datalayer.charger.charger_setpoint_HV_IDC_END = value.toFloat();
+        request->send(200, "text/plain", "Updated successfully");
+      } else {
+        request->send(400, "text/plain", "Bad Request");
+      }
+    });
+
+    // Route for enabling/disabling HV charger
+    server.on("/updateChargerHvEnabled", HTTP_GET, [](AsyncWebServerRequest* request) {
+      if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
+        return request->requestAuthentication();
+      if (request->hasParam("value")) {
+        String value = request->getParam("value")->value();
+        datalayer.charger.charger_HV_enabled = (bool)value.toInt();
+        request->send(200, "text/plain", "Updated successfully");
+      } else {
+        request->send(400, "text/plain", "Bad Request");
+      }
+    });
+
+    // Route for enabling/disabling aux12v charger
+    server.on("/updateChargerAux12vEnabled", HTTP_GET, [](AsyncWebServerRequest* request) {
+      if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password))
+        return request->requestAuthentication();
+      if (request->hasParam("value")) {
+        String value = request->getParam("value")->value();
+        datalayer.charger.charger_aux12V_enabled = (bool)value.toInt();
+        request->send(200, "text/plain", "Updated successfully");
+      } else {
+        request->send(400, "text/plain", "Bad Request");
+      }
+    });
+  }
 
   // Send a GET request to <ESP_IP>/update
   server.on("/debug", HTTP_GET, [](AsyncWebServerRequest* request) {
@@ -1003,9 +1008,9 @@ String processor(const String& var) {
     content += "</h4>";
     content += "<h4 style='color: white;'>Battery protocol: ";
     content += battery->name();
-#ifdef DOUBLE_BATTERY
-    content += " (Double battery)";
-#endif  // DOUBLE_BATTERY
+    if (battery2) {
+      content += " (Double battery)";
+    }
     if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
       content += " (LFP)";
     }
@@ -1017,28 +1022,23 @@ String processor(const String& var) {
     content += "</h4>";
 #endif
 
-#if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
-    content += "<h4 style='color: white;'>Charger protocol: ";
-#ifdef CHEVYVOLT_CHARGER
-    content += "Chevy Volt Gen1 Charger";
-#endif  // CHEVYVOLT_CHARGER
-#ifdef NISSANLEAF_CHARGER
-    content += "Nissan LEAF 2013-2024 PDM charger";
-#endif  // NISSANLEAF_CHARGER
-    content += "</h4>";
-#endif  // defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
+    if (charger) {
+      content += "<h4 style='color: white;'>Charger protocol: ";
+      content += charger->name();
+      content += "</h4>";
+    }
 
     // Close the block
     content += "</div>";
 
-#ifdef DOUBLE_BATTERY
-    // Start a new block with a specific background color. Color changes depending on BMS status
-    content += "<div style='display: flex; width: 100%;'>";
-    content += "<div style='flex: 1; background-color: ";
-#else
-    // Start a new block with a specific background color. Color changes depending on system status
-    content += "<div style='background-color: ";
-#endif  // DOUBLE_BATTERY
+    if (battery2) {
+      // Start a new block with a specific background color. Color changes depending on BMS status
+      content += "<div style='display: flex; width: 100%;'>";
+      content += "<div style='flex: 1; background-color: ";
+    } else {
+      // Start a new block with a specific background color. Color changes depending on system status
+      content += "<div style='background-color: ";
+    }
 
     switch (led_get_color()) {
       case led_color::GREEN:
@@ -1213,7 +1213,7 @@ String processor(const String& var) {
 
     content += "<h4>Automatic contactor closing allowed:</h4>";
     content += "<h4>Battery: ";
-    if (datalayer.system.status.battery_allows_contactor_closing == true) {
+    if (battery->contactor_closing_allowed()) {
       content += "<span>&#10003;</span>";
     } else {
       content += "<span style='color: red;'>&#10005;</span>";
@@ -1273,217 +1273,221 @@ String processor(const String& var) {
     // Close the block
     content += "</div>";
 
-#ifdef DOUBLE_BATTERY
-    content += "<div style='flex: 1; background-color: ";
-    switch (datalayer.battery.status.bms_status) {
-      case ACTIVE:
-        content += "#2D3F2F;";
-        break;
-      case FAULT:
-        content += "#A70107;";
-        break;
-      default:
-        content += "#2D3F2F;";
-        break;
-    }
-    // Add the common style properties
-    content += "padding: 10px; margin-bottom: 10px; border-radius: 50px;'>";
+    if (battery2) {
+      content += "<div style='flex: 1; background-color: ";
+      switch (datalayer.battery.status.bms_status) {
+        case ACTIVE:
+          content += "#2D3F2F;";
+          break;
+        case FAULT:
+          content += "#A70107;";
+          break;
+        default:
+          content += "#2D3F2F;";
+          break;
+      }
+      // Add the common style properties
+      content += "padding: 10px; margin-bottom: 10px; border-radius: 50px;'>";
 
-    // Display battery statistics within this block
-    socRealFloat =
-        static_cast<float>(datalayer.battery2.status.real_soc) / 100.0;  // Convert to float and divide by 100
-    //socScaledFloat; // Same value used for bat2
-    sohFloat = static_cast<float>(datalayer.battery2.status.soh_pptt) / 100.0;  // Convert to float and divide by 100
-    voltageFloat =
-        static_cast<float>(datalayer.battery2.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
-    currentFloat =
-        static_cast<float>(datalayer.battery2.status.current_dA) / 10.0;        // Convert to float and divide by 10
-    powerFloat = static_cast<float>(datalayer.battery2.status.active_power_W);  // Convert to float
-    tempMaxFloat = static_cast<float>(datalayer.battery2.status.temperature_max_dC) / 10.0;  // Convert to float
-    tempMinFloat = static_cast<float>(datalayer.battery2.status.temperature_min_dC) / 10.0;  // Convert to float
-    cell_delta_mv = datalayer.battery2.status.cell_max_voltage_mV - datalayer.battery2.status.cell_min_voltage_mV;
+      // Display battery statistics within this block
+      socRealFloat =
+          static_cast<float>(datalayer.battery2.status.real_soc) / 100.0;  // Convert to float and divide by 100
+      //socScaledFloat; // Same value used for bat2
+      sohFloat = static_cast<float>(datalayer.battery2.status.soh_pptt) / 100.0;  // Convert to float and divide by 100
+      voltageFloat =
+          static_cast<float>(datalayer.battery2.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
+      currentFloat =
+          static_cast<float>(datalayer.battery2.status.current_dA) / 10.0;        // Convert to float and divide by 10
+      powerFloat = static_cast<float>(datalayer.battery2.status.active_power_W);  // Convert to float
+      tempMaxFloat = static_cast<float>(datalayer.battery2.status.temperature_max_dC) / 10.0;  // Convert to float
+      tempMinFloat = static_cast<float>(datalayer.battery2.status.temperature_min_dC) / 10.0;  // Convert to float
+      cell_delta_mv = datalayer.battery2.status.cell_max_voltage_mV - datalayer.battery2.status.cell_min_voltage_mV;
 
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) +
-                 "&percnt; (real: " + String(socRealFloat, 2) + "&percnt;)</h4>";
-    else
-      content += "<h4 style='color: white;'>SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
+      if (datalayer.battery.settings.soc_scaling_active)
+        content += "<h4 style='color: white;'>Scaled SOC: " + String(socScaledFloat, 2) +
+                   "&percnt; (real: " + String(socRealFloat, 2) + "&percnt;)</h4>";
+      else
+        content += "<h4 style='color: white;'>SOC: " + String(socRealFloat, 2) + "&percnt;</h4>";
 
-    content += "<h4 style='color: white;'>SOH: " + String(sohFloat, 2) + "&percnt;</h4>";
-    content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) +
-               " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
-    content += formatPowerValue("Power", powerFloat, "", 1);
+      content += "<h4 style='color: white;'>SOH: " + String(sohFloat, 2) + "&percnt;</h4>";
+      content += "<h4 style='color: white;'>Voltage: " + String(voltageFloat, 1) +
+                 " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
+      content += formatPowerValue("Power", powerFloat, "", 1);
 
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled total capacity: " +
-                 formatPowerValue(datalayer.battery2.info.reported_total_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery2.info.total_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Total capacity", datalayer.battery2.info.total_capacity_Wh, "h", 1);
+      if (datalayer.battery.settings.soc_scaling_active)
+        content += "<h4 style='color: white;'>Scaled total capacity: " +
+                   formatPowerValue(datalayer.battery2.info.reported_total_capacity_Wh, "h", 1) +
+                   " (real: " + formatPowerValue(datalayer.battery2.info.total_capacity_Wh, "h", 1) + ")</h4>";
+      else
+        content += formatPowerValue("Total capacity", datalayer.battery2.info.total_capacity_Wh, "h", 1);
 
-    if (datalayer.battery.settings.soc_scaling_active)
-      content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                 formatPowerValue(datalayer.battery2.status.reported_remaining_capacity_Wh, "h", 1) +
-                 " (real: " + formatPowerValue(datalayer.battery2.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
-    else
-      content += formatPowerValue("Remaining capacity", datalayer.battery2.status.remaining_capacity_Wh, "h", 1);
+      if (datalayer.battery.settings.soc_scaling_active)
+        content += "<h4 style='color: white;'>Scaled remaining capacity: " +
+                   formatPowerValue(datalayer.battery2.status.reported_remaining_capacity_Wh, "h", 1) +
+                   " (real: " + formatPowerValue(datalayer.battery2.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
+      else
+        content += formatPowerValue("Remaining capacity", datalayer.battery2.status.remaining_capacity_Wh, "h", 1);
 
-    if (datalayer.system.settings.equipment_stop_active) {
-      content += formatPowerValue("Max discharge power", datalayer.battery2.status.max_discharge_power_W, "", 1, "red");
-      content += formatPowerValue("Max charge power", datalayer.battery2.status.max_charge_power_W, "", 1, "red");
-      content += "<h4 style='color: red;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A</h4>";
-      content += "<h4 style='color: red;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
-    } else {
-      content += formatPowerValue("Max discharge power", datalayer.battery2.status.max_discharge_power_W, "", 1);
-      content += formatPowerValue("Max charge power", datalayer.battery2.status.max_charge_power_W, "", 1);
-      content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A</h4>";
-      content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
-    }
+      if (datalayer.system.settings.equipment_stop_active) {
+        content +=
+            formatPowerValue("Max discharge power", datalayer.battery2.status.max_discharge_power_W, "", 1, "red");
+        content += formatPowerValue("Max charge power", datalayer.battery2.status.max_charge_power_W, "", 1, "red");
+        content += "<h4 style='color: red;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A</h4>";
+        content += "<h4 style='color: red;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
+      } else {
+        content += formatPowerValue("Max discharge power", datalayer.battery2.status.max_discharge_power_W, "", 1);
+        content += formatPowerValue("Max charge power", datalayer.battery2.status.max_charge_power_W, "", 1);
+        content +=
+            "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A</h4>";
+        content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A</h4>";
+      }
 
-    content += "<h4>Cell min/max: " + String(datalayer.battery2.status.cell_min_voltage_mV) + " mV / " +
-               String(datalayer.battery2.status.cell_max_voltage_mV) + " mV</h4>";
-    if (cell_delta_mv > datalayer.battery2.info.max_cell_voltage_deviation_mV) {
-      content += "<h4 style='color: red;'>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
-    } else {
-      content += "<h4>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
-    }
-    content +=
-        "<h4>Temperature min/max: " + String(tempMinFloat, 1) + " &deg;C / " + String(tempMaxFloat, 1) + " &deg;C</h4>";
-    if (datalayer.battery.status.bms_status == ACTIVE) {
-      content += "<h4>System status: OK </h4>";
-    } else if (datalayer.battery.status.bms_status == UPDATING) {
-      content += "<h4>System status: UPDATING </h4>";
-    } else {
-      content += "<h4>System status: FAULT </h4>";
-    }
-    if (datalayer.battery2.status.current_dA == 0) {
-      content += "<h4>Battery idle</h4>";
-    } else if (datalayer.battery2.status.current_dA < 0) {
-      content += "<h4>Battery discharging!</h4>";
-    } else {  // > 0
-      content += "<h4>Battery charging!</h4>";
-    }
+      content += "<h4>Cell min/max: " + String(datalayer.battery2.status.cell_min_voltage_mV) + " mV / " +
+                 String(datalayer.battery2.status.cell_max_voltage_mV) + " mV</h4>";
+      if (cell_delta_mv > datalayer.battery2.info.max_cell_voltage_deviation_mV) {
+        content += "<h4 style='color: red;'>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
+      } else {
+        content += "<h4>Cell delta: " + String(cell_delta_mv) + " mV</h4>";
+      }
+      content += "<h4>Temperature min/max: " + String(tempMinFloat, 1) + " &deg;C / " + String(tempMaxFloat, 1) +
+                 " &deg;C</h4>";
+      if (datalayer.battery.status.bms_status == ACTIVE) {
+        content += "<h4>System status: OK </h4>";
+      } else if (datalayer.battery.status.bms_status == UPDATING) {
+        content += "<h4>System status: UPDATING </h4>";
+      } else {
+        content += "<h4>System status: FAULT </h4>";
+      }
+      if (datalayer.battery2.status.current_dA == 0) {
+        content += "<h4>Battery idle</h4>";
+      } else if (datalayer.battery2.status.current_dA < 0) {
+        content += "<h4>Battery discharging!</h4>";
+      } else {  // > 0
+        content += "<h4>Battery charging!</h4>";
+      }
 
-    content += "<h4>Automatic contactor closing allowed:</h4>";
-    content += "<h4>Battery: ";
-    if (datalayer.system.status.battery2_allows_contactor_closing == true) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
+      content += "<h4>Automatic contactor closing allowed:</h4>";
+      content += "<h4>Battery: ";
+      if (battery2->contactor_closing_allowed() == true) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
 
-    content += " Inverter: ";
-    if (datalayer.system.status.inverter_allows_contactor_closing == true) {
-      content += "<span>&#10003;</span></h4>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span></h4>";
-    }
+      content += " Inverter: ";
+      if (datalayer.system.status.inverter_allows_contactor_closing == true) {
+        content += "<span>&#10003;</span></h4>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span></h4>";
+      }
 
-    if (emulator_pause_status == NORMAL)
-      content += "<h4>Power status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
-    else
-      content += "<h4 style='color: red;'>Power status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
+      if (emulator_pause_status == NORMAL)
+        content += "<h4>Power status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
+      else
+        content += "<h4 style='color: red;'>Power status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
 
 #ifdef CONTACTOR_CONTROL
-    content += "<h4>Contactors controlled by emulator, state: ";
-    if (datalayer.system.status.contactors_battery2_engaged) {
-      content += "<span style='color: green;'>ON</span>";
-    } else {
-      content += "<span style='color: red;'>OFF</span>";
-    }
-    content += "</h4>";
+      content += "<h4>Contactors controlled by emulator, state: ";
+      if (datalayer.system.status.contactors_battery2_engaged) {
+        content += "<span style='color: green;'>ON</span>";
+      } else {
+        content += "<span style='color: red;'>OFF</span>";
+      }
+      content += "</h4>";
 #ifdef CONTACTOR_CONTROL_DOUBLE_BATTERY
-    content += "<h4>Cont. Neg.: ";
+      content += "<h4>Cont. Neg.: ";
 #ifdef PWM_CONTACTOR_CONTROL
-    if (datalayer.system.status.contactors_battery2_engaged) {
-      content += "<span style='color: green;'>Economized</span>";
-      content += " Cont. Pos.: ";
-      content += "<span style='color: green;'>Economized</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-      content += " Cont. Pos.: ";
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
+      if (datalayer.system.status.contactors_battery2_engaged) {
+        content += "<span style='color: green;'>Economized</span>";
+        content += " Cont. Pos.: ";
+        content += "<span style='color: green;'>Economized</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+        content += " Cont. Pos.: ";
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
 
 #else   // No PWM_CONTACTOR_CONTROL , we can read the pin and see feedback. Helpful if channel overloaded
-    if (digitalRead(SECOND_NEGATIVE_CONTACTOR_PIN) == HIGH) {
-      content += "<span style='color: green;'>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
+      if (digitalRead(SECOND_NEGATIVE_CONTACTOR_PIN) == HIGH) {
+        content += "<span style='color: green;'>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
 
-    content += " Cont. Pos.: ";
-    if (digitalRead(SECOND_POSITIVE_CONTACTOR_PIN) == HIGH) {
-      content += "<span style='color: green;'>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
+      content += " Cont. Pos.: ";
+      if (digitalRead(SECOND_POSITIVE_CONTACTOR_PIN) == HIGH) {
+        content += "<span style='color: green;'>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
 #endif  //no PWM_CONTACTOR_CONTROL
-    content += "</h4>";
+      content += "</h4>";
 #endif  // CONTACTOR_CONTROL_DOUBLE_BATTERY
 #endif  // CONTACTOR_CONTROL
 
-    content += "</div>";
-    content += "</div>";
-#endif  // DOUBLE_BATTERY
-
-#if defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
-    // Start a new block with orange background color
-    content += "<div style='background-color: #FF6E00; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
-
-    content += "<h4>Charger HV Enabled: ";
-    if (datalayer.charger.charger_HV_enabled) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
-    content += "</h4>";
-
-    content += "<h4>Charger Aux12v Enabled: ";
-    if (datalayer.charger.charger_aux12V_enabled) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005;</span>";
-    }
-    content += "</h4>";
-
-    if (charger && charger->type() == ChargerType::ChevyVolt) {
-      float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * datalayer.charger.charger_stat_HVvol);
-      float chgPwrAC = static_cast<float>(datalayer.charger.charger_stat_ACcur * datalayer.charger.charger_stat_ACvol);
-      float chgEff = chgPwrDC / chgPwrAC * 100;
-      float ACcur = datalayer.charger.charger_stat_ACcur;
-      float ACvol = datalayer.charger.charger_stat_ACvol;
-      float HVvol = datalayer.charger.charger_stat_HVvol;
-      float HVcur = datalayer.charger.charger_stat_HVcur;
-      float LVvol = datalayer.charger.charger_stat_LVvol;
-      float LVcur = datalayer.charger.charger_stat_LVcur;
-
-      content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
-      content += "<h4 style='color: white;'>Charger Efficiency: " + String(chgEff) + "%</h4>";
-      content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
-      content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
-      content += "<h4 style='color: white;'>Charger LVDC Output I: " + String(LVcur, 2) + "</h4>";
-      content += "<h4 style='color: white;'>Charger LVDC Output V: " + String(LVvol, 2) + "</h4>";
-      content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
-      content += "<h4 style='color: white;'>Charger AC Input I: " + String(ACcur, 2) + " A</h4>";
+      content += "</div>";
+      content += "</div>";
     }
 
-    if (charger && charger->type() == ChargerType::NissanLeaf) {
-      float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * 100);
-      datalayer.charger.charger_stat_HVcur = chgPwrDC / (datalayer.battery.status.voltage_dV / 10);  // P/U=I
-      datalayer.charger.charger_stat_HVvol = static_cast<float>(datalayer.battery.status.voltage_dV / 10);
-      float ACvol = datalayer.charger.charger_stat_ACvol;
-      float HVvol = datalayer.charger.charger_stat_HVvol;
-      float HVcur = datalayer.charger.charger_stat_HVcur;
+    if (charger) {
+      // Start a new block with orange background color
+      content += "<div style='background-color: #FF6E00; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
 
-      content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
-      content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
-      content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
-      content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
+      content += "<h4>Charger HV Enabled: ";
+      if (datalayer.charger.charger_HV_enabled) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
+      content += "</h4>";
+
+      content += "<h4>Charger Aux12v Enabled: ";
+      if (datalayer.charger.charger_aux12V_enabled) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005;</span>";
+      }
+      content += "</h4>";
+
+      if (charger && charger->type() == ChargerType::ChevyVolt) {
+        float chgPwrDC =
+            static_cast<float>(datalayer.charger.charger_stat_HVcur * datalayer.charger.charger_stat_HVvol);
+        float chgPwrAC =
+            static_cast<float>(datalayer.charger.charger_stat_ACcur * datalayer.charger.charger_stat_ACvol);
+        float chgEff = chgPwrDC / chgPwrAC * 100;
+        float ACcur = datalayer.charger.charger_stat_ACcur;
+        float ACvol = datalayer.charger.charger_stat_ACvol;
+        float HVvol = datalayer.charger.charger_stat_HVvol;
+        float HVcur = datalayer.charger.charger_stat_HVcur;
+        float LVvol = datalayer.charger.charger_stat_LVvol;
+        float LVcur = datalayer.charger.charger_stat_LVcur;
+
+        content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
+        content += "<h4 style='color: white;'>Charger Efficiency: " + String(chgEff) + "%</h4>";
+        content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
+        content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
+        content += "<h4 style='color: white;'>Charger LVDC Output I: " + String(LVcur, 2) + "</h4>";
+        content += "<h4 style='color: white;'>Charger LVDC Output V: " + String(LVvol, 2) + "</h4>";
+        content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
+        content += "<h4 style='color: white;'>Charger AC Input I: " + String(ACcur, 2) + " A</h4>";
+      }
+
+      if (charger && charger->type() == ChargerType::NissanLeaf) {
+        float chgPwrDC = static_cast<float>(datalayer.charger.charger_stat_HVcur * 100);
+        datalayer.charger.charger_stat_HVcur = chgPwrDC / (datalayer.battery.status.voltage_dV / 10);  // P/U=I
+        datalayer.charger.charger_stat_HVvol = static_cast<float>(datalayer.battery.status.voltage_dV / 10);
+        float ACvol = datalayer.charger.charger_stat_ACvol;
+        float HVvol = datalayer.charger.charger_stat_HVvol;
+        float HVcur = datalayer.charger.charger_stat_HVcur;
+
+        content += formatPowerValue("Charger Output Power", chgPwrDC, "", 1);
+        content += "<h4 style='color: white;'>Charger HVDC Output V: " + String(HVvol, 2) + " V</h4>";
+        content += "<h4 style='color: white;'>Charger HVDC Output I: " + String(HVcur, 2) + " A</h4>";
+        content += "<h4 style='color: white;'>Charger AC Input V: " + String(ACvol, 2) + " VAC</h4>";
+      }
+      // Close the block
+      content += "</div>";
     }
-    // Close the block
-    content += "</div>";
-#endif  // defined CHEVYVOLT_CHARGER || defined NISSANLEAF_CHARGER
 
     if (emulator_pause_request_ON)
       content += "<button onclick='PauseBattery(false)'>Resume charge/discharge</button> ";

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -203,7 +203,7 @@ void AforeCanInverter::
   */
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void AforeCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  // Every 1s from inverter
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -220,7 +220,7 @@ static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-static void transmit_can_inverter() {
+void AforeCanInverter::transmit_can() {
   if (time_to_send_info) {  // Set every 1s if we get message from inverter
     transmit_can_frame(&AFORE_350, can_config.inverter);
     transmit_can_frame(&AFORE_351, can_config.inverter);
@@ -235,10 +235,6 @@ static void transmit_can_inverter() {
     transmit_can_frame(&AFORE_35A, can_config.inverter);
     time_to_send_info = false;
   }
-}
-
-void AforeCanInverter::transmit_can() {
-  transmit_can_inverter();
 }
 
 #endif

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "AFORE-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 #define SOCMAX 100
 #define SOCMIN 1
 
@@ -73,7 +75,8 @@ CAN_frame AFORE_35A = {.FD = false,                                             
                        .ID = 0x35A,
                        .data = {0x65, 0x6D, 0x75, 0x6C, 0x61, 0x74, 0x6F, 0x72}};  // Emulator
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void AforeCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   //There are more mappings that could be added, but this should be enough to use as a starting point
 
   /*0x350 Operation Information*/
@@ -200,7 +203,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  // Every 1s from inverter
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -217,7 +220,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   if (time_to_send_info) {  // Set every 1s if we get message from inverter
     transmit_can_frame(&AFORE_350, can_config.inverter);
     transmit_can_frame(&AFORE_351, can_config.inverter);
@@ -233,8 +236,9 @@ void transmit_can_inverter() {
     time_to_send_info = false;
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Afore battery over CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+
+void AforeCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -11,6 +11,7 @@ class AforeCanInverter : public InverterProtocol {
   virtual void update_values_can_inverter();
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Afore battery over CAN";
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 };
 
 #endif

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -1,10 +1,16 @@
 #ifndef AFORE_CAN_H
 #define AFORE_CAN_H
-#include "../include.h"
+//#include "../include.h"
+#include "Inverter.h"
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class AforeCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Afore battery over CAN";
+};
 
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "BYD-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Do not change code below unless you are sure what you are doing */
 static unsigned long previousMillis2s = 0;   // will store last time a 2s CAN Message was send
 static unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was send
@@ -85,7 +87,8 @@ static long inverter_timestamp = 0;
 static bool initialDataSent = false;
 static bool inverterStartedUp = false;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void BydCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   /* Calculate temperature */
   temperature_average =
@@ -167,7 +170,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   BYD_210.data.u8[3] = (datalayer.battery.status.temperature_min_dC & 0x00FF);
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x151:  //Message originating from BYD HVS compatible inverter. Reply with CAN identifier!
       inverterStartedUp = true;
@@ -204,7 +207,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   if (!inverterStartedUp) {
@@ -249,8 +252,9 @@ void send_intial_data() {
   transmit_can_frame(&BYD_3D0_2, can_config.inverter);
   transmit_can_frame(&BYD_3D0_3, can_config.inverter);
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box Premium HVS over CAN Bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+
+void BydCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -170,7 +170,7 @@ void BydCanInverter::
   BYD_210.data.u8[3] = (datalayer.battery.status.temperature_min_dC & 0x00FF);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void BydCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x151:  //Message originating from BYD HVS compatible inverter. Reply with CAN identifier!
       inverterStartedUp = true;
@@ -207,7 +207,7 @@ static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-static void transmit_can_inverter() {
+void BydCanInverter::transmit_can() {
   unsigned long currentMillis = millis();
 
   if (!inverterStartedUp) {
@@ -251,10 +251,6 @@ void send_intial_data() {
   transmit_can_frame(&BYD_3D0_1, can_config.inverter);
   transmit_can_frame(&BYD_3D0_2, can_config.inverter);
   transmit_can_frame(&BYD_3D0_3, can_config.inverter);
-}
-
-void BydCanInverter::transmit_can() {
-  transmit_can_inverter();
 }
 
 #endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -14,6 +14,7 @@ class BydCanInverter : public InverterProtocol {
   virtual void setup();
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; }
   static constexpr char* Name = "BYD Battery-Box Premium HVS over CAN Bus";

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -1,13 +1,22 @@
 #ifndef BYD_CAN_H
 #define BYD_CAN_H
 #include "../include.h"
+#include "Inverter.h"
 
 #define CAN_INVERTER_SELECTED
 #define FW_MAJOR_VERSION 0x03
 #define FW_MINOR_VERSION 0x29
 
 void send_intial_data();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+
+class BydCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; }
+  static constexpr char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
+};
 
 #endif

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -24,28 +24,29 @@ void update_modbus_registers_inverter() {
   handle_update_data_modbusp301_byd();
 }
 
-void handle_static_data_modbus_byd() {
+const uint16_t si_data[] = {21321, 1};
+const uint16_t byd_data[] = {16985, 17408, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const uint16_t battery_data[] = {16985, 17440, 16993, 29812, 25970, 31021, 17007, 30752,
+                                 20594, 25965, 26997, 27936, 18518, 0,     0,     0};
+const uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12598, 0, 0, 0, 0, 0, 0};
+const uint16_t serial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const uint16_t static_data[] = {1, 0};
+const uint16_t* data_array_pointers[] = {si_data, byd_data, battery_data, volt_data, serial_data, static_data};
+const uint16_t data_sizes[] = {sizeof(si_data),   sizeof(byd_data),    sizeof(battery_data),
+                               sizeof(volt_data), sizeof(serial_data), sizeof(static_data)};
+const uint16_t init_p201[13] = {0, 0, 0, MAX_POWER, MAX_POWER, 0, 0, 53248, 10, 53248, 10, 0, 0};
+const uint16_t init_p301[24] = {0,  0,  128, 0, 0,  0,     0, 0, 0,  2000,  0,   2000,
+                                75, 95, 0,   0, 16, 22741, 0, 0, 13, 52064, 230, 9900};
+
+void BydModbusInverter::handle_static_data_modbus() {
   // Store the data into the array
-  static uint16_t si_data[] = {21321, 1};
-  static uint16_t byd_data[] = {16985, 17408, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  static uint16_t battery_data[] = {16985, 17440, 16993, 29812, 25970, 31021, 17007, 30752,
-                                    20594, 25965, 26997, 27936, 18518, 0,     0,     0};
-  static uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12598, 0, 0, 0, 0, 0, 0};
-  static uint16_t serial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  static uint16_t static_data[] = {1, 0};
-  static uint16_t* data_array_pointers[] = {si_data, byd_data, battery_data, volt_data, serial_data, static_data};
-  static uint16_t data_sizes[] = {sizeof(si_data),   sizeof(byd_data),    sizeof(battery_data),
-                                  sizeof(volt_data), sizeof(serial_data), sizeof(static_data)};
-  static uint16_t i = 100;
+  uint16_t i = 100;
   for (uint8_t arr_idx = 0; arr_idx < sizeof(data_array_pointers) / sizeof(uint16_t*); arr_idx++) {
     uint16_t data_size = data_sizes[arr_idx];
     memcpy(&mbPV[i], data_array_pointers[arr_idx], data_size);
     i += data_size / sizeof(uint16_t);
   }
-  static uint16_t init_p201[13] = {0, 0, 0, MAX_POWER, MAX_POWER, 0, 0, 53248, 10, 53248, 10, 0, 0};
   memcpy(&mbPV[200], init_p201, sizeof(init_p201));
-  static uint16_t init_p301[24] = {0,  0,  128, 0, 0,  0,     0, 0, 0,  2000,  0,   2000,
-                                   75, 95, 0,   0, 16, 22741, 0, 0, 13, 52064, 230, 9900};
   memcpy(&mbPV[300], init_p301, sizeof(init_p301));
 }
 
@@ -143,8 +144,5 @@ void verify_inverter_modbus() {
     history_index = (history_index + 1) % HISTORY_LENGTH;
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "BYD 11kWh HVM battery over Modbus RTU", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
-}
+
 #endif

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -1,6 +1,7 @@
 #ifndef BYD_MODBUS_H
 #define BYD_MODBUS_H
 #include "../include.h"
+#include "Inverter.h"
 
 #define MODBUS_INVERTER_SELECTED
 
@@ -14,5 +15,13 @@ void verify_temperature_modbus();
 void verify_inverter_modbus();
 void handle_update_data_modbusp201_byd();
 void handle_update_data_modbusp301_byd();
-void setup_inverter(void);
+
+class BydModbusInverter : public InverterProtocol {
+ public:
+  virtual void handle_static_data_modbus();
+
+  virtual const char* name() { return Name; }
+  static constexpr char* Name = "BYD 11kWh HVM battery over Modbus RTU";
+};
+
 #endif

--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -5,140 +5,6 @@
 
 #include "../communication/can/comm_can.h"
 
-//#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
-#define SEND_1                 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
-                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
-#define SET_30K_OFFSET         //If defined, current values are sent with a 30k offest (useful for ferroamp)
-
-/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
-Change the following only if your inverter is generating fault codes about voltage range */
-#define TOTAL_CELL_AMOUNT 120  //Adjust this parameter in steps of 120 to add another 14,2kWh of capacity
-#define MODULES_IN_SERIES 4
-#define CELLS_PER_MODULE 30
-#define VOLTAGE_LEVEL 384
-#define AH_CAPACITY 37
-
-/* Do not change code below unless you are sure what you are doing */
-//Actual content messages
-CAN_frame PYLON_7310 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7310,
-                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7311 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7311,
-                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7320 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7320,
-                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
-                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_7321 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7321,
-                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
-                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_4210 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4210,
-                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame PYLON_4220 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4220,
-                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame PYLON_4230 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4230,
-                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame PYLON_4240 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4240,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame PYLON_4250 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4250,
-                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4260 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4260,
-                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame PYLON_4270 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4270,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame PYLON_4280 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4280,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4290 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4290,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4211 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4211,
-                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame PYLON_4221 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4221,
-                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame PYLON_4231 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4231,
-                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame PYLON_4241 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4241,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame PYLON_4251 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4251,
-                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4261 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4261,
-                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame PYLON_4271 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4271,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame PYLON_4281 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4281,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4291 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4291,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static uint16_t cell_tweaked_max_voltage_mV = 3300;
-static uint16_t cell_tweaked_min_voltage_mV = 3300;
-
 void FerroampCanInverter::
     update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   //There are more mappings that could be added, but this should be enough to use as a starting point
@@ -440,7 +306,7 @@ void FerroampCanInverter::
   }
 }
 
-static void send_setup_info() {  //Ensemble information
+void FerroampCanInverter::send_setup_info() {  //Ensemble information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_7310, can_config.inverter);
   transmit_can_frame(&PYLON_7320, can_config.inverter);
@@ -451,7 +317,7 @@ static void send_setup_info() {  //Ensemble information
 #endif
 }
 
-static void send_system_data() {  //System equipment information
+void FerroampCanInverter::send_system_data() {  //System equipment information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_4210, can_config.inverter);
   transmit_can_frame(&PYLON_4220, can_config.inverter);
@@ -476,7 +342,7 @@ static void send_system_data() {  //System equipment information
 #endif
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void FerroampCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -4,9 +4,13 @@
 
 #define CAN_INVERTER_SELECTED
 
-void send_system_data();
-void send_setup_info();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class FerroampCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Ferroamp Pylon battery over CAN bus";
+};
 
 #endif

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -8,9 +8,148 @@ class FerroampCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Ferroamp Pylon battery over CAN bus";
+
+ private:
+  void send_system_data();
+  void send_setup_info();
+
+//#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
+#define SEND_1                 //If defined, the messages will have ID ending with 1 (useful for some inverters)
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
+                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
+#define SET_30K_OFFSET         //If defined, current values are sent with a 30k offest (useful for ferroamp)
+
+/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
+Change the following only if your inverter is generating fault codes about voltage range */
+#define TOTAL_CELL_AMOUNT 120  //Adjust this parameter in steps of 120 to add another 14,2kWh of capacity
+#define MODULES_IN_SERIES 4
+#define CELLS_PER_MODULE 30
+#define VOLTAGE_LEVEL 384
+#define AH_CAPACITY 37
+
+  /* Do not change code below unless you are sure what you are doing */
+  //Actual content messages
+  CAN_frame PYLON_7310 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7310,
+                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+  CAN_frame PYLON_7311 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7311,
+                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+  CAN_frame PYLON_7320 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7320,
+                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                   CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+  CAN_frame PYLON_7321 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7321,
+                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                   CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+  CAN_frame PYLON_4210 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4210,
+                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+  CAN_frame PYLON_4220 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4220,
+                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+  CAN_frame PYLON_4230 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4230,
+                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+  CAN_frame PYLON_4240 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4240,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+  CAN_frame PYLON_4250 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4250,
+                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4260 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4260,
+                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+  CAN_frame PYLON_4270 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4270,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+  CAN_frame PYLON_4280 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4280,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4290 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4290,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4211 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4211,
+                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+  CAN_frame PYLON_4221 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4221,
+                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+  CAN_frame PYLON_4231 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4231,
+                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+  CAN_frame PYLON_4241 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4241,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+  CAN_frame PYLON_4251 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4251,
+                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4261 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4261,
+                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+  CAN_frame PYLON_4271 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4271,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+  CAN_frame PYLON_4281 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4281,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4291 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4291,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  uint16_t cell_tweaked_max_voltage_mV = 3300;
+  uint16_t cell_tweaked_min_voltage_mV = 3300;
 };
 
 #endif

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -4,6 +4,8 @@
 #include "../devboard/utils/events.h"
 #include "FOXESS-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Based on info from this excellent repo: https://github.com/FozzieUK/FoxESS-Canbus-Protocol */
 /* The FoxESS protocol emulates the stackable (1-8) 48V towers found in the HV2600 / ECS4100 batteries
 We emulate a full tower setup by default (8*50V=400V) to be more suitable for an EV pack. There are settings
@@ -22,352 +24,9 @@ below that you can customize, incase you use a lower voltage battery with this p
 #define TOTAL_LIFETIME_WH_ACCUMULATED 0  //We dont have this value in the emulator
 
 /* Do not change code below unless you are sure what you are doing */
-static int16_t temperature_average = 0;
-static uint16_t voltage_per_pack = 0;
-static int16_t current_per_pack = 0;
-static uint8_t temperature_max_per_pack = 0;
-static uint8_t temperature_min_per_pack = 0;
-static uint8_t current_pack_info = 0;
 
-// Batch send of CAN message variables
-const uint8_t delay_between_batches_ms = 10;  //TODO, tweak to as low as possible before performance issues appear
-static bool send_bms_info = false;
-static bool send_individual_pack_status = false;
-static bool send_serial_numbers = false;
-static bool send_cellvoltages = false;
-static unsigned long currentMillis = 0;
-static unsigned long previousMillisCellvoltage = 0;
-static unsigned long previousMillisSerialNumber = 0;
-static unsigned long previousMillisBMSinfo = 0;
-static unsigned long previousMillisIndividualPacks = 0;
-static uint8_t can_message_cellvolt_index = 0;
-static uint8_t can_message_serial_index = 0;
-static uint8_t can_message_individualpack_index = 0;
-static uint8_t can_message_bms_index = 0;
-
-//CAN message translations from this amazing repository: https://github.com/rand12345/FOXESS_can_bus
-
-CAN_frame FOXESS_1872 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1872,
-                         .data = {0x40, 0x12, 0x80, 0x0C, 0xCD, 0x00, 0xF4, 0x01}};  //BMS_Limits
-CAN_frame FOXESS_1873 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1873,
-                         .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_PackData
-CAN_frame FOXESS_1874 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1874,
-                         .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_CellData
-CAN_frame FOXESS_1875 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1875,
-                         .data = {0xF9, 0x00, 0xFF, 0x08, 0x01, 0x00, 0x8E, 0x00}};  //BMS_Status
-CAN_frame FOXESS_1876 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1876,
-                         .data = {0x01, 0x00, 0x07, 0x0D, 0x0, 0x0, 0xFE, 0x0C}};  //BMS_PackTemps
-CAN_frame FOXESS_1877 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1877,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x82, 0x00, 0x20, 0x50}};  //BMS_Unk1
-CAN_frame FOXESS_1878 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1878,
-                         .data = {0x07, 0x0A, 0x00, 0x00, 0xD0, 0xFF, 0x4E, 0x00}};  //BMS_PackStats
-CAN_frame FOXESS_1879 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1879,
-                         .data = {0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BMS_Unk2
-CAN_frame FOXESS_1881 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1881,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-CAN_frame FOXESS_1882 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1882,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-CAN_frame FOXESS_1883 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1883,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-
-CAN_frame FOXESS_0C05 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C05,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C06 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C06,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C07 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C07,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C08 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C08,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C09 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C09,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0A = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0A,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0B = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0B,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0C = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0C,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-// Cellvoltages
-CAN_frame FOXESS_0C1D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C1D,                                               //Cell 1-4
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C21 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C21,                                               //Cell 5-8
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C25 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C25,                                               //Cell 9-12
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C29 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C29,                                               //Cell 13-16
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C2D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C2D,                                               //Cell 17-20
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C31 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C31,                                               //Cell 21-24
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C35 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C35,                                               //Cell 25-28
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C39 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C39,                                               //Cell 29-32
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C3D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C3D,                                               //Cell 33-36
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C41 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C41,                                               //Cell 37-40
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C45 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C45,                                               //Cell 41-44
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C49 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C49,                                               //Cell 45-48
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C4D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C4D,                                               //Cell 49-52
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C51 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C51,                                               //Cell 53-56
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C55 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C55,                                               //Cell 57-60
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C59 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C59,                                               //Cell 61-64
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C5D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C5D,                                               //Cell 65-68
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C61 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C61,                                               //Cell 69-72
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C65 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C65,                                               //Cell 73-76
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C69 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C69,                                               //Cell 77-80
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C6D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C6D,                                               //Cell 81-84
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C71 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C71,                                               //Cell 85-88
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C75 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C75,                                               //Cell 89-92
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C79 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C79,                                               //Cell 93-96
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C7D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C7D,                                               //Cell 97-100
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C81 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C81,                                               //Cell 101-104
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C85 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C85,                                               //Cell 105-108
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C89 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C89,                                               //Cell 109-112
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C8D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C8D,                                               //Cell 113-116
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C91 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C91,                                               //Cell 117-120
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C95 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C95,                                               //Cell 121-124
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C99 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C99,                                               //Cell 125-128
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C9D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C9D,                                               //Cell 129-132
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA1 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA1,                                               //Cell 133-136
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA5 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA5,                                               //Cell 137-140
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA9 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA9,                                               //Cell 141-144
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-
-// Temperatures
-CAN_frame FOXESS_0D21 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D21,  //Celltemperatures Pack 1
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D29 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D29,  //Celltemperatures Pack 2
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D31 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D31,  //Celltemperatures Pack 3
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D39 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D39,  //Celltemperatures Pack 4
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D41 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D41,  //Celltemperatures Pack 5
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D49 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D49,  //Celltemperatures Pack 6
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D51 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D51,  //Celltemperatures Pack 7
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D59 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D59,  //Celltemperatures Pack 8
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-
-void update_values_can_inverter() {  //This function maps all the CAN values fetched from battery. It also checks some safeties.
+void FoxessCanInverter::
+    update_values_can_inverter() {  //This function maps all the CAN values fetched from battery. It also checks some safeties.
 
   //Calculate the required values
   temperature_average =
@@ -595,7 +254,7 @@ void update_values_can_inverter() {  //This function maps all the CAN values fet
   // So do we really need to map the same two values over and over to 32 places?
 }
 
-void transmit_can_inverter() {  // This function loops as fast as possible
+void FoxessCanInverter::transmit_can() {  // This function loops as fast as possible
 
   if (send_bms_info) {
     currentMillis = millis();  // Get the current time
@@ -865,7 +524,7 @@ void transmit_can_inverter() {  // This function loops as fast as possible
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void FoxessCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -908,8 +567,5 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
     }
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "FoxESS compatible HV2600/ECS4100 battery", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
-}
+
 #endif

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -4,7 +4,360 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class FoxessCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "FoxESS compatible HV2600/ECS4100 battery";
+
+ private:
+  int16_t temperature_average = 0;
+  uint16_t voltage_per_pack = 0;
+  int16_t current_per_pack = 0;
+  uint8_t temperature_max_per_pack = 0;
+  uint8_t temperature_min_per_pack = 0;
+  uint8_t current_pack_info = 0;
+
+  // Batch send of CAN message variables
+  const uint8_t delay_between_batches_ms = 10;  //TODO, tweak to as low as possible before performance issues appear
+  bool send_bms_info = false;
+  bool send_individual_pack_status = false;
+  bool send_serial_numbers = false;
+  bool send_cellvoltages = false;
+  unsigned long currentMillis = 0;
+  unsigned long previousMillisCellvoltage = 0;
+  unsigned long previousMillisSerialNumber = 0;
+  unsigned long previousMillisBMSinfo = 0;
+  unsigned long previousMillisIndividualPacks = 0;
+  uint8_t can_message_cellvolt_index = 0;
+  uint8_t can_message_serial_index = 0;
+  uint8_t can_message_individualpack_index = 0;
+  uint8_t can_message_bms_index = 0;
+
+  //CAN message translations from this amazing repository: https://github.com/rand12345/FOXESS_can_bus
+
+  CAN_frame FOXESS_1872 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1872,
+                           .data = {0x40, 0x12, 0x80, 0x0C, 0xCD, 0x00, 0xF4, 0x01}};  //BMS_Limits
+  CAN_frame FOXESS_1873 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1873,
+                           .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_PackData
+  CAN_frame FOXESS_1874 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1874,
+                           .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_CellData
+  CAN_frame FOXESS_1875 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1875,
+                           .data = {0xF9, 0x00, 0xFF, 0x08, 0x01, 0x00, 0x8E, 0x00}};  //BMS_Status
+  CAN_frame FOXESS_1876 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1876,
+                           .data = {0x01, 0x00, 0x07, 0x0D, 0x0, 0x0, 0xFE, 0x0C}};  //BMS_PackTemps
+  CAN_frame FOXESS_1877 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1877,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x82, 0x00, 0x20, 0x50}};  //BMS_Unk1
+  CAN_frame FOXESS_1878 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1878,
+                           .data = {0x07, 0x0A, 0x00, 0x00, 0xD0, 0xFF, 0x4E, 0x00}};  //BMS_PackStats
+  CAN_frame FOXESS_1879 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1879,
+                           .data = {0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BMS_Unk2
+  CAN_frame FOXESS_1881 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1881,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+  CAN_frame FOXESS_1882 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1882,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+  CAN_frame FOXESS_1883 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1883,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+
+  CAN_frame FOXESS_0C05 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C05,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C06 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C06,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C07 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C07,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C08 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C08,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C09 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C09,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0A = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0A,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0B = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0B,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0C = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0C,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  // Cellvoltages
+  CAN_frame FOXESS_0C1D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C1D,                                               //Cell 1-4
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C21 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C21,                                               //Cell 5-8
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C25 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C25,                                               //Cell 9-12
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C29 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C29,                                               //Cell 13-16
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C2D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C2D,                                               //Cell 17-20
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C31 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C31,                                               //Cell 21-24
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C35 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C35,                                               //Cell 25-28
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C39 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C39,                                               //Cell 29-32
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C3D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C3D,                                               //Cell 33-36
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C41 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C41,                                               //Cell 37-40
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C45 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C45,                                               //Cell 41-44
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C49 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C49,                                               //Cell 45-48
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C4D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C4D,                                               //Cell 49-52
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C51 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C51,                                               //Cell 53-56
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C55 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C55,                                               //Cell 57-60
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C59 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C59,                                               //Cell 61-64
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C5D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C5D,                                               //Cell 65-68
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C61 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C61,                                               //Cell 69-72
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C65 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C65,                                               //Cell 73-76
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C69 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C69,                                               //Cell 77-80
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C6D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C6D,                                               //Cell 81-84
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C71 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C71,                                               //Cell 85-88
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C75 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C75,                                               //Cell 89-92
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C79 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C79,                                               //Cell 93-96
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C7D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C7D,                                               //Cell 97-100
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C81 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C81,                                               //Cell 101-104
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C85 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C85,                                               //Cell 105-108
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C89 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C89,                                               //Cell 109-112
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C8D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C8D,                                               //Cell 113-116
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C91 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C91,                                               //Cell 117-120
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C95 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C95,                                               //Cell 121-124
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C99 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C99,                                               //Cell 125-128
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C9D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C9D,                                               //Cell 129-132
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA1 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA1,                                               //Cell 133-136
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA5 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA5,                                               //Cell 137-140
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA9 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA9,                                               //Cell 141-144
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+
+  // Temperatures
+  CAN_frame FOXESS_0D21 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D21,  //Celltemperatures Pack 1
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D29 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D29,  //Celltemperatures Pack 2
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D31 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D31,  //Celltemperatures Pack 3
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D39 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D39,  //Celltemperatures Pack 4
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D41 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D41,  //Celltemperatures Pack 5
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D49 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D49,  //Celltemperatures Pack 6
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D51 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D51,  //Celltemperatures Pack 7
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D59 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D59,  //Celltemperatures Pack 8
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+};
 
 #endif

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "GROWATT-HV-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* TODO:
 This protocol has not been tested with any inverter. Proceed with extreme caution.
 Search the file for "TODO" to see all the places that might require work /*
@@ -157,7 +159,8 @@ static const uint8_t delay_between_batches_ms = 10;
 static bool inverter_alive = false;
 static bool time_to_send_1s_data = false;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void GrowattHvInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   if (datalayer.battery.status.voltage_dV > 10) {  // Only update value when we have voltage available to avoid div0
     ampere_hours_remaining =
@@ -493,7 +496,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   GROWATT_3F00.data.u8[7] = 0;  // RESERVED
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x3010:  // Heartbeat command, 1000ms
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -523,7 +526,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
 
   if (!inverter_alive) {
     return;  //Dont send messages towards inverter until it has started
@@ -587,8 +590,8 @@ void transmit_can_inverter() {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Growatt High Voltage protocol via CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+void GrowattHvInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -496,7 +496,7 @@ void GrowattHvInverter::
   GROWATT_3F00.data.u8[7] = 0;  // RESERVED
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void GrowattHvInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x3010:  // Heartbeat command, 1000ms
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -4,7 +4,13 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class GrowattHvInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Growatt High Voltage protocol via CAN";
+};
 
 #endif

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -8,6 +8,7 @@ class GrowattHvInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Growatt High Voltage protocol via CAN";

--- a/Software/src/inverter/GROWATT-LV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-LV-CAN.cpp
@@ -249,7 +249,7 @@ void GrowattLvCanInverter::
   GROWATT_318.data.u8[7] = (datalayer.battery.status.cell_voltages_mV[15] & 0x00FF);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void GrowattLvCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x301:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/GROWATT-LV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-LV-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "GROWATT-LV-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Growatt BMS CAN-Bus-protocol Low Voltage Rev_04
 CAN 2.0A
 500kBit/sec
@@ -79,7 +81,8 @@ static uint16_t cell_delta_mV = 0;
 static uint16_t ampere_hours_remaining = 0;
 static uint16_t ampere_hours_full = 0;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void GrowattLvCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   cell_delta_mV = datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV;
 
@@ -246,7 +249,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   GROWATT_318.data.u8[7] = (datalayer.battery.status.cell_voltages_mV[15] & 0x00FF);
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x301:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -267,12 +270,12 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   // No periodic sending for this battery type. Data is sent when inverter requests it
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Growatt Low Voltage (48V) protocol via CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+void GrowattLvCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -8,6 +8,7 @@ class GrowattLvCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Growatt Low Voltage (48V) protocol via CAN";

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -4,7 +4,13 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class GrowattLvCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Growatt Low Voltage (48V) protocol via CAN";
+};
 
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -3,6 +3,30 @@
 
 #include "../../USER_SETTINGS.h"
 
+// Selection of inverters to the common image.
+#ifdef BUILD_EM_ALL
+#define AFORE_CAN
+#define BYD_CAN_DEYE
+#define BYD_CAN
+#define BYD_MODBUS
+#define BYD_KOSTAL_RS485
+#define FERROAMP_CAN
+#define FOXESS_CAN
+#define GROWATT_HV_CAN
+#define GROWATT_LV_CAN
+// TODO: Combine with ferroamp
+//#define PYLON_CAN
+#define PYLON_LV_CAN
+#define SCHNEIDER_CAN
+#define SMA_BYD_H_CAN
+#define SMA_BYD_HVS_CAN
+#define SMA_LV_CAN
+#define SMA_TRIPOWER_CAN
+#define SOFAR_CAN
+#define SOLAX_CAN
+#define SUNGROW_CAN
+#endif
+
 #ifdef AFORE_CAN
 #include "AFORE-CAN.h"
 #endif
@@ -80,19 +104,19 @@
 #endif
 
 #ifdef CAN_INVERTER_SELECTED
-void update_values_can_inverter();
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
-void transmit_can_inverter();
+//void update_values_can_inverter();
+//void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
+//void transmit_can_inverter();
 #endif
 
 #ifdef MODBUS_INVERTER_SELECTED
-void update_modbus_registers_inverter();
+//void update_modbus_registers_inverter();
 #endif
 
 #ifdef RS485_INVERTER_SELECTED
-void receive_RS485();
-void update_RS485_registers_inverter();
-void setup_inverter();
+//void receive_RS485();
+//void update_RS485_registers_inverter();
+//void setup_inverter();
 #endif
 
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -14,8 +14,7 @@
 #define FOXESS_CAN
 #define GROWATT_HV_CAN
 #define GROWATT_LV_CAN
-// TODO: Combine with ferroamp
-//#define PYLON_CAN
+#define PYLON_CAN
 #define PYLON_LV_CAN
 #define SCHNEIDER_CAN
 #define SMA_BYD_H_CAN

--- a/Software/src/inverter/Inverter.cpp
+++ b/Software/src/inverter/Inverter.cpp
@@ -1,0 +1,215 @@
+#include "Inverter.h"
+#include "INVERTERS.h"
+
+InverterProtocolType userSelectedInverter = InverterProtocolType::BydModbus;
+
+InverterProtocol* init_inverter_protocol(InverterProtocolType type) {
+  switch (type) {
+#ifdef BYD_MODBUS
+    case BydModbus:
+      inverter = new BydModbusInverter();
+      break;
+#endif
+
+#ifdef AFORE_CAN
+    case AforeCan:
+      inverter = new AforeCanInverter();
+      break;
+#endif
+
+#ifdef FERROAMP_CAN
+    case FerroampCan:
+      inverter = new FerroampCanInverter();
+      break;
+#endif
+
+#ifdef FOXESS_CAN
+    case FoxessCan:
+      inverter = new FoxessCanInverter();
+      break;
+#endif
+
+#ifdef GROWATT_HV_CAN
+    case GrowattHvCan:
+      inverter = new GrowattHvInverter();
+      break;
+#endif
+
+#ifdef GROWATT_LV_CAN
+    case GrowattLvCan:
+      inverter = new GrowattLvCanInverter();
+      break;
+#endif
+
+#ifdef BYD_KOSTAL_RS485
+    case KostalRs485:
+      inverter = new KostalRs485Inverter();
+      break;
+#endif
+
+      /*#ifdef PYLON_CAN
+        case PylonCan:
+            inverter = new PylonLvCanInverter();
+            break;
+    #endif*/
+
+#ifdef PYLON_LV_CAN
+    case PylonLvCan:
+      inverter = new PylonLvCanInverter();
+      break;
+#endif
+
+#ifdef SCHNEIDER_CAN
+    case SchneiderCan:
+      inverter = new SchneiderCanInverter();
+      break;
+#endif
+
+#ifdef SMA_BYD_H_CAN
+    case SmaBydHCan:
+      inverter = new SmaBydHCanInverter();
+      break;
+#endif
+
+#ifdef SMA_BYD_HVS_CAN
+    case SmaBydHsvCan:
+      inverter = new SmaBydHvsCanInverter();
+      break;
+#endif
+
+#ifdef SMA_LV_CAN
+    case SmaLvCan:
+      inverter = new SmaLvCanInverter();
+      break;
+#endif
+
+#ifdef SMA_TRIPOWER_CAN
+    case SmaTripowerCan:
+      inverter = new SmaTripowerCanInverter();
+      break;
+#endif
+
+#ifdef SOLAX_CAN
+    case Solax:
+      inverter = new SolaxCanInverter();
+      break;
+#endif
+
+#ifdef SOFAR_CAN
+    case Sofar:
+      inverter = new SofarCanInverter();
+      break;
+#endif
+
+#ifdef SUNGROW_CAN
+    case Sungrow:
+      inverter = new SungrowCanInverter();
+      break;
+#endif
+
+    default:
+      return nullptr;
+  }
+
+  return inverter;
+}
+
+const char* InverterProtocol::name_for_type(InverterProtocolType type) {
+  switch (type) {
+#ifdef BYD_MODBUS
+    case BydModbus:
+      return BydModbusInverter::Name;
+#endif
+
+#ifdef AFORE_CAN
+    case AforeCan:
+      return AforeCanInverter::Name;
+#endif
+
+#ifdef FERROAMP_CAN
+    case FerroampCan:
+      return FerroampCanInverter::Name;
+#endif
+
+#ifdef FOXESS_CAN
+    case FoxessCan:
+      return FoxessCanInverter::Name;
+#endif
+
+#ifdef GROWATT_HV_CAN
+    case GrowattHvCan:
+      return GrowattHvInverter::Name;
+#endif
+
+#ifdef GROWATT_LV_CAN
+    case GrowattLvCan:
+      return GrowattLvCanInverter::Name;
+#endif
+
+#ifdef BYD_KOSTAL_RS485
+    case KostalRs485:
+      return KostalRs485Inverter::Name;
+#endif
+
+#ifdef PYLON_LV_CAN
+    case PylonLvCan:
+      return PylonLvCanInverter::Name;
+#endif
+
+#ifdef SCHNEIDER_CAN
+    case SchneiderCan:
+      return SchneiderCanInverter::Name;
+#endif
+
+#ifdef SMA_BYD_H_CAN
+    case SmaBydHCan:
+      return SmaBydHCanInverter::Name;
+#endif
+
+#ifdef SMA_BYD_HVS_CAN
+    case SmaBydHsvCan:
+      return SmaBydHvsCanInverter::Name;
+#endif
+
+#ifdef SMA_LV_CAN
+    case SmaLvCan:
+      return SmaLvCanInverter::Name;
+#endif
+
+#ifdef SMA_TRIPOWER_CAN
+    case SmaTripowerCan:
+      return SmaTripowerCanInverter::Name;
+#endif
+
+#ifdef SOLAX_CAN
+    case Solax:
+      return SolaxCanInverter::Name;
+#endif
+
+#ifdef SOFAR_CAN
+    case Sofar:
+      return SofarCanInverter::Name;
+#endif
+
+#ifdef SUNGROW_CAN
+    case Sungrow:
+      return SungrowCanInverter::Name;
+#endif
+
+    default:
+      return nullptr;
+  }
+}
+
+std::vector<InverterProtocolType> supported_inverter_protocols() {
+  std::vector<InverterProtocolType> types;
+
+  for (int i = 1; i < static_cast<int>(HighestInverter); i++) {
+    auto type = static_cast<InverterProtocolType>(i);
+    if (InverterProtocol::name_for_type(type) != nullptr) {
+      types.push_back(type);
+    }
+  }
+
+  return types;
+}

--- a/Software/src/inverter/Inverter.h
+++ b/Software/src/inverter/Inverter.h
@@ -1,0 +1,65 @@
+#ifndef INVERTER_H
+#define INVERTER_H
+
+#include <vector>
+#include "src/devboard/utils/types.h"
+
+// Enum number values used in user settings. Retain numbering.
+enum InverterProtocolType {
+  AforeCan = 1,
+  BydCan = 2,
+  BydModbus = 3,
+  FerroampCan = 4,
+  FoxessCan = 5,
+  GrowattHvCan = 6,
+  GrowattLvCan = 7,
+  KostalRs485 = 8,
+  PylonCan = 9,
+  PylonLvCan = 10,
+  SchneiderCan = 11,
+  SmaBydHCan = 12,
+  SmaBydHsvCan = 13,
+  SmaLvCan = 14,
+  SmaTripowerCan = 15,
+  Sofar = 16,
+  Solax = 17,
+  Sungrow = 18,
+  HighestInverter = 19
+};
+
+class InverterProtocol {
+ public:
+  virtual void setup() {}
+  virtual void transmit_can_frame(CAN_frame* tx_frame, int interface) {}
+
+  virtual bool usesCAN() { return false; }
+  virtual void transmit_can() {}
+  virtual void update_values_can_inverter() {}
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {}
+
+  virtual bool usesRS485() { return false; }
+  virtual void receive_RS485() {}
+  virtual int rs485_baudrate() { return 0; }
+  virtual void update_RS485_registers_inverter() {}
+
+  virtual bool usesMODBUS() { return false; }
+  virtual void update_modbus_registers_inverter() {}
+  virtual void handle_static_data_modbus() {}
+
+  virtual const char* name() = 0;
+  static const char* name_for_type(InverterProtocolType type);
+};
+
+class Rs485Inverter : public InverterProtocol {
+ public:
+  virtual void setup();
+};
+
+InverterProtocol* init_inverter_protocol(InverterProtocolType type);
+
+std::vector<InverterProtocolType> supported_inverter_protocols();
+
+extern InverterProtocol* inverter;
+extern InverterProtocolType userSelectedInverter;
+
+#endif

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -204,8 +204,7 @@ void KostalRs485Inverter::update_RS485_registers_inverter() {
     average_temperature_dC = 0;
   }
 
-  if (datalayer.system.status.battery_allows_contactor_closing &
-      datalayer.system.status.inverter_allows_contactor_closing) {
+  if (battery->contactor_closing_allowed() & datalayer.system.status.inverter_allows_contactor_closing) {
     float2frame(CYCLIC_DATA, (float)datalayer.battery.status.voltage_dV / 10, 6);  // Confirmed OK mapping
   } else {
     float2frame(CYCLIC_DATA, 0.0, 6);
@@ -300,7 +299,7 @@ void KostalRs485Inverter::receive_RS485()  // Runs as fast as possible to handle
 {
   currentMillis = millis();
 
-  if (datalayer.system.status.battery_allows_contactor_closing & !contactorMillis) {
+  if (battery->contactor_closing_allowed() & !contactorMillis) {
     contactorMillis = currentMillis;
   }
   if (currentMillis - contactorMillis >= INTERVAL_2_S & !RX_allow) {

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -196,7 +196,7 @@ static bool check_kostal_frame_crc(int len) {
   }
 }
 
-void update_RS485_registers_inverter() {
+void KostalRs485Inverter::update_RS485_registers_inverter() {
 
   average_temperature_dC =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -296,7 +296,7 @@ void update_RS485_registers_inverter() {
   }
 }
 
-void receive_RS485()  // Runs as fast as possible to handle the serial stream
+void KostalRs485Inverter::receive_RS485()  // Runs as fast as possible to handle the serial stream
 {
   currentMillis = millis();
 
@@ -344,7 +344,8 @@ void receive_RS485()  // Runs as fast as possible to handle the serial stream
                 int code = RS485_RXFRAME[6] + RS485_RXFRAME[7] * 0x100;
                 if (code == 0x44a) {
                   //Send cyclic data
-                  update_values_battery();
+                  // TODO: This call is weird: why do it here?
+                  battery->update_values();
                   update_RS485_registers_inverter();
                   if (f2_startup_count < 15) {
                     f2_startup_count++;
@@ -391,10 +392,9 @@ void receive_RS485()  // Runs as fast as possible to handle the serial stream
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup
+void KostalRs485Inverter::setup() {  // Performs one time setup at startup
   datalayer.system.status.inverter_allows_contactor_closing = false;
   dbg_message("inverter_allows_contactor_closing -> false");
-  strncpy(datalayer.system.info.inverter_protocol, "BYD battery via Kostal RS485", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
 }
+
 #endif

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -4,12 +4,22 @@
 #include "../include.h"
 
 #define RS485_INVERTER_SELECTED
-#define RS485_BAUDRATE 57600
 //#define DEBUG_KOSTAL_RS485_DATA  // Enable this line to get TX / RX printed out via logging
 //#define DEBUG_KOSTAL_RS485_DATA_USB  // Enable this line to get TX / RX printed out via USB
 
 #if defined(DEBUG_KOSTAL_RS485_DATA) && !defined(DEBUG_LOG)
 #error "enable LOG_TO_SD, DEBUG_VIA_USB or DEBUG_VIA_WEB in order to use DEBUG_KOSTAL_RS485_DATA"
 #endif
+
+class KostalRs485Inverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BYD battery via Kostal RS485";
+
+  virtual void receive_RS485();
+  virtual void update_RS485_registers_inverter();
+  virtual int rs485_baudrate() { return 57600; }
+};
 
 #endif

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -140,8 +140,8 @@ static uint16_t discharge_cutoff_voltage_dV = 0;
 static uint16_t charge_cutoff_voltage_dV = 0;
 #define VOLTAGE_OFFSET_DV 20  // Small offset voltage to avoid generating voltage events
 
-static void
-update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void PylonCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   //Check what discharge and charge cutoff voltages to send
   if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
@@ -461,7 +461,7 @@ static void send_system_data() {  //System equipment information
 #endif
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void PylonCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -475,14 +475,5 @@ static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
     default:
       break;
   }
-}
-
-static void transmit_can_inverter() {
-  // No periodic sending, we only react on received can messages
-}
-
-static void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Pylontech battery over CAN bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
 }
 #endif

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "PYLON-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 #define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
 //#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
 #define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
@@ -138,7 +140,8 @@ static uint16_t discharge_cutoff_voltage_dV = 0;
 static uint16_t charge_cutoff_voltage_dV = 0;
 #define VOLTAGE_OFFSET_DV 20  // Small offset voltage to avoid generating voltage events
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+static void
+update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   //Check what discharge and charge cutoff voltages to send
   if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
@@ -422,27 +425,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
-      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
-      if (rx_frame.data.u8[0] == 0x02) {
-        send_setup_info();
-      }
-      if (rx_frame.data.u8[0] == 0x00) {
-        send_system_data();
-      }
-      break;
-    default:
-      break;
-  }
-}
-
-void transmit_can_inverter() {
-  // No periodic sending, we only react on received can messages
-}
-
-void send_setup_info() {  //Ensemble information
+static void send_setup_info() {  //Ensemble information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_7310, can_config.inverter);
   transmit_can_frame(&PYLON_7320, can_config.inverter);
@@ -453,7 +436,7 @@ void send_setup_info() {  //Ensemble information
 #endif
 }
 
-void send_system_data() {  //System equipment information
+static void send_system_data() {  //System equipment information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_4210, can_config.inverter);
   transmit_can_frame(&PYLON_4220, can_config.inverter);
@@ -477,7 +460,28 @@ void send_system_data() {  //System equipment information
   transmit_can_frame(&PYLON_4291, can_config.inverter);
 #endif
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+  switch (rx_frame.ID) {
+    case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      if (rx_frame.data.u8[0] == 0x02) {
+        send_setup_info();
+      }
+      if (rx_frame.data.u8[0] == 0x00) {
+        send_system_data();
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+static void transmit_can_inverter() {
+  // No periodic sending, we only react on received can messages
+}
+
+static void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Pylontech battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -4,9 +4,10 @@
 
 #define CAN_INVERTER_SELECTED
 
-void send_system_data();
-void send_setup_info();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class PylonCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -6,8 +6,10 @@
 
 class PylonCanInverter : public InverterProtocol {
  public:
-  virtual void setup();
-  virtual void transmit_can();
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Pylontech battery over CAN bus";
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
+  virtual void update_values_can_inverter();
 };
 
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "PYLON-LV-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Do not change code below unless you are sure what you are doing */
 
 static unsigned long previousMillis1000ms = 0;
@@ -47,7 +49,7 @@ int16_t warning_threshold_of_min(int16_t min_val, int16_t max_val) {
   return min_val + (diff * (100 - WARNINGS_PERCENT)) / 100;
 }
 
-void update_values_can_inverter() {
+void PylonLvCanInverter::update_values_can_inverter() {
   // This function maps all the values fetched from battery CAN to the correct CAN messages
 
   // Set "battery charge voltage" to volts + 1 or user supplied value
@@ -133,7 +135,7 @@ void update_values_can_inverter() {
   // PYLON_35E is pre-filled with the manufacturer name
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  //Message originating from inverter.
       // according to the spec, this message includes only 0-bytes
@@ -158,7 +160,7 @@ void dump_frame(CAN_frame* frame) {
 }
 #endif
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   if (currentMillis - previousMillis1000ms >= 1000) {
@@ -181,8 +183,9 @@ void transmit_can_inverter() {
     transmit_can_frame(&PYLON_35E, can_config.inverter);
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Pylontech LV battery over CAN bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+
+void PylonLvCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -135,7 +135,7 @@ void PylonLvCanInverter::update_values_can_inverter() {
   // PYLON_35E is pre-filled with the manufacturer name
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void PylonLvCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  //Message originating from inverter.
       // according to the spec, this message includes only 0-bytes

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -9,9 +9,13 @@
 // 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
 #define WARNINGS_PERCENT 80
 
-void send_system_data();
-void send_setup_info();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class PylonLvCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Pylontech LV battery over CAN bus";
+};
 
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -13,6 +13,7 @@ class PylonLvCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Pylontech LV battery over CAN bus";

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SCHNEIDER-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* Version 2: SE BMS Communication Protocol 
 Protocol: CAN 2.0 Specification
 Frame: Extended CAN Bus Frame (29 bit identifier)
@@ -87,8 +89,8 @@ static uint16_t warnings = 0;
 static uint16_t faults = 0;
 static uint16_t state = 0;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
-
+void SchneiderCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   /* Calculate temperature */
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -255,7 +257,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SE_320.data.u8[1] = 0x02;
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x310:  // Still alive message from inverter, every 1s
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -265,7 +267,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send 500ms CAN Message
@@ -297,9 +299,8 @@ void transmit_can_inverter() {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup
-  strncpy(datalayer.system.info.inverter_protocol, "Schneider V2 SE BMS CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+void SchneiderCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -257,7 +257,7 @@ void SchneiderCanInverter::
   SE_320.data.u8[1] = 0x02;
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SchneiderCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x310:  // Still alive message from inverter, every 1s
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -267,7 +267,7 @@ static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-static void transmit_can_inverter() {
+void SchneiderCanInverter::transmit_can() {
   unsigned long currentMillis = millis();
 
   // Send 500ms CAN Message
@@ -297,10 +297,6 @@ static void transmit_can_inverter() {
     transmit_can_frame(&SE_332, can_config.inverter);
     transmit_can_frame(&SE_333, can_config.inverter);
   }
-}
-
-void SchneiderCanInverter::transmit_can() {
-  transmit_can_inverter();
 }
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -27,7 +27,13 @@
 #define COMMAND_CHARGE_AND_DISCHARGE_ALLOWED 0x06
 #define COMMAND_STOP 0x08
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SchneiderCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Schneider V2 SE BMS CAN";
+};
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -31,6 +31,7 @@ class SchneiderCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Schneider V2 SE BMS CAN";

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SMA-BYD-H-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
@@ -13,71 +15,73 @@ static uint16_t inverter_voltage = 0;
 static int16_t inverter_current = 0;
 
 //Actual content messages
-CAN_frame SMA_158 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x158,
-                     .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
-CAN_frame SMA_558 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,
-                     .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
+static CAN_frame SMA_158 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x158,
+                            .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
+static CAN_frame SMA_358 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x358,
+                            .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
+static CAN_frame SMA_3D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x3D8,
+                            .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
+static CAN_frame SMA_458 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x458,
+                            .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
+static CAN_frame SMA_4D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x4D8,
+                            .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
+static CAN_frame SMA_518 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x518,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
+static CAN_frame SMA_558 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x558,
+    .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
+static CAN_frame SMA_598 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x598,
+                            .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
+static CAN_frame SMA_5D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x5D8,
+                            .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+static CAN_frame SMA_618_1 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+static CAN_frame SMA_618_2 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
+static CAN_frame SMA_618_3 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
 
 static int16_t temperature_average = 0;
 static uint16_t ampere_hours_remaining = 0;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaBydHCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -196,7 +200,22 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void transmit_can_init() {
+  transmit_can_frame(&SMA_558, can_config.inverter);
+  transmit_can_frame(&SMA_598, can_config.inverter);
+  transmit_can_frame(&SMA_5D8, can_config.inverter);
+  transmit_can_frame(&SMA_618_1, can_config.inverter);
+  transmit_can_frame(&SMA_618_2, can_config.inverter);
+  transmit_can_frame(&SMA_618_3, can_config.inverter);
+  transmit_can_frame(&SMA_158, can_config.inverter);
+  transmit_can_frame(&SMA_358, can_config.inverter);
+  transmit_can_frame(&SMA_3D8, can_config.inverter);
+  transmit_can_frame(&SMA_458, can_config.inverter);
+  transmit_can_frame(&SMA_518, can_config.inverter);
+  transmit_can_frame(&SMA_4D8, can_config.inverter);
+}
+
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -236,7 +255,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message every 100ms if inverter allows contactor closing
@@ -254,24 +273,7 @@ void transmit_can_inverter() {
   }
 }
 
-void transmit_can_init() {
-  transmit_can_frame(&SMA_558, can_config.inverter);
-  transmit_can_frame(&SMA_598, can_config.inverter);
-  transmit_can_frame(&SMA_5D8, can_config.inverter);
-  transmit_can_frame(&SMA_618_1, can_config.inverter);
-  transmit_can_frame(&SMA_618_2, can_config.inverter);
-  transmit_can_frame(&SMA_618_3, can_config.inverter);
-  transmit_can_frame(&SMA_158, can_config.inverter);
-  transmit_can_frame(&SMA_358, can_config.inverter);
-  transmit_can_frame(&SMA_3D8, can_config.inverter);
-  transmit_can_frame(&SMA_458, can_config.inverter);
-  transmit_can_frame(&SMA_518, can_config.inverter);
-  transmit_can_frame(&SMA_4D8, can_config.inverter);
-}
-
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "SMA CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+static void setup_inverter(void) {                                    // Performs one time setup at startup over CAN bus
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
   pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
 #ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
@@ -279,4 +281,13 @@ void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
 }
+
+void SmaBydHCanInverter::setup() {
+  setup_inverter();
+}
+
+void SmaBydHCanInverter::transmit_can() {
+  transmit_can_inverter();
+}
+
 #endif

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -215,7 +215,7 @@ static void transmit_can_init() {
   transmit_can_frame(&SMA_4D8, can_config.inverter);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaBydHCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -7,8 +7,14 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+class SmaBydHCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "SMA CAN";
+};
 
 #endif

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -12,6 +12,7 @@ class SmaBydHCanInverter : public InverterProtocol {
   virtual void setup();
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "SMA CAN";

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -219,7 +219,7 @@ static void transmit_can_init() {
   transmit_can_frame(&SMA_4D8, can_config.inverter);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaBydHvsCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SMA-BYD-HVS-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
@@ -13,76 +15,78 @@ static uint16_t inverter_voltage = 0;
 static int16_t inverter_current = 0;
 
 //Actual content messages
-CAN_frame SMA_158 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x158,  // All 0xAA, no faults active
-                     .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x11, 0xA0, 0x07, 0x00, 0x01, 0x5E, 0x00, 0xC8}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x13, 0x2E, 0x27, 0x10, 0x00, 0x45, 0xF9, 0x00}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x11, 0xC8, 0x00, 0x00, 0x0E, 0xF4}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x10, 0x62, 0x00, 0x16, 0x01, 0x68, 0x03, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x01, 0x4A, 0x01, 0x25, 0xFF, 0xFF, 0xFF, 0xFF}};
+static CAN_frame SMA_158 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x158,  // All 0xAA, no faults active
+                            .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
+static CAN_frame SMA_358 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x358,
+                            .data = {0x11, 0xA0, 0x07, 0x00, 0x01, 0x5E, 0x00, 0xC8}};
+static CAN_frame SMA_3D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x3D8,
+                            .data = {0x13, 0x2E, 0x27, 0x10, 0x00, 0x45, 0xF9, 0x00}};
+static CAN_frame SMA_458 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x458,
+                            .data = {0x00, 0x00, 0x11, 0xC8, 0x00, 0x00, 0x0E, 0xF4}};
+static CAN_frame SMA_4D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x4D8,
+                            .data = {0x10, 0x62, 0x00, 0x16, 0x01, 0x68, 0x03, 0x08}};
+static CAN_frame SMA_518 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x518,
+                            .data = {0x01, 0x4A, 0x01, 0x25, 0xFF, 0xFF, 0xFF, 0xFF}};
 
 // Pairing/Battery setup information
 
-CAN_frame SMA_558 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,
-                     .data = {0x03, 0x13, 0x00, 0x03, 0x00, 0x66, 0x04, 0x07}};  //4x BYD modules, Vendor ID 7 BYD
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x00, 0x01, 0x0F, 0x2C, 0x5C, 0x98, 0xB6, 0xEE}};
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x31}};  //- B o x  H 1
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x30, 0x2E, 0x32, 0x00, 0x00, 0x00, 0x00}};  // 0 . 2
+static CAN_frame SMA_558 = {
+    .FD = false,
+    .ext_ID = false,
+    .DLC = 8,
+    .ID = 0x558,
+    .data = {0x03, 0x13, 0x00, 0x03, 0x00, 0x66, 0x04, 0x07}};  //4x BYD modules, Vendor ID 7 BYD
+static CAN_frame SMA_598 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x598,
+                            .data = {0x00, 0x01, 0x0F, 0x2C, 0x5C, 0x98, 0xB6, 0xEE}};
+static CAN_frame SMA_5D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x5D8,
+                            .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+static CAN_frame SMA_618_1 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+static CAN_frame SMA_618_2 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x31}};  //- B o x  H 1
+static CAN_frame SMA_618_3 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x02, 0x30, 0x2E, 0x32, 0x00, 0x00, 0x00, 0x00}};  // 0 . 2
 
 static int16_t discharge_current = 0;
 static int16_t charge_current = 0;
 static int16_t temperature_average = 0;
 static uint16_t ampere_hours_remaining = 0;
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaBydHvsCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -200,7 +204,22 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void transmit_can_init() {
+  transmit_can_frame(&SMA_558, can_config.inverter);
+  transmit_can_frame(&SMA_598, can_config.inverter);
+  transmit_can_frame(&SMA_5D8, can_config.inverter);
+  transmit_can_frame(&SMA_618_1, can_config.inverter);
+  transmit_can_frame(&SMA_618_2, can_config.inverter);
+  transmit_can_frame(&SMA_618_3, can_config.inverter);
+  transmit_can_frame(&SMA_158, can_config.inverter);
+  transmit_can_frame(&SMA_358, can_config.inverter);
+  transmit_can_frame(&SMA_3D8, can_config.inverter);
+  transmit_can_frame(&SMA_458, can_config.inverter);
+  transmit_can_frame(&SMA_518, can_config.inverter);
+  transmit_can_frame(&SMA_4D8, can_config.inverter);
+}
+
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -240,7 +259,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message every 100ms if inverter allows contactor closing
@@ -257,24 +276,7 @@ void transmit_can_inverter() {
   }
 }
 
-void transmit_can_init() {
-  transmit_can_frame(&SMA_558, can_config.inverter);
-  transmit_can_frame(&SMA_598, can_config.inverter);
-  transmit_can_frame(&SMA_5D8, can_config.inverter);
-  transmit_can_frame(&SMA_618_1, can_config.inverter);
-  transmit_can_frame(&SMA_618_2, can_config.inverter);
-  transmit_can_frame(&SMA_618_3, can_config.inverter);
-  transmit_can_frame(&SMA_158, can_config.inverter);
-  transmit_can_frame(&SMA_358, can_config.inverter);
-  transmit_can_frame(&SMA_3D8, can_config.inverter);
-  transmit_can_frame(&SMA_458, can_config.inverter);
-  transmit_can_frame(&SMA_518, can_config.inverter);
-  transmit_can_frame(&SMA_4D8, can_config.inverter);
-}
-
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box HVS over SMA CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+static void setup_inverter(void) {                                    // Performs one time setup at startup over CAN bus
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
   pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
 #ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
@@ -282,4 +284,13 @@ void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
 }
+
+void SmaBydHvsCanInverter::setup() {
+  setup_inverter();
+}
+
+void SmaBydHvsCanInverter::transmit_can() {
+  transmit_can_inverter();
+}
+
 #endif

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -7,8 +7,14 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+class SmaBydHvsCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "BYD Battery-Box HVS over SMA CAN";
+};
 
 #endif

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -12,6 +12,7 @@ class SmaBydHvsCanInverter : public InverterProtocol {
   virtual void setup();
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "BYD Battery-Box HVS over SMA CAN";

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -117,7 +117,7 @@ void SmaLvCanInverter::
   //TODO: Map error/warnings in 0x35A
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaLvCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -12,6 +12,7 @@ class SmaLvCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "SMA Low Voltage (48V) protocol via CAN";

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -1,13 +1,20 @@
 #ifndef SMA_LV_CAN_H
 #define SMA_LV_CAN_H
 #include "../include.h"
+#include "Inverter.h"
 
 #define CAN_INVERTER_SELECTED
 
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SmaLvCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "SMA Low Voltage (48V) protocol via CAN";
+};
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SMA-TRIPOWER-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* TODO:
 - Figure out the manufacturer info needed in transmit_can_init() CAN messages
   - CAN logs from real system might be needed
@@ -34,68 +36,69 @@ static int16_t temperature_average = 0;
 static uint16_t ampere_hours_remaining = 0;
 
 //Actual content messages
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x12, 0x40, 0x0C, 0x80, 0x01, 0x00, 0x01, 0x00}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x04, 0x06, 0x27, 0x10, 0x00, 0x19, 0x00, 0xFA}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x73, 0xAE, 0x00, 0x00, 0x64, 0x64}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x10, 0x62, 0x00, 0x00, 0x00, 0x78, 0x02, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x00, 0x96, 0x00, 0x78, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_558 = {.FD = false,  //Pairing first message
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,                                                // BYD HVS 10.2 kWh (0x66 might be kWh)
-                     .data = {0x03, 0x24, 0x00, 0x04, 0x00, 0x66, 0x04, 0x09}};  //Amount of modules? Vendor ID?
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x12, 0xD6, 0x43, 0xA4, 0x00, 0x00, 0x00, 0x00}};  //B0-4 Serial 301100932
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_0 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //BATTERY
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
+static CAN_frame SMA_358 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x358,
+                            .data = {0x12, 0x40, 0x0C, 0x80, 0x01, 0x00, 0x01, 0x00}};
+static CAN_frame SMA_3D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x3D8,
+                            .data = {0x04, 0x06, 0x27, 0x10, 0x00, 0x19, 0x00, 0xFA}};
+static CAN_frame SMA_458 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x458,
+                            .data = {0x00, 0x00, 0x73, 0xAE, 0x00, 0x00, 0x64, 0x64}};
+static CAN_frame SMA_4D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x4D8,
+                            .data = {0x10, 0x62, 0x00, 0x00, 0x00, 0x78, 0x02, 0x08}};
+static CAN_frame SMA_518 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x518,
+                            .data = {0x00, 0x96, 0x00, 0x78, 0x00, 0x00, 0x00, 0x00}};
+static CAN_frame SMA_558 = {.FD = false,  //Pairing first message
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x558,  // BYD HVS 10.2 kWh (0x66 might be kWh)
+                            .data = {0x03, 0x24, 0x00, 0x04, 0x00, 0x66, 0x04, 0x09}};  //Amount of modules? Vendor ID?
+static CAN_frame SMA_598 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x598,
+                            .data = {0x12, 0xD6, 0x43, 0xA4, 0x00, 0x00, 0x00, 0x00}};  //B0-4 Serial 301100932
+static CAN_frame SMA_5D8 = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x5D8,
+                            .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+static CAN_frame SMA_618_0 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //BATTERY
+static CAN_frame SMA_618_1 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
+static CAN_frame SMA_618_2 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
+static CAN_frame SMA_618_3 = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x618,
+                              .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaTripowerCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -148,7 +151,39 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
+  if (listLength >= 20) {
+    return;  //TODO: scream.
+  }
+  framesToSend[listLength] = {
+      .frame = frame,
+      .callback = callback,
+  };
+  listLength++;
+}
+
+static void completePairing() {
+  pairing_completed = true;
+}
+
+static void transmit_can_init() {
+  listLength = 0;  // clear all frames
+
+  pushFrame(&SMA_558);    //Pairing start - Vendor
+  pushFrame(&SMA_598);    //Serial
+  pushFrame(&SMA_5D8);    //BYD
+  pushFrame(&SMA_618_0);  //BATTERY
+  pushFrame(&SMA_618_1);  //-Box Pr
+  pushFrame(&SMA_618_2);  //emium H
+  pushFrame(&SMA_618_3);  //VS
+  pushFrame(&SMA_358);
+  pushFrame(&SMA_3D8);
+  pushFrame(&SMA_458);
+  pushFrame(&SMA_4D8);
+  pushFrame(&SMA_518, completePairing);
+}
+
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -179,18 +214,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
-  if (listLength >= 20) {
-    return;  //TODO: scream.
-  }
-  framesToSend[listLength] = {
-      .frame = frame,
-      .callback = callback,
-  };
-  listLength++;
-}
-
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send CAN Message only if we're enabled by inverter
@@ -230,36 +254,21 @@ void transmit_can_inverter() {
   }
 }
 
-void completePairing() {
-  pairing_completed = true;
-}
-
-void transmit_can_init() {
-  listLength = 0;  // clear all frames
-
-  pushFrame(&SMA_558);    //Pairing start - Vendor
-  pushFrame(&SMA_598);    //Serial
-  pushFrame(&SMA_5D8);    //BYD
-  pushFrame(&SMA_618_0);  //BATTERY
-  pushFrame(&SMA_618_1);  //-Box Pr
-  pushFrame(&SMA_618_2);  //emium H
-  pushFrame(&SMA_618_3);  //VS
-  pushFrame(&SMA_358);
-  pushFrame(&SMA_3D8);
-  pushFrame(&SMA_458);
-  pushFrame(&SMA_4D8);
-  pushFrame(&SMA_518, completePairing);
-}
-
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "SMA Tripower CAN", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+static void setup_inverter(void) {                                    // Performs one time setup at startup over CAN bus
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
   pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);
 #ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
   pinMode(INVERTER_CONTACTOR_ENABLE_LED_PIN, OUTPUT);
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
+}
+
+void SmaTripowerCanInverter::setup() {
+  setup_inverter();
+}
+
+void SmaTripowerCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -183,7 +183,7 @@ static void transmit_can_init() {
   pushFrame(&SMA_518, completePairing);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaTripowerCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -12,6 +12,7 @@ class SmaTripowerCanInverter : public InverterProtocol {
   virtual void setup();
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "SMA Tripower CAN";

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -7,8 +7,14 @@
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+class SmaTripowerCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "SMA Tripower CAN";
+};
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -233,7 +233,7 @@ void SofarCanInverter::
   SOFAR_356.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SofarCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SOFAR-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* This implementation of the SOFAR can protocol is halfway done. What's missing is implementing the inverter replies, all the CAN messages are listed, but the can sending is missing. */
 
 /* Do not change code below unless you are sure what you are doing */
@@ -202,7 +204,8 @@ CAN_frame SOFAR_7C0 = {.FD = false,
                        .ID = 0x7C0,
                        .data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x80, 0x00}};
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SofarCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   //Maxvoltage (eg 400.0V = 4000 , 16bits long) Charge Cutoff Voltage
   SOFAR_351.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV >> 8);
@@ -230,7 +233,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOFAR_356.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -247,7 +250,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -264,8 +267,8 @@ void transmit_can_inverter() {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Sofar BMS (Extended Frame) over CAN bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+void SofarCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -4,7 +4,13 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SofarCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Sofar BMS (Extended Frame) over CAN bus";
+};
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -8,6 +8,7 @@ class SofarCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Sofar BMS (Extended Frame) over CAN bus";

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -213,7 +213,7 @@ static void transmit_can_inverter() {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SolaxCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -4,6 +4,8 @@
 #include "../devboard/utils/events.h"
 #include "SOLAX-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 #define NUMBER_OF_MODULES 0
 #define BATTERY_TYPE 0x50
 // If you are having BattVoltFault issues, configure the above values according to wiki page
@@ -106,7 +108,8 @@ CAN_frame SOLAX_100A001 = {.FD = false, .ext_ID = true, .DLC = 0, .ID = 0x100A00
 #define Contactor_Open_Payload __builtin_bswap64(0x0200010000000000)
 #define Contactor_Close_Payload __builtin_bswap64(0x0200010001000000)
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SolaxCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // If not receiveing any communication from the inverter, open contactors and return to battery announce state
   if (millis() - LastFrameTime >= SolaxTimeout) {
     datalayer.system.status.inverter_allows_contactor_closing = false;
@@ -206,11 +209,11 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -297,9 +300,16 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 #endif
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup
-  strncpy(datalayer.system.info.inverter_protocol, "SolaX Triple Power LFP over CAN bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+static void setup_inverter(void) {                                    // Performs one time setup at startup
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
 }
+
+void SolaxCanInverter::setup() {
+  setup_inverter();
+}
+
+void SolaxCanInverter::transmit_can() {
+  transmit_can_inverter();
+}
+
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,7 +14,14 @@
 #define FAULT_SOLAX 3
 #define UPDATING_FW 4
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SolaxCanInverter : public InverterProtocol {
+ public:
+  virtual void setup();
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "SolaX Triple Power LFP over CAN bus";
+};
 
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -19,6 +19,7 @@ class SolaxCanInverter : public InverterProtocol {
   virtual void setup();
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "SolaX Triple Power LFP over CAN bus";

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -414,7 +414,7 @@ void SungrowCanInverter::
 #endif
 }
 
-static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SungrowCanInverter::map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter
     case 0x000:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -3,6 +3,8 @@
 #include "../datalayer/datalayer.h"
 #include "SUNGROW-CAN.h"
 
+#include "../communication/can/comm_can.h"
+
 /* TODO: 
 This protocol is still under development. It can not be used yet for Sungrow inverters, 
 see the Wiki for more info on how to use your Sungrow inverter */
@@ -253,7 +255,8 @@ CAN_frame SUNGROW_71E = {.FD = false,
                          .ID = 0x71E,
                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN messages
+void SungrowCanInverter::
+    update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN messages
 
   //Maxvoltage (eg 400.0V = 4000 , 16bits long)
   SUNGROW_701.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
@@ -411,7 +414,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 #endif
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+static void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter
     case 0x000:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -557,7 +560,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+static void transmit_can_inverter() {
   unsigned long currentMillis = millis();
 
   // Send 1s CAN Message
@@ -599,8 +602,9 @@ void transmit_can_inverter() {
     }
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "Sungrow SBR064 battery over CAN bus", 63);
-  datalayer.system.info.inverter_protocol[63] = '\0';
+
+void SungrowCanInverter::transmit_can() {
+  transmit_can_inverter();
 }
+
 #endif

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -4,7 +4,13 @@
 
 #define CAN_INVERTER_SELECTED
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SungrowCanInverter : public InverterProtocol {
+ public:
+  virtual void transmit_can();
+  virtual void update_values_can_inverter();
+
+  virtual const char* name() { return Name; };
+  static constexpr char* Name = "Sungrow SBR064 battery over CAN bus";
+};
 
 #endif

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -8,6 +8,7 @@ class SungrowCanInverter : public InverterProtocol {
  public:
   virtual void transmit_can();
   virtual void update_values_can_inverter();
+  virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
   static constexpr char* Name = "Sungrow SBR064 battery over CAN bus";


### PR DESCRIPTION
### What
This proof-of-concept PR includes the changes necessary to build all battery and inverter protocol implementations into one binary and allows battery and inverter to be selected at run-time in emulator settings. It still also supports selecting a single battery or inverter at build-time as before.

Great care was taken to retain the existing structure of the code: no unnecessary files were added or removed and changes were targeted in existing places when possible.

I recommend this POC PR to be used as a basis for the final implementation.

Notable missing features:

- Some battery / inverter combinations have GPIO conflicts that should be handled at run-time. The current build-time checks prevent compilation of all batteries.
- Some BMS not included in the build
- Error handling in out-of-memory situations
- Support for other HW than Lilygo
- Complete charger selection

### Why
A common image would make it much easier to take battery emulator in use since it ideally would not require users to build the image at all, simply transfer it to their HW of choice. This would be a much more robust and reliable experience for the users. There are also obvious benefits to code maintainability and reuse. This also provides new opportunities to refactor other parts of the implementation to make much more settings at run-time.

### How
Existing implementation already has clear separation of battery/inverter implementation into C-style modules but since the interface was with global functions (e.g. transmit_can_battery), simply building all the modules into binary would introduce linker conflicts. This PR introduces some **abstract base classes** for batteries and inverters that the battery and inverter modules can then implement in a concrete class.

User can select a battery and the identifier of the battery type is stored in settings. When the emulator starts it constructs a concrete battery class based on this selection. The main loop may then use the abstract interface to call battery dependent functions as before. Same mechanism is used for inverter protocols.

Earlier code had a lot static data in battery implementations. Compiling all this in would overflow RAM budget, so some of that is moved to battery class's private members.
