### PR TITLE
Volvo: Update voltage limits for SPA

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -6,11 +6,11 @@
 #define BATTERY_SELECTED
 #define MAX_PACK_VOLTAGE_108S_DV 4540
 #define MIN_PACK_VOLTAGE_108S_DV 2938
-#define MAX_PACK_VOLTAGE_96S_DV 4030
+#define MAX_PACK_VOLTAGE_96S_DV 4170
 #define MIN_PACK_VOLTAGE_96S_DV 2620
 #define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4210  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
+#define MAX_CELL_VOLTAGE_MV 4350
+#define MIN_CELL_VOLTAGE_MV 2700
 
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);


### PR DESCRIPTION
### What
This PR updates the voltage limits for Volvo SPA batteries

### Why
It was not possible to charge 96S battery to 100%

### How
We tweak the limits to allow 417V pack voltage