### PR TITLE
Moving battery min max values into base class

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -80,7 +80,8 @@ void BMWi3Battery::update_values() {  //This function maps all the values fetche
     m_target->info.max_design_voltage_dV = max_pack_voltage_dv();
     m_target->info.min_design_voltage_dV = min_pack_voltage_dv();
     m_target->info.max_cell_voltage_mV = max_cell_deviation_mv();
-    m_target->info.min_cell_voltage_mV = min_cell_voltage_mv();;
+    m_target->info.min_cell_voltage_mV = min_cell_voltage_mv();
+    ;
   }
 
   // Perform other safety checks

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -77,22 +77,10 @@ void BMWi3Battery::update_values() {  //This function maps all the values fetche
 
   if (battery_info_available) {
     // Start checking safeties. First up, cellvoltages!
-    if (detectedBattery == BATTERY_60AH) {
-      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
-      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
-      m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_60AH;
-      m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_60AH;
-    } else if (detectedBattery == BATTERY_94AH) {
-      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_94AH;
-      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_94AH;
-      m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_94AH;
-      m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_94AH;
-    } else {  // BATTERY_120AH
-      m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_120AH;
-      m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_120AH;
-      m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_120AH;
-      m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_120AH;
-    }
+    m_target->info.max_design_voltage_dV = max_pack_voltage_dv();
+    m_target->info.min_design_voltage_dV = min_pack_voltage_dv();
+    m_target->info.max_cell_voltage_mV = max_cell_deviation_mv();
+    m_target->info.min_cell_voltage_mV = min_cell_voltage_mv();;
   }
 
   // Perform other safety checks
@@ -505,10 +493,10 @@ void BMWi3Battery::transmit_can() {
 
 void BMWi3Battery::setup(void) {  // Performs one time setup at startup
   //Before we have started up and detected which battery is in use, use 60AH values
-  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
-  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
-  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  m_target->info.number_of_cells = NUMBER_OF_CELLS;
+  m_target->info.max_design_voltage_dV = max_pack_voltage_dv();
+  m_target->info.min_design_voltage_dV = min_pack_voltage_dv();
+  m_target->info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
+  m_target->info.number_of_cells = number_of_cells();
   allow_contactor_closing();
 
   pinMode(m_wakeup_pin, OUTPUT);

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -7,21 +7,6 @@
 
 #define BATTERY_SELECTED
 
-#define MAX_CELL_VOLTAGE_60AH 4110   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_60AH 2700   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_94AH 4140   // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_94AH 2700   // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_VOLTAGE_120AH 4190  // Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_120AH 2790  // Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 250    // LED turns yellow on the board if mv delta exceeds this value
-#define MAX_PACK_VOLTAGE_60AH 3950   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_60AH 2590   // Discharge stops if pack voltage exceeds this value
-#define MAX_PACK_VOLTAGE_94AH 3980   // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_94AH 2590   // Discharge stops if pack voltage exceeds this value
-#define MAX_PACK_VOLTAGE_120AH 4030  // Charge stops if pack voltage exceeds this value
-#define MIN_PACK_VOLTAGE_120AH 2680  // Discharge stops if pack voltage exceeds this value
-#define NUMBER_OF_CELLS 96
-
 class BMWi3Battery : public CanBattery {
  public:
   BMWi3Battery(DATALAYER_BATTERY_TYPE* target, CAN_Interface can_interface, int wakeup_pin) : CanBattery(BMWi3) {
@@ -31,13 +16,56 @@ class BMWi3Battery : public CanBattery {
   }
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BMW i3";
+  static constexpr const char* Name = "BMW i3";
 
   virtual bool supportsDoubleBattery() { return true; };
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_cell_voltage_mv() { 
+    if (detectedBattery == BATTERY_60AH) {
+      return 4110;
+    } else if (detectedBattery == BATTERY_94AH) {
+      return 4140;
+    } else if (detectedBattery == BATTERY_120AH) {
+      return 4190;
+    }
+    return 0;
+  };
+  virtual uint16_t min_cell_voltage_mv() { 
+    if (detectedBattery == BATTERY_60AH) {
+      return 2700;
+    } else if (detectedBattery == BATTERY_94AH) {
+      return 2700;
+    } else if (detectedBattery == BATTERY_120AH) {
+      return 2790;
+    }
+    return 0;
+  };
+  virtual uint16_t max_pack_voltage_dv() { 
+    if (detectedBattery == BATTERY_60AH) {
+      return 3950;
+    } else if (detectedBattery == BATTERY_94AH) {
+      return 3980;
+    } else if (detectedBattery == BATTERY_120AH) {
+      return 4030;
+    }
+    return 0;
+  };
+  virtual uint16_t min_pack_voltage_dv() { 
+    if (detectedBattery == BATTERY_60AH) {
+      return 2590;
+    } else if (detectedBattery == BATTERY_94AH) {
+      return 2590;
+    } else if (detectedBattery == BATTERY_120AH) {
+      return 2680;
+    }
+    return 0;
+  };
+  virtual uint16_t max_cell_deviation_mv() { return 250; };
+  virtual uint8_t number_of_cells() { return 96; };
 
  private:
   DATALAYER_BATTERY_TYPE* m_target;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -24,7 +24,7 @@ class BMWi3Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
-  virtual uint16_t max_cell_voltage_mv() { 
+  virtual uint16_t max_cell_voltage_mv() {
     if (detectedBattery == BATTERY_60AH) {
       return 4110;
     } else if (detectedBattery == BATTERY_94AH) {
@@ -34,7 +34,7 @@ class BMWi3Battery : public CanBattery {
     }
     return 0;
   };
-  virtual uint16_t min_cell_voltage_mv() { 
+  virtual uint16_t min_cell_voltage_mv() {
     if (detectedBattery == BATTERY_60AH) {
       return 2700;
     } else if (detectedBattery == BATTERY_94AH) {
@@ -44,7 +44,7 @@ class BMWi3Battery : public CanBattery {
     }
     return 0;
   };
-  virtual uint16_t max_pack_voltage_dv() { 
+  virtual uint16_t max_pack_voltage_dv() {
     if (detectedBattery == BATTERY_60AH) {
       return 3950;
     } else if (detectedBattery == BATTERY_94AH) {
@@ -54,7 +54,7 @@ class BMWi3Battery : public CanBattery {
     }
     return 0;
   };
-  virtual uint16_t min_pack_voltage_dv() { 
+  virtual uint16_t min_pack_voltage_dv() {
     if (detectedBattery == BATTERY_60AH) {
       return 2590;
     } else if (detectedBattery == BATTERY_94AH) {

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -416,11 +416,11 @@ void BMWIXBattery::setup(void) {  // Performs one time setup at startup
   transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET, can_config.battery);
 
   //Before we have started up and detected which battery is in use, use 108S values
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
   allow_contactor_closing();
 }
 

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -6,11 +6,6 @@
 
 #define BATTERY_SELECTED
 
-#define MAX_PACK_VOLTAGE_DV 4650  //4650 = 465.0V
-#define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4300  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_DISCHARGE_POWER_ALLOWED_W 10000
 #define MAX_CHARGE_POWER_ALLOWED_W 10000
 #define MAX_CHARGE_POWER_WHEN_TOPBALANCING_W 500
@@ -22,11 +17,17 @@ class BMWIXBattery : public CanBattery {
  public:
   BMWIXBattery() : CanBattery(BMWIX) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BMW iX and i4-7 platform";
+  static constexpr const char* Name = "BMW iX and i4-7 platform";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_cell_voltage_mv() { return 4300; }
+  virtual uint16_t min_cell_voltage_mv() { return 2800; }
+  virtual uint16_t max_pack_voltage_dv() { return 4650; }
+  virtual uint16_t min_pack_voltage_dv() { return 3000; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
 
  private:
   uint8_t increment_uds_req_id_counter(uint8_t index);

--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -713,11 +713,11 @@ void BMWPhevBattery::setup(void) {  // Performs one time setup at startup
   transmit_can_frame(&BMWPHEV_6F1_REQUEST_ISOLATION_TEST,
                      can_config.battery);  // Run Internal Isolation Test at startup
 
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
   allow_contactor_closing();
 }
 

--- a/Software/src/battery/BMW-PHEV-BATTERY.h
+++ b/Software/src/battery/BMW-PHEV-BATTERY.h
@@ -5,11 +5,6 @@
 
 #define BATTERY_SELECTED
 
-#define MAX_PACK_VOLTAGE_DV 4650  //4650 = 465.0V
-#define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4300  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_DISCHARGE_POWER_ALLOWED_W 10000
 #define MAX_CHARGE_POWER_ALLOWED_W 10000
 #define MAX_CHARGE_POWER_WHEN_TOPBALANCING_W 500
@@ -22,12 +17,18 @@ class BMWPhevBattery : public CanBattery {
   BMWPhevBattery() : CanBattery(BMWPhev) {}
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BMW PHEV Battery";
+  static constexpr const char* Name = "BMW PHEV Battery";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual u16_t min_cell_voltage_mv() { return 2800; }
+  virtual u16_t max_cell_voltage_mv() { return 4300; }
+  virtual u16_t min_pack_voltage_dv() { return 3000; }
+  virtual u16_t max_pack_voltage_dv() { return 4650; }
+  virtual u16_t max_cell_deviation_mv() { return 250; }
 
  private:
   void startUDSMultiFrameReception(uint16_t totalLength, uint8_t moduleID);

--- a/Software/src/battery/BMW-SBOX.h
+++ b/Software/src/battery/BMW-SBOX.h
@@ -23,7 +23,7 @@ class BMWSboxBattery : public CanBattery {
  public:
   BMWSboxBattery() : CanBattery(BMWSBox) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BMW SBOX";
+  static constexpr const char* Name = "BMW SBOX";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -709,11 +709,11 @@ void BoltAmperaBattery::transmit_can() {
 
 void BoltAmperaBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
   allow_contactor_closing();
 }
 

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -5,12 +5,6 @@
 
 #define BATTERY_SELECTED
 
-#define MAX_PACK_VOLTAGE_DV 4150  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2500
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-
 #define POLL_7E4_CAPACITY_EST_GEN1 0x41A3
 #define POLL_7E4_CAPACITY_EST_GEN2 0x45F9
 #define POLL_7E4_SOC_DISPLAY 0x8334
@@ -180,12 +174,18 @@ class BoltAmperaBattery : public CanBattery {
  public:
   BoltAmperaBattery() : CanBattery(BoltAmpera) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Chevrolet Bolt EV/Opel Ampera-e";
+  static constexpr const char* Name = "Chevrolet Bolt EV/Opel Ampera-e";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4150; }
+  virtual uint16_t min_pack_voltage_dv() { return 2500; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   /*TODO, messages we might need to send towards the battery to keep it happy and close contactors

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -15,15 +15,9 @@
 
 /* Do not modify the rows below */
 #define BATTERY_SELECTED
-#define CELLCOUNT_EXTENDED 126
-#define CELLCOUNT_STANDARD 104
-#define MAX_PACK_VOLTAGE_EXTENDED_DV 4410  //Extended range
-#define MIN_PACK_VOLTAGE_EXTENDED_DV 3800  //Extended range
-#define MAX_PACK_VOLTAGE_STANDARD_DV 3640  //Standard range
-#define MIN_PACK_VOLTAGE_STANDARD_DV 3136  //Standard range
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 3800  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2800  //Battery is put into emergency stop if one cell goes below this value
+#define NOT_DETERMINED_YET 0
+#define STANDARD_RANGE 1
+#define EXTENDED_RANGE 2
 
 class BydAtto3Battery : public CanBattery {
  public:
@@ -32,20 +26,48 @@ class BydAtto3Battery : public CanBattery {
     m_can_interface = can_interface;
   }
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BYD Atto 3";
+  static constexpr const char* Name = "BYD Atto 3";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
+  virtual uint16_t max_pack_voltage_dv() { 
+    if (battery_type == STANDARD_RANGE) {
+      return 3640;
+    } else if (battery_type == EXTENDED_RANGE) {
+      return 4410;
+    } else {
+      return 0;
+    }
+  };
+  virtual uint16_t min_pack_voltage_dv() { 
+    if (battery_type == STANDARD_RANGE) {
+      return 3136;
+    } else if (battery_type == EXTENDED_RANGE) {
+      return 3800;
+    } else {
+      return 0;
+    }
+  };
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 3800; }
+  virtual uint16_t min_cell_voltage_mv() { return 2800; }
+  virtual uint8_t number_of_cells() { 
+    if (battery_type == STANDARD_RANGE) {
+      return 104;
+    } else if (battery_type == EXTENDED_RANGE) {
+      return 126;
+    } else {
+      return 0;
+    }
+  }
+
  private:
   DATALAYER_BATTERY_TYPE* m_target;
   CAN_Interface m_can_interface;
 
-#define NOT_DETERMINED_YET 0
-#define STANDARD_RANGE 1
-#define EXTENDED_RANGE 2
   uint8_t battery_type = NOT_DETERMINED_YET;
   unsigned long previousMillis50 = 0;   // will store last time a 50ms CAN Message was send
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -33,7 +33,7 @@ class BydAtto3Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
-  virtual uint16_t max_pack_voltage_dv() { 
+  virtual uint16_t max_pack_voltage_dv() {
     if (battery_type == STANDARD_RANGE) {
       return 3640;
     } else if (battery_type == EXTENDED_RANGE) {
@@ -42,7 +42,7 @@ class BydAtto3Battery : public CanBattery {
       return 0;
     }
   };
-  virtual uint16_t min_pack_voltage_dv() { 
+  virtual uint16_t min_pack_voltage_dv() {
     if (battery_type == STANDARD_RANGE) {
       return 3136;
     } else if (battery_type == EXTENDED_RANGE) {
@@ -54,7 +54,7 @@ class BydAtto3Battery : public CanBattery {
   virtual uint16_t max_cell_deviation_mv() { return 150; }
   virtual uint16_t max_cell_voltage_mv() { return 3800; }
   virtual uint16_t min_cell_voltage_mv() { return 2800; }
-  virtual uint8_t number_of_cells() { 
+  virtual uint8_t number_of_cells() {
     if (battery_type == STANDARD_RANGE) {
       return 104;
     } else if (battery_type == EXTENDED_RANGE) {

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -66,8 +66,12 @@ class BatteryBase {
   virtual void receive_RS485() = 0;
 
   //5000 = 500.0V
-  virtual uint16_t max_cell_voltage_mv() { return 0; } //Battery is put into emergency stop if one cell goes over this value
-  virtual uint16_t min_cell_voltage_mv() { return 0; } //Battery is put into emergency stop if one cell goes below this value
+  virtual uint16_t max_cell_voltage_mv() {
+    return 0;
+  }  //Battery is put into emergency stop if one cell goes over this value
+  virtual uint16_t min_cell_voltage_mv() {
+    return 0;
+  }  //Battery is put into emergency stop if one cell goes below this value
   virtual uint16_t max_pack_voltage_dv() { return 0; }
   virtual uint16_t min_pack_voltage_dv() { return 0; }
   virtual uint16_t max_cell_deviation_mv() { return 0; }

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -65,6 +65,14 @@ class BatteryBase {
   virtual void transmit_RS485() = 0;
   virtual void receive_RS485() = 0;
 
+  //5000 = 500.0V
+  virtual uint16_t max_cell_voltage_mv() { return 0; } //Battery is put into emergency stop if one cell goes over this value
+  virtual uint16_t min_cell_voltage_mv() { return 0; } //Battery is put into emergency stop if one cell goes below this value
+  virtual uint16_t max_pack_voltage_dv() { return 0; }
+  virtual uint16_t min_pack_voltage_dv() { return 0; }
+  virtual uint16_t max_cell_deviation_mv() { return 0; }
+  virtual uint8_t number_of_cells() { return 0; }
+
   virtual bool requiresPrechargeControl() { return false; }
 
   bool contactor_closing_allowed() { return m_contactor_closing_allowed; }

--- a/Software/src/battery/CELLPOWER-BMS.h
+++ b/Software/src/battery/CELLPOWER-BMS.h
@@ -17,7 +17,7 @@ class CellPowerBms : public CanBattery {
  public:
   CellPowerBms() : CanBattery(CellPower) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Cellpower BMS";
+  static constexpr const char* Name = "Cellpower BMS";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -16,7 +16,7 @@ class ChademoBattery : public CanBattery {
  public:
   ChademoBattery() : CanBattery(Chademo) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Chademo V2X mode";
+  static constexpr const char* Name = "Chademo V2X mode";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -1027,11 +1027,11 @@ void CmfaEvBattery::transmit_can() {
 void CmfaEvBattery::setup(void) {  // Performs one time setup at startup
   allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 72;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif  //CMFA_EV_BATTERY

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -3,11 +3,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 3040  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2185
-#define MAX_CELL_DEVIATION_MV 100
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 // OBD2 PID polls. Some of these have been reverse engineered, but there are many unknown values still
 #define PID_POLL_SOCZ 0x9001  //122 in log
@@ -156,11 +151,17 @@ class CmfaEvBattery : public CanBattery {
  public:
   CmfaEvBattery() : CanBattery(CmfaEv) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "CMFA platform, 27 kWh battery";
+  static constexpr const char* Name = "CMFA platform, 27 kWh battery";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 3040; }
+  virtual uint16_t min_pack_voltage_dv() { return 2185; }
+  virtual uint16_t max_cell_deviation_mv() { return 100; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 };
 
 #endif

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -61,11 +61,11 @@ void DalyBms::update_values() {
 }
 
 void DalyBms::setup(void) {  // Performs one time setup at startup
-  datalayer.battery.info.number_of_cells = CELL_COUNT;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.number_of_cells = number_of_cells();
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_deviation_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
   datalayer.battery.info.total_capacity_Wh = BATTERY_WH_MAX;
 }
 

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -2,11 +2,6 @@
 #define DALY_BMS_H
 
 /* Tweak these according to your battery build */
-#define CELL_COUNT 14
-#define MAX_PACK_VOLTAGE_DV 580   //580 = 58.0V
-#define MIN_PACK_VOLTAGE_DV 460   //480 = 48.0V
-#define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 3200  //Battery is put into emergency stop if one cell goes below this value
 #define POWER_PER_PERCENT 50     // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
 #define POWER_PER_DEGREE_C 60    // max power added/removed per degree above/below 0°C
 #define POWER_AT_0_DEGREE_C 800  // power at 0°C
@@ -18,7 +13,7 @@ class DalyBms : public RS485Battery {
  public:
   DalyBms() : RS485Battery(Daly) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "DALY RS485";
+  static constexpr const char* Name = "DALY RS485";
 
   virtual void setup();
   virtual void update_values();
@@ -26,6 +21,13 @@ class DalyBms : public RS485Battery {
   virtual int rs485_baudrate() { return 9600; }
   virtual void transmit_RS485();
   virtual void receive_RS485();
+
+  virtual uint16_t max_pack_voltage_dv() { return 580; }
+  virtual uint16_t min_pack_voltage_dv() { return 460; }
+  virtual uint16_t max_cell_deviation_mv() { return 100; }
+  virtual uint16_t max_cell_voltage_mv() { return 4200; }
+  virtual uint16_t min_cell_voltage_mv() { return 3200; }
+  virtual uint8_t number_of_cells() { return 14; }
 };
 
 #endif

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -4,17 +4,18 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CELL_DEVIATION_MV 250
 
 class StellantisEcmpBattery : public CanBattery {
  public:
   StellantisEcmpBattery() : CanBattery(Ecmp) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "ECMP battery";
+  static constexpr const char* Name = "ECMP battery";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
 };
 
 #endif

--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -576,7 +576,7 @@ void FoxessBattery::transmit_can() {
   }
 }
 
-void FoxessBattery::setup() { // Performs one time setup at startup
+void FoxessBattery::setup() {                  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 0;  //Startup with no cells, populates later when we know packsize
   datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
   datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();

--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -576,17 +576,13 @@ void FoxessBattery::transmit_can() {
   }
 }
 
-static void setup_battery(void) {              // Performs one time setup at startup
+void FoxessBattery::setup() { // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 0;  //Startup with no cells, populates later when we know packsize
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-}
-
-void FoxessBattery::setup() {
-  setup_battery();
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif

--- a/Software/src/battery/FOXESS-BATTERY.h
+++ b/Software/src/battery/FOXESS-BATTERY.h
@@ -5,21 +5,21 @@
 
 #define BATTERY_SELECTED
 
-#define MAX_PACK_VOLTAGE_DV 4672  //467.2V for HS20.8 (used during startup, refined later)
-#define MIN_PACK_VOLTAGE_DV 800   //80.V for HS5.2 (used during startup, refined later)
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 3800  //LiFePO4 Prismaticc Cell
-#define MIN_CELL_VOLTAGE_MV 2700  //LiFePO4 Prismatic Cell
-
 class FoxessBattery : public CanBattery {
  public:
   FoxessBattery() : CanBattery(Foxess) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "FoxESS HV2600/ECS4100 OEM battery";
+  static constexpr const char* Name = "FoxESS HV2600/ECS4100 OEM battery";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4672; }
+  virtual uint16_t min_pack_voltage_dv() { return 800; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 3800; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -198,7 +198,7 @@ void ImievCzeroIonBattery::transmit_can() {
   }
 }
 
-void ImievCzeroIonBattery::setup() { // Performs one time setup at startup
+void ImievCzeroIonBattery::setup() {  // Performs one time setup at startup
   datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
   datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
   datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -198,16 +198,12 @@ void ImievCzeroIonBattery::transmit_can() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-}
-
-void ImievCzeroIonBattery::setup() {
-  setup_battery();
+void ImievCzeroIonBattery::setup() { // Performs one time setup at startup
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -4,21 +4,22 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 3696  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3160
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4150  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2750  //Battery is put into emergency stop if one cell goes below this value
 
 class ImievCzeroIonBattery : public CanBattery {
  public:
   ImievCzeroIonBattery() : CanBattery(ImievCzeroIon) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "I-Miev / C-Zero / Ion Triplet";
+  static constexpr const char* Name = "I-Miev / C-Zero / Ion Triplet";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 3696; }
+  virtual uint16_t min_pack_voltage_dv() { return 3160; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 4150; }
+  virtual uint16_t min_cell_voltage_mv() { return 2750; }
 
  private:
   uint8_t errorCode = 0;  //stores if we have an error code active from battery control logic

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -256,11 +256,11 @@ static void transmit_can_battery() {
 
 void JaguarIpaceBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 108;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 
   allow_contactor_closing();
 }

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -3,21 +3,22 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4546  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3370
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 class JaguarIpaceBattery : public CanBattery {
  public:
   JaguarIpaceBattery() : CanBattery(JaguarIpace) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Jaguar I-PACE";
+  static constexpr const char* Name = "Jaguar I-PACE";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4546; }
+  virtual uint16_t min_pack_voltage_dv() { return 3370; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 };
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1143,11 +1143,11 @@ void KiaEGmpBattery::setup(void) {  // Performs one time setup at startup
 
   allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 192;  // TODO: will vary depending on battery
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 void KiaEGmpBattery::update_values() {

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -9,11 +9,6 @@ extern ACAN2517FD canfd;
 #define ESTIMATE_SOC_FROM_CELLVOLTAGE
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 8064  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 4320
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2950  //Battery is put into emergency stop if one cell goes below this value
 #define MAXCHARGEPOWERALLOWED 10000
 #define MAXDISCHARGEPOWERALLOWED 10000
 #define RAMPDOWN_SOC 9000           // 90.00 SOC% to start ramping down from max charge power towards 0 at 100.00%
@@ -27,11 +22,17 @@ class KiaEGmpBattery : public CanBattery {
  public:
   KiaEGmpBattery() : CanBattery(KiaEGmp) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Kia/Hyundai EGMP platform";
+  static constexpr const char* Name = "Kia/Hyundai EGMP platform";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 8064; }
+  virtual uint16_t min_pack_voltage_dv() { return 4320; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2950; }
 };
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -22,7 +22,7 @@ class KiaHyundai64Battery : public CanBattery {
     m_can_interface = can_interface;
   }
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Kia/Hyundai 64/40kWh battery";
+  static constexpr const char* Name = "Kia/Hyundai 64/40kWh battery";
   virtual bool supportsDoubleBattery() { return true; };
 
   virtual void setup();

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -4,22 +4,23 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 2550  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 1700
-#define MAX_CELL_DEVIATION_MV 100
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 class KiaHyundaiHybridBattery : public CanBattery {
  public:
   KiaHyundaiHybridBattery() : CanBattery(KiaHyundaiHybrid) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Kia/Hyundai Hybrid";
+  static constexpr const char* Name = "Kia/Hyundai Hybrid";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 2550; }
+  virtual uint16_t min_pack_voltage_dv() { return 1700; }
+  virtual uint16_t max_cell_deviation_mv() { return 100; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 };
 
 #endif

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -155,7 +155,7 @@ class MebBattery : public CanBattery {
  public:
   MebBattery() : CanBattery(Meb) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Volkswagen Group MEB platform via CAN-FD";
+  static constexpr const char* Name = "Volkswagen Group MEB platform via CAN-FD";
 
   virtual void setup();
   virtual void update_values();

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -4,22 +4,23 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3100
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 class MG5Battery : public CanBattery {
  public:
   MG5Battery() : CanBattery(Mg5) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "MG 5 battery";
+  static constexpr const char* Name = "MG 5 battery";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4040; }
+  virtual uint16_t min_pack_voltage_dv() { return 3100; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 };
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -936,11 +936,11 @@ void decodeChallengeData(unsigned int incomingChallenge, unsigned char* solvedCh
 
 void NissanLeafBattery::setup(void) {  // Performs one time setup at startup
   m_target->info.number_of_cells = 96;
-  m_target->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  m_target->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  m_target->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  m_target->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  m_target->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  m_target->info.max_design_voltage_dV = max_pack_voltage_dv();
+  m_target->info.min_design_voltage_dV = min_pack_voltage_dv();
+  m_target->info.max_cell_voltage_mV = max_cell_voltage_mv();
+  m_target->info.min_cell_voltage_mV = min_cell_voltage_mv();
+  m_target->info.max_cell_voltage_deviation_mV = max_cell_voltage_mv();
 }
 
 #endif  //NISSAN_LEAF_BATTERY

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -7,11 +7,6 @@
 #include "Battery.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2600
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame rx_frame);
@@ -32,7 +27,7 @@ class NissanLeafBattery : public CanBattery {
     m_can_interface = can_interface;
   }
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Nissan LEAF battery";
+  static constexpr const char* Name = "Nissan LEAF battery";
 
   virtual bool supportsDoubleBattery() { return true; };
 
@@ -40,6 +35,12 @@ class NissanLeafBattery : public CanBattery {
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t  max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t  min_cell_voltage_mv() { return 2700; }
+  virtual uint16_t  max_pack_voltage_dv() { return 4040; }
+  virtual uint16_t  min_pack_voltage_dv() { return 2600; }
+  virtual uint16_t  max_cell_deviation_mv() { return 150; }
 
  private:
   void clearSOH();

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -36,11 +36,11 @@ class NissanLeafBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
-  virtual uint16_t  max_cell_voltage_mv() { return 4250; }
-  virtual uint16_t  min_cell_voltage_mv() { return 2700; }
-  virtual uint16_t  max_pack_voltage_dv() { return 4040; }
-  virtual uint16_t  min_pack_voltage_dv() { return 2600; }
-  virtual uint16_t  max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
+  virtual uint16_t max_pack_voltage_dv() { return 4040; }
+  virtual uint16_t min_pack_voltage_dv() { return 2600; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
 
  private:
   void clearSOH();

--- a/Software/src/battery/ORION-BMS.cpp
+++ b/Software/src/battery/ORION-BMS.cpp
@@ -61,7 +61,7 @@ void OrionBms::update_values() {
   datalayer.battery.status.cell_min_voltage_mV = Minimum_Cell_Voltage;
 
   //If user did not configure amount of cells correctly in the header file, update the value
-  if ((amount_of_detected_cells > NUMBER_OF_CELLS) && (amount_of_detected_cells < MAX_AMOUNT_CELLS)) {
+  if ((amount_of_detected_cells > number_of_cells()) && (amount_of_detected_cells < MAX_AMOUNT_CELLS)) {
     datalayer.battery.info.number_of_cells = amount_of_detected_cells;
   }
 }
@@ -112,11 +112,11 @@ void OrionBms::handle_incoming_can_frame(CAN_frame rx_frame) {
 }
 
 void OrionBms::setup(void) {  // Performs one time setup at startup
-  datalayer.battery.info.number_of_cells = NUMBER_OF_CELLS;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.number_of_cells = number_of_cells();
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_deviation_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
   allow_contactor_closing();
 }
 

--- a/Software/src/battery/ORION-BMS.h
+++ b/Software/src/battery/ORION-BMS.h
@@ -5,19 +5,11 @@
 
 #define BATTERY_SELECTED
 
-/* Change the following to suit your battery */
-#define NUMBER_OF_CELLS 96
-#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 1500
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 150
-
 class OrionBms : public CanBattery {
  public:
   OrionBms() : CanBattery(OrionBMS) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "DIY battery with Orion BMS (Victron setting)";
+  static constexpr const char* Name = "DIY battery with Orion BMS (Victron setting)";
 
   virtual void setup();
   virtual void update_values();
@@ -25,6 +17,13 @@ class OrionBms : public CanBattery {
 
   // No transmit needed for this type
   virtual void transmit_can() {}
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 1500; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
+  virtual uint8_t number_of_cells() { return 96; }
 
  private:
   uint16_t cellvoltages[MAX_AMOUNT_CELLS];  //array with all the cellvoltages

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -7,11 +7,6 @@
 #define BATTERY_SELECTED
 
 /* Change the following to suit your battery */
-#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 1500
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 150
 
 class PylonBattery : public CanBattery {
  public:
@@ -20,13 +15,19 @@ class PylonBattery : public CanBattery {
     m_can_interface = can_interface;
   }
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Pylon compatible battery";
+  static constexpr const char* Name = "Pylon compatible battery";
   virtual bool supportsDoubleBattery() { return true; };
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 1500; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   DATALAYER_BATTERY_TYPE* m_target;

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -5,23 +5,22 @@
 
 #define BATTERY_SELECTED
 
-/* Change the following to suit your battery */
-#define MAX_PACK_VOLTAGE_DV 5000  //TODO: Configure
-#define MIN_PACK_VOLTAGE_DV 0     //TODO: Configure
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 150
-
 class RangeRoverPhevBattery : public CanBattery {
  public:
   RangeRoverPhevBattery() : CanBattery(RangeRoverPhev) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Range Rover 13kWh PHEV battery (L494/L405)";
+  static constexpr const char* Name = "Range Rover 13kWh PHEV battery (L494/L405)";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 0; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   unsigned long previousMillis50ms = 0;  // will store last time a 50ms CAN Message was sent

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -185,11 +185,11 @@ void RenaultKangooBattery::transmit_can() {
 }
 
 void RenaultKangooBattery::setup(void) {  // Performs one time setup at startup
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -4,7 +4,7 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power
+#define MAX_CHARGE_POWER_W 5000  // Battery can be charged with this amount of power
 
 class RenaultKangooBattery : public CanBattery {
  public:

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -4,11 +4,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4150  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2500
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 #define MAX_CHARGE_POWER_W 5000   // Battery can be charged with this amount of power
 
 class RenaultKangooBattery : public CanBattery {
@@ -16,12 +11,18 @@ class RenaultKangooBattery : public CanBattery {
   RenaultKangooBattery() : CanBattery(RenaultKangoo) {}
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Renault Kangoo";
+  static constexpr const char* Name = "Renault Kangoo";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4150; }
+  virtual uint16_t min_pack_voltage_dv() { return 2500; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   uint32_t LB_Battery_Voltage = 3700;

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -15,8 +15,8 @@ class RenaultTwizyBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
 
-  virtual uint16_t max_pack_voltage_dv() { return 579; } // 57.9V at 100% SOC (with 70% SOH, new one might be higher)
-  virtual uint16_t min_pack_voltage_dv() { return 480; } // 48.4V at 13.76% SOC
+  virtual uint16_t max_pack_voltage_dv() { return 579; }  // 57.9V at 100% SOC (with 70% SOH, new one might be higher)
+  virtual uint16_t min_pack_voltage_dv() { return 480; }  // 48.4V at 13.76% SOC
   virtual uint16_t max_cell_deviation_mv() { return 150; }
   virtual uint16_t max_cell_voltage_mv() { return 4200; }
   virtual uint16_t min_cell_voltage_mv() { return 3400; }

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -3,22 +3,23 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 579  // 57.9V at 100% SOC (with 70% SOH, new one might be higher)
-#define MIN_PACK_VOLTAGE_DV 480  // 48.4V at 13.76% SOC
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4200  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 3400  //Battery is put into emergency stop if one cell goes below this value
 
 class RenaultTwizyBattery : public CanBattery {
  public:
   RenaultTwizyBattery() : CanBattery(RenaultTwizy) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Renault Twizy";
+  static constexpr const char* Name = "Renault Twizy";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 579; } // 57.9V at 100% SOC (with 70% SOH, new one might be higher)
+  virtual uint16_t min_pack_voltage_dv() { return 480; } // 48.4V at 13.76% SOC
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4200; }
+  virtual uint16_t min_cell_voltage_mv() { return 3400; }
 };
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -485,11 +485,11 @@ void RenaultZoeBattery::transmit_can() {
 void RenaultZoeBattery::setup() {  // Performs one time setup at startup
   allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -3,22 +3,23 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4200  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 class RenaultZoeBattery : public CanBattery {
  public:
   RenaultZoeBattery() : CanBattery(RenaultZoeGen1) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Renault Zoe Gen1";
+  static constexpr const char* Name = "Renault Zoe Gen1";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4200; }
+  virtual uint16_t min_pack_voltage_dv() { return 3000; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   uint16_t LB_SOC = 50;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -283,11 +283,11 @@ void RenaultZoeGen2Battery::transmit_can() {
 void RenaultZoeGen2Battery::setup(void) {  // Performs one time setup at startup
   allow_contactor_closing();
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -3,11 +3,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4100  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 3000
-#define MAX_CELL_DEVIATION_MV 150
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 #define POLL_SOC 0x9001
 #define POLL_USABLE_SOC 0x9002
@@ -55,11 +50,17 @@ class RenaultZoeGen2Battery : public CanBattery {
  public:
   RenaultZoeGen2Battery() : CanBattery(RenaultZoeGen2) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Renault Zoe Gen2 50kWh";
+  static constexpr const char* Name = "Renault Zoe Gen2 50kWh";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4100; }
+  virtual uint16_t min_pack_voltage_dv() { return 3000; }
+  virtual uint16_t max_cell_deviation_mv() { return 150; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   uint16_t battery_soc = 0;

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -5,11 +5,6 @@
 #include "../include.h"
 
 /* Tweak these according to your battery build */
-#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 1500
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 250
 #define MAX_DISCHARGE_POWER_ALLOWED_W 5000
 #define MAX_CHARGE_POWER_ALLOWED_W 5000
 #define MAX_CHARGE_POWER_WHEN_TOPBALANCING_W 500
@@ -23,12 +18,18 @@ class RjxzsBms : public CanBattery {
  public:
   RjxzsBms() : CanBattery(RjxzsBMS) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "RJXZS BMS, DIY battery";
+  static constexpr const char* Name = "RJXZS BMS, DIY battery";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 1500; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was sent

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -5,11 +5,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2880
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
 
@@ -21,12 +16,18 @@ class SantaFePhevBattery : public CanBattery {
   }
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Santa Fe PHEV";
+  static constexpr const char* Name = "Santa Fe PHEV";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4040; }
+  virtual uint16_t min_pack_voltage_dv() { return 2880; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   DATALAYER_BATTERY_TYPE* m_target;

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -90,11 +90,11 @@ void SimpBmsBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 }
 
 void SimpBmsBattery::setup(void) {  // Performs one time setup at startup
-  datalayer.battery.info.number_of_cells = CELL_COUNT;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.number_of_cells = number_of_cells();
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_deviation_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
   allow_contactor_closing();
 }
 

--- a/Software/src/battery/SIMPBMS-BATTERY.h
+++ b/Software/src/battery/SIMPBMS-BATTERY.h
@@ -5,24 +5,23 @@
 
 #define BATTERY_SELECTED
 
-/* DEFAULT VALUES BMS will send configured */
-#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 1500
-#define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
-#define MAX_CELL_DEVIATION_MV 500
-#define CELL_COUNT 96
-
 class SimpBmsBattery : public CanBattery {
  public:
   SimpBmsBattery() : CanBattery(SimpBms) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "SIMPBMS battery";
+  static constexpr const char* Name = "SIMPBMS battery";
 
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can() {}
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 1500; }
+  virtual uint16_t max_cell_deviation_mv() { return 500; }
+  virtual uint16_t max_cell_voltage_mv() { return 4250; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
+  virtual uint8_t number_of_cells() { return 96; }
 
  private:
 #define SIMPBMS_MAX_CELLS 128

--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -33,8 +33,7 @@ CAN_frame SONO_401 = {.FD = false,  //Message of Vehicle Date, 1000ms
                       .ID = 0x400,
                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-static void
-update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void SonoBattery::update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = (realSOC * 100);  //increase SOC range from 0-100 -> 100.00
 
@@ -62,7 +61,7 @@ update_values_battery() {  //This function maps all the values fetched via CAN t
   datalayer.battery.status.temperature_max_dC = temperatureMax;
 }
 
-static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void SonoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x100:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -139,7 +138,7 @@ static void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-static void transmit_can_battery() {
+void SonoBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   // Send 100ms CAN Message
@@ -170,13 +169,13 @@ static void transmit_can_battery() {
   }
 }
 
-static void setup_battery(void) {  // Performs one time setup at startup
+void SonoBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
   datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
 }
 

--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -33,7 +33,8 @@ CAN_frame SONO_401 = {.FD = false,  //Message of Vehicle Date, 1000ms
                       .ID = 0x400,
                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-void SonoBattery::update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void SonoBattery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.real_soc = (realSOC * 100);  //increase SOC range from 0-100 -> 100.00
 

--- a/Software/src/battery/SONO-BATTERY.h
+++ b/Software/src/battery/SONO-BATTERY.h
@@ -4,11 +4,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 5000  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2500
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 3800  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 uint8_t CalculateCRC8(CAN_frame rx_frame);
 
@@ -16,11 +11,17 @@ class SonoBattery : public CanBattery {
  public:
   SonoBattery() : CanBattery(Sono) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Sono Motors Sion 64kWh LFP ";
+  static constexpr const char* Name = "Sono Motors Sion 64kWh LFP ";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 5000; }
+  virtual uint16_t min_pack_voltage_dv() { return 2500; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 3800; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 };
 
 #endif

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -495,7 +495,7 @@ class Tesla3YBattery : public TeslaBattery {
   virtual void setup();
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Tesla Model 3/Y";
+  static constexpr const char* Name = "Tesla Model 3/Y";
 
  protected:
   virtual void detect_chemistry();
@@ -507,7 +507,7 @@ class TeslaSXBattery : public TeslaBattery {
   virtual void setup();
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Tesla Model S/X";
+  static constexpr const char* Name = "Tesla Model S/X";
 
  protected:
   virtual void model_specific_transmit_can();

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -4,7 +4,6 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_CELL_DEVIATION_MV 9999
 
 class TestFakeBattery : public CanBattery {
  public:
@@ -13,13 +12,15 @@ class TestFakeBattery : public CanBattery {
     m_can_interface = can_interface;
   }
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Fake battery for testing purposes";
+  static constexpr const char* Name = "Fake battery for testing purposes";
 
   virtual bool supportsDoubleBattery() { return true; };
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_cell_deviation_mv() { return 9999; }
 
  private:
   DATALAYER_BATTERY_TYPE* m_target;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -16,7 +16,7 @@ class VolvoSpaBattery : public CanBattery {
  public:
   VolvoSpaBattery() : CanBattery(VolvoSpa) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Volvo / Polestar 69/78kWh SPA battery";
+  static constexpr const char* Name = "Volvo / Polestar 69/78kWh SPA battery";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -564,10 +564,10 @@ void VolvoSpaHybridBattery::transmit_can() {
 
 void VolvoSpaHybridBattery::setup(void) {        // Performs one time setup at startup
   datalayer.battery.info.number_of_cells = 102;  //was 108, changed
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer.battery.info.max_design_voltage_dV = max_pack_voltage_dv();
+  datalayer.battery.info.min_design_voltage_dV = min_pack_voltage_dv();
+  datalayer.battery.info.max_cell_voltage_mV = max_cell_voltage_mv();
+  datalayer.battery.info.min_cell_voltage_mV = min_cell_voltage_mv();
+  datalayer.battery.info.max_cell_voltage_deviation_mV = max_cell_deviation_mv();
 }
 #endif

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
@@ -4,21 +4,22 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
-#define MAX_PACK_VOLTAGE_DV 4294  //5000 = 500.0V
-#define MIN_PACK_VOLTAGE_DV 2754
-#define MAX_CELL_DEVIATION_MV 250
-#define MAX_CELL_VOLTAGE_MV 4210  //Battery is put into emergency stop if one cell goes over this value
-#define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
 class VolvoSpaHybridBattery : public CanBattery {
  public:
   VolvoSpaHybridBattery() : CanBattery(VolvoSpaHybrid) {}
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Volvo PHEV battery";
+  static constexpr const char* Name = "Volvo PHEV battery";
   virtual void setup();
   virtual void update_values();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void transmit_can();
+
+  virtual uint16_t max_pack_voltage_dv() { return 4294; }
+  virtual uint16_t min_pack_voltage_dv() { return 2754; }
+  virtual uint16_t max_cell_deviation_mv() { return 250; }
+  virtual uint16_t max_cell_voltage_mv() { return 4210; }
+  virtual uint16_t min_cell_voltage_mv() { return 2700; }
 
  private:
   void readCellVoltages();

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -21,7 +21,7 @@ class ChevyVoltCharger : public Charger {
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Chevy Volt Gen1 Charger";
+  static constexpr const char* Name = "Chevy Volt Gen1 Charger";
 };
 
 #endif

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -12,7 +12,7 @@ class NissanLeafCharger : public Charger {
   virtual void map_can_frame_to_variable_charger(CAN_frame rx_frame);
   virtual void transmit_can();
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Nissan LEAF 2013-2024 PDM charger";
+  static constexpr const char* Name = "Nissan LEAF 2013-2024 PDM charger";
 };
 
 #endif

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -10,7 +10,7 @@ class AforeCanInverter : public InverterProtocol {
   virtual void transmit_can();
   virtual void update_values_can_inverter();
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Afore battery over CAN";
+  static constexpr const char* Name = "Afore battery over CAN";
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 };
 

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -17,7 +17,7 @@ class BydCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; }
-  static constexpr char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
+  static constexpr const char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
 };
 
 #endif

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -21,7 +21,7 @@ class BydModbusInverter : public InverterProtocol {
   virtual void handle_static_data_modbus();
 
   virtual const char* name() { return Name; }
-  static constexpr char* Name = "BYD 11kWh HVM battery over Modbus RTU";
+  static constexpr const char* Name = "BYD 11kWh HVM battery over Modbus RTU";
 };
 
 #endif

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -11,7 +11,7 @@ class FerroampCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Ferroamp Pylon battery over CAN bus";
+  static constexpr const char* Name = "Ferroamp Pylon battery over CAN bus";
 
  private:
   void send_system_data();

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -11,7 +11,7 @@ class FoxessCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "FoxESS compatible HV2600/ECS4100 battery";
+  static constexpr const char* Name = "FoxESS compatible HV2600/ECS4100 battery";
 
  private:
   int16_t temperature_average = 0;

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -11,7 +11,7 @@ class GrowattHvInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Growatt High Voltage protocol via CAN";
+  static constexpr const char* Name = "Growatt High Voltage protocol via CAN";
 };
 
 #endif

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -11,7 +11,7 @@ class GrowattLvCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Growatt Low Voltage (48V) protocol via CAN";
+  static constexpr const char* Name = "Growatt Low Voltage (48V) protocol via CAN";
 };
 
 #endif

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -15,7 +15,7 @@ class KostalRs485Inverter : public InverterProtocol {
  public:
   virtual void setup();
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BYD battery via Kostal RS485";
+  static constexpr const char* Name = "BYD battery via Kostal RS485";
 
   virtual void receive_RS485();
   virtual void update_RS485_registers_inverter();

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -7,7 +7,7 @@
 class PylonCanInverter : public InverterProtocol {
  public:
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Pylontech battery over CAN bus";
+  static constexpr const char* Name = "Pylontech battery over CAN bus";
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
   virtual void update_values_can_inverter();
 };

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -16,7 +16,7 @@ class PylonLvCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Pylontech LV battery over CAN bus";
+  static constexpr const char* Name = "Pylontech LV battery over CAN bus";
 };
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -34,7 +34,7 @@ class SchneiderCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Schneider V2 SE BMS CAN";
+  static constexpr const char* Name = "Schneider V2 SE BMS CAN";
 };
 
 #endif

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -15,7 +15,7 @@ class SmaBydHCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "SMA CAN";
+  static constexpr const char* Name = "SMA CAN";
 };
 
 #endif

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -15,7 +15,7 @@ class SmaBydHvsCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "BYD Battery-Box HVS over SMA CAN";
+  static constexpr const char* Name = "BYD Battery-Box HVS over SMA CAN";
 };
 
 #endif

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -15,7 +15,7 @@ class SmaLvCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "SMA Low Voltage (48V) protocol via CAN";
+  static constexpr const char* Name = "SMA Low Voltage (48V) protocol via CAN";
 };
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -15,7 +15,7 @@ class SmaTripowerCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "SMA Tripower CAN";
+  static constexpr const char* Name = "SMA Tripower CAN";
 };
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -11,7 +11,7 @@ class SofarCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Sofar BMS (Extended Frame) over CAN bus";
+  static constexpr const char* Name = "Sofar BMS (Extended Frame) over CAN bus";
 };
 
 #endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -22,7 +22,7 @@ class SolaxCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "SolaX Triple Power LFP over CAN bus";
+  static constexpr const char* Name = "SolaX Triple Power LFP over CAN bus";
 };
 
 #endif

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -11,7 +11,7 @@ class SungrowCanInverter : public InverterProtocol {
   virtual void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 
   virtual const char* name() { return Name; };
-  static constexpr char* Name = "Sungrow SBR064 battery over CAN bus";
+  static constexpr const char* Name = "Sungrow SBR064 battery over CAN bus";
 };
 
 #endif


### PR DESCRIPTION
### What
This PR moves battery min max values into the base class. This removes many warnings for redefining values and will allow future simplification of the datalayer
