### PR TITLE
BYD Modbus: Update FW and Serial number

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -30,9 +30,9 @@ void handle_static_data_modbus_byd() {
   static uint16_t byd_data[] = {16985, 17408, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   static uint16_t battery_data[] = {16985, 17440, 16993, 29812, 25970, 31021, 17007, 30752,
                                     20594, 25965, 26997, 27936, 18518, 0,     0,     0};
-  static uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12857, 0, 0, 0, 0, 0, 0};
-  static uint16_t serial_data[] = {20528, 13104, 21552, 12848, 23090, 12336, 14384, 12339,
-                                   13368, 14384, 20,    20,    0,     0,     0,     0};
+  static uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12854, 0, 0, 0, 0, 0, 0};
+  static uint16_t serial_data[] = {20528, 13104, 21552, 12848, 23089, 14641, 12593, 14384,
+                                   12336, 12337, 0,     0,     0,     0,     0,     0};
   static uint16_t static_data[] = {1, 0};
   static uint16_t* data_array_pointers[] = {si_data, byd_data, battery_data, volt_data, serial_data, static_data};
   static uint16_t data_sizes[] = {sizeof(si_data),   sizeof(byd_data),    sizeof(battery_data),

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -30,8 +30,9 @@ void handle_static_data_modbus_byd() {
   static uint16_t byd_data[] = {16985, 17408, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   static uint16_t battery_data[] = {16985, 17440, 16993, 29812, 25970, 31021, 17007, 30752,
                                     20594, 25965, 26997, 27936, 18518, 0,     0,     0};
-  static uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12598, 0, 0, 0, 0, 0, 0};
-  static uint16_t serial_data[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  static uint16_t volt_data[] = {13614, 12288, 0, 0, 0, 0, 0, 0, 13102, 12857, 0, 0, 0, 0, 0, 0};
+  static uint16_t serial_data[] = {20528, 13104, 21552, 12848, 23090, 12336, 14384, 12339,
+                                   13368, 14384, 20,    20,    0,     0,     0,     0};
   static uint16_t static_data[] = {1, 0};
   static uint16_t* data_array_pointers[] = {si_data, byd_data, battery_data, volt_data, serial_data, static_data};
   static uint16_t data_sizes[] = {sizeof(si_data),   sizeof(byd_data),    sizeof(battery_data),


### PR DESCRIPTION
### What
This PR updates the BYD reported FW/Serial data

### Why
To increase compatibility and not appear as an old battery from 2021

This PR also fixes the issue that Fronius Software "ROW 1.36.5-1" released on April 23rd breaks compatibility with the Battery-Emulator project.

### How
We update the FW version from 3.16 -> 3.26. We also add a default serial number to the data field.

![image](https://github.com/user-attachments/assets/80c10b13-0b5e-4318-9d09-3d10f6897cb9)
