### PR TITLE
Refactoring: Simplify can sending routine and performance check

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -52,6 +52,7 @@ volatile unsigned long long bmsResetTimeOffset = 0;
 const char* version_number = "8.12.dev";
 
 // Interval timers
+volatile unsigned long currentMillis = 0;
 unsigned long previousMillis10ms = 0;
 unsigned long previousMillisUpdateVal = 0;
 unsigned long lastMillisOverflowCheck = 0;
@@ -208,6 +209,7 @@ void core_loop(void*) {
   led_init();
 
   while (true) {
+
     START_TIME_MEASUREMENT(all);
     START_TIME_MEASUREMENT(comm);
 #ifdef EQUIPMENT_STOP_BUTTON
@@ -227,8 +229,12 @@ void core_loop(void*) {
 #endif  // WEBSERVER
 
     // Process
-    if (millis() - previousMillis10ms >= INTERVAL_10_MS) {
-      previousMillis10ms = millis();
+    currentMillis = millis();
+    if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {
+      if ((currentMillis - previousMillis10ms >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
+        set_event(EVENT_TASK_OVERRUN, (currentMillis - previousMillis10ms));
+      }
+      previousMillis10ms = currentMillis;
 #ifdef FUNCTION_TIME_MEASUREMENT
       START_TIME_MEASUREMENT(time_10ms);
 #endif
@@ -242,8 +248,8 @@ void core_loop(void*) {
 #endif
     }
 
-    if (millis() - previousMillisUpdateVal >= INTERVAL_1_S) {
-      previousMillisUpdateVal = millis();  // Order matters on the update_loop!
+    if (currentMillis - previousMillisUpdateVal >= INTERVAL_1_S) {
+      previousMillisUpdateVal = currentMillis;  // Order matters on the update_loop!
 #ifdef FUNCTION_TIME_MEASUREMENT
       START_TIME_MEASUREMENT(time_values);
 #endif
@@ -264,7 +270,7 @@ void core_loop(void*) {
     START_TIME_MEASUREMENT(cantx);
 #endif
     // Output
-    transmit_can();  // Send CAN messages to all components
+    transmit_can(currentMillis);  // Send CAN messages to all components
 
 #ifdef RS485_BATTERY_SELECTED
     transmit_rs485();

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -5,7 +5,7 @@
 #ifdef BMW_SBOX
 #include "BMW-SBOX.h"
 void handle_incoming_can_frame_shunt(CAN_frame rx_frame);
-void transmit_can_shunt();
+void transmit_can_shunt(unsigned long currentMillis);
 void setup_can_shunt();
 #endif
 
@@ -155,7 +155,7 @@ void transmit_rs485();
 void receive_RS485();
 #else
 void handle_incoming_can_frame_battery(CAN_frame rx_frame);
-void transmit_can_battery();
+void transmit_can_battery(unsigned long currentMillis);
 #endif
 
 #ifdef DOUBLE_BATTERY

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -877,18 +877,11 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   if (battery_awake) {
     //Send 20ms message
     if (currentMillis - previousMillis20 >= INTERVAL_20_MS) {
-      // Check if sending of CAN messages has been delayed too much.
-      if ((currentMillis - previousMillis20 >= INTERVAL_20_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-        set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis20));
-      } else {
-        clear_event(EVENT_CAN_OVERRUN);
-      }
       previousMillis20 = currentMillis;
 
       if (startup_counter_contactor < 160) {

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -11,8 +11,6 @@ static unsigned long previousMillis100 = 0;    // will store last time a 100ms C
 static unsigned long previousMillis200 = 0;    // will store last time a 200ms CAN Message was send
 static unsigned long previousMillis500 = 0;    // will store last time a 500ms CAN Message was send
 static unsigned long previousMillis640 = 0;    // will store last time a 600ms CAN Message was send
-static unsigned long previousMillis1000 = 0;   // will store last time a 1000ms CAN Message was send
-static unsigned long previousMillis5000 = 0;   // will store last time a 5000ms CAN Message was send
 static unsigned long previousMillis10000 = 0;  // will store last time a 10000ms CAN Message was send
 
 #define ALIVE_MAX_VALUE 14  // BMW CAN messages contain alive counter, goes from 0...14
@@ -839,8 +837,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   //if (battery_awake) { //We can always send CAN as the iX BMS will wake up on vehicle comms
   // Send 100ms CAN Message
@@ -862,14 +859,6 @@ void transmit_can_battery() {
     BMWiX_C0.data.u8[0] = increment_C0_counter(BMWiX_C0.data.u8[0]);  //Keep Alive 1
     transmit_can_frame(&BMWiX_C0, can_config.battery);
   }
-  // Send 1000ms CAN Message
-  if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
-    previousMillis1000 = currentMillis;
-  }
-  // Send 5000ms CAN Message
-  if (currentMillis - previousMillis5000 >= INTERVAL_5_S) {
-    previousMillis5000 = currentMillis;
-  }
   // Send 10000ms CAN Message
   if (currentMillis - previousMillis10000 >= INTERVAL_10_S) {
     previousMillis10000 = currentMillis;
@@ -877,18 +866,6 @@ void transmit_can_battery() {
     transmit_can_frame(&BMWiX_6F4_REQUEST_BALANCING_START, can_config.battery);
   }
 }
-//We can always send CAN as the iX BMS will wake up on vehicle comms
-// else {
-//   previousMillis20 = currentMillis;
-//   previousMillis100 = currentMillis;
-//   previousMillis200 = currentMillis;
-//   previousMillis500 = currentMillis;
-//   previousMillis640 = currentMillis;
-//   previousMillis1000 = currentMillis;
-//   previousMillis5000 = currentMillis;
-//   previousMillis10000 = currentMillis;
-// }
-//} //We can always send CAN as the iX BMS will wake up on vehicle comms
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "BMW iX and i4-7 platform", 63);

--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -1005,8 +1005,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   //if (battery_awake) { //We can always send CAN as the PHEV BMS will wake up on vehicle comms
 

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -769,17 +769,10 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   //Send 20ms message
   if (currentMillis - previousMillis20ms >= INTERVAL_20_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis20ms >= INTERVAL_20_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis20ms));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis20ms = currentMillis;
     transmit_can_frame(&BOLT_778, can_config.battery);
   }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -389,16 +389,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   //Send 50ms message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis50 >= INTERVAL_50_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis50));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis50 = currentMillis;
 
     // Set close contactors to allowed (Useful for crashed packs, started via contactor control thru GPIO)

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -316,11 +316,10 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
+
   // Send 1s CAN Message
   if (currentMillis - previousMillis1s >= INTERVAL_1_S) {
-
     previousMillis1s = currentMillis;
 
     /*

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -655,9 +655,7 @@ void update_evse_discharge_capabilities(CAN_frame& f) {
   CHADEMO_208.data.u8[7] = highByte(x208_evse_dischg_cap.lower_threshold_voltage);
 }
 
-void transmit_can_battery() {
-
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   handlerBeforeMillis = currentMillis;
   handle_chademo_sequence();
@@ -665,12 +663,6 @@ void transmit_can_battery() {
 
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis100 = currentMillis;
 
     /* no EVSE messages should be sent until the vehicle has

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -513,14 +513,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis10ms >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10ms));
-    }
     previousMillis10ms = currentMillis;
     transmit_can_frame(&CMFA_1EA, can_config.battery);
     transmit_can_frame(&CMFA_135, can_config.battery);

--- a/Software/src/battery/CanBattery.h
+++ b/Software/src/battery/CanBattery.h
@@ -11,7 +11,7 @@ class CanBattery {
   virtual void setup(void) = 0;
   virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
   virtual void update_values() = 0;
-  virtual void transmit_can() = 0;
+  virtual void transmit_can(unsigned long currentMillis) = 0;
 };
 
 #endif

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -288,8 +288,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
     previousMillis1000 = currentMillis;

--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -474,9 +474,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
-
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500 >= INTERVAL_500_MS) {
     previousMillis500 = currentMillis;

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -207,16 +207,10 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
+
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis100 = currentMillis;
 
     // Send CAN goes here...

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -120,14 +120,6 @@ void update_values_battery() {
 }
 
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
-
-  // Do not log noisy startup messages - there are many !
-  if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
-      rx_frame.data.u8[2] == 0 && rx_frame.data.u8[3] == 0 && rx_frame.data.u8[4] == 0 && rx_frame.data.u8[5] == 0 &&
-      rx_frame.data.u8[6] == 0x80 && rx_frame.data.u8[7] == 0) {
-    return;
-  }
-
   switch (rx_frame.ID) {  // These messages are periodically transmitted by the battery
     case 0x080:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -222,34 +214,13 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
     default:
       break;
   }
-
-  // Discard non-interesting can messages so they do not get logged via serial
-  if (rx_frame.ID < 0x500) {
-    return;
-  }
-
-  // All CAN messages recieved will be logged via serial
-  logging.print(millis());  // Example printout, time, ID, length, data: 7553  1DB  8  FF C0 B9 EA 0 0 2 5D
-  logging.print("  ");
-  logging.print(rx_frame.ID, HEX);
-  logging.print("  ");
-  logging.print(rx_frame.DLC);
-  logging.print("  ");
-  for (int i = 0; i < rx_frame.DLC; ++i) {
-    logging.print(rx_frame.data.u8[i], HEX);
-    logging.print(" ");
-  }
-  logging.println("");
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
-
+void transmit_can_battery(unsigned long currentMillis) {
   /* Send keep-alive every 200ms */
   if (currentMillis - previousMillisKeepAlive >= INTERVAL_200_MS) {
     previousMillisKeepAlive = currentMillis;
     transmit_can_frame(&ipace_keep_alive, can_config.battery);
-    return;
   }
 }
 

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -17,7 +17,7 @@ class JaguarIpaceBattery : public CanBattery {
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
-  virtual void transmit_can();
+  virtual void transmit_can(unsigned long currentMillis);
 };
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -1082,8 +1082,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   if (startedUp) {
     //Send Contactor closing message loop
     // Check if we still have messages to send
@@ -1107,13 +1106,6 @@ void transmit_can_battery() {
 
     //Send 200ms CANFD message
     if (currentMillis - previousMillis200ms >= INTERVAL_200_MS) {
-      previousMillis200ms = currentMillis;
-      // Check if sending of CAN messages has been delayed too much.
-      if ((currentMillis - previousMillis200ms >= INTERVAL_200_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-        set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis200ms));
-      } else {
-        clear_event(EVENT_CAN_OVERRUN);
-      }
       previousMillis200ms = currentMillis;
 
       EGMP_7E4.data.u8[3] = KIA_7E4_COUNTER;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -924,8 +924,7 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 }
 #endif  //DOUBLE_BATTERY
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   if (!startedUp) {
     return;  // Don't send any CAN messages towards battery until it has started up
@@ -948,12 +947,6 @@ void transmit_can_battery() {
   }
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis10 = currentMillis;
 
     switch (counter_200) {

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -230,8 +230,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   // Send 1000ms CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -1627,9 +1627,8 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
-  // Send 10ms CAN Message
+void transmit_can_battery(unsigned long currentMillis) {
+
   if (currentMillis > last_can_msg_timestamp + 500) {
 #ifdef DEBUG_LOG
     if (first_can_msg)
@@ -1642,15 +1641,8 @@ void transmit_can_battery() {
       datalayer.system.status.battery_allows_contactor_closing = false;
     }
   }
-
+  // Send 10ms CAN Message
   if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis10ms >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME) &&
-        previousMillis10ms > 0) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10ms));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis10ms = currentMillis;
 
     MEB_0FC.data.u8[1] = ((MEB_0FC.data.u8[1] & 0xF0) | counter_10ms);

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -108,16 +108,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   //Send 10ms message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis10 = currentMillis;
 
     transmit_can_frame(&MG_5_100, can_config.battery);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1071,13 +1071,10 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
 
   if (datalayer.system.status.BMS_reset_in_progress || datalayer.system.status.BMS_startup_in_progress) {
     // Transmitting towards battery is halted while BMS is being reset
-    // Reset sending counters to avoid overrun messages when reset is over
     previousMillis10 = currentMillis;
     previousMillis100 = currentMillis;
     previousMillis10s = currentMillis;
@@ -1088,12 +1085,6 @@ void transmit_can_battery() {
 
     //Send 10ms message
     if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
-      // Check if sending of CAN messages has been delayed too much.
-      if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-        set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
-      } else {
-        clear_event(EVENT_CAN_OVERRUN);
-      }
       previousMillis10 = currentMillis;
 
       switch (mprun10) {

--- a/Software/src/battery/ORION-BMS.cpp
+++ b/Software/src/battery/ORION-BMS.cpp
@@ -132,8 +132,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // No transmission needed for this integration
 }
 

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -158,11 +158,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
-
     previousMillis1000 = currentMillis;
 
     transmit_can_frame(&PYLON_3010, can_config.battery);  // Heartbeat

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -301,11 +301,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50ms >= INTERVAL_50_MS) {
-
     previousMillis50ms = currentMillis;
 
     transmit_can_frame(&RANGE_ROVER_18B, can_config.battery);

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -210,8 +210,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message (for 2.4s, then pause 10s)
   if ((currentMillis - previousMillis100) >= (INTERVAL_100_MS + GVL_pause)) {
     previousMillis100 = currentMillis;

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -127,7 +127,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void transmit_can_battery(unsigned long currentMillis) {
   // we do not need to send anything to the battery for now
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -490,14 +490,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
-    }
     previousMillis100 = currentMillis;
     transmit_can_frame(&ZOE_423, can_config.battery);
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -371,8 +371,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
@@ -391,10 +390,6 @@ void transmit_can_battery() {
 
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis200 >= INTERVAL_200_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis200));
-    }
     previousMillis200 = currentMillis;
 
     // Update current poll from the array

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -571,11 +571,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 10s CAN Message
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
-
     previousMillis10s = currentMillis;
 
     if (datalayer.battery.status.bms_status == FAULT) {

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -333,17 +333,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
-
+void transmit_can_battery(unsigned long currentMillis) {
   //Send 10ms message
   if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis10 >= INTERVAL_10_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis10));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis10 = currentMillis;
 
     SANTAFE_200.data.u8[6] = (counter_200 << 1);

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -115,7 +115,9 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {}
+void transmit_can_battery(unsigned long currentMillis) {
+  // No periodic transmitting for this battery type
+}
 
 void setup_battery(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "SIMPBMS battery", 63);

--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -137,9 +137,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
       break;
   }
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
-
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1864,13 +1864,11 @@ int index_1CF = 0;
 int index_118 = 0;
 #endif  //defined(TESLA_MODEL_SX_BATTERY) || defined(EXP_TESLA_BMS_DIGITAL_HVIL)
 
-void transmit_can_battery() {
+void transmit_can_battery(unsigned long currentMillis) {
   /*From bielec: My fist 221 message, to close the contactors is 0x41, 0x11, 0x01, 0x00, 0x00, 0x00, 0x20, 0x96 and then, 
 to cause "hv_up_for_drive" I send an additional 221 message 0x61, 0x15, 0x01, 0x00, 0x00, 0x00, 0x20, 0xBA  so 
 two 221 messages are being continuously transmitted.   When I want to shut down, I stop the second message and only send 
 the first, for a few cycles, then stop all  messages which causes the contactor to open. */
-
-  unsigned long currentMillis = millis();
 
   if (!cellvoltagesRead) {
     return;  //All cellvoltages not read yet, do not proceed with contactor closing
@@ -1906,12 +1904,6 @@ the first, for a few cycles, then stop all  messages which causes the contactor 
 
   //Send 50ms message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis50 >= INTERVAL_50_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis50));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis50 = currentMillis;
 
     if ((datalayer.system.status.inverter_allows_contactor_closing == true) &&

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -130,8 +130,7 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -435,16 +435,9 @@ void readCellVoltages() {
   transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis100 = currentMillis;
 
     transmit_can_frame(&VOLVO_536, can_config.battery);  //Send 0x536 Network managing frame to keep BMS alive

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -610,16 +610,9 @@ void readCellVoltages() {
   transmit_can_frame(&VOLVO_CELL_U_Req, can_config.battery);  //Send cell voltage read request for first module
 }
 
-void transmit_can_battery() {
-  unsigned long currentMillis = millis();
+void transmit_can_battery(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    // Check if sending of CAN messages has been delayed too much.
-    if ((currentMillis - previousMillis100 >= INTERVAL_100_MS_DELAYED) && (currentMillis > BOOTUP_TIME)) {
-      set_event(EVENT_CAN_OVERRUN, (currentMillis - previousMillis100));
-    } else {
-      clear_event(EVENT_CAN_OVERRUN);
-    }
     previousMillis100 = currentMillis;
 
     transmit_can_frame(&VOLVO_536, can_config.battery);  //Send 0x536 Network managing frame to keep BMS alive

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -11,6 +11,6 @@
 #endif
 
 void map_can_frame_to_variable_charger(CAN_frame rx_frame);
-void transmit_can_charger();
+void transmit_can_charger(unsigned long currentMillis);
 
 #endif

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -98,8 +98,7 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_charger() {
-  unsigned long currentMillis = millis();
+void transmit_can_charger(unsigned long currentMillis) {
   uint16_t Vol_temp = 0;
 
   uint16_t setpoint_HV_VDC = floor(datalayer.charger.charger_setpoint_HV_VDC);

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -156,8 +156,7 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_charger() {
-  unsigned long currentMillis = millis();
+void transmit_can_charger(unsigned long currentMillis) {
 
   /* Send keepalive with mode every 10ms */
   if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -3,12 +3,12 @@
 #include "src/devboard/sdcard/sdcard.h"
 
 // Parameters
-
-CAN_device_t CAN_cfg;          // CAN Config
-const int rx_queue_size = 10;  // Receive Queue size
+CAN_device_t CAN_cfg;              // CAN Config
+const uint8_t rx_queue_size = 10;  // Receive Queue size
 volatile bool send_ok_native = 0;
 volatile bool send_ok_2515 = 0;
 volatile bool send_ok_2518 = 0;
+static unsigned long previousMillis10 = 0;
 
 #ifdef CAN_ADDON
 static const uint32_t QUARTZ_FREQUENCY = CRYSTAL_FREQUENCY_MHZ * 1000000UL;  //MHZ configured in USER_SETTINGS.h
@@ -105,25 +105,26 @@ void init_CAN() {
 }
 
 // Transmit functions
-void transmit_can() {
+void transmit_can(unsigned long currentMillis) {
+
   if (!allowed_to_send_CAN) {
     return;  //Global block of CAN messages
   }
 
 #ifndef RS485_BATTERY_SELECTED
-  transmit_can_battery();
+  transmit_can_battery(currentMillis);
 #endif
 
 #ifdef CAN_INVERTER_SELECTED
-  transmit_can_inverter();
+  transmit_can_inverter(currentMillis);
 #endif  // CAN_INVERTER_SELECTED
 
 #ifdef CHARGER_SELECTED
-  transmit_can_charger();
+  transmit_can_charger(currentMillis);
 #endif  // CHARGER_SELECTED
 
 #ifdef CAN_SHUNT_SELECTED
-  transmit_can_shunt();
+  transmit_can_shunt(currentMillis);
 #endif  // CAN_SHUNT_SELECTED
 }
 

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -40,10 +40,11 @@ void transmit_can_frame();
  * @brief Send CAN messages to all components 
  *
  * @param[in] void
+ * @param[in] unsigned long currentMillis
  *
  * @return void
  */
-void transmit_can();
+void transmit_can(unsigned long currentMillis);
 
 /**
  * @brief Receive CAN messages from all interfaces 

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -94,7 +94,7 @@ void init_contactors() {
 #ifdef BMS_2_POWER  //Hardware supports 2x BMS
   pinMode(BMS_2_POWER, OUTPUT);
   digitalWrite(BMS_2_POWER, HIGH);
-#endif BMS_2_POWER
+#endif                                                        //BMS_2_POWER
 #endif                                                        // HW with dedicated BMS pins
 #if defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)  // User has enabled BMS reset, turn on output on start
   pinMode(BMS_POWER, OUTPUT);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -39,7 +39,7 @@ void init_events(void) {
   events.entries[EVENT_CANMCP2515_INIT_FAILURE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CANFD_BUFFER_FULL].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_BUFFER_FULL].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_CAN_OVERRUN].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_TASK_OVERRUN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CAN_CORRUPTED_WARNING].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_NATIVE_TX_FAILURE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CAN_BATTERY_MISSING].level = EVENT_LEVEL_ERROR;
@@ -176,8 +176,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "MCP2518FD message failed to send. Buffer full or no one on the bus to ACK the message!";
     case EVENT_CAN_BUFFER_FULL:
       return "MCP2515 message failed to send. Buffer full or no one on the bus to ACK the message!";
-    case EVENT_CAN_OVERRUN:
-      return "CAN message failed to send within defined time. Contact developers, CPU load might be too high.";
+    case EVENT_TASK_OVERRUN:
+      return "Task took too long to complete. CPU load might be too high. Info message, no action required.";
     case EVENT_CAN_CORRUPTED_WARNING:
       return "High amount of corrupted CAN messages detected. Check CAN wire shielding!";
     case EVENT_CAN_NATIVE_TX_FAILURE:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -12,7 +12,6 @@
   XX(EVENT_CANMCP2515_INIT_FAILURE)            \
   XX(EVENT_CANFD_BUFFER_FULL)                  \
   XX(EVENT_CAN_BUFFER_FULL)                    \
-  XX(EVENT_CAN_OVERRUN)                        \
   XX(EVENT_CAN_CORRUPTED_WARNING)              \
   XX(EVENT_CAN_BATTERY_MISSING)                \
   XX(EVENT_CAN_BATTERY2_MISSING)               \
@@ -73,6 +72,7 @@
   XX(EVENT_SERIAL_RX_FAILURE)                  \
   XX(EVENT_SERIAL_TX_FAILURE)                  \
   XX(EVENT_SERIAL_TRANSMITTER_FAILURE)         \
+  XX(EVENT_TASK_OVERRUN)                       \
   XX(EVENT_RESET_UNKNOWN)                      \
   XX(EVENT_RESET_POWERON)                      \
   XX(EVENT_RESET_EXT)                          \

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -37,12 +37,6 @@ enum PrechargeState {
 #define INTERVAL_60_S 60000
 
 #define INTERVAL_10_MS_DELAYED 15
-#define INTERVAL_20_MS_DELAYED 30
-#define INTERVAL_30_MS_DELAYED 40
-#define INTERVAL_50_MS_DELAYED 65
-#define INTERVAL_100_MS_DELAYED 120
-#define INTERVAL_200_MS_DELAYED 240
-#define INTERVAL_500_MS_DELAYED 550
 
 #define CAN_STILL_ALIVE 60
 // Set by battery each time we get a CAN message. Decrements every second. When reaching 0, sets event

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -217,7 +217,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
   if (time_to_send_info) {  // Set every 1s if we get message from inverter
     transmit_can_frame(&AFORE_350, can_config.inverter);
     transmit_can_frame(&AFORE_351, can_config.inverter);

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -204,8 +204,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   if (!inverterStartedUp) {
     //Avoid sending messages towards inverter, unless it has woken up and sent something to us first

--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -453,7 +453,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
   // No periodic sending, we only react on received can messages
 }
 

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -595,10 +595,9 @@ void update_values_can_inverter() {  //This function maps all the CAN values fet
   // So do we really need to map the same two values over and over to 32 places?
 }
 
-void transmit_can_inverter() {  // This function loops as fast as possible
+void transmit_can_inverter(unsigned long currentMillis) {
 
   if (send_bms_info) {
-    currentMillis = millis();  // Get the current time
 
     // Check if enough time has passed since the last batch
     if (currentMillis - previousMillisBMSinfo >= delay_between_batches_ms) {
@@ -634,7 +633,6 @@ void transmit_can_inverter() {  // This function loops as fast as possible
   }
 
   if (send_individual_pack_status) {
-    currentMillis = millis();  // Get the current time
 
     // Check if enough time has passed since the last batch
     if (currentMillis - previousMillisIndividualPacks >= delay_between_batches_ms) {
@@ -670,7 +668,6 @@ void transmit_can_inverter() {  // This function loops as fast as possible
   }
 
   if (send_serial_numbers) {
-    currentMillis = millis();  // Get the current time
 
     // Check if enough time has passed since the last batch
     if (currentMillis - previousMillisSerialNumber >= delay_between_batches_ms) {
@@ -781,7 +778,6 @@ void transmit_can_inverter() {  // This function loops as fast as possible
   }
 
   if (send_cellvoltages) {
-    currentMillis = millis();  // Get the current time
 
     // Check if enough time has passed since the last batch
     if (currentMillis - previousMillisCellvoltage >= delay_between_batches_ms) {

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -523,13 +523,11 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
 
   if (!inverter_alive) {
     return;  //Dont send messages towards inverter until it has started
   }
-
-  unsigned long currentMillis = millis();
 
   //Check if 1 second has passed, then we start sending!
   if (currentMillis - previousMillis1s >= INTERVAL_1_S) {

--- a/Software/src/inverter/GROWATT-LV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-LV-CAN.cpp
@@ -267,7 +267,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
   // No periodic sending for this battery type. Data is sent when inverter requests it
 }
 

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -82,7 +82,7 @@
 #ifdef CAN_INVERTER_SELECTED
 void update_values_can_inverter();
 void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
-void transmit_can_inverter();
+void transmit_can_inverter(unsigned long currentMillis);
 #endif
 
 #ifdef MODBUS_INVERTER_SELECTED

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -438,7 +438,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
   // No periodic sending, we only react on received can messages
 }
 

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -158,8 +158,7 @@ void dump_frame(CAN_frame* frame) {
 }
 #endif
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   if (currentMillis - previousMillis1000ms >= 1000) {
     previousMillis1000ms = currentMillis;

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -265,8 +265,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -236,8 +236,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   // Send CAN Message every 100ms if inverter allows contactor closing
   if (datalayer.system.status.inverter_allows_contactor_closing) {

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -240,8 +240,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   // Send CAN Message every 100ms if inverter allows contactor closing
   if (datalayer.system.status.inverter_allows_contactor_closing) {

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -136,8 +136,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   if (currentMillis - previousMillis100ms >= INTERVAL_100_MS) {
     previousMillis100ms = currentMillis;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -190,8 +190,7 @@ void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
   listLength++;
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
 
   // Send CAN Message only if we're enabled by inverter
   if (!datalayer.system.status.inverter_allows_contactor_closing) {

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -247,8 +247,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
+void transmit_can_inverter(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -206,7 +206,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 
-void transmit_can_inverter() {
+void transmit_can_inverter(unsigned long currentMillis) {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -557,9 +557,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter() {
-  unsigned long currentMillis = millis();
-
+void transmit_can_inverter(unsigned long currentMillis) {
   // Send 1s CAN Message
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;


### PR DESCRIPTION
### What
This PR simplifies CAN sending routine in each integration. It also renames the CAN_OVERRUN event to TASK_OVERRUN with a more reassuring info text

### Why
To increase performance
To reduce complexity
To reduce support load regarding the CAN_OVERRUN events

### How
Performance is increased by reducing amount of millis() calls
TASK_OVERRUN is checked in main loop instead of each CAN sending routine
