### PR TITLE
Bugfix: Edit SMA inverter input pin for Stark CMR

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -52,7 +52,7 @@ GPIOs on extra header
 #define BMS_POWER 23
 
 // SMA CAN contactor pins
-#define INVERTER_CONTACTOR_ENABLE_PIN 19
+#define INVERTER_CONTACTOR_ENABLE_PIN 2
 
 // LED
 #define LED_PIN 4


### PR DESCRIPTION
### What
This PR changes the default pin used for SMA Enable line signal

### Why
Initial implementation picked a free GPIO (pin19). This pin is not optimal, since the Stark CMR has a dedicated SIGNAL IN pin (pin2) that can take the 11V input directly

### How
19 changes to 2
