### PR TITLE
Common base class for batteries

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,0 +1,30 @@
+#include "BATTERIES.h"
+#include "../include.h"
+
+// These functions adapt the old C-style global functions battery-API to the
+// object-oriented battery API.
+
+#ifdef OO_BATTERY_SELECTED
+
+static CanBattery* battery;
+
+void setup_battery() {
+  // Currently only one battery is implemented as a class.
+  // TODO: Extend based on build-time or run-time selected battery.
+  battery = new RenaultZoeGen1Battery();
+  battery->setup();
+}
+
+void update_values_battery() {
+  battery->update_values();
+}
+
+void transmit_can_battery() {
+  battery->transmit_can();
+}
+
+void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+  battery->handle_incoming_can_frame(rx_frame);
+}
+
+#endif

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,4 +1,3 @@
-#include "BATTERIES.h"
 #include "../include.h"
 
 // These functions adapt the old C-style global functions battery-API to the

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -2,6 +2,19 @@
 #define BATTERIES_H
 #include "../../USER_SETTINGS.h"
 
+#include "src/devboard/utils/types.h"
+
+// Abstract base class for next-generation battery implementations.
+// Defines the interface to call battery specific functionality.
+// No support for double battery yet.
+class CanBattery {
+ public:
+  virtual void setup(void) = 0;
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
+  virtual void update_values() = 0;
+  virtual void transmit_can() = 0;
+};
+
 #ifdef BMW_SBOX
 #include "BMW-SBOX.h"
 void handle_incoming_can_frame_shunt(CAN_frame rx_frame);

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -4,6 +4,8 @@
 #include "../devboard/utils/events.h"
 #include "RENAULT-ZOE-GEN1-BATTERY.h"
 
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 /* Information in this file is based of the OVMS V3 vehicle_renaultzoe.cpp component 
 https://github.com/openvehicles/Open-Vehicle-Monitoring-System-3/blob/master/vehicle/OVMS.V3/components/vehicle_renaultzoe/src/vehicle_renaultzoe.cpp
 The Zoe BMS apparently does not send total pack voltage, so we use the polled 96x cellvoltages summed up as total voltage
@@ -75,7 +77,8 @@ static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN
 static unsigned long previousMillis250 = 0;  // will store last time a 250ms CAN Message was sent
 static uint8_t counter_423 = 0;
 
-void update_values_battery() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
+void RenaultZoeGen1Battery::
+    update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
   datalayer.battery.status.soh_pptt = (LB_SOH * 100);  // Increase range from 99% -> 99.00%
 
   datalayer.battery.status.real_soc = SOC_polled;
@@ -134,7 +137,7 @@ void update_values_battery() {  //This function maps all the values fetched via 
   datalayer.battery.status.voltage_dV = static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // mV to dV
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x155:  //10ms - Charging power, current and SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -490,7 +493,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_battery() {
+void RenaultZoeGen1Battery::transmit_can() {
   unsigned long currentMillis = millis();
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
@@ -542,7 +545,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+void RenaultZoeGen1Battery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Renault Zoe Gen1 22/40kWh", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -3,13 +3,22 @@
 #include "../include.h"
 
 #define BATTERY_SELECTED
+
+// Indicates that the object-oriented battery interface is to be activated.
+#define OO_BATTERY_SELECTED
+
 #define MAX_PACK_VOLTAGE_DV 4200  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3000
 #define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class RenaultZoeGen1Battery : public CanBattery {
+ public:
+  virtual void setup(void);
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void update_values();
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/communication/can/obd.cpp
+++ b/Software/src/communication/can/obd.cpp
@@ -1,6 +1,8 @@
 #include "obd.h"
 #include "comm_can.h"
 
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 void show_dtc(uint8_t byte0, uint8_t byte1);
 
 void show_dtc(uint8_t byte0, uint8_t byte1) {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -11,6 +11,8 @@
 #include "../utils/timer.h"
 #include "esp_task_wdt.h"
 
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
+
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
 


### PR DESCRIPTION
### What
This PR implements a minimal, abstract base class, which is a new type of battery API. When later implemented by all batteries, it allows all battery code to be compiled into common image. This first stage implements a minimal change: one battery implementation (Zoe Gen1) changed to this design.

This PR contains no functionality changes.

### Why
A base class approach is needed to gradually convert the code base to support common image.

### How

CanBattery base class is an abstract base class for batteries (supporting CAN bus). The API is identical to the C-style API but allows in the future multiple run-time implementations of batteries.
