### PR TITLE
Common base class for inverter protocols

### DIFF
--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -30,10 +30,8 @@ void init_rs485() {
   Serial2.begin(RS485_BAUDRATE, SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
 #endif  // RS485_INVERTER_SELECTED || RS485_BATTERY_SELECTED
 #ifdef MODBUS_INVERTER_SELECTED
-#ifdef BYD_MODBUS
   // Init Static data to the RTU Modbus
-  handle_static_data_modbus_byd();
-#endif  // BYD_MODBUS
+  handle_static_data_modbus();
   // Init Serial2 connected to the RTU Modbus
   RTUutils::prepareHardwareSerial(Serial2);
   Serial2.begin(9600, SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -17,14 +17,20 @@ static uint8_t history_index = 0;
 static uint8_t bms_char_dis_status = STANDBY;
 static bool all_401_values_equal = false;
 
-void update_modbus_registers_inverter() {
+void verify_inverter_modbus();
+void verify_temperature_modbus();
+void handle_update_data_modbusp201_byd();
+void handle_update_data_modbusp301_byd();
+void handle_static_data_modbus_byd();
+
+void BydModbusInverter::update_modbus_registers() {
   verify_temperature_modbus();
   verify_inverter_modbus();
   handle_update_data_modbusp201_byd();
   handle_update_data_modbusp301_byd();
 }
 
-void handle_static_data_modbus_byd() {
+void BydModbusInverter::handle_static_data() {
   // Store the data into the array
   static uint16_t si_data[] = {21321, 1};
   static uint16_t byd_data[] = {16985, 17408, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -144,8 +150,10 @@ void verify_inverter_modbus() {
     history_index = (history_index + 1) % HISTORY_LENGTH;
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+
+void BydModbusInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "BYD 11kWh HVM battery over Modbus RTU", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
+
 #endif

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -3,16 +3,18 @@
 #include "../include.h"
 
 #define MODBUS_INVERTER_SELECTED
+#define OO_INVERTER_PROTOCOL_SELECTED
 
 #define MB_RTU_NUM_VALUES 13100
 #define MAX_POWER 40960  //BYD Modbus specific value
 
 extern uint16_t mbPV[MB_RTU_NUM_VALUES];
 
-void handle_static_data_modbus_byd();
-void verify_temperature_modbus();
-void verify_inverter_modbus();
-void handle_update_data_modbusp201_byd();
-void handle_update_data_modbusp301_byd();
-void setup_inverter(void);
+class BydModbusInverter : public ModbusInverterProtocol {
+ public:
+  void setup();
+  void update_modbus_registers();
+  void handle_static_data();
+};
+
 #endif

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -1,0 +1,24 @@
+#include "../include.h"
+
+// These functions adapt the old C-style global functions inverter-API to the
+// object-oriented inverter protocol API.
+
+#ifdef OO_INVERTER_PROTOCOL_SELECTED
+
+ModbusInverterProtocol* inverter;
+
+void setup_inverter() {
+  // Currently only a single inverter protocol is implemented as a class
+  inverter = new BydModbusInverter();
+  inverter->setup();
+}
+
+void update_modbus_registers_inverter() {
+  inverter->update_modbus_registers();
+}
+
+void handle_static_data_modbus() {
+  inverter->handle_static_data();
+}
+
+#endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -1,6 +1,19 @@
 #ifndef INVERTERS_H
 #define INVERTERS_H
 
+// The abstract base class for all inverter protocols
+class InverterProtocol {
+ public:
+  virtual void setup() = 0;
+};
+
+// The abstract base class for all Modbus inverter protocols
+class ModbusInverterProtocol : public InverterProtocol {
+ public:
+  virtual void update_modbus_registers() = 0;
+  virtual void handle_static_data();
+};
+
 #include "../../USER_SETTINGS.h"
 
 #ifdef AFORE_CAN
@@ -87,6 +100,8 @@ void transmit_can_inverter();
 
 #ifdef MODBUS_INVERTER_SELECTED
 void update_modbus_registers_inverter();
+void setup_inverter();
+void handle_static_data_modbus();
 #endif
 
 #ifdef RS485_INVERTER_SELECTED


### PR DESCRIPTION
### What
This PR implements a minimal, abstract base class for **inverter protocol** implementations. When later implemented by all inverter protocols, it allows all inverter code to be compiled into common image. This first stage implements a minimal change: one inverter implementation (BYD Modbus) changed to this design with relevant adaptation code.

This PR contains no functionality changes.

### Why
A base class approach for inverter protocols is needed to gradually convert the code base to support common image.

### How
InverterProtocol and ModbusInverterProtocol abstract classes are the base classes for batteries (first supporting only Modbus). The API is identical to the C-style API but allows in the future multiple run-time implementations of inverter protocols.