### PR TITLE
Use common battery base class for Jaguar Ipace battery

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,4 +1,4 @@
-#include "BATTERIES.h"
+#include "../include.h"
 
 // These functions adapt the old C-style global functions battery-API to the
 // object-oriented battery API.

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,16 +1,19 @@
-#include "../include.h"
+#include "BATTERIES.h"
 
 // These functions adapt the old C-style global functions battery-API to the
 // object-oriented battery API.
 
-#ifdef OO_BATTERY_SELECTED
+// The instantiated class is defined by the pre-compiler define
+// to support battery class selection at compile-time
+#ifdef SELECTED_BATTERY_CLASS
 
-static CanBattery* battery;
+static CanBattery* battery = nullptr;
 
 void setup_battery() {
-  // Currently only one battery is implemented as a class.
-  // TODO: Extend based on build-time or run-time selected battery.
-  battery = new RenaultZoeGen1Battery();
+  // Instantiate the battery only once just in case this function gets called multiple times.
+  if (battery == nullptr) {
+    battery = new SELECTED_BATTERY_CLASS();
+  }
   battery->setup();
 }
 

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -2,19 +2,6 @@
 #define BATTERIES_H
 #include "../../USER_SETTINGS.h"
 
-#include "src/devboard/utils/types.h"
-
-// Abstract base class for next-generation battery implementations.
-// Defines the interface to call battery specific functionality.
-// No support for double battery yet.
-class CanBattery {
- public:
-  virtual void setup(void) = 0;
-  virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
-  virtual void update_values() = 0;
-  virtual void transmit_can() = 0;
-};
-
 #ifdef BMW_SBOX
 #include "BMW-SBOX.h"
 void handle_incoming_can_frame_shunt(CAN_frame rx_frame);

--- a/Software/src/battery/CanBattery.h
+++ b/Software/src/battery/CanBattery.h
@@ -1,0 +1,17 @@
+#ifndef CAN_BATTERY_H
+#define CAN_BATTERY_H
+
+#include "src/devboard/utils/types.h"
+
+// Abstract base class for next-generation battery implementations.
+// Defines the interface to call battery specific functionality.
+// No support for double battery yet.
+class CanBattery {
+ public:
+  virtual void setup(void) = 0;
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
+  virtual void update_values() = 0;
+  virtual void transmit_can() = 0;
+};
+
+#endif

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef JAGUAR_IPACE_BATTERY
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "JAGUAR-IPACE-BATTERY.h"
@@ -62,7 +63,7 @@ void print_units(char* header, int value, char* units) {
   logging.print(units);
 }
 
-void update_values_battery() {
+void JaguarIpaceBattery::update_values() {
 
   datalayer.battery.status.real_soc = HVBattAvgSOC * 100;  //Add two decimals
 
@@ -119,7 +120,7 @@ void update_values_battery() {
 #endif
 }
 
-void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
+void JaguarIpaceBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
   // Do not log noisy startup messages - there are many !
   if (rx_frame.ID == 0 && rx_frame.DLC == 8 && rx_frame.data.u8[0] == 0 && rx_frame.data.u8[1] == 0 &&
@@ -242,7 +243,7 @@ void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   logging.println("");
 }
 
-void transmit_can_battery() {
+void JaguarIpaceBattery::transmit_can() {
   unsigned long currentMillis = millis();
 
   /* Send keep-alive every 200ms */
@@ -253,7 +254,7 @@ void transmit_can_battery() {
   }
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+void JaguarIpaceBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Jaguar I-PACE", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 108;

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -1,15 +1,23 @@
 #ifndef JAGUAR_IPACE_BATTERY_H
 #define JAGUAR_IPACE_BATTERY_H
-#include "../include.h"
+
+#include "CanBattery.h"
 
 #define BATTERY_SELECTED
+#define SELECTED_BATTERY_CLASS JaguarIpaceBattery
+
 #define MAX_PACK_VOLTAGE_DV 4546  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3370
 #define MAX_CELL_DEVIATION_MV 250
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
+class JaguarIpaceBattery : public CanBattery {
+ public:
+  virtual void setup(void);
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void update_values();
+  virtual void transmit_can();
+};
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -1,11 +1,10 @@
 #ifndef RENAULT_ZOE_GEN1_BATTERY_H
 #define RENAULT_ZOE_GEN1_BATTERY_H
-#include "../include.h"
+
+#include "CanBattery.h"
 
 #define BATTERY_SELECTED
-
-// Indicates that the object-oriented battery interface is to be activated.
-#define OO_BATTERY_SELECTED
+#define SELECTED_BATTERY_CLASS RenaultZoeGen1Battery
 
 #define MAX_PACK_VOLTAGE_DV 4200  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 3000

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -16,6 +16,7 @@
 #endif  //CANFD_ADDON
 
 void dump_can_frame(CAN_frame& frame, frameDirection msgDir);
+void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
 /**
  * @brief Initialization function for CAN.


### PR DESCRIPTION
Convert Jaguar I-PACE battery implementation to use the common base class. The concrete battery class selected is indicated by SELECTED_BATTERY_CLASS define.