### PR TITLE
Microfeature: Add high temperature fault event :thermometer: 

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -19,11 +19,19 @@ battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
 
 void update_machineryprotection() {
-  // Check if the CPU is too hot
+  /* Check if the ESP32 CPU running the Battery-Emulator is too hot. 
+  We start with a warning, you can start to see Wifi issues if ut becomes too hot 
+  If the chip starts to approach the design limit, we perform a graceful shutdown */
   if (datalayer.system.info.CPU_temperature > 80.0f) {
-    set_event(EVENT_CPU_OVERHEAT, 0);
+    set_event(EVENT_CPU_OVERHEATING, 0);
   } else {
-    clear_event(EVENT_CPU_OVERHEAT);
+    clear_event(EVENT_CPU_OVERHEATING);
+  }
+  if (datalayer.system.info.CPU_temperature > 110.0f) {
+    set_event(EVENT_CPU_OVERHEATED, 0);
+  }
+  if (datalayer.system.info.CPU_temperature < 105.0f) {
+    clear_event(EVENT_CPU_OVERHEATED);  //Hysteresis on the clearing
   }
 
   // Check health status of CAN interfaces

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -20,7 +20,7 @@ battery_pause_status emulator_pause_status = NORMAL;
 
 void update_machineryprotection() {
   /* Check if the ESP32 CPU running the Battery-Emulator is too hot. 
-  We start with a warning, you can start to see Wifi issues if ut becomes too hot 
+  We start with a warning, you can start to see Wifi issues if it becomes too hot 
   If the chip starts to approach the design limit, we perform a graceful shutdown */
   if (datalayer.system.info.CPU_temperature > 80.0f) {
     set_event(EVENT_CPU_OVERHEATING, 0);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -47,7 +47,8 @@ void init_events(void) {
   events.entries[EVENT_CAN_CHARGER_MISSING].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CAN_INVERTER_MISSING].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CONTACTOR_WELDED].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_CPU_OVERHEAT].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CPU_OVERHEATING].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CPU_OVERHEATED].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_WATER_INGRESS].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DISCHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
@@ -193,8 +194,10 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Inverter not sending messages via CAN for the last 60 seconds. Check wiring!";
     case EVENT_CONTACTOR_WELDED:
       return "Contactors sticking/welded. Inspect battery with caution!";
-    case EVENT_CPU_OVERHEAT:
+    case EVENT_CPU_OVERHEATING:
       return "Battery-Emulator CPU overheating! Increase airflow/cooling to increase hardware lifespan!";
+    case EVENT_CPU_OVERHEATED:
+      return "Battery-Emulator CPU melting! Performing controlled shutdown until temperature drops!";
     case EVENT_CHARGE_LIMIT_EXCEEDED:
       return "Inverter is charging faster than battery is allowing.";
     case EVENT_DISCHARGE_LIMIT_EXCEEDED:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -21,7 +21,8 @@
   XX(EVENT_CAN_NATIVE_TX_FAILURE)              \
   XX(EVENT_CHARGE_LIMIT_EXCEEDED)              \
   XX(EVENT_CONTACTOR_WELDED)                   \
-  XX(EVENT_CPU_OVERHEAT)                       \
+  XX(EVENT_CPU_OVERHEATING)                    \
+  XX(EVENT_CPU_OVERHEATED)                     \
   XX(EVENT_DISCHARGE_LIMIT_EXCEEDED)           \
   XX(EVENT_WATER_INGRESS)                      \
   XX(EVENT_12V_LOW)                            \


### PR DESCRIPTION
### What
This PR adds a high temperature Fault event

### Why
To be able to perform a graceful shutdown incase the Battery-Emulator overheats. It is better to stop gracefully, than wait for CPU to crash.

### How
If the CPU temperature exceeds 110°C, we Fault the emulator. If we are able to cool down below 105°C, we resume operation.