### PR TITLE
Fix startup crash when using Modbus inverter

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -101,12 +101,13 @@ void setup() {
   init_precharge_control();
 #endif  // PRECHARGE_CONTROL
 
-  init_rs485();
-
 #if defined(CAN_INVERTER_SELECTED) || defined(MODBUS_INVERTER_SELECTED) || defined(RS485_INVERTER_SELECTED)
   setup_inverter();
 #endif
   setup_battery();
+
+  init_rs485();
+
 #ifdef EQUIPMENT_STOP_BUTTON
   init_equipment_stop_button();
 #endif


### PR DESCRIPTION
### What
This PR fixes a startup crash loop that occurs when using Modbus communication

### Why
![image](https://github.com/user-attachments/assets/2f6136d7-5561-40a9-8c19-b952e3b9124b)

### How
By first initializing which inverter to use, and then starting the init_rs485, the crash is avoided
