### PR TITLE
Bugfix: Scaled capacity overhaul

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -496,11 +496,11 @@ void update_calculated_values() {
     datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
   }
 #endif  // DOUBLE_BATTERY
-  // Check if millis() has overflowed. Used in events to keep better track of time
-  if (millis() < lastMillisOverflowCheck) {  // Overflow detected
+  // Check if millis has overflowed. Used in events to keep better track of time
+  if (currentMillis < lastMillisOverflowCheck) {  // Overflow detected
     datalayer.system.status.millisrolloverCount++;
   }
-  lastMillisOverflowCheck = millis();
+  lastMillisOverflowCheck = currentMillis;
 }
 
 void update_values_inverter() {


### PR DESCRIPTION
### What
This PR overhauls the scaled value calculations

### Why
The calculation has remained untouched for a long time. It has many bugs and missing functionality
Fixes #1104 
Also fixes #396 
Partially makes #926 better

### How
We fix several issues:
- When negative scaling is used, it no longer results in the capacity remaining jumping to 0 for the whole range, as reported in 1104
- When double batteries are used, we now report the total capacity for bat1+bat2 towards the inverter
- We fix a place in the code where division by 0 could occur (if user sets min/max SOC setting to same values), making the board crash :warning: 
- We increase system performance, by removing millis() calls in the update_calculated_values() function

On Double Battery setups, the capacity is now summed together (Visible in Battery1 Reported fields)
![image](https://github.com/user-attachments/assets/576c2839-7111-432f-bbe7-14912da5c882)

