### PR TITLE
Nissan Leaf battery class with double battery support

### DIFF
--- a/.github/workflows/compile-all-double-batteries.yml
+++ b/.github/workflows/compile-all-double-batteries.yml
@@ -1,0 +1,93 @@
+# This is the name of the workflow, visible on GitHub UI.
+name: Compile All Double Batteries
+
+# Here we tell GitHub when to run the workflow.
+on:
+  # The workflow is run when a commit is pushed or for a
+  # Pull Request.
+  - push
+  - pull_request
+
+# This is the list of jobs that will be run concurrently.
+jobs:
+  # This pre-job is run to skip workflows in case a workflow is already run, i.e. because the workflow is triggered by both push and pull_request
+  skip-duplicate-actions:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  # Since we use a build matrix, the actual number of jobs
+  # started depends on how many configurations the matrix
+  # will produce.
+  build-batteries:
+    needs: skip-duplicate-actions
+    if: needs.skip-duplicate-actions.outputs.should_skip != 'true'
+
+    # Here we tell GitHub that the jobs must be determined
+    # dynamically depending on a matrix configuration.
+    strategy:
+      # The matrix will produce one job for each combination of parameters.
+      matrix:
+        # This is the development board hardware for which the code will be compiled.
+        # FBQN stands for "fully qualified board name", and is used by Arduino to define the hardware to compile for.
+        fqbn:
+          - esp32:esp32:esp32
+          # further ESP32 chips
+          #- esp32:esp32:esp32c3
+          #- esp32:esp32:esp32c2
+          #- esp32:esp32:esp32c6
+          #- esp32:esp32:esp32h2
+          #- esp32:esp32:esp32s3
+        # These are the batteries for which the code will be compiled.
+        battery:
+          - BMW_I3_BATTERY 
+          - BYD_ATTO_3_BATTERY
+          - KIA_HYUNDAI_64_BATTERY
+          - PYLON_BATTERY
+          - SANTA_FE_PHEV_BATTERY
+          - TEST_FAKE_BATTERY
+        # These are the emulated inverter communication protocols for which the code will be compiled.
+        inverter:
+          - BYD_CAN
+        # These are the supported hardware platforms for which the code will be compiled.
+        hardware:
+          - HW_LILYGO
+
+    # This is the platform GitHub will use to run our workflow.
+    runs-on: ubuntu-latest
+
+    # This is the list of steps this job will run.
+    steps:
+      # First we clone the repo using the `checkout` action.
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      # Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+      - name: Copy USER_SECRETS.TEMPLATE.h to USER_SECRETS.h
+        run: cp ./Software/USER_SECRETS.TEMPLATE.h ./Software/USER_SECRETS.h
+
+      # We use the `arduino/setup-arduino-cli` action to install and
+      # configure the Arduino CLI on the system.
+      - name: Setup Arduino CLI
+        uses: arduino/setup-arduino-cli@v2
+
+      # We then install the platform.
+      - name: Install platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32
+
+      # Finally, we compile the sketch, using the FQBN that was set
+      # in the build matrix, and using build flags to define the
+      # battery and inverter set in the build matrix.
+      - name: Compile Sketch
+        run: arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property "build.extra_flags=-Wall -Wextra -Wpedantic -Werror -DESP32 -DDOUBLE_BATTERY -D${{ matrix.battery}} -D${{ matrix.inverter}} -D${{ matrix.hardware}}" ./Software

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -16,12 +16,7 @@ static CanBattery* battery2 = nullptr;
 void setup_battery() {
   // Instantiate the battery only once just in case this function gets called multiple times.
   if (battery == nullptr) {
-#ifdef DOUBLE_BATTERY
-    battery = new SELECTED_BATTERY_CLASS(&datalayer.battery, &datalayer.system.status.battery_allows_contactor_closing,
-                                         EXTENDED_DATA_PTR, can_config.battery);
-#else
     battery = new SELECTED_BATTERY_CLASS();
-#endif
   }
   battery->setup();
 

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -39,8 +39,16 @@ void update_values_battery() {
   battery->update_values();
 }
 
+// transmit_can_battery is called once and we need to
+// call both batteries.
 void transmit_can_battery(unsigned long currentMillis) {
   battery->transmit_can(currentMillis);
+
+#ifdef DOUBLE_BATTERY
+  if (battery2) {
+    battery2->transmit_can(currentMillis);
+  }
+#endif
 }
 
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -9,12 +9,30 @@
 
 static CanBattery* battery = nullptr;
 
+#ifdef DOUBLE_BATTERY
+static CanBattery* battery2 = nullptr;
+#endif
+
 void setup_battery() {
   // Instantiate the battery only once just in case this function gets called multiple times.
   if (battery == nullptr) {
+#ifdef DOUBLE_BATTERY
+    battery = new SELECTED_BATTERY_CLASS(&datalayer.battery, &datalayer.system.status.battery_allows_contactor_closing,
+                                         EXTENDED_DATA_PTR, can_config.battery);
+#else
     battery = new SELECTED_BATTERY_CLASS();
+#endif
   }
   battery->setup();
+
+#ifdef DOUBLE_BATTERY
+  if (battery2 == nullptr) {
+    battery2 =
+        new SELECTED_BATTERY_CLASS(&datalayer.battery2, &datalayer.system.status.battery2_allows_contactor_closing,
+                                   nullptr, can_config.battery_double);
+  }
+  battery2->setup();
+#endif
 }
 
 void update_values_battery() {
@@ -28,5 +46,15 @@ void transmit_can_battery(unsigned long currentMillis) {
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
   battery->handle_incoming_can_frame(rx_frame);
 }
+
+#ifdef DOUBLE_BATTERY
+void update_values_battery2() {
+  battery2->update_values();
+}
+
+void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
+  battery2->handle_incoming_can_frame(rx_frame);
+}
+#endif
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -9,220 +9,48 @@
 #include "../datalayer/datalayer_extended.h"  //For "More battery info" webpage
 #include "../devboard/utils/events.h"
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-static unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
-static uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
-static uint8_t mprun10 = 0;                  //counter 0-3
-static uint8_t mprun100 = 0;                 //counter 0-3
-
-// These CAN messages need to be sent towards the battery to keep it alive
-CAN_frame LEAF_1F2 = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 8,
-                      .ID = 0x1F2,
-                      .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
-CAN_frame LEAF_50B = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 7,
-                      .ID = 0x50B,
-                      .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
-CAN_frame LEAF_50C = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 6,
-                      .ID = 0x50C,
-                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame LEAF_1D4 = {.FD = false,
-                      .ext_ID = false,
-                      .DLC = 8,
-                      .ID = 0x1D4,
-                      .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
-// Active polling messages
-uint8_t PIDgroups[] = {0x01, 0x02, 0x04, 0x83, 0x84, 0x90};
-uint8_t PIDindex = 0;
-CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
-                                .ext_ID = false,
-                                .DLC = 8,
-                                .ID = 0x79B,
-                                .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
-CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
-                                    .ext_ID = false,
-                                    .DLC = 8,
-                                    .ID = 0x79B,
-                                    .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-
-// The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
-// groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second
-// replies with all the battery’s cells voltages in millivolt, the third and the fifth one are still unknown, the
-// fourth contains the four battery packs temperatures, and the last one tells which cell has the shunt active.
-// There are also two more groups: group 61, which replies with lots of CAN messages (up to 48); here we
-// found the SOH value, and group 84 that replies with the HV battery production serial.
-
-static uint8_t crctable[256] = {
-    0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,
-    247, 114, 80,  213, 223, 90,  203, 78,  68,  193, 67,  198, 204, 73,  216, 93,  87,  210, 240, 117, 127, 250,
-    107, 238, 228, 97,  160, 37,  47,  170, 59,  190, 180, 49,  19,  150, 156, 25,  136, 13,  7,   130, 134, 3,
-    9,   140, 29,  152, 146, 23,  53,  176, 186, 63,  174, 43,  33,  164, 101, 224, 234, 111, 254, 123, 113, 244,
-    214, 83,  89,  220, 77,  200, 194, 71,  197, 64,  74,  207, 94,  219, 209, 84,  118, 243, 249, 124, 237, 104,
-    98,  231, 38,  163, 169, 44,  189, 56,  50,  183, 149, 16,  26,  159, 14,  139, 129, 4,   137, 12,  6,   131,
-    18,  151, 157, 24,  58,  191, 181, 48,  161, 36,  46,  171, 106, 239, 229, 96,  241, 116, 126, 251, 217, 92,
-    86,  211, 66,  199, 205, 72,  202, 79,  69,  192, 81,  212, 222, 91,  121, 252, 246, 115, 226, 103, 109, 232,
-    41,  172, 166, 35,  178, 55,  61,  184, 154, 31,  21,  144, 1,   132, 142, 11,  15,  138, 128, 5,   148, 17,
-    27,  158, 188, 57,  51,  182, 39,  162, 168, 45,  236, 105, 99,  230, 119, 242, 248, 125, 95,  218, 208, 85,
-    196, 65,  75,  206, 76,  201, 195, 70,  215, 82,  88,  221, 255, 122, 112, 245, 100, 225, 235, 110, 175, 42,
-    32,  165, 52,  177, 187, 62,  28,  153, 147, 22,  135, 2,   8,   141};
-
-//Nissan LEAF battery parameters from constantly sent CAN
-#define ZE0_BATTERY 0
-#define AZE0_BATTERY 1
-#define ZE1_BATTERY 2
-static uint8_t LEAF_battery_Type = ZE0_BATTERY;
-static bool battery_can_alive = false;
-#define WH_PER_GID 77                               //One GID is this amount of Watt hours
-static uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
-static uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW
-static int16_t battery_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
-static int16_t battery_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
-static uint16_t battery_TEMP = 0;                   //Temporary value used in status checks
-static uint16_t battery_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
-static uint16_t battery_GIDS = 273;                 //Startup in 24kWh mode
-static uint16_t battery_MAX = 0;
-static uint16_t battery_Max_GIDS = 273;               //Startup in 24kWh mode
-static uint16_t battery_StateOfHealth = 99;           //State of health %
-static uint16_t battery_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-static int16_t battery_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
-static int16_t battery_HistData_Temperature_MAX = 6;  //-40 to 86*C
-static int16_t battery_HistData_Temperature_MIN = 5;  //-40 to 86*C
-static int16_t battery_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
-static uint8_t battery_Relay_Cut_Request = 0;         //battery_FAIL
-static uint8_t battery_Failsafe_Status = 0;           //battery_STATUS
-static bool battery_Interlock =
-    true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
-static bool battery_Full_CHARGE_flag = false;  //battery_FCHGEND , Goes to 1 if battery is fully charged
-static bool battery_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
-static bool battery_Capacity_Empty = false;    //battery_EMPTY, , Goes to 1 if battery is empty
-static bool battery_HeatExist = false;  //battery_HEATEXIST, Specifies if battery pack is equipped with heating elements
-static bool battery_Heating_Stop = false;                   //When transitioning from 0->1, signals a STOP heat request
-static bool battery_Heating_Start = false;                  //When transitioning from 1->0, signals a START heat request
-static bool battery_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
-
-// Nissan LEAF battery data from polled CAN messages
-static uint8_t battery_request_idx = 0;
-static uint8_t group_7bb = 0;
-static bool stop_battery_query = true;
-static uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
-static uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
-static uint8_t battery_cellcounter = 0;
-static uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint16_t battery_HX = 0;              //Internal resistance
-static uint16_t battery_insulation = 0;      //Insulation resistance
-static uint16_t battery_temp_raw_1 = 0;
-static uint8_t battery_temp_raw_2_highnibble = 0;
-static uint16_t battery_temp_raw_2 = 0;
-static uint16_t battery_temp_raw_3 = 0;
-static uint16_t battery_temp_raw_4 = 0;
-static uint16_t battery_temp_raw_max = 0;
-static uint16_t battery_temp_raw_min = 0;
-static int16_t battery_temp_polled_max = 0;
-static int16_t battery_temp_polled_min = 0;
-static uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
-static uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
-static uint8_t BMSIDcode[8] = {0};
-#ifdef DOUBLE_BATTERY
-static uint8_t LEAF_battery2_Type = ZE0_BATTERY;
-static bool battery2_can_alive = false;
-static uint16_t battery2_Discharge_Power_Limit = 0;  //Limit in kW
-static uint16_t battery2_Charge_Power_Limit = 0;     //Limit in kW
-static int16_t battery2_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
-static int16_t battery2_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
-static uint16_t battery2_TEMP = 0;                   //Temporary value used in status checks
-static uint16_t battery2_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
-static uint16_t battery2_GIDS = 273;                 //Startup in 24kWh mode
-static uint16_t battery2_MAX = 0;
-static uint16_t battery2_Max_GIDS = 273;      //Startup in 24kWh mode
-static uint16_t battery2_StateOfHealth = 99;  //State of health %
-static uint16_t battery2_Total_Voltage2 = 0;  //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-static int16_t battery2_Current2 = 0;         //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
-static int16_t battery2_HistData_Temperature_MAX = 6;  //-40 to 86*C
-static int16_t battery2_HistData_Temperature_MIN = 5;  //-40 to 86*C
-static int16_t battery2_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
-static uint8_t battery2_Relay_Cut_Request = 0;         //battery2_FAIL
-static uint8_t battery2_Failsafe_Status = 0;           //battery2_STATUS
-static bool battery2_Interlock =
-    true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
-static bool battery2_Full_CHARGE_flag = false;  //battery2_FCHGEND , Goes to 1 if battery is fully charged
-static bool battery2_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
-static bool battery2_Capacity_Empty = false;    //battery2_EMPTY, , Goes to 1 if battery is empty
-static bool battery2_HeatExist =
-    false;  //battery2_HEATEXIST, Specifies if battery pack is equipped with heating elements
-static bool battery2_Heating_Stop = false;   //When transitioning from 0->1, signals a STOP heat request
-static bool battery2_Heating_Start = false;  //When transitioning from 1->0, signals a START heat request
-static bool battery2_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
-// Polled values
-static uint8_t battery2_group_7bb = 0;
-static uint8_t battery2_request_idx = 0;
-static uint16_t battery2_cell_voltages[97];  //array with all the cellvoltages
-static uint8_t battery2_cellcounter = 0;
-static uint16_t battery2_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-static uint16_t battery2_HX = 0;              //Internal resistance
-static uint16_t battery2_insulation = 0;      //Insulation resistance
-static uint16_t battery2_temp_raw_1 = 0;
-static uint8_t battery2_temp_raw_2_highnibble = 0;
-static uint16_t battery2_temp_raw_2 = 0;
-static uint16_t battery2_temp_raw_3 = 0;
-static uint16_t battery2_temp_raw_4 = 0;
-static uint16_t battery2_temp_raw_max = 0;
-static uint16_t battery2_temp_raw_min = 0;
-static int16_t battery2_temp_polled_max = 0;
-static int16_t battery2_temp_polled_min = 0;
-#endif  // DOUBLE_BATTERY
-
-// Clear SOH values
-static uint8_t stateMachineClearSOH = 0xFF;
-static uint32_t incomingChallenge = 0xFFFFFFFF;
-static uint8_t solvedChallenge[8];
-static bool challengeFailed = false;
-
-CAN_frame LEAF_CLEAR_SOH = {.FD = false,
-                            .ext_ID = false,
-                            .DLC = 8,
-                            .ID = 0x79B,
-                            .data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+uint16_t Temp_fromRAW_to_F(uint16_t temperature);
+//Cryptographic functions
+void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);
+unsigned int CyclicXorHash16Bit(unsigned int param_1, unsigned int param_2);
+unsigned int ComputeMaskedXorProduct(unsigned int param_1, unsigned int param_2, unsigned int param_3);
+short ShortMaskedSumAndProduct(short param_1, short param_2);
+unsigned int MaskedBitwiseRotateMultiply(unsigned int param_1, unsigned int param_2);
+unsigned int CryptAlgo(unsigned int param_1, unsigned int param_2, unsigned int param_3);
 
 void NissanLeafBattery::
     update_values() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
   /* Start with mapping all values */
 
-  datalayer.battery.status.soh_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
+  datalayer_battery->status.soh_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
 
-  datalayer.battery.status.real_soc = (battery_SOC * 10);
+  datalayer_battery->status.real_soc = (battery_SOC * 10);
 
-  datalayer.battery.status.voltage_dV =
+  datalayer_battery->status.voltage_dV =
       (battery_Total_Voltage2 * 5);  //0.5V/bit, multiply by 5 to get Voltage+1decimal (350.5V = 701)
 
-  datalayer.battery.status.current_dA =
+  datalayer_battery->status.current_dA =
       (battery_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
 
   if (battery_Max_GIDS == 273) {  //battery_Max_GIDS is stuck at 273 on ZE0
-    datalayer.battery.info.total_capacity_Wh = ((battery_Max_GIDS * WH_PER_GID * battery_StateOfHealth) / 100);
+    datalayer_battery->info.total_capacity_Wh = ((battery_Max_GIDS * WH_PER_GID * battery_StateOfHealth) / 100);
   } else {  //battery_Max_GIDS updates on newer generations, making for a total_capacity_Wh value that makes sense
-    datalayer.battery.info.total_capacity_Wh = (battery_Max_GIDS * WH_PER_GID);
+    datalayer_battery->info.total_capacity_Wh = (battery_Max_GIDS * WH_PER_GID);
   }
 
-  datalayer.battery.status.remaining_capacity_Wh = battery_Wh_Remaining;
+  datalayer_battery->status.remaining_capacity_Wh = battery_Wh_Remaining;
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
   if (LEAF_battery_Type == ZE0_BATTERY) {
     //Since we only have average value, send the minimum as -1.0 degrees below average
-    datalayer.battery.status.temperature_min_dC =
+    datalayer_battery->status.temperature_min_dC =
         ((battery_AverageTemperature * 10) - 10);  //Increase range from C to C+1, remove 1.0C
-    datalayer.battery.status.temperature_max_dC = (battery_AverageTemperature * 10);  //Increase range from C to C+1
+    datalayer_battery->status.temperature_max_dC = (battery_AverageTemperature * 10);  //Increase range from C to C+1
   } else if (LEAF_battery_Type == AZE0_BATTERY) {
     //Use the value sent constantly via CAN in 5C0 (only available on AZE0)
-    datalayer.battery.status.temperature_min_dC =
+    datalayer_battery->status.temperature_min_dC =
         (battery_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
-    datalayer.battery.status.temperature_max_dC =
+    datalayer_battery->status.temperature_max_dC =
         (battery_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
   } else {  // ZE1 (TODO: Once the muxed value in 5C0 becomes known, switch to using that instead of this complicated polled value)
     if (battery_temp_raw_min != 0)  //We have a polled value available
@@ -230,42 +58,42 @@ void NissanLeafBattery::
       battery_temp_polled_min = ((Temp_fromRAW_to_F(battery_temp_raw_min) - 320) * 5) / 9;  //Convert from F to C
       battery_temp_polled_max = ((Temp_fromRAW_to_F(battery_temp_raw_max) - 320) * 5) / 9;  //Convert from F to C
       if (battery_temp_polled_min < battery_temp_polled_max) {  //Catch any edge cases from Temp_fromRAW_to_F function
-        datalayer.battery.status.temperature_min_dC = battery_temp_polled_min;
-        datalayer.battery.status.temperature_max_dC = battery_temp_polled_max;
+        datalayer_battery->status.temperature_min_dC = battery_temp_polled_min;
+        datalayer_battery->status.temperature_max_dC = battery_temp_polled_max;
       } else {
-        datalayer.battery.status.temperature_min_dC = battery_temp_polled_max;
-        datalayer.battery.status.temperature_max_dC = battery_temp_polled_min;
+        datalayer_battery->status.temperature_min_dC = battery_temp_polled_max;
+        datalayer_battery->status.temperature_max_dC = battery_temp_polled_min;
       }
     }
   }
 
-  datalayer.battery.status.max_discharge_power_W = (battery_Discharge_Power_Limit * 1000);  //kW to W
+  datalayer_battery->status.max_discharge_power_W = (battery_Discharge_Power_Limit * 1000);  //kW to W
 
-  datalayer.battery.status.max_charge_power_W = (battery_Charge_Power_Limit * 1000);  //kW to W
+  datalayer_battery->status.max_charge_power_W = (battery_Charge_Power_Limit * 1000);  //kW to W
 
   //Allow contactors to close
   if (battery_can_alive) {
-    datalayer.system.status.battery_allows_contactor_closing = true;
+    *allows_contactor_closing = true;
   }
 
   /*Extra safety functions below*/
   if (battery_GIDS < 10)  //700Wh left in battery!
   {                       //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
     set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery.status.real_soc = 0;
-    datalayer.battery.status.max_discharge_power_W = 0;
+    datalayer_battery->status.real_soc = 0;
+    datalayer_battery->status.max_discharge_power_W = 0;
   }
 
   if (battery_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
     set_event(EVENT_BATTERY_FULL, 0);
-    datalayer.battery.status.max_charge_power_W = 0;
+    datalayer_battery->status.max_charge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_FULL);
   }
 
   if (battery_Capacity_Empty) {  //Battery reports that it is fully discharged. Stop all further discharging incase it hasn't already
     set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery.status.max_discharge_power_W = 0;
+    datalayer_battery->status.max_discharge_power_W = 0;
   } else {
     clear_event(EVENT_BATTERY_EMPTY);
   }
@@ -278,8 +106,8 @@ void NissanLeafBattery::
 
   if (battery_Relay_Cut_Request) {  //battery_FAIL, BMS requesting shutdown and contactors to be opened
     //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
-    datalayer.battery.status.max_discharge_power_W = 0;
-    datalayer.battery.status.max_charge_power_W = 0;
+    datalayer_battery->status.max_discharge_power_W = 0;
+    datalayer_battery->status.max_charge_power_W = 0;
   }
 
   if (battery_Failsafe_Status > 0)  // 0 is normal, start charging/discharging
@@ -340,430 +168,45 @@ void NissanLeafBattery::
   }
 
   // Update webserver datalayer
-  memcpy(datalayer_extended.nissanleaf.BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
-  memcpy(datalayer_extended.nissanleaf.BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
-  memcpy(datalayer_extended.nissanleaf.BMSIDcode, BMSIDcode, sizeof(BMSIDcode));
-  datalayer_extended.nissanleaf.LEAF_gen = LEAF_battery_Type;
-  datalayer_extended.nissanleaf.GIDS = battery_GIDS;
-  datalayer_extended.nissanleaf.ChargePowerLimit = battery_Charge_Power_Limit;
-  datalayer_extended.nissanleaf.MaxPowerForCharger = battery_MAX_POWER_FOR_CHARGER;
-  datalayer_extended.nissanleaf.Interlock = battery_Interlock;
-  datalayer_extended.nissanleaf.Insulation = battery_insulation;
-  datalayer_extended.nissanleaf.RelayCutRequest = battery_Relay_Cut_Request;
-  datalayer_extended.nissanleaf.FailsafeStatus = battery_Failsafe_Status;
-  datalayer_extended.nissanleaf.Full = battery_Full_CHARGE_flag;
-  datalayer_extended.nissanleaf.Empty = battery_Capacity_Empty;
-  datalayer_extended.nissanleaf.MainRelayOn = battery_MainRelayOn_flag;
-  datalayer_extended.nissanleaf.HeatExist = battery_HeatExist;
-  datalayer_extended.nissanleaf.HeatingStop = battery_Heating_Stop;
-  datalayer_extended.nissanleaf.HeatingStart = battery_Heating_Start;
-  datalayer_extended.nissanleaf.HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
-  datalayer_extended.nissanleaf.CryptoChallenge = incomingChallenge;
-  datalayer_extended.nissanleaf.SolvedChallengeMSB =
-      ((solvedChallenge[7] << 24) | (solvedChallenge[6] << 16) | (solvedChallenge[5] << 8) | solvedChallenge[4]);
-  datalayer_extended.nissanleaf.SolvedChallengeLSB =
-      ((solvedChallenge[3] << 24) | (solvedChallenge[2] << 16) | (solvedChallenge[1] << 8) | solvedChallenge[0]);
-  datalayer_extended.nissanleaf.challengeFailed = challengeFailed;
+  if (datalayer_nissan) {
+    memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
+    memcpy(datalayer_nissan->BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
+    memcpy(datalayer_nissan->BMSIDcode, BMSIDcode, sizeof(BMSIDcode));
+    datalayer_nissan->LEAF_gen = LEAF_battery_Type;
+    datalayer_nissan->GIDS = battery_GIDS;
+    datalayer_nissan->ChargePowerLimit = battery_Charge_Power_Limit;
+    datalayer_nissan->MaxPowerForCharger = battery_MAX_POWER_FOR_CHARGER;
+    datalayer_nissan->Interlock = battery_Interlock;
+    datalayer_nissan->Insulation = battery_insulation;
+    datalayer_nissan->RelayCutRequest = battery_Relay_Cut_Request;
+    datalayer_nissan->FailsafeStatus = battery_Failsafe_Status;
+    datalayer_nissan->Full = battery_Full_CHARGE_flag;
+    datalayer_nissan->Empty = battery_Capacity_Empty;
+    datalayer_nissan->MainRelayOn = battery_MainRelayOn_flag;
+    datalayer_nissan->HeatExist = battery_HeatExist;
+    datalayer_nissan->HeatingStop = battery_Heating_Stop;
+    datalayer_nissan->HeatingStart = battery_Heating_Start;
+    datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
+    datalayer_nissan->CryptoChallenge = incomingChallenge;
+    datalayer_nissan->SolvedChallengeMSB =
+        ((solvedChallenge[7] << 24) | (solvedChallenge[6] << 16) | (solvedChallenge[5] << 8) | solvedChallenge[4]);
+    datalayer_nissan->SolvedChallengeLSB =
+        ((solvedChallenge[3] << 24) | (solvedChallenge[2] << 16) | (solvedChallenge[1] << 8) | solvedChallenge[0]);
+    datalayer_nissan->challengeFailed = challengeFailed;
 
-  // Update requests from webserver datalayer
-  if (datalayer_extended.nissanleaf.UserRequestSOHreset) {
-    stateMachineClearSOH = 0;  //Start the statemachine
-    datalayer_extended.nissanleaf.UserRequestSOHreset = false;
-  }
-}
-
-#ifdef DOUBLE_BATTERY
-
-void update_values_battery2() {  // Handle the values coming in from battery #2
-  /* Start with mapping all values */
-
-  datalayer.battery2.status.soh_pptt = (battery2_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
-
-  datalayer.battery2.status.real_soc = (battery2_SOC * 10);
-
-  datalayer.battery2.status.voltage_dV =
-      (battery2_Total_Voltage2 * 5);  //0.5V/bit, multiply by 5 to get Voltage+1decimal (350.5V = 701)
-
-  datalayer.battery2.status.current_dA =
-      (battery2_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
-
-  if (battery2_Max_GIDS == 273) {  //battery2_Max_GIDS is stuck at 273 on 24kWh packs
-    datalayer.battery2.info.total_capacity_Wh = ((battery2_Max_GIDS * WH_PER_GID * battery2_StateOfHealth) / 100);
-  } else {  //battery_Max_GIDS updates on newer generations, making for a total_capacity_Wh value that makes sense
-    datalayer.battery2.info.total_capacity_Wh = (battery2_Max_GIDS * WH_PER_GID);
-  }
-
-  datalayer.battery2.status.remaining_capacity_Wh = battery2_Wh_Remaining;
-
-  //Update temperature readings. Method depends on which generation LEAF battery is used
-  if (LEAF_battery2_Type == ZE0_BATTERY) {
-    //Since we only have average value, send the minimum as -1.0 degrees below average
-    datalayer.battery2.status.temperature_min_dC =
-        ((battery2_AverageTemperature * 10) - 10);  //Increase range from C to C+1, remove 1.0C
-    datalayer.battery2.status.temperature_max_dC = (battery2_AverageTemperature * 10);  //Increase range from C to C+1
-  } else if (LEAF_battery2_Type == AZE0_BATTERY) {
-    //Use the value sent constantly via CAN in 5C0 (only available on AZE0)
-    datalayer.battery2.status.temperature_min_dC =
-        (battery2_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
-    datalayer.battery2.status.temperature_max_dC =
-        (battery2_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
-  } else {  // ZE1 (TODO: Once the muxed value in 5C0 becomes known, switch to using that instead of this complicated polled value)
-    if (battery2_temp_raw_min != 0)  //We have a polled value available
-    {
-      battery2_temp_polled_min = ((Temp_fromRAW_to_F(battery2_temp_raw_min) - 320) * 5) / 9;  //Convert from F to C
-      battery2_temp_polled_max = ((Temp_fromRAW_to_F(battery2_temp_raw_max) - 320) * 5) / 9;  //Convert from F to C
-      if (battery2_temp_polled_min < battery2_temp_polled_max) {  //Catch any edge cases from Temp_fromRAW_to_F function
-        datalayer.battery2.status.temperature_min_dC = battery2_temp_polled_min;
-        datalayer.battery2.status.temperature_max_dC = battery2_temp_polled_max;
-      } else {
-        datalayer.battery2.status.temperature_min_dC = battery2_temp_polled_max;
-        datalayer.battery2.status.temperature_max_dC = battery2_temp_polled_min;
-      }
-    }
-  }
-
-  datalayer.battery2.status.max_discharge_power_W = (battery2_Discharge_Power_Limit * 1000);  //kW to W
-
-  datalayer.battery2.status.max_charge_power_W = (battery2_Charge_Power_Limit * 1000);  //kW to W
-
-  /*Extra safety functions below*/
-  if (battery2_GIDS < 10)  //700Wh left in battery!
-  {                        //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
-    set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery2.status.real_soc = 0;
-    datalayer.battery2.status.max_discharge_power_W = 0;
-  }
-
-  if (battery2_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
-    set_event(EVENT_BATTERY_FULL, 0);
-    datalayer.battery2.status.max_charge_power_W = 0;
-  } else {
-    clear_event(EVENT_BATTERY_FULL);
-  }
-
-  if (battery2_Capacity_Empty) {  //Battery reports that it is fully discharged. Stop all further discharging incase it hasn't already
-    set_event(EVENT_BATTERY_EMPTY, 0);
-    datalayer.battery2.status.max_discharge_power_W = 0;
-  } else {
-    clear_event(EVENT_BATTERY_EMPTY);
-  }
-
-  if (battery2_Total_Voltage2 == 0x3FF) {  //Battery reports critical measurement unavailable
-    set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
-  } else {
-    clear_event(EVENT_BATTERY_VALUE_UNAVAILABLE);
-  }
-
-  if (battery2_Relay_Cut_Request) {  //battery2_FAIL, BMS requesting shutdown and contactors to be opened
-    //Note, this is sometimes triggered during the night while idle, and the BMS recovers after a while. Removed latching from this scenario
-    datalayer.battery2.status.max_discharge_power_W = 0;
-    datalayer.battery2.status.max_charge_power_W = 0;
-  }
-
-  if (battery2_Failsafe_Status > 0)  // 0 is normal, start charging/discharging
-  {
-    switch (battery2_Failsafe_Status) {
-      case (1):
-        //Normal Stop Request
-        //This means that battery is fully discharged and it's OK to stop the session. For stationary storage we don't disconnect contactors, so we do nothing here.
-        break;
-      case (2):
-        //Charging Mode Stop Request
-        //This means that battery is fully charged and it's OK to stop the session. For stationary storage we don't disconnect contactors, so we do nothing here.
-        break;
-      case (3):
-        //Charging Mode Stop Request & Normal Stop Request
-        //Normal stop request. For stationary storage we don't disconnect contactors, so we ignore this.
-        break;
-      case (4):
-        //Caution Lamp Request
-        set_event(EVENT_BATTERY_CAUTION, 2);
-        break;
-      case (5):
-        //Caution Lamp Request & Normal Stop Request
-        set_event(EVENT_BATTERY_DISCHG_STOP_REQ, 2);
-        break;
-      case (6):
-        //Caution Lamp Request & Charging Mode Stop Request
-        set_event(EVENT_BATTERY_CHG_STOP_REQ, 2);
-        break;
-      case (7):
-        //Caution Lamp Request & Charging Mode Stop Request & Normal Stop Request
-        set_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, 2);
-        break;
-      default:
-        break;
-    }
-  } else {  //battery2_Failsafe_Status == 0
-    clear_event(EVENT_BATTERY_DISCHG_STOP_REQ);
-    clear_event(EVENT_BATTERY_CHG_STOP_REQ);
-    clear_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ);
-  }
-
-#ifdef INTERLOCK_REQUIRED
-  if (!battery2_Interlock) {
-    set_event(EVENT_HVIL_FAILURE, 2);
-  } else {
-    clear_event(EVENT_HVIL_FAILURE);
-  }
-#endif
-
-  if (battery2_HeatExist) {
-    if (battery2_Heating_Stop) {
-      set_event(EVENT_BATTERY_WARMED_UP, 2);
-    }
-    if (battery2_Heating_Start) {
-      set_event(EVENT_BATTERY_REQUESTS_HEAT, 2);
+    // Update requests from webserver datalayer
+    if (datalayer_nissan->UserRequestSOHreset) {
+      stateMachineClearSOH = 0;  //Start the statemachine
+      datalayer_nissan->UserRequestSOHreset = false;
     }
   }
 }
-void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  switch (rx_frame.ID) {
-    case 0x1DB:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_Current2 = (rx_frame.data.u8[0] << 3) | (rx_frame.data.u8[1] & 0xe0) >> 5;
-      if (battery2_Current2 & 0x0400) {
-        // negative so extend the sign bit
-        battery2_Current2 |= 0xf800;
-      }  //BatteryCurrentSignal , 2s comp, 1lSB = 0.5A/bit
-
-      battery2_TEMP = ((rx_frame.data.u8[2] << 2) | (rx_frame.data.u8[3] & 0xc0) >> 6);  //0.5V/bit
-      if (battery2_TEMP != 0x3ff) {  //3FF is unavailable value. Can happen directly on reboot.
-        battery2_Total_Voltage2 = battery2_TEMP;
-      }
-
-      //Collect various data from the BMS
-      battery2_Relay_Cut_Request = ((rx_frame.data.u8[1] & 0x18) >> 3);
-      battery2_Failsafe_Status = (rx_frame.data.u8[1] & 0x07);
-      battery2_MainRelayOn_flag = (bool)((rx_frame.data.u8[3] & 0x20) >> 5);
-      //battery2_allows_contactor_closing written by check_interconnect_available();
-      battery2_Full_CHARGE_flag = (bool)((rx_frame.data.u8[3] & 0x10) >> 4);
-      battery2_Interlock = (bool)((rx_frame.data.u8[3] & 0x08) >> 3);
-      break;
-    case 0x1DC:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_Discharge_Power_Limit = ((rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6) / 4.0);
-      battery2_Charge_Power_Limit = (((rx_frame.data.u8[1] & 0x3F) << 4 | rx_frame.data.u8[2] >> 4) / 4.0);
-      battery2_MAX_POWER_FOR_CHARGER = ((((rx_frame.data.u8[2] & 0x0F) << 6 | rx_frame.data.u8[3] >> 2) / 10.0) - 10);
-      break;
-    case 0x55B:
-      if (is_message_corrupt(rx_frame)) {
-        datalayer.battery2.status.CAN_error_counter++;
-        break;  //Message content malformed, abort reading data from it
-      }
-      battery2_TEMP = (rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6);
-      if (battery2_TEMP != 0x3ff) {  //3FF is unavailable value
-        battery2_SOC = battery2_TEMP;
-      }
-      battery2_Capacity_Empty = (bool)((rx_frame.data.u8[6] & 0x80) >> 7);
-      break;
-    case 0x5BC:
-      battery2_can_alive = true;
-      datalayer.battery2.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
-
-      battery2_MAX = ((rx_frame.data.u8[5] & 0x10) >> 4);
-      if (battery2_MAX) {
-        battery2_Max_GIDS = (rx_frame.data.u8[0] << 2) | ((rx_frame.data.u8[1] & 0xC0) >> 6);
-        //Max gids active, do nothing
-        //Only the 30/40/62kWh packs have this mux
-      } else {  //Normal current GIDS value is transmitted
-        battery2_GIDS = (rx_frame.data.u8[0] << 2) | ((rx_frame.data.u8[1] & 0xC0) >> 6);
-        battery2_Wh_Remaining = (battery2_GIDS * WH_PER_GID);
-      }
-
-      if (LEAF_battery2_Type == ZE0_BATTERY) {
-        battery2_AverageTemperature = (rx_frame.data.u8[3] - 40);  //In celcius, -40 to +55
-      }
-
-      battery2_TEMP = (rx_frame.data.u8[4] >> 1);
-      if (battery2_TEMP != 0) {
-        battery2_StateOfHealth = battery2_TEMP;  //Collect state of health from battery
-      }
-      break;
-    case 0x5C0:
-      //This temperature only works for 2013-2017 AZE0 LEAF packs, the mux is different on other generations
-      if (LEAF_battery2_Type == AZE0_BATTERY) {
-        if ((rx_frame.data.u8[0] >> 6) ==
-            1) {  // Battery MAX temperature. Effectively has only 7-bit precision, as the bottom bit is always 0.
-          battery2_HistData_Temperature_MAX = ((rx_frame.data.u8[2] / 2) - 40);
-        }
-        if ((rx_frame.data.u8[0] >> 6) ==
-            3) {  // Battery MIN temperature. Effectively has only 7-bit precision, as the bottom bit is always 0.
-          battery2_HistData_Temperature_MIN = ((rx_frame.data.u8[2] / 2) - 40);
-        }
-      }
-
-      battery2_HeatExist = (rx_frame.data.u8[4] & 0x01);
-      battery2_Heating_Stop = ((rx_frame.data.u8[0] & 0x10) >> 4);
-      battery2_Heating_Start = ((rx_frame.data.u8[0] & 0x20) >> 5);
-      battery2_Batt_Heater_Mail_Send_Request = (rx_frame.data.u8[1] & 0x01);
-
-      break;
-    case 0x59E:
-      //AZE0 2013-2017 or ZE1 2018-2023 battery detected
-      //Only detect as AZE0 if not already set as ZE1
-      if (LEAF_battery2_Type != ZE1_BATTERY) {
-        LEAF_battery2_Type = AZE0_BATTERY;
-      }
-      break;
-    case 0x1ED:
-    case 0x1C2:
-      //ZE1 2018-2023 battery detected!
-      LEAF_battery2_Type = ZE1_BATTERY;
-      break;
-    case 0x79B:
-      stop_battery_query = true;             //Someone is trying to read data with Leafspy, stop our own polling!
-      hold_off_with_polling_10seconds = 10;  //Polling is paused for 100s
-      break;
-    case 0x7BB:
-
-      if (stop_battery_query) {  //Leafspy/Service request is active, stop our own polling
-        break;
-      }
-
-      //First check which group data we are getting
-      if (rx_frame.data.u8[0] == 0x10) {  //First message of a group
-        battery2_group_7bb = rx_frame.data.u8[3];
-      }
-
-      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery_double);
-
-      if (battery2_group_7bb == 0x01)  //High precision SOC, Current, voltages etc.
-      {
-        if (rx_frame.data.u8[0] == 0x10) {  //First frame
-          //High precision battery2_current_1 resides here, but has been deemed unusable by 62kWh owners
-        }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second frame
-          //High precision battery2_current_2 resides here, but has been deemed unusable by 62kWh owners
-        }
-
-        if (rx_frame.data.u8[0] == 0x23) {  // Fourth frame
-          battery2_insulation = (uint16_t)((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-        }
-
-        if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame
-          battery2_HX = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 102.4;
-        }
-      }
-
-      if (battery2_group_7bb == 0x02)  //Cell Voltages
-      {
-        if (rx_frame.data.u8[0] == 0x10) {  //first frame is anomalous
-          battery2_request_idx = 0;
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-          break;
-        }
-        if (rx_frame.data.u8[6] == 0xFF && rx_frame.data.u8[0] == 0x2C) {  //Last frame
-          //Last frame does not contain any cell data, calculate the result
-
-          //Map all cell voltages to the global array
-          memcpy(datalayer.battery2.status.cell_voltages_mV, battery2_cell_voltages, 96 * sizeof(uint16_t));
-
-          //calculate min/max voltages
-          battery2_min_max_voltage[0] = 9999;
-          battery2_min_max_voltage[1] = 0;
-          for (battery2_cellcounter = 0; battery2_cellcounter < 96; battery2_cellcounter++) {
-            if (battery2_min_max_voltage[0] > battery2_cell_voltages[battery2_cellcounter])
-              battery2_min_max_voltage[0] = battery2_cell_voltages[battery2_cellcounter];
-            if (battery2_min_max_voltage[1] < battery2_cell_voltages[battery2_cellcounter])
-              battery2_min_max_voltage[1] = battery2_cell_voltages[battery2_cellcounter];
-          }
-
-          datalayer.battery2.status.cell_max_voltage_mV = battery2_min_max_voltage[1];
-          datalayer.battery2.status.cell_min_voltage_mV = battery2_min_max_voltage[0];
-
-          break;
-        }
-
-        if ((rx_frame.data.u8[0] % 2) == 0) {  //even frames
-          battery2_cell_voltages[battery2_request_idx++] |= rx_frame.data.u8[1];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-        } else {  //odd frames
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
-          battery2_cell_voltages[battery2_request_idx++] = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6];
-          battery2_cell_voltages[battery2_request_idx] = (rx_frame.data.u8[7] << 8);
-        }
-      }
-
-      if (battery2_group_7bb == 0x04) {     //Temperatures
-        if (rx_frame.data.u8[0] == 0x10) {  //First message
-          battery2_temp_raw_1 = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-          battery2_temp_raw_2_highnibble = rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second message
-          battery2_temp_raw_2 = (battery2_temp_raw_2_highnibble << 8) | rx_frame.data.u8[1];
-          battery2_temp_raw_3 = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
-          battery2_temp_raw_4 = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x22) {  //Third message
-          //All values read, let's figure out the min/max!
-
-          if (battery2_temp_raw_3 == 65535) {  //We are on a 2013+ pack that only has three temp sensors.
-            //Start with finding max value
-            battery2_temp_raw_max = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_4;
-            }
-            //Then find min
-            battery2_temp_raw_min = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_4;
-            }
-          } else {  //All 4 temp sensors available on 2011-2012
-            //Start with finding max value
-            battery2_temp_raw_max = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_3 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_3;
-            }
-            if (battery2_temp_raw_4 > battery2_temp_raw_max) {
-              battery2_temp_raw_max = battery2_temp_raw_4;
-            }
-            //Then find min
-            battery2_temp_raw_min = battery2_temp_raw_1;
-            if (battery2_temp_raw_2 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_3 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_2;
-            }
-            if (battery2_temp_raw_4 < battery2_temp_raw_min) {
-              battery2_temp_raw_min = battery2_temp_raw_4;
-            }
-          }
-        }
-      }
-
-      break;
-    default:
-      break;
-  }
-}
-#endif  // DOUBLE_BATTERY
 
 void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1DB:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        datalayer_battery->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_Current2 = (rx_frame.data.u8[0] << 3) | (rx_frame.data.u8[1] & 0xe0) >> 5;
@@ -786,7 +229,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x1DC:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        datalayer_battery->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_Discharge_Power_Limit = ((rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6) / 4.0);
@@ -795,7 +238,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x55B:
       if (is_message_corrupt(rx_frame)) {
-        datalayer.battery.status.CAN_error_counter++;
+        datalayer_battery->status.CAN_error_counter++;
         break;  //Message content malformed, abort reading data from it
       }
       battery_TEMP = (rx_frame.data.u8[0] << 2 | rx_frame.data.u8[1] >> 6);
@@ -806,7 +249,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x5BC:
       battery_can_alive = true;
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
 
       battery_MAX = ((rx_frame.data.u8[5] & 0x10) >> 4);
       if (battery_MAX) {
@@ -888,7 +331,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         group_7bb = rx_frame.data.u8[3];
       }
 
-      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_config.battery);  //Request the next frame for the group
+      transmit_can_frame(&LEAF_NEXT_LINE_REQUEST, can_interface);  //Request the next frame for the group
 
       if (group_7bb == 0x01)  //High precision SOC, Current, voltages etc.
       {
@@ -920,7 +363,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           //Last frame does not contain any cell data, calculate the result
 
           //Map all cell voltages to the global array
-          memcpy(datalayer.battery.status.cell_voltages_mV, battery_cell_voltages, 96 * sizeof(uint16_t));
+          memcpy(datalayer_battery->status.cell_voltages_mV, battery_cell_voltages, 96 * sizeof(uint16_t));
 
           //calculate min/max voltages
           battery_min_max_voltage[0] = 9999;
@@ -932,8 +375,8 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               battery_min_max_voltage[1] = battery_cell_voltages[battery_cellcounter];
           }
 
-          datalayer.battery.status.cell_max_voltage_mV = battery_min_max_voltage[1];
-          datalayer.battery.status.cell_min_voltage_mV = battery_min_max_voltage[0];
+          datalayer_battery->status.cell_max_voltage_mV = battery_min_max_voltage[1];
+          datalayer_battery->status.cell_min_voltage_mV = battery_min_max_voltage[0];
 
           break;
         }
@@ -1108,10 +551,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
           LEAF_1D4.data.u8[7] = 0xDE;
           break;
       }
-      transmit_can_frame(&LEAF_1D4, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_1D4, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_1D4, can_interface);
 
       switch (mprun10r) {
         case (0):
@@ -1204,10 +644,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
 
 //Only send this message when NISSANLEAF_CHARGER is not defined (otherwise it will collide!)
 #ifndef NISSANLEAF_CHARGER
-      transmit_can_frame(&LEAF_1F2, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_1F2, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_1F2, can_interface);
 #endif
 
       mprun10r = (mprun10r + 1) % 20;  // 0x1F2 patter repeats after 20 messages. 0-1..19-0
@@ -1231,10 +668,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       }
 
       // VCM message, containing info if battery should sleep or stay awake
-      transmit_can_frame(&LEAF_50B, can_config.battery);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_50B, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_50B, can_interface);  // HCM_WakeUpSleepCommand == 11b == WakeUp, and CANMASK = 1
 
       LEAF_50C.data.u8[3] = mprun100;
       switch (mprun100) {
@@ -1255,10 +689,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
           LEAF_50C.data.u8[5] = 0x9A;
           break;
       }
-      transmit_can_frame(&LEAF_50C, can_config.battery);
-#ifdef DOUBLE_BATTERY
-      transmit_can_frame(&LEAF_50C, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+      transmit_can_frame(&LEAF_50C, can_interface);
 
       mprun100 = (mprun100 + 1) % 4;  // mprun100 cycles between 0-1-2-3-0-1...
     }
@@ -1274,10 +705,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
         PIDindex = (PIDindex + 1) % 6;  // 6 = amount of elements in the PIDgroups[]
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
-        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery);
-#ifdef DOUBLE_BATTERY
-        transmit_can_frame(&LEAF_GROUP_REQUEST, can_config.battery_double);
-#endif  // DOUBLE_BATTERY
+        transmit_can_frame(&LEAF_GROUP_REQUEST, can_interface);
       }
 
       if (hold_off_with_polling_10seconds > 0) {
@@ -1289,7 +717,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
   }
 }
 
-bool is_message_corrupt(CAN_frame rx_frame) {
+bool NissanLeafBattery::is_message_corrupt(CAN_frame rx_frame) {
   uint8_t crc = 0;
   for (uint8_t j = 0; j < 7; j++) {
     crc = crctable[(crc ^ static_cast<uint8_t>(rx_frame.data.u8[j])) % 256];
@@ -1328,7 +756,7 @@ uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrib
   return static_cast<uint16_t>(1094 + (309 - temperature) * 2.5714285714285715);
 }
 
-void clearSOH(void) {
+void NissanLeafBattery::clearSOH(void) {
   stop_battery_query = true;
   hold_off_with_polling_10seconds = 10;  // Active battery polling is paused for 100 seconds
 
@@ -1339,19 +767,19 @@ void clearSOH(void) {
       break;
     case 1:  // Set CAN_PROCESS_FLAG to 0xC0
       LEAF_CLEAR_SOH.data = {0x02, 0x10, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // BMS should reply 02 50 C0 FF FF FF FF FF
       stateMachineClearSOH = 2;
       break;
     case 2:  // Set something ?
       LEAF_CLEAR_SOH.data = {0x02, 0x3E, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // BMS should reply 7E FF FF FF FF FF FF
       stateMachineClearSOH = 3;
       break;
     case 3:  // Request challenge to solve
       LEAF_CLEAR_SOH.data = {0x02, 0x27, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // BMS should reply with (challenge) 06 67 65 (02 DD 86 43) FF
       stateMachineClearSOH = 4;
       break;
@@ -1359,34 +787,34 @@ void clearSOH(void) {
       decodeChallengeData(incomingChallenge, solvedChallenge);
       LEAF_CLEAR_SOH.data = {
           0x10, 0x0A, 0x27, 0x66, solvedChallenge[0], solvedChallenge[1], solvedChallenge[2], solvedChallenge[3]};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // BMS should reply 7BB 8 30 01 00 FF FF FF FF FF // Proceed with more data (PID ACK)
       stateMachineClearSOH = 5;
       break;
     case 5:  // Reply with even more decoded challenge data
       LEAF_CLEAR_SOH.data = {
           0x21, solvedChallenge[4], solvedChallenge[5], solvedChallenge[6], solvedChallenge[7], 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // BMS should reply 02 67 66 FF FF FF FF FF // Thank you for the data
       stateMachineClearSOH = 6;
       break;
     case 6:  // Check if solved data was OK
       LEAF_CLEAR_SOH.data = {0x03, 0x31, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       //7BB 8 03 71 03 01 FF FF FF FF // If all is well, BMS replies with 03 71 03 01.
       //Incase you sent wrong challenge, you get 03 7f 31 12
       stateMachineClearSOH = 7;
       break;
     case 7:  // Reset SOH% request
       LEAF_CLEAR_SOH.data = {0x03, 0x31, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       //7BB 8 03 71 03 02 FF FF FF FF // 03 71 03 02 means that BMS accepted command.
       //7BB 03 7f 31 12 means your challenge was wrong, so command ignored
       stateMachineClearSOH = 8;
       break;
     case 8:  // Please proceed with resetting SOH
       LEAF_CLEAR_SOH.data = {0x02, 0x10, 0x81, 0x00, 0x00, 0x00, 0x00, 0x00};
-      transmit_can_frame(&LEAF_CLEAR_SOH, can_config.battery);
+      transmit_can_frame(&LEAF_CLEAR_SOH, can_interface);
       // 7BB 8 02 50 81 FF FF FF FF FF // SOH reset OK
       stateMachineClearSOH = 255;
       break;
@@ -1511,12 +939,12 @@ void decodeChallengeData(unsigned int incomingChallenge, unsigned char* solvedCh
 void NissanLeafBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Nissan LEAF battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer_battery->info.number_of_cells = 96;
+  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 }
 
 #endif  //NISSAN_LEAF_BATTERY

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -18,14 +18,18 @@
 
 class NissanLeafBattery : public CanBattery {
  public:
+  // Use this constructor for the second battery.
   NissanLeafBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, bool* allows_contactor_closing_ptr,
                     DATALAYER_INFO_NISSAN_LEAF* extended, int targetCan) {
     datalayer_battery = datalayer_ptr;
     allows_contactor_closing = allows_contactor_closing_ptr;
     datalayer_nissan = extended;
     can_interface = targetCan;
+
+    battery_Total_Voltage2 = 0;
   }
 
+  // Use the default constructor to create the first or single battery.
   NissanLeafBattery() {
     datalayer_battery = &datalayer.battery;
     allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -1,10 +1,14 @@
 #ifndef NISSAN_LEAF_BATTERY_H
 #define NISSAN_LEAF_BATTERY_H
 
+#include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
+#include "../include.h"
 #include "CanBattery.h"
 
 #define BATTERY_SELECTED
 #define SELECTED_BATTERY_CLASS NissanLeafBattery
+#define EXTENDED_DATA_PTR (&datalayer_extended.nissanleaf)
 
 #define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 2600
@@ -14,21 +18,167 @@
 
 class NissanLeafBattery : public CanBattery {
  public:
+  NissanLeafBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, bool* allows_contactor_closing_ptr,
+                    DATALAYER_INFO_NISSAN_LEAF* extended, int targetCan) {
+    datalayer_battery = datalayer_ptr;
+    allows_contactor_closing = allows_contactor_closing_ptr;
+    datalayer_nissan = extended;
+    can_interface = targetCan;
+  }
+
+  NissanLeafBattery() {
+    datalayer_battery = &datalayer.battery;
+    allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
+    datalayer_nissan = &datalayer_extended.nissanleaf;
+    can_interface = can_config.battery;
+  }
+
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-};
 
-uint16_t Temp_fromRAW_to_F(uint16_t temperature);
-bool is_message_corrupt(CAN_frame rx_frame);
-void clearSOH(void);
-//Cryptographic functions
-void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);
-unsigned int CyclicXorHash16Bit(unsigned int param_1, unsigned int param_2);
-unsigned int ComputeMaskedXorProduct(unsigned int param_1, unsigned int param_2, unsigned int param_3);
-short ShortMaskedSumAndProduct(short param_1, short param_2);
-unsigned int MaskedBitwiseRotateMultiply(unsigned int param_1, unsigned int param_2);
-unsigned int CryptAlgo(unsigned int param_1, unsigned int param_2, unsigned int param_3);
+ private:
+  bool is_message_corrupt(CAN_frame rx_frame);
+  void clearSOH(void);
+
+  DATALAYER_BATTERY_TYPE* datalayer_battery;
+  DATALAYER_INFO_NISSAN_LEAF* datalayer_nissan;
+  bool* allows_contactor_closing;
+
+  int can_interface;
+
+  unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+  unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
+  uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
+  uint8_t mprun10 = 0;                  //counter 0-3
+  uint8_t mprun100 = 0;                 //counter 0-3
+
+  // These CAN messages need to be sent towards the battery to keep it alive
+  CAN_frame LEAF_1F2 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1F2,
+                        .data = {0x10, 0x64, 0x00, 0xB0, 0x00, 0x1E, 0x00, 0x8F}};
+  CAN_frame LEAF_50B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 7,
+                        .ID = 0x50B,
+                        .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_50C = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 6,
+                        .ID = 0x50C,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_1D4 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1D4,
+                        .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
+  // Active polling messages
+  uint8_t PIDgroups[6] = {0x01, 0x02, 0x04, 0x83, 0x84, 0x90};
+  uint8_t PIDindex = 0;
+  CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
+                                  .ext_ID = false,
+                                  .DLC = 8,
+                                  .ID = 0x79B,
+                                  .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
+  CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
+                                      .ext_ID = false,
+                                      .DLC = 8,
+                                      .ID = 0x79B,
+                                      .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+
+  // The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
+  // groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second
+  // replies with all the battery’s cells voltages in millivolt, the third and the fifth one are still unknown, the
+  // fourth contains the four battery packs temperatures, and the last one tells which cell has the shunt active.
+  // There are also two more groups: group 61, which replies with lots of CAN messages (up to 48); here we
+  // found the SOH value, and group 84 that replies with the HV battery production serial.
+
+  uint8_t crctable[256] = {
+      0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,
+      247, 114, 80,  213, 223, 90,  203, 78,  68,  193, 67,  198, 204, 73,  216, 93,  87,  210, 240, 117, 127, 250,
+      107, 238, 228, 97,  160, 37,  47,  170, 59,  190, 180, 49,  19,  150, 156, 25,  136, 13,  7,   130, 134, 3,
+      9,   140, 29,  152, 146, 23,  53,  176, 186, 63,  174, 43,  33,  164, 101, 224, 234, 111, 254, 123, 113, 244,
+      214, 83,  89,  220, 77,  200, 194, 71,  197, 64,  74,  207, 94,  219, 209, 84,  118, 243, 249, 124, 237, 104,
+      98,  231, 38,  163, 169, 44,  189, 56,  50,  183, 149, 16,  26,  159, 14,  139, 129, 4,   137, 12,  6,   131,
+      18,  151, 157, 24,  58,  191, 181, 48,  161, 36,  46,  171, 106, 239, 229, 96,  241, 116, 126, 251, 217, 92,
+      86,  211, 66,  199, 205, 72,  202, 79,  69,  192, 81,  212, 222, 91,  121, 252, 246, 115, 226, 103, 109, 232,
+      41,  172, 166, 35,  178, 55,  61,  184, 154, 31,  21,  144, 1,   132, 142, 11,  15,  138, 128, 5,   148, 17,
+      27,  158, 188, 57,  51,  182, 39,  162, 168, 45,  236, 105, 99,  230, 119, 242, 248, 125, 95,  218, 208, 85,
+      196, 65,  75,  206, 76,  201, 195, 70,  215, 82,  88,  221, 255, 122, 112, 245, 100, 225, 235, 110, 175, 42,
+      32,  165, 52,  177, 187, 62,  28,  153, 147, 22,  135, 2,   8,   141};
+
+//Nissan LEAF battery parameters from constantly sent CAN
+#define ZE0_BATTERY 0
+#define AZE0_BATTERY 1
+#define ZE1_BATTERY 2
+  uint8_t LEAF_battery_Type = ZE0_BATTERY;
+  bool battery_can_alive = false;
+#define WH_PER_GID 77                          //One GID is this amount of Watt hours
+  uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
+  uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW
+  int16_t battery_MAX_POWER_FOR_CHARGER = 0;   //Limit in kW
+  int16_t battery_SOC = 500;                   //0 - 100.0 % (0-1000) The real SOC% in the battery
+  uint16_t battery_TEMP = 0;                   //Temporary value used in status checks
+  uint16_t battery_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
+  uint16_t battery_GIDS = 273;                 //Startup in 24kWh mode
+  uint16_t battery_MAX = 0;
+  uint16_t battery_Max_GIDS = 273;               //Startup in 24kWh mode
+  uint16_t battery_StateOfHealth = 99;           //State of health %
+  uint16_t battery_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
+  int16_t battery_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
+  int16_t battery_HistData_Temperature_MAX = 6;  //-40 to 86*C
+  int16_t battery_HistData_Temperature_MIN = 5;  //-40 to 86*C
+  int16_t battery_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
+  uint8_t battery_Relay_Cut_Request = 0;         //battery_FAIL
+  uint8_t battery_Failsafe_Status = 0;           //battery_STATUS
+  bool battery_Interlock =
+      true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
+  bool battery_Full_CHARGE_flag = false;  //battery_FCHGEND , Goes to 1 if battery is fully charged
+  bool battery_MainRelayOn_flag = false;  //No-Permission=0, Main Relay On Permission=1
+  bool battery_Capacity_Empty = false;    //battery_EMPTY, , Goes to 1 if battery is empty
+  bool battery_HeatExist = false;      //battery_HEATEXIST, Specifies if battery pack is equipped with heating elements
+  bool battery_Heating_Stop = false;   //When transitioning from 0->1, signals a STOP heat request
+  bool battery_Heating_Start = false;  //When transitioning from 1->0, signals a START heat request
+  bool battery_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
+
+  // Nissan LEAF battery data from polled CAN messages
+  uint8_t battery_request_idx = 0;
+  uint8_t group_7bb = 0;
+  bool stop_battery_query = true;
+  uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
+  uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
+  uint8_t battery_cellcounter = 0;
+  uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
+  uint16_t battery_HX = 0;              //Internal resistance
+  uint16_t battery_insulation = 0;      //Insulation resistance
+  uint16_t battery_temp_raw_1 = 0;
+  uint8_t battery_temp_raw_2_highnibble = 0;
+  uint16_t battery_temp_raw_2 = 0;
+  uint16_t battery_temp_raw_3 = 0;
+  uint16_t battery_temp_raw_4 = 0;
+  uint16_t battery_temp_raw_max = 0;
+  uint16_t battery_temp_raw_min = 0;
+  int16_t battery_temp_polled_max = 0;
+  int16_t battery_temp_polled_min = 0;
+  uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
+  uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
+  uint8_t BMSIDcode[8] = {0};
+
+  // Clear SOH values
+  uint8_t stateMachineClearSOH = 0xFF;
+  uint32_t incomingChallenge = 0xFFFFFFFF;
+  uint8_t solvedChallenge[8];
+  bool challengeFailed = false;
+
+  CAN_frame LEAF_CLEAR_SOH = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x79B,
+                              .data = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+};
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -1,19 +1,27 @@
 #ifndef NISSAN_LEAF_BATTERY_H
 #define NISSAN_LEAF_BATTERY_H
 
-#include "../include.h"
+#include "CanBattery.h"
 
 #define BATTERY_SELECTED
+#define SELECTED_BATTERY_CLASS NissanLeafBattery
+
 #define MAX_PACK_VOLTAGE_DV 4040  //5000 = 500.0V
 #define MIN_PACK_VOLTAGE_DV 2600
 #define MAX_CELL_DEVIATION_MV 150
 #define MAX_CELL_VOLTAGE_MV 4250  //Battery is put into emergency stop if one cell goes over this value
 #define MIN_CELL_VOLTAGE_MV 2700  //Battery is put into emergency stop if one cell goes below this value
 
+class NissanLeafBattery : public CanBattery {
+ public:
+  virtual void setup(void);
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void update_values();
+  virtual void transmit_can(unsigned long currentMillis);
+};
+
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 bool is_message_corrupt(CAN_frame rx_frame);
-void setup_battery(void);
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
 void clearSOH(void);
 //Cryptographic functions
 void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef NISSANLEAF_CHARGER
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "NISSAN-LEAF-CHARGER.h"
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -1,7 +1,9 @@
 #ifndef _DATALAYER_H_
 #define _DATALAYER_H_
 
-#include "../include.h"
+#include "../../USER_SETTINGS.h"
+#include "../devboard/utils/types.h"
+#include "../system_settings.h"
 
 typedef struct {
   /** uint32_t */

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -1,7 +1,8 @@
 #ifndef _DATALAYER_EXTENDED_H_
 #define _DATALAYER_EXTENDED_H_
 
-#include "../include.h"
+#include <stdint.h>
+#include "../../USER_SETTINGS.h"
 
 typedef struct {
   /** uint16_t */


### PR DESCRIPTION
### What
This PR ports Nissan Leaf battery to use the class interface. In addition this introduces a way to implement double battery support with the new class interface.

### Why
This is part of a continuous effort to bring all batteries to class based interface.

### How
Nissan Leaf battery specific code is implemented as C++ class. Two instances of the same class is used when double battery support is activated. This design eliminates the need of duplicate code. Each instance uses separate CAN bus and writes to a different part of the "datalayer" similarly as the earlier double battery implementation. Static variables are moved to class members to allow two identical copies to exist in memory at the same time. The two battery instances operate identically with the exception of the first battery only updating the "extended datalayer".
