### PR TITLE
Use common base class for Afore CAN inverter protocol

### DIFF
--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef AFORE_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "AFORE-CAN.h"
 
@@ -7,73 +8,9 @@
 #define SOCMIN 1
 
 /* Do not change code below unless you are sure what you are doing */
-/* The code is following the Afore 2.3 CAN standard, little-endian, 500kbps, from 2023.08.07 */
-static uint8_t inverter_status =
-    0;  //0 = init, 1 = standby, 2 = starting, 3 = grid connected, 4 off-grid, 5 diesel generator, 6 grid connected, but disconnected, 7off grid and disconnected, 8 = power failure processing, 9 = power off, 10 = Failure
-static bool time_to_send_info = false;
-static uint8_t char0 = 0;
-static uint8_t char1 = 0;
-static uint8_t char2 = 0;
-static uint8_t char3 = 0;
-static uint8_t char4 = 0;
-//Actual content messages
-CAN_frame AFORE_350 = {.FD = false,  // Operation information
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x350,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_351 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x351,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_352 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x352,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_353 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x353,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_354 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x354,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_355 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x355,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_356 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x356,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_357 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x357,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_358 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x358,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame AFORE_359 = {.FD = false,  // Serial number 0-7
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x359,
-                       .data = {0x62, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79, 0x2D}};  // Battery-
-CAN_frame AFORE_35A = {.FD = false,                                                // Serial number 8-15
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x35A,
-                       .data = {0x65, 0x6D, 0x75, 0x6C, 0x61, 0x74, 0x6F, 0x72}};  // Emulator
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void AforeCanInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   //There are more mappings that could be added, but this should be enough to use as a starting point
 
   /*0x350 Operation Information*/
@@ -200,7 +137,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void AforeCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:  // Every 1s from inverter
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -217,7 +154,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void AforeCanInverter::transmit_can(unsigned long currentMillis) {
   if (time_to_send_info) {  // Set every 1s if we get message from inverter
     transmit_can_frame(&AFORE_350, can_config.inverter);
     transmit_can_frame(&AFORE_351, can_config.inverter);
@@ -233,7 +170,8 @@ void transmit_can_inverter(unsigned long currentMillis) {
     time_to_send_info = false;
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+
+void AforeCanInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Afore battery over CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -3,8 +3,81 @@
 #include "../include.h"
 
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS AforeCanInverter
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class AforeCanInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+  void update_values();
+
+ private:
+  /* The code is following the Afore 2.3 CAN standard, little-endian, 500kbps, from 2023.08.07 */
+  uint8_t inverter_status =
+      0;  //0 = init, 1 = standby, 2 = starting, 3 = grid connected, 4 off-grid, 5 diesel generator, 6 grid connected, but disconnected, 7off grid and disconnected, 8 = power failure processing, 9 = power off, 10 = Failure
+  bool time_to_send_info = false;
+  uint8_t char0 = 0;
+  uint8_t char1 = 0;
+  uint8_t char2 = 0;
+  uint8_t char3 = 0;
+  uint8_t char4 = 0;
+  //Actual content messages
+  CAN_frame AFORE_350 = {.FD = false,  // Operation information
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x350,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_351 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x351,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_352 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x352,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_353 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x353,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_354 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x354,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_355 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x355,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_356 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x356,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_357 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x357,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_358 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x358,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame AFORE_359 = {.FD = false,  // Serial number 0-7
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x359,
+                         .data = {0x62, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79, 0x2D}};  // Battery-
+  CAN_frame AFORE_35A = {.FD = false,                                                // Serial number 8-15
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x35A,
+                         .data = {0x65, 0x6D, 0x75, 0x6C, 0x61, 0x74, 0x6F, 0x72}};  // Emulator
+};
 
 #endif

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -95,7 +95,7 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       inverterStartedUp = true;
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[0] & 0x01) {  //Battery requests identification
-        send_intial_data();
+        send_initial_data();
       } else {  // We can identify what inverter type we are connected to
         for (uint8_t i = 0; i < 7; i++) {
           datalayer.system.info.inverter_brand[i] = rx_frame.data.u8[i + 1];
@@ -135,7 +135,7 @@ void BydCanInverter::transmit_can(unsigned long currentMillis) {
 
   // Send initial CAN data once on bootup
   if (!initialDataSent) {
-    send_intial_data();
+    send_initial_data();
     initialDataSent = true;
   }
 
@@ -161,7 +161,7 @@ void BydCanInverter::transmit_can(unsigned long currentMillis) {
   }
 }
 
-void BydCanInverter::send_intial_data() {
+void BydCanInverter::send_initial_data() {
   transmit_can_frame(&BYD_250, can_config.inverter);
   transmit_can_frame(&BYD_290, can_config.inverter);
   transmit_can_frame(&BYD_2D0, can_config.inverter);

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -11,13 +11,12 @@
 class BydCanInverter : public CanInverterProtocol {
  public:
   void setup();
-  void send_intial_data();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-
- private:
   void update_values();
 
+ private:
+  void send_initial_data();
   unsigned long previousMillis2s = 0;   // will store last time a 2s CAN Message was send
   unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was send
   unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -16,8 +16,6 @@ class ModbusInverterProtocol : public InverterProtocol {
 
 class CanInverterProtocol : public InverterProtocol {
  public:
-  virtual void send_intial_data() = 0;
-
   //This function maps all the values fetched from battery CAN to the correct CAN messages
   virtual void update_values() = 0;
 


### PR DESCRIPTION
Yet another inverter protocol converted to use the common base class.