### PR TITLE
Chargers use a base class

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -101,6 +101,10 @@ void setup() {
   init_precharge_control();
 #endif  // PRECHARGE_CONTROL
 
+#if defined(CHARGER_SELECTED)
+  setup_charger();
+#endif
+
 #if defined(CAN_INVERTER_SELECTED) || defined(MODBUS_INVERTER_SELECTED) || defined(RS485_INVERTER_SELECTED)
   setup_inverter();
 #endif

--- a/Software/src/charger/CHARGERS.cpp
+++ b/Software/src/charger/CHARGERS.cpp
@@ -1,0 +1,19 @@
+#include "../include.h"
+
+#ifdef SELECTED_CHARGER_CLASS
+
+static CanCharger* charger;
+
+void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
+  charger->map_can_frame_to_variable(rx_frame);
+}
+
+void transmit_can_charger(unsigned long currentMillis) {
+  charger->transmit_can(currentMillis);
+}
+
+void setup_charger() {
+  charger = new SELECTED_CHARGER_CLASS();
+}
+
+#endif

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -12,5 +12,6 @@
 
 void map_can_frame_to_variable_charger(CAN_frame rx_frame);
 void transmit_can_charger(unsigned long currentMillis);
+void setup_charger();
 
 #endif

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -19,29 +19,8 @@
  * 2024 smaresca
  */
 
-/* CAN cycles and timers */
-static unsigned long previousMillis30ms = 0;    // 30ms cycle for keepalive frames
-static unsigned long previousMillis200ms = 0;   // 200ms cycle for commanding I/V targets
-static unsigned long previousMillis5000ms = 0;  // 5s status printout to serial
-
-enum CHARGER_MODES : uint8_t { MODE_DISABLED = 0, MODE_LV, MODE_HV, MODE_HVLV };
-
-//Actual content messages
-static CAN_frame charger_keepalive_frame = {.FD = false,
-                                            .ext_ID = false,
-                                            .DLC = 1,
-                                            .ID = 0x30E,  //one byte only, indicating enabled or disabled
-                                            .data = {MODE_DISABLED}};
-
-static CAN_frame charger_set_targets = {
-    .FD = false,
-    .ext_ID = false,
-    .DLC = 4,
-    .ID = 0x304,
-    .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a static value, meaning unknown
-
 /* We are mostly sending out not receiving */
-void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
+void ChevyVoltCharger::map_can_frame_to_variable(CAN_frame rx_frame) {
   uint16_t charger_stat_HVcur_temp = 0;
   uint16_t charger_stat_HVvol_temp = 0;
   uint16_t charger_stat_LVcur_temp = 0;
@@ -98,7 +77,7 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_charger(unsigned long currentMillis) {
+void ChevyVoltCharger::transmit_can(unsigned long currentMillis) {
   uint16_t Vol_temp = 0;
 
   uint16_t setpoint_HV_VDC = floor(datalayer.charger.charger_setpoint_HV_VDC);

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -3,7 +3,10 @@
 #include <Arduino.h>
 #include "../include.h"
 
+#include "CanCharger.h"
+
 #define CHARGER_SELECTED
+#define SELECTED_CHARGER_CLASS ChevyVoltCharger
 
 /* Charger hardware limits
  *
@@ -14,5 +17,32 @@
 #define CHEVYVOLT_MIN_HVDC 200.0
 #define CHEVYVOLT_MAX_AMP 11.5
 #define CHEVYVOLT_MAX_POWER 3300
+
+class ChevyVoltCharger : public CanCharger {
+ public:
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+  void transmit_can(unsigned long currentMillis);
+
+ private:
+  /* CAN cycles and timers */
+  unsigned long previousMillis30ms = 0;    // 30ms cycle for keepalive frames
+  unsigned long previousMillis200ms = 0;   // 200ms cycle for commanding I/V targets
+  unsigned long previousMillis5000ms = 0;  // 5s status printout to serial
+
+  enum CHARGER_MODES : uint8_t { MODE_DISABLED = 0, MODE_LV, MODE_HV, MODE_HVLV };
+
+  //Actual content messages
+  CAN_frame charger_keepalive_frame = {.FD = false,
+                                       .ext_ID = false,
+                                       .DLC = 1,
+                                       .ID = 0x30E,  //one byte only, indicating enabled or disabled
+                                       .data = {MODE_DISABLED}};
+
+  CAN_frame charger_set_targets = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 4,
+                                   .ID = 0x304,
+                                   .data = {0x40, 0x00, 0x00, 0x00}};  // data[0] is a value, meaning unknown
+};
 
 #endif

--- a/Software/src/charger/CanCharger.h
+++ b/Software/src/charger/CanCharger.h
@@ -1,0 +1,12 @@
+#ifndef CAN_CHARGER_H
+#define CAN_CHARGER_H
+
+#include "src/devboard/utils/types.h"
+
+class CanCharger {
+ public:
+  virtual void map_can_frame_to_variable(CAN_frame rx_frame) = 0;
+  virtual void transmit_can(unsigned long currentMillis) = 0;
+};
+
+#endif

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.cpp
@@ -20,68 +20,6 @@
  * battery onto the CAN bus. 
 */
 
-/* CAN cycles and timers */
-static unsigned long previousMillis10ms = 0;
-static unsigned long previousMillis100ms = 0;
-
-/* LEAF charger/battery parameters */
-enum OBC_MODES : uint8_t {
-  IDLE_OR_QC = 1,
-  FINISHED = 2,
-  CHARGING_OR_INTERRUPTED = 4,
-  IDLE1 = 8,
-  IDLE2 = 9,
-  PLUGGED_IN_WAITING_ON_TIMER
-};
-enum OBC_VOLTAGES : uint8_t { NO_SIGNAL = 0, AC110 = 1, AC230 = 2, ABNORMAL_WAVE = 3 };
-static uint16_t OBC_Charge_Power = 0;  // Actual charger output
-static uint8_t mprun100 = 0;           // Counter 0-3
-static uint8_t mprun10 = 0;            // Counter 0-3
-static uint8_t OBC_Charge_Status = IDLE_OR_QC;
-static uint8_t OBC_Status_AC_Voltage = 0;  //1=110V, 2=230V
-static uint8_t OBCpowerSetpoint = 0;
-static uint8_t OBCpower = 0;
-static bool PPStatus = false;
-static bool OBCwakeup = false;
-
-//Actual content messages
-static CAN_frame LEAF_1DB = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x1DB,
-                             .data = {0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00}};
-static CAN_frame LEAF_1DC = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x1DC,
-                             .data = {0x6E, 0x0A, 0x05, 0xD5, 0x00, 0x00, 0x00, 0x00}};
-static CAN_frame LEAF_1F2 = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x1F2,
-                             .data = {0x30, 0x00, 0x20, 0xAC, 0x00, 0x3C, 0x00, 0x8F}};
-static CAN_frame LEAF_50B = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 7,
-                             .ID = 0x50B,
-                             .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
-static CAN_frame LEAF_55B = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x55B,
-                             .data = {0xA4, 0x40, 0xAA, 0x00, 0xDF, 0xC0, 0x10, 0x00}};
-static CAN_frame LEAF_5BC = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x5BC,
-                             .data = {0x3D, 0x80, 0xF0, 0x64, 0xB0, 0x01, 0x00, 0x32}};
-
-static CAN_frame LEAF_59E = {.FD = false,
-                             .ext_ID = false,
-                             .DLC = 8,
-                             .ID = 0x59E,
-                             .data = {0x00, 0x00, 0x0C, 0x76, 0x18, 0x00, 0x00, 0x00}};
-
 static uint8_t crctable[256] = {
     0,   133, 143, 10,  155, 30,  20,  145, 179, 54,  60,  185, 40,  173, 167, 34,  227, 102, 108, 233, 120, 253,
     247, 114, 80,  213, 223, 90,  203, 78,  68,  193, 67,  198, 204, 73,  216, 93,  87,  210, 240, 117, 127, 250,
@@ -114,7 +52,7 @@ static uint8_t calculate_checksum_nibble(CAN_frame* frame) {
   return sum;
 }
 
-void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
+void NissanLeafCharger::map_can_frame_to_variable(CAN_frame rx_frame) {
 
   switch (rx_frame.ID) {
     case 0x679:  // This message fires once when charging cable is plugged in
@@ -156,7 +94,7 @@ void map_can_frame_to_variable_charger(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_charger(unsigned long currentMillis) {
+void NissanLeafCharger::transmit_can(unsigned long currentMillis) {
 
   /* Send keepalive with mode every 10ms */
   if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -3,6 +3,77 @@
 #include <Arduino.h>
 #include "../include.h"
 
+#include "CanCharger.h"
 #define CHARGER_SELECTED
+#define SELECTED_CHARGER_CLASS NissanLeafCharger
+
+class NissanLeafCharger : public CanCharger {
+ public:
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+  void transmit_can(unsigned long currentMillis);
+
+ private:
+  /* CAN cycles and timers */
+  unsigned long previousMillis10ms = 0;
+  unsigned long previousMillis100ms = 0;
+
+  /* LEAF charger/battery parameters */
+  enum OBC_MODES : uint8_t {
+    IDLE_OR_QC = 1,
+    FINISHED = 2,
+    CHARGING_OR_INTERRUPTED = 4,
+    IDLE1 = 8,
+    IDLE2 = 9,
+    PLUGGED_IN_WAITING_ON_TIMER
+  };
+  enum OBC_VOLTAGES : uint8_t { NO_SIGNAL = 0, AC110 = 1, AC230 = 2, ABNORMAL_WAVE = 3 };
+  uint16_t OBC_Charge_Power = 0;  // Actual charger output
+  uint8_t mprun100 = 0;           // Counter 0-3
+  uint8_t mprun10 = 0;            // Counter 0-3
+  uint8_t OBC_Charge_Status = IDLE_OR_QC;
+  uint8_t OBC_Status_AC_Voltage = 0;  //1=110V, 2=230V
+  uint8_t OBCpowerSetpoint = 0;
+  uint8_t OBCpower = 0;
+  bool PPStatus = false;
+  bool OBCwakeup = false;
+
+  //Actual content messages
+  CAN_frame LEAF_1DB = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1DB,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_1DC = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1DC,
+                        .data = {0x6E, 0x0A, 0x05, 0xD5, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_1F2 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1F2,
+                        .data = {0x30, 0x00, 0x20, 0xAC, 0x00, 0x3C, 0x00, 0x8F}};
+  CAN_frame LEAF_50B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 7,
+                        .ID = 0x50B,
+                        .data = {0x00, 0x00, 0x06, 0xC0, 0x00, 0x00, 0x00}};
+  CAN_frame LEAF_55B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x55B,
+                        .data = {0xA4, 0x40, 0xAA, 0x00, 0xDF, 0xC0, 0x10, 0x00}};
+  CAN_frame LEAF_5BC = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x5BC,
+                        .data = {0x3D, 0x80, 0xF0, 0x64, 0xB0, 0x01, 0x00, 0x32}};
+
+  CAN_frame LEAF_59E = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x59E,
+                        .data = {0x00, 0x00, 0x0C, 0x76, 0x18, 0x00, 0x00, 0x00}};
+};
 
 #endif


### PR DESCRIPTION
### What
This PR converts the two charger implementation to use a common base class.

### Why
To support the future common image with run-time selectable chargers as well.

### How
We follow a similar pattern as with batteries and inverter protocols: A common abstract base class is defined for CAN chargers and both charger implementations implement that interface. Charger is setup by instantiating the corresponding class and the old API is implemented by calling methods on the instance.