### PR TITLE
BMW iX: add functionality to close and open contactors

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -19,4 +19,69 @@
 void setup_battery(void);
 void transmit_can_frame(CAN_frame* tx_frame, int interface);
 
+/**
+ * @brief Handle incoming user request to close or open contactors
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void HandleIncomingUserRequest(void);
+
+/**
+ * @brief Handle incoming inverter request to close or open contactors.alignas
+ * 
+ * This function uses the "inverter_allows_contactor_closing" flag from the datalayer, to determine if CAN messages shall be sent to the battery to close or open the contactors.
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void HandleIncomingInverterRequest(void);
+
+/**
+ * @brief Close contactors of the BMW iX battery
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void BmwIxCloseContactors(void);
+
+/**
+ * @brief Handle close contactors requests for the BMW iX battery
+ *
+ * @param[in] counter_10ms Counter that increments by 1, every 10ms
+ *
+ * @return void
+ */
+void HandleBmwIxCloseContactorsRequest(uint16_t counter_10ms);
+
+/**
+ * @brief Keep contactors of the BMW iX battery closed
+ *
+ * @param[in] counter_100ms Counter that increments by 1, every 100 ms
+ *
+ * @return void
+ */
+void BmwIxKeepContactorsClosed(uint8_t counter_100ms);
+
+/**
+ * @brief Open contactors of the BMW iX battery
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void BmwIxOpenContactors(void);
+
+/**
+ * @brief Handle open contactors requests for the BMW iX battery
+ *
+ * @param[in] counter_10ms Counter that increments by 1, every 10ms
+ *
+ * @return void
+ */
+void HandleBmwIxOpenContactorsRequest(uint16_t counter_10ms);
+
 #endif

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -41,6 +41,9 @@ typedef struct {
 } DATALAYER_INFO_BOLTAMPERA;
 
 typedef struct {
+  /** User requesting contactor open or close via WebUI*/
+  bool UserRequestContactorClose = false;
+  bool UserRequestContactorOpen = false;
   /** uint16_t */
   /** Terminal 30 - 12V SME Supply Voltage */
   uint16_t T30_Voltage = 0;

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -58,6 +58,8 @@ String advanced_battery_processor(const String& var) {
 #endif  //BOLT_AMPERA_BATTERY
 
 #ifdef BMW_IX_BATTERY
+    content += "<button onclick='askContactorClose()'>Close Contactors</button>";
+    content += "<button onclick='askContactorOpen()'>Open Contactors</button>";
     content +=
         "<h4>Battery Voltage after Contactor: " + String(datalayer_extended.bmwix.battery_voltage_after_contactor) +
         " dV</h4>";
@@ -1492,6 +1494,7 @@ String advanced_battery_processor(const String& var) {
 #endif
 
     content += "</div>";
+
     content += "<script>";
     content +=
         "function askTeslaClearIsolation() { if (window.confirm('Are you sure you want to clear any active isolation "
@@ -1504,6 +1507,7 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+
     content += "<script>";
     content +=
         "function askTeslaResetBMS() { if (window.confirm('Are you sure you want to reset the "
@@ -1516,6 +1520,7 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+
     content += "<script>";
     content +=
         "function askResetCrash() { if (window.confirm('Are you sure you want to reset crash data? "
@@ -1540,6 +1545,33 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+
+    content += "<script>";
+    content +=
+        "function askContactorClose() { if (window.confirm('Are you sure you want to tirgger "
+        "a contactor close request?')) { "
+        "bmwIxCloseContactorRequest(); } }";
+    content += "function bmwIxCloseContactorRequest() {";
+    content += "  var xhr = new XMLHttpRequest();";
+    content += "  xhr.open('GET', '/bmwIxCloseContactorRequest', true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function goToMainPage() { window.location.href = '/'; }";
+    content += "</script>";
+
+    content += "<script>";
+    content +=
+        "function askContactorOpen() { if (window.confirm('Are you sure you want to tirgger "
+        "a contactor open request?')) { "
+        "bmwIxOpenContactorRequest(); } }";
+    content += "function bmwIxOpenContactorRequest() {";
+    content += "  var xhr = new XMLHttpRequest();";
+    content += "  xhr.open('GET', '/bmwIxOpenContactorRequest', true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function goToMainPage() { window.location.href = '/'; }";
+    content += "</script>";
+
     content += "<script>";
     content +=
         "function askResetSOH() { if (window.confirm('Are you sure you want to reset degradation data? "
@@ -1552,6 +1584,7 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+
     content += "<script>";
     content +=
         "function Volvo_askEraseDTC() { if (window.confirm('Are you sure you want to erase DTCs?')) { "
@@ -1585,6 +1618,7 @@ String advanced_battery_processor(const String& var) {
     content += "}";
     content += "function goToMainPage() { window.location.href = '/'; }";
     content += "</script>";
+
     // Additial functions added
     content += "<script>";
     content += "function exportLog() { window.location.href = '/export_log'; }";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -599,6 +599,24 @@ void init_webserver() {
     request->send(200, "text/plain", "Updated successfully");
   });
 
+  // Route for closing BMW iX Contactors
+  server.on("/bmwIxCloseContactorRequest", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
+      return request->requestAuthentication();
+    }
+    datalayer_extended.bmwix.UserRequestContactorClose = true;
+    request->send(200, "text/plain", "Updated successfully");
+  });
+
+  // Route for opening BMW iX Contactors
+  server.on("/bmwIxOpenContactorRequest", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
+      return request->requestAuthentication();
+    }
+    datalayer_extended.bmwix.UserRequestContactorOpen = true;
+    request->send(200, "text/plain", "Updated successfully");
+  });
+
   // Route for resetting SOH on Nissan LEAF batteries
   server.on("/resetSOH", HTTP_GET, [](AsyncWebServerRequest* request) {
     if (WEBSERVER_AUTH_REQUIRED && !request->authenticate(http_username, http_password)) {
@@ -1207,15 +1225,14 @@ String processor(const String& var) {
       }
     }
 
-    content += "<h4>Automatic contactor closing allowed:</h4>";
-    content += "<h4>Battery: ";
+    content += "<h4>Battery allows contactor closing: ";
     if (datalayer.system.status.battery_allows_contactor_closing == true) {
       content += "<span>&#10003;</span>";
     } else {
       content += "<span style='color: red;'>&#10005;</span>";
     }
 
-    content += " Inverter: ";
+    content += " Inverter allows contactor closing: ";
     if (datalayer.system.status.inverter_allows_contactor_closing == true) {
       content += "<span>&#10003;</span></h4>";
     } else {


### PR DESCRIPTION
### What
This PR:
- adds functionality to close and open the contactors for BMW iX batteries
- adds buttons to the "More battery info" page to close and open the contactors
- updates the webserver to clarify that ✅  and ❌ indicate that the battery/inverter **allows contactors closing**.

### Why
To support contactor closing for the BMW iX batteries.

### How
Updates to the BMW iX code, including functions to close the contactors, keep the contactors closed, open the contactors, and to handle the user requests from the webserver to open or close the contactors.