### PR TITLE
Kostal inverter class and RS485/Modbus refactoring

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -512,15 +512,15 @@ void update_calculated_values() {
 }
 
 void update_values_inverter() {
+#ifdef SELECTED_INVERTER_CLASS
+  if (inverter) {
+    inverter->update_values();
+  }
+#else
 #ifdef CAN_INVERTER_SELECTED
   update_values_can_inverter();
 #endif  // CAN_INVERTER_SELECTED
-#ifdef MODBUS_INVERTER_SELECTED
-  update_modbus_registers_inverter();
-#endif  // CAN_INVERTER_SELECTED
-#ifdef RS485_INVERTER_SELECTED
-  update_RS485_registers_inverter();
-#endif  // CAN_INVERTER_SELECTED
+#endif
 }
 
 void check_reset_reason() {

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,5 +1,8 @@
 #include "../include.h"
 
+#include "CanBattery.h"
+#include "RS485Battery.h"
+
 // These functions adapt the old C-style global functions battery-API to the
 // object-oriented battery API.
 
@@ -7,10 +10,10 @@
 // to support battery class selection at compile-time
 #ifdef SELECTED_BATTERY_CLASS
 
-static CanBattery* battery = nullptr;
+static Battery* battery = nullptr;
 
 #ifdef DOUBLE_BATTERY
-static CanBattery* battery2 = nullptr;
+static Battery* battery2 = nullptr;
 #endif
 
 void setup_battery() {
@@ -37,17 +40,15 @@ void update_values_battery() {
 // transmit_can_battery is called once and we need to
 // call both batteries.
 void transmit_can_battery(unsigned long currentMillis) {
-  battery->transmit_can(currentMillis);
+  ((CanBattery*)battery)->transmit_can(currentMillis);
 
 #ifdef DOUBLE_BATTERY
-  if (battery2) {
-    battery2->transmit_can(currentMillis);
-  }
+  ((CanBattery*)battery2)->transmit_can(currentMillis);
 #endif
 }
 
 void handle_incoming_can_frame_battery(CAN_frame rx_frame) {
-  battery->handle_incoming_can_frame(rx_frame);
+  ((CanBattery*)battery)->handle_incoming_can_frame(rx_frame);
 }
 
 #ifdef DOUBLE_BATTERY
@@ -56,8 +57,19 @@ void update_values_battery2() {
 }
 
 void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
-  battery2->handle_incoming_can_frame(rx_frame);
+  ((CanBattery*)battery2)->handle_incoming_can_frame(rx_frame);
 }
+#endif
+
+#ifdef RS485_BATTERY_SELECTED
+void transmit_rs485() {
+  ((RS485Battery*)battery)->transmit_rs485();
+}
+
+void receive_RS485() {
+  ((RS485Battery*)battery)->receive_RS485();
+}
+
 #endif
 
 #endif

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -1,0 +1,12 @@
+#ifndef BATTERY_H
+#define BATTERY_H
+
+// Abstract base class for next-generation battery implementations.
+// Defines the interface to call battery specific functionality.
+class Battery {
+ public:
+  virtual void setup(void) = 0;
+  virtual void update_values() = 0;
+};
+
+#endif

--- a/Software/src/battery/CanBattery.h
+++ b/Software/src/battery/CanBattery.h
@@ -1,16 +1,14 @@
 #ifndef CAN_BATTERY_H
 #define CAN_BATTERY_H
 
+#include "Battery.h"
+
 #include "src/devboard/utils/types.h"
 
-// Abstract base class for next-generation battery implementations.
-// Defines the interface to call battery specific functionality.
-// No support for double battery yet.
-class CanBattery {
+// Abstract base class for batteries using the CAN bus
+class CanBattery : public Battery {
  public:
-  virtual void setup(void) = 0;
   virtual void handle_incoming_can_frame(CAN_frame rx_frame) = 0;
-  virtual void update_values() = 0;
   virtual void transmit_can(unsigned long currentMillis) = 0;
 };
 

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -19,7 +19,7 @@ static uint16_t cellvoltage_max_mV = 0;
 static uint16_t SOC = 0;
 static bool has_fault = false;
 
-void update_values_battery() {
+void DalyBms::update_values() {
   datalayer.battery.status.real_soc = SOC;
   datalayer.battery.status.voltage_dV = voltage_dV;  //value is *10 (3700 = 370.0)
   datalayer.battery.status.current_dA = current_dA;  //value is *10 (150 = 15.0)
@@ -60,7 +60,7 @@ void update_values_battery() {
   datalayer.battery.status.real_bms_status = has_fault ? BMS_FAULT : BMS_ACTIVE;
 }
 
-void setup_battery(void) {  // Performs one time setup at startup
+void DalyBms::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "DALY RS485", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = CELL_COUNT;
@@ -70,6 +70,8 @@ void setup_battery(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.total_capacity_Wh = BATTERY_WH_MAX;
   datalayer.system.status.battery_allows_contactor_closing = true;
+
+  Serial2.begin(baud_rate(), SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
 }
 
 uint8_t calculate_checksum(uint8_t buff[12]) {
@@ -154,7 +156,7 @@ void decode_packet(uint8_t command, uint8_t data[8]) {
   }
 }
 
-void transmit_rs485() {
+void DalyBms::transmit_rs485() {
   static uint8_t nextCommand = 0x90;
 
   if (millis() - lastPacket > 60) {
@@ -178,7 +180,7 @@ void transmit_rs485() {
   }
 }
 
-void receive_RS485() {
+void DalyBms::receive_RS485() {
   static uint8_t recv_buff[13] = {0};
   static uint8_t recv_len = 0;
 

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -1,6 +1,8 @@
 #ifndef DALY_BMS_H
 #define DALY_BMS_H
 
+#include "RS485Battery.h"
+
 /* Tweak these according to your battery build */
 #define CELL_COUNT 14
 #define MAX_PACK_VOLTAGE_DV 580   //580 = 58.0V
@@ -14,6 +16,17 @@
 /* Do not modify any rows below*/
 #define BATTERY_SELECTED
 #define RS485_BATTERY_SELECTED
-#define RS485_BAUDRATE 9600
+#define SELECTED_BATTERY_CLASS DalyBms
+
+class DalyBms : public RS485Battery {
+ public:
+  void setup();
+  void update_values();
+  void transmit_rs485();
+  void receive_RS485();
+
+ private:
+  int baud_rate() { return 9600; }
+};
 
 #endif

--- a/Software/src/battery/RS485Battery.h
+++ b/Software/src/battery/RS485Battery.h
@@ -1,0 +1,15 @@
+#ifndef RS485_BATTERY_H
+#define RS485_BATTERY_H
+
+#include "Battery.h"
+
+#include "src/devboard/utils/types.h"
+
+// Abstract base class for batteries using the RS485 interface
+class RS485Battery : public Battery {
+ public:
+  virtual void receive_RS485() = 0;
+  virtual void transmit_rs485() = 0;
+};
+
+#endif

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -1,19 +1,7 @@
 #include "comm_rs485.h"
 #include "../../include.h"
 
-// Parameters
-
-#ifdef MODBUS_INVERTER_SELECTED
-#define MB_RTU_NUM_VALUES 13100
-uint16_t mbPV[MB_RTU_NUM_VALUES];  // Process variable memory
-// Create a ModbusRTU server instance listening on Serial2 with 2000ms timeout
-ModbusServerRTU MBserver(Serial2, 2000);
-#endif
-
-// Initialization functions
-
 void init_rs485() {
-// Set up Modbus RTU Server
 #ifdef RS485_EN_PIN
   pinMode(RS485_EN_PIN, OUTPUT);
   digitalWrite(RS485_EN_PIN, HIGH);
@@ -26,21 +14,7 @@ void init_rs485() {
   pinMode(PIN_5V_EN, OUTPUT);
   digitalWrite(PIN_5V_EN, HIGH);
 #endif  // PIN_5V_EN
-#if defined(RS485_INVERTER_SELECTED) || defined(RS485_BATTERY_SELECTED)
-  Serial2.begin(RS485_BAUDRATE, SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
-#endif  // RS485_INVERTER_SELECTED || RS485_BATTERY_SELECTED
-#ifdef MODBUS_INVERTER_SELECTED
-  // Init Static data to the RTU Modbus
-  handle_static_data_modbus();
-  // Init Serial2 connected to the RTU Modbus
-  RTUutils::prepareHardwareSerial(Serial2);
-  Serial2.begin(9600, SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
-  // Register served function code worker for server
-  MBserver.registerWorker(MBTCP_ID, READ_HOLD_REGISTER, &FC03);
-  MBserver.registerWorker(MBTCP_ID, WRITE_HOLD_REGISTER, &FC06);
-  MBserver.registerWorker(MBTCP_ID, WRITE_MULT_REGISTERS, &FC16);
-  MBserver.registerWorker(MBTCP_ID, R_W_MULT_REGISTERS, &FC23);
-  // Start ModbusRTU background task
-  MBserver.begin(Serial2, MODBUS_CORE);
-#endif  // MODBUS_INVERTER_SELECTED
+
+  // Inverters and batteries are expected to initialize their serial port in their setup-function
+  // for RS485 or Modbus comms.
 }

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -5,6 +5,8 @@
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS AforeCanInverter
 
+#include "CanInverterProtocol.h"
+
 class AforeCanInverter : public CanInverterProtocol {
  public:
   void setup();

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -8,6 +8,8 @@
 #define FW_MAJOR_VERSION 0x03
 #define FW_MINOR_VERSION 0x29
 
+#include "CanInverterProtocol.h"
+
 class BydCanInverter : public CanInverterProtocol {
  public:
   void setup();

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -5,16 +5,22 @@
 #define MODBUS_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS BydModbusInverter
 
-#define MB_RTU_NUM_VALUES 13100
-#define MAX_POWER 40960  //BYD Modbus specific value
-
-extern uint16_t mbPV[MB_RTU_NUM_VALUES];
+#include "ModbusInverterProtocol.h"
 
 class BydModbusInverter : public ModbusInverterProtocol {
  public:
   void setup();
-  void update_modbus_registers();
+  void update_values();
+
+ private:
   void handle_static_data();
+  void verify_temperature();
+  void verify_inverter_modbus();
+  void handle_update_data_modbusp201_byd();
+  void handle_update_data_modbusp301_byd();
+
+  //BYD Modbus specific value
+  const int MAX_POWER = 40960;
 };
 
 #endif

--- a/Software/src/inverter/CanInverterProtocol.h
+++ b/Software/src/inverter/CanInverterProtocol.h
@@ -1,0 +1,14 @@
+#ifndef CANINVERTER_PROTOCOL_H
+#define CANINVERTER_PROTOCOL_H
+
+#include "InverterProtocol.h"
+
+#include "src/devboard/utils/types.h"
+
+class CanInverterProtocol : public InverterProtocol {
+ public:
+  virtual void transmit_can(unsigned long currentMillis) = 0;
+  virtual void map_can_frame_to_variable(CAN_frame rx_frame) = 0;
+};
+
+#endif

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -2,6 +2,8 @@
 #define FERROAMP_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS FerroampCanInverter
 

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -47,4 +47,10 @@ void transmit_can_inverter(unsigned long currentMillis) {
 }
 #endif
 
+#ifdef RS485_INVERTER_SELECTED
+void receive_RS485() {
+  ((Rs485InverterProtocol*)inverter)->receive_RS485();
+}
+#endif
+
 #endif

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -26,18 +26,12 @@ void setup_inverter() {
   inverter = can_inverter;
 #endif
 
+#ifdef RS485_INVERTER_SELECTED
+  inverter = new SELECTED_INVERTER_CLASS();
+#endif
+
   inverter->setup();
 }
-
-#ifdef MODBUS_INVERTER_SELECTED
-void update_modbus_registers_inverter() {
-  modbus_inverter->update_modbus_registers();
-}
-
-void handle_static_data_modbus() {
-  modbus_inverter->handle_static_data();
-}
-#endif
 
 #ifdef CAN_INVERTER_SELECTED
 void update_values_can_inverter() {

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -90,4 +90,8 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 void transmit_can_inverter(unsigned long currentMillis);
 #endif
 
+#ifdef RS485_INVERTER_SELECTED
+void receive_RS485();
+#endif
+
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -1,28 +1,8 @@
 #ifndef INVERTERS_H
 #define INVERTERS_H
 
-// The abstract base class for all inverter protocols
-class InverterProtocol {
- public:
-  virtual void setup() = 0;
-};
-
-// The abstract base class for all Modbus inverter protocols
-class ModbusInverterProtocol : public InverterProtocol {
- public:
-  virtual void update_modbus_registers() = 0;
-  virtual void handle_static_data();
-};
-
-class CanInverterProtocol : public InverterProtocol {
- public:
-  //This function maps all the values fetched from battery CAN to the correct CAN messages
-  virtual void update_values() = 0;
-
-  virtual void transmit_can(unsigned long currentMillis) = 0;
-
-  virtual void map_can_frame_to_variable(CAN_frame rx_frame) = 0;
-};
+#include "InverterProtocol.h"
+extern InverterProtocol* inverter;
 
 #include "../../USER_SETTINGS.h"
 
@@ -102,23 +82,12 @@ class CanInverterProtocol : public InverterProtocol {
 #include "SUNGROW-CAN.h"
 #endif
 
+void setup_inverter();
+
 #ifdef CAN_INVERTER_SELECTED
 void update_values_can_inverter();
 void map_can_frame_to_variable_inverter(CAN_frame rx_frame);
 void transmit_can_inverter(unsigned long currentMillis);
-void setup_inverter();
-#endif
-
-#ifdef MODBUS_INVERTER_SELECTED
-void update_modbus_registers_inverter();
-void setup_inverter();
-void handle_static_data_modbus();
-#endif
-
-#ifdef RS485_INVERTER_SELECTED
-void receive_RS485();
-void update_RS485_registers_inverter();
-void setup_inverter();
 #endif
 
 #endif

--- a/Software/src/inverter/InverterProtocol.h
+++ b/Software/src/inverter/InverterProtocol.h
@@ -1,0 +1,13 @@
+#ifndef INVERTER_PROTOCOL_H
+#define INVERTER_PROTOCOL_H
+
+// The abstract base class for all inverter protocols
+class InverterProtocol {
+ public:
+  virtual void setup() = 0;
+
+  // This function maps all the values fetched from battery to the correct battery emulator data structures
+  virtual void update_values() = 0;
+};
+
+#endif

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -4,99 +4,7 @@
 #include "../devboard/utils/events.h"
 #include "KOSTAL-RS485.h"
 
-#define RS485_HEALTHY \
-  12  // How many value updates we can go without inverter gets reported as missing \
-      // e.g. value set to 12, 12*5sec=60seconds without comm before event is raised
-static const uint8_t KOSTAL_FRAMEHEADER[5] = {0x62, 0xFF, 0x02, 0xFF, 0x29};
-static const uint8_t KOSTAL_FRAMEHEADER2[5] = {0x63, 0xFF, 0x02, 0xFF, 0x29};
-static uint16_t nominal_voltage_dV = 0;
-static int16_t average_temperature_dC = 0;
-static uint8_t incoming_message_counter = RS485_HEALTHY;
-static int8_t f2_startup_count = 0;
-
-static boolean B1_delay = false;
-static unsigned long B1_last_millis = 0;
-static unsigned long currentMillis;
-static unsigned long startupMillis = 0;
-static unsigned long contactorMillis = 0;
-
-static uint16_t rx_index = 0;
-static boolean RX_allow = false;
-
-union f32b {
-  float f;
-  byte b[4];
-};
-
-// clang-format off
-uint8_t BATTERY_INFO[40] = {
-    0x00,                         // First zero byte pointer
-    0xE2, 0xFF, 0x02, 0xFF, 0x29, // Frame header
-    0x00, 0x00, 0x80, 0x43,       // 256.063 Nominal voltage / 5*51.2=256
-    0xE4, 0x70, 0x8A, 0x5C,       // Manufacture date (Epoch time) (BYD: GetBatteryInfo this[0x10ac])
-    0xB5, 0x00, 0xD3, 0x00,       // Battery Serial number? Modbus register 527 - 0x10b0
-    0x00, 0x00, 0xC8, 0x41,       // Nominal Capacity (0x10b4)
-    0xC2, 0x18,                   // Battery Firmware, modbus register 586  (0x10b8)
-    0x00,                         // Static (BYD: GetBatteryInfo this[0x10ba])
-    0x00,                         // ?
-    0x59, 0x42,                   // Vendor identifier
-                                  //       0x59 0x42 -> 'YB' -> BYD
-                                  //       0x59 0x44 -> 'YD' -> Dyness
-    0x00, 0x00,                   // Static (BYD: GetBatteryInfo this[0x10be])
-    0x00, 0x00,
-    0x05, 0x00,                   // Number of blocks in series (uint16)
-    0xA0, 0x00, 0x00, 0x00,
-    0x4D, // CRC
-    0x00};
-// clang-format on
-
-// values in CYCLIC_DATA will be overwritten at update_modbus_registers_inverter()
-
-// clang-format off
-uint8_t CYCLIC_DATA[64] = {
-    0x00,                          // First zero byte pointer
-    0xE2, 0xFF, 0x02, 0xFF, 0x29,  // Frame header
-    0x1D, 0x5A, 0x85, 0x43,        // Current Voltage            (float32)   Bytes  6- 9    Modbus register 216
-    0x00, 0x00, 0x8D, 0x43,        // Max Voltage                (float32)   Bytes 10-13
-    0x00, 0x00, 0xAC, 0x41,        // Battery Temperature        (float32)   Bytes 14-17    Modbus register 214
-    0x00, 0x00, 0x00, 0x00,        // Peak Current (1s period?)  (float32)   Bytes 18-21
-    0x00, 0x00, 0x00, 0x00,        // Avg current  (1s period?)  (float32)   Bytes 22-25
-    0x00, 0x00, 0x48, 0x42,        // Max discharge current      (float32)   Bytes 26-29    Sunspec: ADisChaMax
-    0x00, 0x00, 0xC8, 0x41,        // Battery gross capacity, Ah (float32)   Bytes 30-33    Modbus register 512
-    0x00, 0x00, 0xA0, 0x41,        // Max charge current         (float32)   Bytes 34-37    0.0f when SoC is 100%, Sunspec: AChaMax
-    0xCD, 0xCC, 0xB4, 0x41,        // MaxCellTemp                (float32)   Bytes 38-41
-    0x00, 0x00, 0xA4, 0x41,        // MinCellTemp                (float32)   Bytes 42-45
-    0xA4, 0x70, 0x55, 0x40,        // MaxCellVolt                (float32)   Bytes 46-49
-    0x7D, 0x3F, 0x55, 0x40,        // MinCellVolt                (float32)   Bytes 50-53
-
-    0xFE, 0x04,  // Bytes 54-55, Cycle count (uint16)
-    0x00,        // Byte 56, charge/discharge control, 0=disable, 1=enable
-    0x00,        // Byte 57, When SoC is 100%, seen as 0x40
-    0x64,        // Byte 58, SoC (uint8)
-    0x00,        // Byte 59, Unknown
-    0x00,        // Byte 60, Unknown
-    0x01,        // Byte 61, Unknown, 1 only at first frame, 0 otherwise
-    0x00,        // Byte 62, CRC
-    0x00};
-// clang-format on
-
-// FE 04 01 40 xx 01 01 02 yy (fully charged)
-// FE 02 01 02 xx 01 01 02 yy (charging or discharging)
-
-uint8_t STATUS_FRAME[9] = {
-    0x00, 0xE2, 0xFF, 0x02, 0xFF, 0x29,  //header
-    0x06,                                //Unknown (battery status/error?)
-    0xEF,                                //CRC
-    0x00                                 //endbyte
-};
-
-uint8_t ACK_FRAME[8] = {0x07, 0xE3, 0xFF, 0x02, 0xFF, 0x29, 0xF4, 0x00};
-
-uint8_t RS485_RXFRAME[300];
-
-bool register_content_ok = false;
-
-static void float2frame(byte* arr, float value, byte framepointer) {
+void KostalInverterProtocol::float2frame(byte* arr, float value, byte framepointer) {
   f32b g;
   g.f = value;
   arr[framepointer] = g.b[0];
@@ -176,7 +84,7 @@ static byte calculate_kostal_crc(byte* lfc, int len) {
   return (byte)(-sum & 0xff);
 }
 
-static bool check_kostal_frame_crc(int len) {
+bool KostalInverterProtocol::check_kostal_frame_crc(int len) {
   unsigned int sum = 0;
   int zeropointer = RS485_RXFRAME[0];
   int last_zero = 0;
@@ -196,7 +104,7 @@ static bool check_kostal_frame_crc(int len) {
   }
 }
 
-void update_RS485_registers_inverter() {
+void KostalInverterProtocol::update_values() {
 
   average_temperature_dC =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -296,7 +204,7 @@ void update_RS485_registers_inverter() {
   }
 }
 
-void receive_RS485()  // Runs as fast as possible to handle the serial stream
+void KostalInverterProtocol::receive_RS485()  // Runs as fast as possible to handle the serial stream
 {
   currentMillis = millis();
 
@@ -345,7 +253,7 @@ void receive_RS485()  // Runs as fast as possible to handle the serial stream
                 if (code == 0x44a) {
                   //Send cyclic data
                   update_values_battery();
-                  update_RS485_registers_inverter();
+                  update_values();
                   if (f2_startup_count < 15) {
                     f2_startup_count++;
                   }
@@ -391,10 +299,12 @@ void receive_RS485()  // Runs as fast as possible to handle the serial stream
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup
+void KostalInverterProtocol::setup(void) {  // Performs one time setup at startup
   datalayer.system.status.inverter_allows_contactor_closing = false;
   dbg_message("inverter_allows_contactor_closing -> false");
   strncpy(datalayer.system.info.inverter_protocol, "BYD battery via Kostal RS485", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
+
+  Serial2.begin(baud_rate(), SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
 }
 #endif

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -3,13 +3,121 @@
 #include <Arduino.h>
 #include "../include.h"
 
+#include "Rs485InverterProtocol.h"
+
 #define RS485_INVERTER_SELECTED
-#define RS485_BAUDRATE 57600
+#define SELECTED_INVERTER_CLASS KostalInverterProtocol
+
 //#define DEBUG_KOSTAL_RS485_DATA  // Enable this line to get TX / RX printed out via logging
 //#define DEBUG_KOSTAL_RS485_DATA_USB  // Enable this line to get TX / RX printed out via USB
 
 #if defined(DEBUG_KOSTAL_RS485_DATA) && !defined(DEBUG_LOG)
 #error "enable LOG_TO_SD, DEBUG_VIA_USB or DEBUG_VIA_WEB in order to use DEBUG_KOSTAL_RS485_DATA"
 #endif
+
+class KostalInverterProtocol : public Rs485InverterProtocol {
+ public:
+  void setup();
+  void receive_RS485();
+  void update_values();
+
+ private:
+  int baud_rate() { return 57600; }
+  void float2frame(byte* arr, float value, byte framepointer);
+  bool check_kostal_frame_crc(int len);
+
+  // How many value updates we can go without inverter gets reported as missing \
+    // e.g. value set to 12, 12*5sec=60seconds without comm before event is raised
+  const int RS485_HEALTHY = 12;
+
+  const uint8_t KOSTAL_FRAMEHEADER[5] = {0x62, 0xFF, 0x02, 0xFF, 0x29};
+  const uint8_t KOSTAL_FRAMEHEADER2[5] = {0x63, 0xFF, 0x02, 0xFF, 0x29};
+  uint16_t nominal_voltage_dV = 0;
+  int16_t average_temperature_dC = 0;
+  uint8_t incoming_message_counter = RS485_HEALTHY;
+  int8_t f2_startup_count = 0;
+
+  boolean B1_delay = false;
+  unsigned long B1_last_millis = 0;
+  unsigned long currentMillis;
+  unsigned long startupMillis = 0;
+  unsigned long contactorMillis = 0;
+
+  uint16_t rx_index = 0;
+  boolean RX_allow = false;
+
+  union f32b {
+    float f;
+    byte b[4];
+  };
+
+  // clang-format off
+uint8_t BATTERY_INFO[40] = {
+    0x00,                         // First zero byte pointer
+    0xE2, 0xFF, 0x02, 0xFF, 0x29, // Frame header
+    0x00, 0x00, 0x80, 0x43,       // 256.063 Nominal voltage / 5*51.2=256
+    0xE4, 0x70, 0x8A, 0x5C,       // Manufacture date (Epoch time) (BYD: GetBatteryInfo this[0x10ac])
+    0xB5, 0x00, 0xD3, 0x00,       // Battery Serial number? Modbus register 527 - 0x10b0
+    0x00, 0x00, 0xC8, 0x41,       // Nominal Capacity (0x10b4)
+    0xC2, 0x18,                   // Battery Firmware, modbus register 586  (0x10b8)
+    0x00,                         // (BYD: GetBatteryInfo this[0x10ba])
+    0x00,                         // ?
+    0x59, 0x42,                   // Vendor identifier
+                                  //       0x59 0x42 -> 'YB' -> BYD
+                                  //       0x59 0x44 -> 'YD' -> Dyness
+    0x00, 0x00,                   // (BYD: GetBatteryInfo this[0x10be])
+    0x00, 0x00,
+    0x05, 0x00,                   // Number of blocks in series (uint16)
+    0xA0, 0x00, 0x00, 0x00,
+    0x4D, // CRC
+    0x00};
+  // clang-format on
+
+  // values in CYCLIC_DATA will be overwritten at update_values()
+
+  // clang-format off
+uint8_t CYCLIC_DATA[64] = {
+    0x00,                          // First zero byte pointer
+    0xE2, 0xFF, 0x02, 0xFF, 0x29,  // Frame header
+    0x1D, 0x5A, 0x85, 0x43,        // Current Voltage            (float32)   Bytes  6- 9    Modbus register 216
+    0x00, 0x00, 0x8D, 0x43,        // Max Voltage                (float32)   Bytes 10-13
+    0x00, 0x00, 0xAC, 0x41,        // Battery Temperature        (float32)   Bytes 14-17    Modbus register 214
+    0x00, 0x00, 0x00, 0x00,        // Peak Current (1s period?)  (float32)   Bytes 18-21
+    0x00, 0x00, 0x00, 0x00,        // Avg current  (1s period?)  (float32)   Bytes 22-25
+    0x00, 0x00, 0x48, 0x42,        // Max discharge current      (float32)   Bytes 26-29    Sunspec: ADisChaMax
+    0x00, 0x00, 0xC8, 0x41,        // Battery gross capacity, Ah (float32)   Bytes 30-33    Modbus register 512
+    0x00, 0x00, 0xA0, 0x41,        // Max charge current         (float32)   Bytes 34-37    0.0f when SoC is 100%, Sunspec: AChaMax
+    0xCD, 0xCC, 0xB4, 0x41,        // MaxCellTemp                (float32)   Bytes 38-41
+    0x00, 0x00, 0xA4, 0x41,        // MinCellTemp                (float32)   Bytes 42-45
+    0xA4, 0x70, 0x55, 0x40,        // MaxCellVolt                (float32)   Bytes 46-49
+    0x7D, 0x3F, 0x55, 0x40,        // MinCellVolt                (float32)   Bytes 50-53
+
+    0xFE, 0x04,  // Bytes 54-55, Cycle count (uint16)
+    0x00,        // Byte 56, charge/discharge control, 0=disable, 1=enable
+    0x00,        // Byte 57, When SoC is 100%, seen as 0x40
+    0x64,        // Byte 58, SoC (uint8)
+    0x00,        // Byte 59, Unknown
+    0x00,        // Byte 60, Unknown
+    0x01,        // Byte 61, Unknown, 1 only at first frame, 0 otherwise
+    0x00,        // Byte 62, CRC
+    0x00};
+  // clang-format on
+
+  // FE 04 01 40 xx 01 01 02 yy (fully charged)
+  // FE 02 01 02 xx 01 01 02 yy (charging or discharging)
+
+  uint8_t STATUS_FRAME[9] = {
+      0x00, 0xE2, 0xFF, 0x02, 0xFF, 0x29,  //header
+      0x06,                                //Unknown (battery status/error?)
+      0xEF,                                //CRC
+      0x00                                 //endbyte
+  };
+
+  uint8_t ACK_FRAME[8] = {0x07, 0xE3, 0xFF, 0x02, 0xFF, 0x29, 0xF4, 0x00};
+
+  uint8_t RS485_RXFRAME[300];
+
+  bool register_content_ok = false;
+};
 
 #endif

--- a/Software/src/inverter/ModbusInverterProtocol.cpp
+++ b/Software/src/inverter/ModbusInverterProtocol.cpp
@@ -1,0 +1,4 @@
+#include "ModbusInverterProtocol.h"
+
+static const int MB_RTU_NUM_VALUES = 13100;
+uint16_t mbPV[MB_RTU_NUM_VALUES];  // Process variable memory

--- a/Software/src/inverter/ModbusInverterProtocol.h
+++ b/Software/src/inverter/ModbusInverterProtocol.h
@@ -1,0 +1,23 @@
+#ifndef MODBUS_INVERTER_PROTOCOL_H
+#define MODBUS_INVERTER_PROTOCOL_H
+
+#include <stdint.h>
+#include "../lib/eModbus-eModbus/ModbusServerRTU.h"
+#include "HardwareSerial.h"
+#include "InverterProtocol.h"
+
+extern uint16_t mbPV[];
+
+// The abstract base class for all Modbus inverter protocols
+class ModbusInverterProtocol : public InverterProtocol {
+ protected:
+  // Create a ModbusRTU server instance with 2000ms timeout
+  ModbusInverterProtocol() : MBserver(2000) { mbPV = ::mbPV; }
+
+  static const int MB_RTU_NUM_VALUES = 13100;
+  uint16_t* mbPV;  // Process variable memory
+
+  ModbusServerRTU MBserver;
+};
+
+#endif

--- a/Software/src/inverter/ModbusInverterProtocol.h
+++ b/Software/src/inverter/ModbusInverterProtocol.h
@@ -15,7 +15,9 @@ class ModbusInverterProtocol : public InverterProtocol {
   ModbusInverterProtocol() : MBserver(2000) { mbPV = ::mbPV; }
 
   static const int MB_RTU_NUM_VALUES = 13100;
-  uint16_t* mbPV;  // Process variable memory
+
+  // Modbus register file
+  uint16_t* mbPV;
 
   ModbusServerRTU MBserver;
 };

--- a/Software/src/inverter/Rs485InverterProtocol.h
+++ b/Software/src/inverter/Rs485InverterProtocol.h
@@ -1,0 +1,12 @@
+#ifndef RS485CANINVERTER_PROTOCOL_H
+#define RS485INVERTER_PROTOCOL_H
+
+#include "InverterProtocol.h"
+
+class Rs485InverterProtocol : public InverterProtocol {
+ public:
+  virtual void receive_RS485() = 0;
+  virtual int baud_rate() = 0;
+};
+
+#endif


### PR DESCRIPTION
### What and how
- Kostal RS485 inverter protocol implemented as a class
- Proper base classes for Modbus and RS485 inverters and batteries
- Modbus functionality moved to Modbus base class
- Simplify inverter class API with a single update_values()

### Why
- Yet another inverter implemented as a class to support common image build
