### PR TITLE
Bugfix: Update precharge control to handle dedicated pins

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -244,7 +244,7 @@ void core_loop(void*) {
       led_exe();
       handle_contactors();  // Take care of startup precharge/contactor closing
 #ifdef PRECHARGE_CONTROL
-      handle_precharge_control();
+      handle_precharge_control(currentMillis);
 #endif  // PRECHARGE_CONTROL
 #ifdef FUNCTION_TIME_MEASUREMENT
       END_TIME_MEASUREMENT_MAX(time_10ms, datalayer.system.status.time_10ms_us);

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -92,7 +92,8 @@
 //#define NISSANLEAF_CHARGER  //Enable this line to control a Nissan LEAF PDM connected to battery - for example, when generator charging
 
 /* Automatic Precharge settings (Optional) If you have a battery that expects an external voltage applied before opening contactors (within the battery), configure this section */
-//#define PRECHARGE_CONTROL      //Enable this line to control a modified HIA4V1 (see wiki) by PWM on the PRECHARGE_PIN.
+//#define PRECHARGE_CONTROL      //Enable this line to control a modified HIA4V1 via PWM on the HIA4V1_PIN (see Wiki and HAL for pin definition)
+//#define INVERTER_DISCONNECT_CONTACTOR_IS_NORMALLY_OPEN //Enable this line if you use a normally open contactor instead of normally closed
 
 /* Other options */
 //#define EQUIPMENT_STOP_BUTTON    // Enable this to allow an equipment stop button connected to the Battery-Emulator to disengage the battery

--- a/Software/src/communication/precharge_control/precharge_control.h
+++ b/Software/src/communication/precharge_control/precharge_control.h
@@ -17,19 +17,10 @@ void init_precharge_control();
 /**
  * @brief Handle contactors
  *
- * @param[in] void
+ * @param[in] unsigned long currentMillis
  *
  * @return void
  */
-void handle_precharge_control();
-
-/**
- * @brief Handle contactors of battery 2
- *
- * @param[in] void
- *
- * @return void
- */
-void handle_contactors_battery2();
+void handle_precharge_control(unsigned long currentMillis);
 
 #endif  // _PRECHARGE_CONTROL_H_

--- a/Software/src/devboard/hal/hw_3LB.h
+++ b/Software/src/devboard/hal/hw_3LB.h
@@ -61,6 +61,10 @@
 // SMA CAN contactor pins
 #define INVERTER_CONTACTOR_ENABLE_PIN 36
 
+// Automatic precharging
+#define HIA4V1_PIN 25
+#define INVERTER_DISCONNECT_CONTACTOR_PIN 32
+
 // SD card
 //#define SD_MISO_PIN 2
 //#define SD_MOSI_PIN 15

--- a/Software/src/devboard/hal/hw_devkit.h
+++ b/Software/src/devboard/hal/hw_devkit.h
@@ -62,6 +62,10 @@ The pin layout below supports the following:
 // Equipment stop pin
 #define EQUIPMENT_STOP_PIN GPIO_NUM_12
 
+// Automatic precharging
+#define HIA4V1_PIN GPIO_NUM_17
+#define INVERTER_DISCONNECT_CONTACTOR_PIN GPIO_NUM_5
+
 // BMW_I3_BATTERY wake up pin
 #ifdef BMW_I3_BATTERY
 #define WUP_PIN1 GPIO_NUM_25  // Wake up pin for battery 1

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -53,6 +53,10 @@
 #define PRECHARGE_PIN 25
 #define BMS_POWER 18  // Note, this pin collides with CAN add-ons and Chademo
 
+// Automatic precharging
+#define HIA4V1_PIN 25
+#define INVERTER_DISCONNECT_CONTACTOR_PIN 32
+
 // SMA CAN contactor pins
 #define INVERTER_CONTACTOR_ENABLE_PIN 5
 

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -51,6 +51,10 @@ GPIOs on extra header
 #define PRECHARGE_PIN 25
 #define BMS_POWER 23
 
+// Automatic precharging
+#define HIA4V1_PIN 19  //Available as extra GPIO via pin header
+#define INVERTER_DISCONNECT_CONTACTOR_PIN 25
+
 // SMA CAN contactor pins
 #define INVERTER_CONTACTOR_ENABLE_PIN 2
 


### PR DESCRIPTION
### What
This PR refactors the PRECHARGE_CONTROL to be able to work properly with Stark CMR

### Why
Stark CMR has separate pin required for the PWM to work with the precharge

### How
This PR does the following
- All boards HAL files are updated with new pin definitions HIA4V1_PIN and INVERTER_DISCONNECT_CONTACTOR_PIN
- Added configurable option INVERTER_DISCONNECT_CONTACTOR_IS_NORMALLY_OPEN to the USER_SETTINGS
- Slight performance increase by passing currentMillis to the precharge function

