### PR TITLE
Improvement: Add emojis to make builds more identifiable

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -1,5 +1,5 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Batteries
+name: 🔋 Compile All Batteries
 
 # Here we tell GitHub when to run the workflow.
 on:

--- a/.github/workflows/compile-all-combinations.yml
+++ b/.github/workflows/compile-all-combinations.yml
@@ -1,5 +1,5 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Combinations
+name: 🔌🔋💫 Compile All Combinations
 
 # Here we tell GitHub when to run the workflow.
 on:

--- a/.github/workflows/compile-all-double-batteries.yml
+++ b/.github/workflows/compile-all-double-batteries.yml
@@ -1,5 +1,5 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Double Batteries
+name: 🔋🔋 Compile All Double Batteries
 
 # Here we tell GitHub when to run the workflow.
 on:

--- a/.github/workflows/compile-all-hardware.yml
+++ b/.github/workflows/compile-all-hardware.yml
@@ -1,5 +1,5 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Hardware
+name: 🤖 Compile All Hardware
 
 # Here we tell GitHub when to run the workflow.
 on:

--- a/.github/workflows/compile-all-inverters.yml
+++ b/.github/workflows/compile-all-inverters.yml
@@ -1,5 +1,5 @@
 # This is the name of the workflow, visible on GitHub UI.
-name: Compile All Inverters
+name: 🔌 Compile All Inverters
 
 # Here we tell GitHub when to run the workflow.
 on:

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -1,6 +1,6 @@
 # This GithHub Action runs the pre-commit defined in the .pre-commit-config.yaml file
 
-name: Run pre-commit
+name: 📝 Run pre-commit
 
 on:
   - push

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Run Unit Tests
+name: ⚙️ Run Unit Tests
 
 
 on: [push, pull_request]


### PR DESCRIPTION
### What
This PR adds emojis to all the Github builds 

### Why
To more quickly be able to catch at a glance what type of build is failing

### How
🔌🔋💫🤖⚙️📝
