### PR TITLE
Convert the remaining inverter protocols to use the common base class and build them all

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -102,10 +102,7 @@ void setup() {
 #endif  // PRECHARGE_CONTROL
 
   setup_charger();
-
-#if defined(CAN_INVERTER_SELECTED) || defined(MODBUS_INVERTER_SELECTED) || defined(RS485_INVERTER_SELECTED)
   setup_inverter();
-#endif
   setup_battery();
 
   init_rs485();
@@ -512,15 +509,9 @@ void update_calculated_values() {
 }
 
 void update_values_inverter() {
-#ifdef SELECTED_INVERTER_CLASS
   if (inverter) {
     inverter->update_values();
   }
-#else
-#ifdef CAN_INVERTER_SELECTED
-  update_values_can_inverter();
-#endif  // CAN_INVERTER_SELECTED
-#endif
 }
 
 void check_reset_reason() {

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -179,6 +179,7 @@ typedef struct {
   CAN_Interface charger;
   CAN_Interface shunt;
 } CAN_Configuration;
+extern const char* getCANInterfaceName(CAN_Interface interface);
 extern volatile CAN_Configuration can_config;
 extern volatile uint8_t AccessPointEnabled;
 extern const uint8_t wifi_channel;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -39,13 +39,10 @@ String settings_processor(const String& var) {
                String(getCANInterfaceName(can_config.battery_double)) + "</span></h4>";
 #endif  // DOUBLE_BATTERY
 
-#ifdef CAN_INVERTER_SELECTED
-    content += "<h4 style='color: white;'>Inverter interface: <span id='Inverter'>" +
-               String(getCANInterfaceName(can_config.inverter)) + "</span></h4>";
-#endif  //CAN_INVERTER_SELECTED
-#ifdef MODBUS_INVERTER_SELECTED
-    content += "<h4 style='color: white;'>Inverter interface: RS485<span id='Inverter'></span></h4>";
-#endif
+    if (inverter) {
+      content += "<h4 style='color: white;'>Inverter interface: <span id='Inverter'>" +
+                 String(inverter->interface_name()) + "</span></h4>";
+    }
 
 #ifdef CAN_SHUNT_SELECTED
     content += "<h4 style='color: white;'>Shunt Interface: <span id='Shunt'>" +

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef AFORE_CAN
+#include "AFORE-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "AFORE-CAN.h"
+#include "../include.h"
 
 #define SOCMAX 100
 #define SOCMIN 1
@@ -175,4 +174,3 @@ void AforeCanInverter::setup(void) {  // Performs one time setup at startup over
   strncpy(datalayer.system.info.inverter_protocol, "Afore battery over CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -2,8 +2,10 @@
 #define AFORE_CAN_H
 #include "../include.h"
 
+#ifdef AFORE_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS AforeCanInverter
+#endif
 
 #include "CanInverterProtocol.h"
 

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef BYD_CAN
+#include "BYD-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "BYD-CAN.h"
+#include "../include.h"
 
 /* Do not change code below unless you are sure what you are doing */
 
@@ -175,4 +174,3 @@ void BydCanInverter::setup(void) {  // Performs one time setup at startup over C
   strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box Premium HVS over CAN Bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -2,8 +2,10 @@
 #define BYD_CAN_H
 #include "../include.h"
 
+#ifdef BYD_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS BydCanInverter
+#endif
 
 #define FW_MAJOR_VERSION 0x03
 #define FW_MINOR_VERSION 0x29

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -7,9 +7,6 @@
 #define SELECTED_INVERTER_CLASS BydCanInverter
 #endif
 
-#define FW_MAJOR_VERSION 0x03
-#define FW_MINOR_VERSION 0x29
-
 #include "CanInverterProtocol.h"
 
 class BydCanInverter : public CanInverterProtocol {
@@ -25,7 +22,9 @@ class BydCanInverter : public CanInverterProtocol {
   unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was send
   unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
 
-#define VOLTAGE_OFFSET_DV 20
+  static const int FW_MAJOR_VERSION = 0x03;
+  static const int FW_MINOR_VERSION = 0x29;
+  static const int VOLTAGE_OFFSET_DV = 20;
 
   CAN_frame BYD_250 = {.FD = false,
                        .ext_ID = false,

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef BYD_MODBUS
+#include "BYD-MODBUS.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
+#include "../include.h"
 #include "../lib/eModbus-eModbus/scripts/mbServerFCs.h"
-#include "BYD-MODBUS.h"
 
 // For modbus register definitions, see https://gitlab.com/pelle8/inverter_resources/-/blob/main/byd_registers_modbus_rtu.md
 
@@ -166,5 +165,3 @@ void BydModbusInverter::setup(void) {  // Performs one time setup at startup ove
   // Start ModbusRTU background task
   MBserver.begin(Serial2, MODBUS_CORE);
 }
-
-#endif

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -2,8 +2,10 @@
 #define BYD_MODBUS_H
 #include "../include.h"
 
+#ifdef BYD_MODBUS
 #define MODBUS_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS BydModbusInverter
+#endif
 
 #include "ModbusInverterProtocol.h"
 

--- a/Software/src/inverter/CanInverterProtocol.h
+++ b/Software/src/inverter/CanInverterProtocol.h
@@ -7,6 +7,7 @@
 
 class CanInverterProtocol : public InverterProtocol {
  public:
+  virtual const char* interface_name() { return getCANInterfaceName(can_config.inverter); }
   virtual void transmit_can(unsigned long currentMillis) = 0;
   virtual void map_can_frame_to_variable(CAN_frame rx_frame) = 0;
 };

--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef FERROAMP_CAN
+#include "FERROAMP-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "FERROAMP-CAN.h"
+#include "../include.h"
 
 void FerroampCanInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
@@ -365,4 +364,3 @@ void FerroampCanInverter::setup(void) {  // Performs one time setup at startup o
   strncpy(datalayer.system.info.inverter_protocol, "Ferroamp Pylon battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef FERROAMP_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS FerroampCanInverter
+#endif
 
 class FerroampCanInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -10,11 +10,8 @@
 class FerroampCanInverter : public CanInverterProtocol {
  public:
   void setup();
-
   void update_values();
-
   void transmit_can(unsigned long currentMillis);
-
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
  private:

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -26,13 +26,13 @@ class FerroampCanInverter : public CanInverterProtocol {
                                //useful for some inverters like Sofar that report the voltages incorrect otherwise
 #define SET_30K_OFFSET         //If defined, current values are sent with a 30k offest (useful for ferroamp)
 
-/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
+  /* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
 Change the following only if your inverter is generating fault codes about voltage range */
-#define TOTAL_CELL_AMOUNT 120  //Adjust this parameter in steps of 120 to add another 14,2kWh of capacity
-#define MODULES_IN_SERIES 4
-#define CELLS_PER_MODULE 30
-#define VOLTAGE_LEVEL 384
-#define AH_CAPACITY 37
+  static const int TOTAL_CELL_AMOUNT = 120;  //Adjust this parameter in steps of 120 to add another 14,2kWh of capacity
+  static const int MODULES_IN_SERIES = 4;
+  static const int CELLS_PER_MODULE = 30;
+  static const int VOLTAGE_LEVEL = 384;
+  static const int AH_CAPACITY = 37;
 
   //Actual content messages
   CAN_frame PYLON_7310 = {.FD = false,

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef FOXESS_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "FOXESS-CAN.h"
@@ -22,352 +23,9 @@ below that you can customize, incase you use a lower voltage battery with this p
 #define TOTAL_LIFETIME_WH_ACCUMULATED 0  //We dont have this value in the emulator
 
 /* Do not change code below unless you are sure what you are doing */
-static int16_t temperature_average = 0;
-static uint16_t voltage_per_pack = 0;
-static int16_t current_per_pack = 0;
-static uint8_t temperature_max_per_pack = 0;
-static uint8_t temperature_min_per_pack = 0;
-static uint8_t current_pack_info = 0;
 
-// Batch send of CAN message variables
-const uint8_t delay_between_batches_ms = 10;  //TODO, tweak to as low as possible before performance issues appear
-static bool send_bms_info = false;
-static bool send_individual_pack_status = false;
-static bool send_serial_numbers = false;
-static bool send_cellvoltages = false;
-static unsigned long currentMillis = 0;
-static unsigned long previousMillisCellvoltage = 0;
-static unsigned long previousMillisSerialNumber = 0;
-static unsigned long previousMillisBMSinfo = 0;
-static unsigned long previousMillisIndividualPacks = 0;
-static uint8_t can_message_cellvolt_index = 0;
-static uint8_t can_message_serial_index = 0;
-static uint8_t can_message_individualpack_index = 0;
-static uint8_t can_message_bms_index = 0;
-
-//CAN message translations from this amazing repository: https://github.com/rand12345/FOXESS_can_bus
-
-CAN_frame FOXESS_1872 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1872,
-                         .data = {0x40, 0x12, 0x80, 0x0C, 0xCD, 0x00, 0xF4, 0x01}};  //BMS_Limits
-CAN_frame FOXESS_1873 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1873,
-                         .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_PackData
-CAN_frame FOXESS_1874 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1874,
-                         .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_CellData
-CAN_frame FOXESS_1875 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1875,
-                         .data = {0xF9, 0x00, 0xFF, 0x08, 0x01, 0x00, 0x8E, 0x00}};  //BMS_Status
-CAN_frame FOXESS_1876 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1876,
-                         .data = {0x01, 0x00, 0x07, 0x0D, 0x0, 0x0, 0xFE, 0x0C}};  //BMS_PackTemps
-CAN_frame FOXESS_1877 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1877,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x82, 0x00, 0x20, 0x50}};  //BMS_Unk1
-CAN_frame FOXESS_1878 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1878,
-                         .data = {0x07, 0x0A, 0x00, 0x00, 0xD0, 0xFF, 0x4E, 0x00}};  //BMS_PackStats
-CAN_frame FOXESS_1879 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1879,
-                         .data = {0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BMS_Unk2
-CAN_frame FOXESS_1881 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1881,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-CAN_frame FOXESS_1882 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1882,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-CAN_frame FOXESS_1883 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x1883,
-                         .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
-
-CAN_frame FOXESS_0C05 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C05,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C06 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C06,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C07 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C07,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C08 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C08,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C09 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C09,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0A = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0A,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0B = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0B,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-CAN_frame FOXESS_0C0C = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C0C,
-                         .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
-// Cellvoltages
-CAN_frame FOXESS_0C1D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C1D,                                               //Cell 1-4
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C21 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C21,                                               //Cell 5-8
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C25 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C25,                                               //Cell 9-12
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C29 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C29,                                               //Cell 13-16
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C2D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C2D,                                               //Cell 17-20
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C31 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C31,                                               //Cell 21-24
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C35 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C35,                                               //Cell 25-28
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C39 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C39,                                               //Cell 29-32
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C3D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C3D,                                               //Cell 33-36
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C41 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C41,                                               //Cell 37-40
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C45 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C45,                                               //Cell 41-44
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C49 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C49,                                               //Cell 45-48
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C4D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C4D,                                               //Cell 49-52
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C51 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C51,                                               //Cell 53-56
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C55 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C55,                                               //Cell 57-60
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C59 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C59,                                               //Cell 61-64
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C5D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C5D,                                               //Cell 65-68
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C61 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C61,                                               //Cell 69-72
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C65 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C65,                                               //Cell 73-76
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C69 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C69,                                               //Cell 77-80
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C6D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C6D,                                               //Cell 81-84
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C71 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C71,                                               //Cell 85-88
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C75 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C75,                                               //Cell 89-92
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C79 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C79,                                               //Cell 93-96
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C7D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C7D,                                               //Cell 97-100
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C81 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C81,                                               //Cell 101-104
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C85 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C85,                                               //Cell 105-108
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C89 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C89,                                               //Cell 109-112
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C8D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C8D,                                               //Cell 113-116
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C91 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C91,                                               //Cell 117-120
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C95 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C95,                                               //Cell 121-124
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C99 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C99,                                               //Cell 125-128
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0C9D = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0C9D,                                               //Cell 129-132
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA1 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA1,                                               //Cell 133-136
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA5 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA5,                                               //Cell 137-140
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-CAN_frame FOXESS_0CA9 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0CA9,                                               //Cell 141-144
-                         .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
-
-// Temperatures
-CAN_frame FOXESS_0D21 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D21,  //Celltemperatures Pack 1
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D29 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D29,  //Celltemperatures Pack 2
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D31 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D31,  //Celltemperatures Pack 3
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D39 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D39,  //Celltemperatures Pack 4
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D41 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D41,  //Celltemperatures Pack 5
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D49 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D49,  //Celltemperatures Pack 6
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D51 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D51,  //Celltemperatures Pack 7
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-CAN_frame FOXESS_0D59 = {.FD = false,
-                         .ext_ID = true,
-                         .DLC = 8,
-                         .ID = 0x0D59,  //Celltemperatures Pack 8
-                         .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
-
-void update_values_can_inverter() {  //This function maps all the CAN values fetched from battery. It also checks some safeties.
+void FoxessCanInverter::
+    update_values() {  //This function maps all the CAN values fetched from battery. It also checks some safeties.
 
   //Calculate the required values
   temperature_average =
@@ -595,7 +253,7 @@ void update_values_can_inverter() {  //This function maps all the CAN values fet
   // So do we really need to map the same two values over and over to 32 places?
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void FoxessCanInverter::transmit_can(unsigned long currentMillis) {
 
   if (send_bms_info) {
 
@@ -861,7 +519,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void FoxessCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -904,7 +562,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
     }
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void FoxessCanInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "FoxESS compatible HV2600/ECS4100 battery", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef FOXESS_CAN
+#include "FOXESS-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "FOXESS-CAN.h"
+#include "../include.h"
 
 /* Based on info from this excellent repo: https://github.com/FozzieUK/FoxESS-Canbus-Protocol */
 /* The FoxESS protocol emulates the stackable (1-8) 48V towers found in the HV2600 / ECS4100 batteries
@@ -566,4 +565,3 @@ void FoxessCanInverter::setup(void) {  // Performs one time setup at startup ove
   strncpy(datalayer.system.info.inverter_protocol, "FoxESS compatible HV2600/ECS4100 battery", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -2,9 +2,363 @@
 #define FOXESS_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS FoxessCanInverter
+
+class FoxessCanInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  int16_t temperature_average = 0;
+  uint16_t voltage_per_pack = 0;
+  int16_t current_per_pack = 0;
+  uint8_t temperature_max_per_pack = 0;
+  uint8_t temperature_min_per_pack = 0;
+  uint8_t current_pack_info = 0;
+
+  // Batch send of CAN message variables
+  const uint8_t delay_between_batches_ms = 10;  //TODO, tweak to as low as possible before performance issues appear
+  bool send_bms_info = false;
+  bool send_individual_pack_status = false;
+  bool send_serial_numbers = false;
+  bool send_cellvoltages = false;
+  unsigned long currentMillis = 0;
+  unsigned long previousMillisCellvoltage = 0;
+  unsigned long previousMillisSerialNumber = 0;
+  unsigned long previousMillisBMSinfo = 0;
+  unsigned long previousMillisIndividualPacks = 0;
+  uint8_t can_message_cellvolt_index = 0;
+  uint8_t can_message_serial_index = 0;
+  uint8_t can_message_individualpack_index = 0;
+  uint8_t can_message_bms_index = 0;
+
+  //CAN message translations from this amazing repository: https://github.com/rand12345/FOXESS_can_bus
+
+  CAN_frame FOXESS_1872 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1872,
+                           .data = {0x40, 0x12, 0x80, 0x0C, 0xCD, 0x00, 0xF4, 0x01}};  //BMS_Limits
+  CAN_frame FOXESS_1873 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1873,
+                           .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_PackData
+  CAN_frame FOXESS_1874 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1874,
+                           .data = {0xA3, 0x10, 0x0D, 0x00, 0x5D, 0x00, 0x77, 0x07}};  //BMS_CellData
+  CAN_frame FOXESS_1875 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1875,
+                           .data = {0xF9, 0x00, 0xFF, 0x08, 0x01, 0x00, 0x8E, 0x00}};  //BMS_Status
+  CAN_frame FOXESS_1876 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1876,
+                           .data = {0x01, 0x00, 0x07, 0x0D, 0x0, 0x0, 0xFE, 0x0C}};  //BMS_PackTemps
+  CAN_frame FOXESS_1877 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1877,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x82, 0x00, 0x20, 0x50}};  //BMS_Unk1
+  CAN_frame FOXESS_1878 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1878,
+                           .data = {0x07, 0x0A, 0x00, 0x00, 0xD0, 0xFF, 0x4E, 0x00}};  //BMS_PackStats
+  CAN_frame FOXESS_1879 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1879,
+                           .data = {0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //BMS_Unk2
+  CAN_frame FOXESS_1881 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1881,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+  CAN_frame FOXESS_1882 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1882,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+  CAN_frame FOXESS_1883 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x1883,
+                           .data = {0x10, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+
+  CAN_frame FOXESS_0C05 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C05,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C06 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C06,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C07 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C07,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C08 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C08,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C09 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C09,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0A = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0A,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0B = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0B,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  CAN_frame FOXESS_0C0C = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C0C,
+                           .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xD0, 0xD0}};
+  // Cellvoltages
+  CAN_frame FOXESS_0C1D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C1D,                                               //Cell 1-4
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C21 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C21,                                               //Cell 5-8
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C25 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C25,                                               //Cell 9-12
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C29 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C29,                                               //Cell 13-16
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C2D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C2D,                                               //Cell 17-20
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C31 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C31,                                               //Cell 21-24
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C35 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C35,                                               //Cell 25-28
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C39 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C39,                                               //Cell 29-32
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C3D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C3D,                                               //Cell 33-36
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C41 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C41,                                               //Cell 37-40
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C45 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C45,                                               //Cell 41-44
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C49 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C49,                                               //Cell 45-48
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C4D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C4D,                                               //Cell 49-52
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C51 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C51,                                               //Cell 53-56
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C55 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C55,                                               //Cell 57-60
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C59 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C59,                                               //Cell 61-64
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C5D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C5D,                                               //Cell 65-68
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C61 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C61,                                               //Cell 69-72
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C65 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C65,                                               //Cell 73-76
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C69 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C69,                                               //Cell 77-80
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C6D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C6D,                                               //Cell 81-84
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C71 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C71,                                               //Cell 85-88
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C75 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C75,                                               //Cell 89-92
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C79 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C79,                                               //Cell 93-96
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C7D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C7D,                                               //Cell 97-100
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C81 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C81,                                               //Cell 101-104
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C85 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C85,                                               //Cell 105-108
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C89 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C89,                                               //Cell 109-112
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C8D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C8D,                                               //Cell 113-116
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C91 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C91,                                               //Cell 117-120
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C95 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C95,                                               //Cell 121-124
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C99 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C99,                                               //Cell 125-128
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0C9D = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0C9D,                                               //Cell 129-132
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA1 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA1,                                               //Cell 133-136
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA5 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA5,                                               //Cell 137-140
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+  CAN_frame FOXESS_0CA9 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0CA9,                                               //Cell 141-144
+                           .data = {0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C, 0xE4, 0x0C}};  //All cells init to 3300mV
+
+  // Temperatures
+  CAN_frame FOXESS_0D21 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D21,  //Celltemperatures Pack 1
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D29 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D29,  //Celltemperatures Pack 2
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D31 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D31,  //Celltemperatures Pack 3
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D39 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D39,  //Celltemperatures Pack 4
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D41 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D41,  //Celltemperatures Pack 5
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D49 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D49,  //Celltemperatures Pack 6
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D51 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D51,  //Celltemperatures Pack 7
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+  CAN_frame FOXESS_0D59 = {.FD = false,
+                           .ext_ID = true,
+                           .DLC = 8,
+                           .ID = 0x0D59,  //Celltemperatures Pack 8
+                           .data = {0x49, 0x48, 0x47, 0x47, 0x48, 0x49, 0x46, 0x47}};
+};
 
 #endif

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef FOXESS_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS FoxessCanInverter
+#endif
 
 class FoxessCanInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef GROWATT_HV_CAN
+#include "GROWATT-HV-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "GROWATT-HV-CAN.h"
+#include "../include.h"
 
 /* TODO:
 This protocol has not been tested with any inverter. Proceed with extreme caution.
@@ -455,4 +454,3 @@ void GrowattHvInverter::setup(void) {  // Performs one time setup at startup ove
   strncpy(datalayer.system.info.inverter_protocol, "Growatt High Voltage protocol via CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef GROWATT_HV_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "GROWATT-HV-CAN.h"
 
@@ -21,143 +22,8 @@ FCC - Full charge capacity
 RM - Remaining capacity
 BMS - Battery Information Collector*/
 
-//Total number of Cells (1-512)
-//(Total number of Cells = number of Packs in parallel * number of Modules in series * number of Cells in the module)
-#define TOTAL_NUMBER_OF_CELLS 300
-// Number of Modules in series (1-32)
-#define NUMBER_OF_MODULES_IN_SERIES 20
-// Number of packs in parallel (1-65536)
-#define NUMBER_OF_PACKS_IN_PARALLEL 1
-//Manufacturer abbreviation, part 1
-#define MANUFACTURER_ASCII_0 0x47  //G
-#define MANUFACTURER_ASCII_1 0x54  //T
-
-/* Do not change code below unless you are sure what you are doing */
-
-//Actual content messages
-CAN_frame GROWATT_3110 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3110,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3120 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3120,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3130 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3130,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3140 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3140,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3150 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3150,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3160 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3160,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3170 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3170,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3180 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3180,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3190 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3190,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3200 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3200,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3210 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3210,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3220 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3220,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3230 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3230,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3240 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3240,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3250 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3250,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3260 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3260,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3270 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3270,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3280 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3280,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3290 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3290,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame GROWATT_3F00 = {.FD = false,
-                          .ext_ID = true,
-                          .DLC = 8,
-                          .ID = 0x3F00,
-                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static unsigned long previousMillis1s = 0;  // will store last time a 1s CAN Message was send
-static unsigned long previousMillisBatchSend = 0;
-static uint32_t unix_time = 0;
-static uint16_t ampere_hours_remaining = 0;
-static uint16_t ampere_hours_full = 0;
-static uint16_t send_times = 0;  // Overflows every 18hours. Cumulative number, plus 1 for each transmission
-static uint8_t safety_specification = 0;
-static uint8_t charging_command = 0;
-static uint8_t discharging_command = 0;
-static uint8_t shielding_external_communication_failure = 0;
-static uint8_t clearing_battery_fault =
-    0;  //When PCS receives the forced charge Mark 1 and Cell under- voltage protection fault, it will send 0XAA
-static uint8_t ISO_detection_command = 0;
-static uint8_t sleep_wakeup_control = 0;
-static uint8_t PCS_working_status = 0;     //00 standby, 01 operating
-static uint8_t serial_number_counter = 0;  //0-1-2-0-1-2...
-static uint8_t can_message_batch_index = 0;
-static const uint8_t delay_between_batches_ms = 10;
-static bool inverter_alive = false;
-static bool time_to_send_1s_data = false;
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void GrowattHvInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   if (datalayer.battery.status.voltage_dV > 10) {  // Only update value when we have voltage available to avoid div0
     ampere_hours_remaining =
@@ -493,7 +359,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   GROWATT_3F00.data.u8[7] = 0;  // RESERVED
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void GrowattHvInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x3010:  // Heartbeat command, 1000ms
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -523,7 +389,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void GrowattHvInverter::transmit_can(unsigned long currentMillis) {
 
   if (!inverter_alive) {
     return;  //Dont send messages towards inverter until it has started
@@ -585,7 +451,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void GrowattHvInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Growatt High Voltage protocol via CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -2,9 +2,154 @@
 #define GROWATT_HV_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS GrowattHvInverter
+
+class GrowattHvInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+//Total number of Cells (1-512)
+//(Total number of Cells = number of Packs in parallel * number of Modules in series * number of Cells in the module)
+#define TOTAL_NUMBER_OF_CELLS 300
+// Number of Modules in series (1-32)
+#define NUMBER_OF_MODULES_IN_SERIES 20
+// Number of packs in parallel (1-65536)
+#define NUMBER_OF_PACKS_IN_PARALLEL 1
+//Manufacturer abbreviation, part 1
+#define MANUFACTURER_ASCII_0 0x47  //G
+#define MANUFACTURER_ASCII_1 0x54  //T
+
+  /* Do not change code below unless you are sure what you are doing */
+
+  //Actual content messages
+  CAN_frame GROWATT_3110 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3110,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3120 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3120,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3130 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3130,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3140 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3140,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3150 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3150,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3160 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3160,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3170 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3170,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3180 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3180,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3190 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3190,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3200 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3200,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3210 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3210,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3220 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3220,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3230 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3230,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3240 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3240,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3250 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3250,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3260 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3260,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3270 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3270,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3280 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3280,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3290 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3290,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_3F00 = {.FD = false,
+                            .ext_ID = true,
+                            .DLC = 8,
+                            .ID = 0x3F00,
+                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  unsigned long previousMillis1s = 0;  // will store last time a 1s CAN Message was send
+  unsigned long previousMillisBatchSend = 0;
+  uint32_t unix_time = 0;
+  uint16_t ampere_hours_remaining = 0;
+  uint16_t ampere_hours_full = 0;
+  uint16_t send_times = 0;  // Overflows every 18hours. Cumulative number, plus 1 for each transmission
+  uint8_t safety_specification = 0;
+  uint8_t charging_command = 0;
+  uint8_t discharging_command = 0;
+  uint8_t shielding_external_communication_failure = 0;
+  uint8_t clearing_battery_fault =
+      0;  //When PCS receives the forced charge Mark 1 and Cell under- voltage protection fault, it will send 0XAA
+  uint8_t ISO_detection_command = 0;
+  uint8_t sleep_wakeup_control = 0;
+  uint8_t PCS_working_status = 0;     //00 standby, 01 operating
+  uint8_t serial_number_counter = 0;  //0-1-2-0-1-2...
+  uint8_t can_message_batch_index = 0;
+  const uint8_t delay_between_batches_ms = 10;
+  bool inverter_alive = false;
+  bool time_to_send_1s_data = false;
+};
 
 #endif

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef GROWATT_HV_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS GrowattHvInverter
+#endif
 
 class GrowattHvInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -17,16 +17,16 @@ class GrowattHvInverter : public CanInverterProtocol {
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
  private:
-//Total number of Cells (1-512)
-//(Total number of Cells = number of Packs in parallel * number of Modules in series * number of Cells in the module)
-#define TOTAL_NUMBER_OF_CELLS 300
-// Number of Modules in series (1-32)
-#define NUMBER_OF_MODULES_IN_SERIES 20
-// Number of packs in parallel (1-65536)
-#define NUMBER_OF_PACKS_IN_PARALLEL 1
-//Manufacturer abbreviation, part 1
-#define MANUFACTURER_ASCII_0 0x47  //G
-#define MANUFACTURER_ASCII_1 0x54  //T
+  //Total number of Cells (1-512)
+  //(Total number of Cells = number of Packs in parallel * number of Modules in series * number of Cells in the module)
+  static const int TOTAL_NUMBER_OF_CELLS = 300;
+  // Number of Modules in series (1-32)
+  static const int NUMBER_OF_MODULES_IN_SERIES = 20;
+  // Number of packs in parallel (1-65536)
+  static const int NUMBER_OF_PACKS_IN_PARALLEL = 1;
+  //Manufacturer abbreviation, part 1
+  static const int MANUFACTURER_ASCII_0 = 0x47;  //G
+  static const int MANUFACTURER_ASCII_1 = 0x54;  //T
 
   /* Do not change code below unless you are sure what you are doing */
 

--- a/Software/src/inverter/GROWATT-LV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-LV-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef GROWATT_LV_CAN
+#include "GROWATT-LV-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "GROWATT-LV-CAN.h"
+#include "../include.h"
 
 /* Growatt BMS CAN-Bus-protocol Low Voltage Rev_04
 CAN 2.0A
@@ -208,4 +207,3 @@ void GrowattLvInverter::setup(void) {  // Performs one time setup at startup ove
   strncpy(datalayer.system.info.inverter_protocol, "Growatt Low Voltage (48V) protocol via CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -2,9 +2,85 @@
 #define GROWATT_LV_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS GrowattLvInverter
+
+class GrowattLvInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  //Actual content messages
+  CAN_frame GROWATT_311 = {.FD = false,  //Voltage and charge limits and status
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x311,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_312 = {.FD = false,  //status bits , pack number, total cell number
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x312,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_313 = {.FD = false,  //voltage, current, temp, soc, soh
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x313,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_314 = {.FD = false,  //capacity, delta V, cycle count
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x314,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_319 = {.FD = false,  //max/min cell voltage, num of cell max/min, protect pack ID
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x319,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_320 = {.FD = false,  //manufacturer name, hw ver, sw  ver, date and time
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x320,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_321 = {.FD = false,  //Update status, ID
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x321,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  //Cellvoltages
+  CAN_frame GROWATT_315 = {.FD = false,  //Cells 1-4
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x315,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_316 = {.FD = false,  //Cells 5-8
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x316,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_317 = {.FD = false,  //Cells 9-12
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x317,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GROWATT_318 = {.FD = false,  //Cells 13-16
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x318,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+#define VOLTAGE_OFFSET_DV 40  //Offset in deciVolt from max charge voltage and min discharge voltage
+#define MAX_VOLTAGE_DV 630
+#define MIN_VOLTAGE_DV 410
+
+  uint16_t cell_delta_mV = 0;
+  uint16_t ampere_hours_remaining = 0;
+  uint16_t ampere_hours_full = 0;
+};
 
 #endif

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef GROWATT_LV_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS GrowattLvInverter
+#endif
 
 class GrowattLvInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -76,9 +76,9 @@ class GrowattLvInverter : public CanInverterProtocol {
                            .ID = 0x318,
                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
-#define VOLTAGE_OFFSET_DV 40  //Offset in deciVolt from max charge voltage and min discharge voltage
-#define MAX_VOLTAGE_DV 630
-#define MIN_VOLTAGE_DV 410
+  static const int VOLTAGE_OFFSET_DV = 40;  //Offset in deciVolt from max charge voltage and min discharge voltage
+  static const int MAX_VOLTAGE_DV = 630;
+  static const int MIN_VOLTAGE_DV = 410;
 
   uint16_t cell_delta_mV = 0;
   uint16_t ampere_hours_remaining = 0;

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -3,9 +3,7 @@
 // These functions adapt the old C-style global functions inverter-API to the
 // object-oriented inverter protocol API.
 
-#ifdef SELECTED_INVERTER_CLASS
-
-InverterProtocol* inverter;
+InverterProtocol* inverter = nullptr;
 
 #ifdef CAN_INVERTER_SELECTED
 CanInverterProtocol* can_inverter;
@@ -30,7 +28,9 @@ void setup_inverter() {
   inverter = new SELECTED_INVERTER_CLASS();
 #endif
 
-  inverter->setup();
+  if (inverter) {
+    inverter->setup();
+  }
 }
 
 #ifdef CAN_INVERTER_SELECTED
@@ -51,6 +51,4 @@ void transmit_can_inverter(unsigned long currentMillis) {
 void receive_RS485() {
   ((Rs485InverterProtocol*)inverter)->receive_RS485();
 }
-#endif
-
 #endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -6,81 +6,29 @@ extern InverterProtocol* inverter;
 
 #include "../../USER_SETTINGS.h"
 
-#ifdef AFORE_CAN
 #include "AFORE-CAN.h"
-#endif
 
 #ifdef BYD_CAN_DEYE
 #define BYD_CAN
 #endif
 
-#ifdef BYD_CAN
 #include "BYD-CAN.h"
-#endif
-
-#ifdef BYD_MODBUS
 #include "BYD-MODBUS.h"
-#endif
-
-#ifdef BYD_KOSTAL_RS485
-#include "KOSTAL-RS485.h"
-#endif
-
-#ifdef FERROAMP_CAN
 #include "FERROAMP-CAN.h"
-#endif
-
-#ifdef FOXESS_CAN
 #include "FOXESS-CAN.h"
-#endif
-
-#ifdef GROWATT_HV_CAN
 #include "GROWATT-HV-CAN.h"
-#endif
-
-#ifdef GROWATT_LV_CAN
 #include "GROWATT-LV-CAN.h"
-#endif
-
-#ifdef PYLON_CAN
+#include "KOSTAL-RS485.h"
 #include "PYLON-CAN.h"
-#endif
-
-#ifdef PYLON_LV_CAN
 #include "PYLON-LV-CAN.h"
-#endif
-
-#ifdef SCHNEIDER_CAN
 #include "SCHNEIDER-CAN.h"
-#endif
-
-#ifdef SMA_BYD_H_CAN
 #include "SMA-BYD-H-CAN.h"
-#endif
-
-#ifdef SMA_BYD_HVS_CAN
 #include "SMA-BYD-HVS-CAN.h"
-#endif
-
-#ifdef SMA_LV_CAN
 #include "SMA-LV-CAN.h"
-#endif
-
-#ifdef SMA_TRIPOWER_CAN
 #include "SMA-TRIPOWER-CAN.h"
-#endif
-
-#ifdef SOFAR_CAN
 #include "SOFAR-CAN.h"
-#endif
-
-#ifdef SOLAX_CAN
 #include "SOLAX-CAN.h"
-#endif
-
-#ifdef SUNGROW_CAN
 #include "SUNGROW-CAN.h"
-#endif
 
 void setup_inverter();
 

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -30,6 +30,7 @@ extern InverterProtocol* inverter;
 #include "SOLAX-CAN.h"
 #include "SUNGROW-CAN.h"
 
+// Call to initialize the build-time selected inverter. Safe to call even though inverter was not selected.
 void setup_inverter();
 
 #ifdef CAN_INVERTER_SELECTED

--- a/Software/src/inverter/InverterProtocol.h
+++ b/Software/src/inverter/InverterProtocol.h
@@ -5,6 +5,7 @@
 class InverterProtocol {
  public:
   virtual void setup() = 0;
+  virtual const char* interface_name() = 0;
 
   // This function maps all the values fetched from battery to the correct battery emulator data structures
   virtual void update_values() = 0;

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef BYD_KOSTAL_RS485
+#include "KOSTAL-RS485.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "KOSTAL-RS485.h"
+#include "../include.h"
 
 void KostalInverterProtocol::float2frame(byte* arr, float value, byte framepointer) {
   f32b g;
@@ -307,4 +306,3 @@ void KostalInverterProtocol::setup(void) {  // Performs one time setup at startu
 
   Serial2.begin(baud_rate(), SERIAL_8N1, RS485_RX_PIN, RS485_TX_PIN);
 }
-#endif

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -5,8 +5,10 @@
 
 #include "Rs485InverterProtocol.h"
 
+#ifdef BYD_KOSTAL_RS485
 #define RS485_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS KostalInverterProtocol
+#endif
 
 //#define DEBUG_KOSTAL_RS485_DATA  // Enable this line to get TX / RX printed out via logging
 //#define DEBUG_KOSTAL_RS485_DATA_USB  // Enable this line to get TX / RX printed out via USB

--- a/Software/src/inverter/ModbusInverterProtocol.h
+++ b/Software/src/inverter/ModbusInverterProtocol.h
@@ -10,6 +10,8 @@ extern uint16_t mbPV[];
 
 // The abstract base class for all Modbus inverter protocols
 class ModbusInverterProtocol : public InverterProtocol {
+  virtual const char* interface_name() { return "RS485 / Modbus"; }
+
  protected:
   // Create a ModbusRTU server instance with 2000ms timeout
   ModbusInverterProtocol() : MBserver(2000) { mbPV = ::mbPV; }

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -1,144 +1,11 @@
 #include "../include.h"
 #ifdef PYLON_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "PYLON-CAN.h"
 
-#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
-//#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
-                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
-//#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
-
-/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
-Change the following only if your inverter is generating fault codes about voltage range */
-#define TOTAL_CELL_AMOUNT 120
-#define MODULES_IN_SERIES 4
-#define CELLS_PER_MODULE 30
-#define VOLTAGE_LEVEL 384
-#define AH_CAPACITY 37
-
-/* Do not change code below unless you are sure what you are doing */
-//Actual content messages
-CAN_frame PYLON_7310 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7310,
-                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7311 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7311,
-                        .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
-CAN_frame PYLON_7320 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7320,
-                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
-                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_7321 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x7321,
-                        .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
-                                 CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                 AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
-CAN_frame PYLON_4210 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4210,
-                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame PYLON_4220 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4220,
-                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame PYLON_4230 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4230,
-                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame PYLON_4240 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4240,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame PYLON_4250 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4250,
-                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4260 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4260,
-                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame PYLON_4270 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4270,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame PYLON_4280 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4280,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4290 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4290,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4211 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4211,
-                        .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
-CAN_frame PYLON_4221 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4221,
-                        .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
-CAN_frame PYLON_4231 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4231,
-                        .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
-CAN_frame PYLON_4241 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4241,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
-CAN_frame PYLON_4251 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4251,
-                        .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4261 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4261,
-                        .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
-CAN_frame PYLON_4271 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4271,
-                        .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
-CAN_frame PYLON_4281 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4281,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame PYLON_4291 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x4291,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static uint16_t discharge_cutoff_voltage_dV = 0;
-static uint16_t charge_cutoff_voltage_dV = 0;
-#define VOLTAGE_OFFSET_DV 20  // Small offset voltage to avoid generating voltage events
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void PylonInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   //Check what discharge and charge cutoff voltages to send
   if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
@@ -422,7 +289,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void PylonInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x4200:  //Message originating from inverter. Depending on which data is required, act accordingly
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -438,11 +305,11 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void PylonInverter::transmit_can(unsigned long currentMillis) {
   // No periodic sending, we only react on received can messages
 }
 
-void send_setup_info() {  //Ensemble information
+void PylonInverter::send_setup_info() {  //Ensemble information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_7310, can_config.inverter);
   transmit_can_frame(&PYLON_7320, can_config.inverter);
@@ -453,7 +320,7 @@ void send_setup_info() {  //Ensemble information
 #endif
 }
 
-void send_system_data() {  //System equipment information
+void PylonInverter::send_system_data() {  //System equipment information
 #ifdef SEND_0
   transmit_can_frame(&PYLON_4210, can_config.inverter);
   transmit_can_frame(&PYLON_4220, can_config.inverter);
@@ -477,7 +344,8 @@ void send_system_data() {  //System equipment information
   transmit_can_frame(&PYLON_4291, can_config.inverter);
 #endif
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+
+void PylonInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Pylontech battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef PYLON_CAN
+#include "PYLON-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "PYLON-CAN.h"
+#include "../include.h"
 
 void PylonInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
@@ -349,4 +348,3 @@ void PylonInverter::setup(void) {  // Performs one time setup at startup over CA
   strncpy(datalayer.system.info.inverter_protocol, "Pylontech battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -24,15 +24,15 @@ class PylonInverter : public CanInverterProtocol {
 //#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
 #define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
                                     //useful for some inverters like Sofar that report the voltages incorrect otherwise
-//#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
+  //#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
 
-/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
+  /* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
      Change the following only if your inverter is generating fault codes about voltage range */
-#define TOTAL_CELL_AMOUNT 120
-#define MODULES_IN_SERIES 4
-#define CELLS_PER_MODULE 30
-#define VOLTAGE_LEVEL 384
-#define AH_CAPACITY 37
+  static const int TOTAL_CELL_AMOUNT = 120;
+  static const int MODULES_IN_SERIES = 4;
+  static const int CELLS_PER_MODULE = 30;
+  static const int VOLTAGE_LEVEL = 384;
+  static const int AH_CAPACITY = 37;
 
   /* Do not change code below unless you are sure what you are doing */
   //Actual content messages
@@ -153,7 +153,8 @@ class PylonInverter : public CanInverterProtocol {
 
   uint16_t discharge_cutoff_voltage_dV = 0;
   uint16_t charge_cutoff_voltage_dV = 0;
-#define VOLTAGE_OFFSET_DV 20  // Small offset voltage to avoid generating voltage events
+
+  static const int VOLTAGE_OFFSET_DV = 20;  // Small offset voltage to avoid generating voltage events
 };
 
 #endif

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef PYLON_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS PylonInverter
+#endif
 
 class PylonInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -2,11 +2,156 @@
 #define PYLON_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void send_system_data();
-void send_setup_info();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS PylonInverter
+
+class PylonInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  void send_system_data();
+  void send_setup_info();
+
+#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
+//#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
+                                    //useful for some inverters like Sofar that report the voltages incorrect otherwise
+//#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
+
+/* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
+     Change the following only if your inverter is generating fault codes about voltage range */
+#define TOTAL_CELL_AMOUNT 120
+#define MODULES_IN_SERIES 4
+#define CELLS_PER_MODULE 30
+#define VOLTAGE_LEVEL 384
+#define AH_CAPACITY 37
+
+  /* Do not change code below unless you are sure what you are doing */
+  //Actual content messages
+  CAN_frame PYLON_7310 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7310,
+                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+  CAN_frame PYLON_7311 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7311,
+                          .data = {0x01, 0x00, 0x02, 0x01, 0x01, 0x02, 0x00, 0x00}};
+  CAN_frame PYLON_7320 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7320,
+                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                   CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+  CAN_frame PYLON_7321 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x7321,
+                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                                   CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
+                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+  CAN_frame PYLON_4210 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4210,
+                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+  CAN_frame PYLON_4220 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4220,
+                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+  CAN_frame PYLON_4230 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4230,
+                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+  CAN_frame PYLON_4240 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4240,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+  CAN_frame PYLON_4250 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4250,
+                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4260 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4260,
+                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+  CAN_frame PYLON_4270 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4270,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+  CAN_frame PYLON_4280 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4280,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4290 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4290,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4211 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4211,
+                          .data = {0xA5, 0x09, 0x30, 0x75, 0x9D, 0x04, 0x2E, 0x64}};
+  CAN_frame PYLON_4221 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4221,
+                          .data = {0x8C, 0x0A, 0xE9, 0x07, 0x4A, 0x79, 0x4A, 0x79}};
+  CAN_frame PYLON_4231 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4231,
+                          .data = {0xDF, 0x0C, 0xDA, 0x0C, 0x03, 0x00, 0x06, 0x00}};
+  CAN_frame PYLON_4241 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4241,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x11, 0x00, 0x03, 0x00}};
+  CAN_frame PYLON_4251 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4251,
+                          .data = {0x03, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4261 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4261,
+                          .data = {0xAC, 0xC7, 0x74, 0x27, 0x03, 0x00, 0x02, 0x00}};
+  CAN_frame PYLON_4271 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4271,
+                          .data = {0x7E, 0x04, 0x62, 0x04, 0x05, 0x00, 0x01, 0x00}};
+  CAN_frame PYLON_4281 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4281,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_4291 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x4291,
+                          .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  uint16_t discharge_cutoff_voltage_dV = 0;
+  uint16_t charge_cutoff_voltage_dV = 0;
+#define VOLTAGE_OFFSET_DV 20  // Small offset voltage to avoid generating voltage events
+};
 
 #endif

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef PYLON_LV_CAN
+#include "PYLON-LV-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "PYLON-LV-CAN.h"
+#include "../include.h"
 
 // when e.g. the min temperature is 0, max is 100 and the warning percent is 80%
 // a warning should be generated at 20 (i.e. at 20% of the value range)
@@ -150,4 +149,3 @@ void PylonLvInverter::setup(void) {  // Performs one time setup at startup over 
   strncpy(datalayer.system.info.inverter_protocol, "Pylontech LV battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef PYLON_LV_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS PylonLvInverter
+#endif
 
 class PylonLvInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -2,16 +2,63 @@
 #define PYLON_LV_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS PylonLvInverter
 
-#define MANUFACTURER_NAME "BatEmuLV"
-#define PACK_NUMBER 0x01
-// 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
-#define WARNINGS_PERCENT 80
+class PylonLvInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
 
-void send_system_data();
-void send_setup_info();
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+ private:
+  void send_system_data();
+  void send_setup_info();
+  int16_t warning_threshold_of_min(int16_t min_val, int16_t max_val);
+
+  static const int PACK_NUMBER = 0x01;
+
+  // 80 means after reaching 80% of a nominal value a warning is produced (e.g. 80% of max current)
+  static const int WARNINGS_PERCENT = 80;
+
+  static constexpr const char* MANUFACTURER_NAME = "BatEmuLV";
+
+  unsigned long previousMillis1000ms = 0;
+
+  CAN_frame PYLON_351 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 6,
+                         .ID = 0x351,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_355 = {.FD = false, .ext_ID = false, .DLC = 4, .ID = 0x355, .data = {0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_356 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 6,
+                         .ID = 0x356,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame PYLON_359 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 7,
+                         .ID = 0x359,
+                         .data = {0x00, 0x00, 0x00, 0x00, PACK_NUMBER, 'P', 'N'}};
+  CAN_frame PYLON_35C = {.FD = false, .ext_ID = false, .DLC = 2, .ID = 0x35C, .data = {0x00, 0x00}};
+  CAN_frame PYLON_35E = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x35E,
+                         .data = {
+                             MANUFACTURER_NAME[0],
+                             MANUFACTURER_NAME[1],
+                             MANUFACTURER_NAME[2],
+                             MANUFACTURER_NAME[3],
+                             MANUFACTURER_NAME[4],
+                             MANUFACTURER_NAME[5],
+                             MANUFACTURER_NAME[6],
+                             MANUFACTURER_NAME[7],
+                         }};
+};
 
 #endif

--- a/Software/src/inverter/Rs485InverterProtocol.h
+++ b/Software/src/inverter/Rs485InverterProtocol.h
@@ -5,6 +5,7 @@
 
 class Rs485InverterProtocol : public InverterProtocol {
  public:
+  virtual const char* interface_name() { return "RS485"; }
   virtual void receive_RS485() = 0;
   virtual int baud_rate() = 0;
 };

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef SCHNEIDER_CAN
+#include "SCHNEIDER-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "SCHNEIDER-CAN.h"
+#include "../include.h"
 
 /* Version 2: SE BMS Communication Protocol 
 Protocol: CAN 2.0 Specification
@@ -231,5 +230,3 @@ void SchneiderInverter::setup(void) {  // Performs one time setup
   strncpy(datalayer.system.info.inverter_protocol, "Schneider V2 SE BMS CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-
-#endif

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SCHNEIDER_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "SCHNEIDER-CAN.h"
 
@@ -16,78 +17,8 @@ Endian: Big Endian (MSB, most significant byte of a value received first)*/
   - We will need CAN logs from existing battery OR contact Schneider for one free number
 */
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
-static unsigned long previousMillis2s = 0;     // will store last time a 2s CAN Message was send
-static unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was send
-
-CAN_frame SE_320 = {.FD = false,  //SE BMS Protocol Version
-                    .ext_ID = true,
-                    .DLC = 2,
-                    .ID = 0x320,
-                    .data = {0x00, 0x02}};  //TODO: How do we reply with Protocol Version: 0x0002 ?
-CAN_frame SE_321 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x321,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_322 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x322,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_323 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x323,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_324 = {.FD = false, .ext_ID = true, .DLC = 4, .ID = 0x324, .data = {0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_325 = {.FD = false, .ext_ID = true, .DLC = 6, .ID = 0x325, .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_326 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x326,
-                    .data = {0x00, STATE_STARTING, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_327 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x327,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_328 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x328,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_330 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x330,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_331 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x331,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_332 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x332,
-                    .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SE_333 = {.FD = false,
-                    .ext_ID = true,
-                    .DLC = 8,
-                    .ID = 0x333,
-                    .data = {0x53, 0x45, 0x42, 0x4D, 0x53, 0x00, 0x00, 0x00}};  //SEBMS
-
-static int16_t temperature_average = 0;
-static uint16_t remaining_capacity_ah = 0;
-static uint16_t fully_charged_capacity_ah = 0;
-static uint16_t commands = 0;
-static uint16_t warnings = 0;
-static uint16_t faults = 0;
-static uint16_t state = 0;
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SchneiderInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   /* Calculate temperature */
   temperature_average =
@@ -255,7 +186,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SE_320.data.u8[1] = 0x02;
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SchneiderInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x310:  // Still alive message from inverter, every 1s
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -265,7 +196,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SchneiderInverter::transmit_can(unsigned long currentMillis) {
 
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
@@ -296,7 +227,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup
+void SchneiderInverter::setup(void) {  // Performs one time setup
   strncpy(datalayer.system.info.inverter_protocol, "Schneider V2 SE BMS CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -2,7 +2,10 @@
 #define SCHNEIDER_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SchneiderInverter
 
 #define STATE_OFFLINE 0
 #define STATE_STANDBY 1
@@ -27,7 +30,84 @@
 #define COMMAND_CHARGE_AND_DISCHARGE_ALLOWED 0x06
 #define COMMAND_STOP 0x08
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+class SchneiderInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  /* Do not change code below unless you are sure what you are doing */
+  unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
+  unsigned long previousMillis2s = 0;     // will store last time a 2s CAN Message was send
+  unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was send
+
+  CAN_frame SE_320 = {.FD = false,  //SE BMS Protocol Version
+                      .ext_ID = true,
+                      .DLC = 2,
+                      .ID = 0x320,
+                      .data = {0x00, 0x02}};  //TODO: How do we reply with Protocol Version: 0x0002 ?
+  CAN_frame SE_321 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x321,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_322 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x322,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_323 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x323,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_324 = {.FD = false, .ext_ID = true, .DLC = 4, .ID = 0x324, .data = {0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_325 = {.FD = false, .ext_ID = true, .DLC = 6, .ID = 0x325, .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_326 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x326,
+                      .data = {0x00, STATE_STARTING, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_327 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x327,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_328 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x328,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_330 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x330,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_331 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x331,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_332 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x332,
+                      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SE_333 = {.FD = false,
+                      .ext_ID = true,
+                      .DLC = 8,
+                      .ID = 0x333,
+                      .data = {0x53, 0x45, 0x42, 0x4D, 0x53, 0x00, 0x00, 0x00}};  //SEBMS
+
+  int16_t temperature_average = 0;
+  uint16_t remaining_capacity_ah = 0;
+  uint16_t fully_charged_capacity_ah = 0;
+  uint16_t commands = 0;
+  uint16_t warnings = 0;
+  uint16_t faults = 0;
+  uint16_t state = 0;
+};
 
 #endif

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -4,31 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SCHNEIDER_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SchneiderInverter
-
-#define STATE_OFFLINE 0
-#define STATE_STANDBY 1
-#define STATE_STARTING 2
-#define STATE_ONLINE 3
-#define STATE_FAULTED 4
-
-// Same enumerations used for Fault and Warning
-#define FAULTS_CHARGE_OVERCURRENT 0
-#define FAULTS_DISCHARGE_OVERCURRENT 1
-#define FAULTS_OVER_TEMPERATURE 2
-#define FAULTS_UNDER_TEMPERATURE 3
-#define FAULTS_OVER_VOLTAGE 4
-#define FAULTS_UNDER_VOLTAGE 5
-#define FAULTS_CELL_IMBALANCE 6
-#define FAULTS_INTERNAL_COM_ERROR 7
-#define FAULTS_SYSTEM_ERROR 8
-
-// Commands. Bit0 forced charge request. Bit1 charge permitted. Bit2 discharge permitted. Bit3 Stop
-#define COMMAND_ONLY_CHARGE_ALLOWED 0x02
-#define COMMAND_ONLY_DISCHARGE_ALLOWED 0x04
-#define COMMAND_CHARGE_AND_DISCHARGE_ALLOWED 0x06
-#define COMMAND_STOP 0x08
+#endif
 
 class SchneiderInverter : public CanInverterProtocol {
  public:
@@ -38,7 +17,29 @@ class SchneiderInverter : public CanInverterProtocol {
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
  private:
-  /* Do not change code below unless you are sure what you are doing */
+  static const int STATE_OFFLINE = 0;
+  static const int STATE_STANDBY = 1;
+  static const int STATE_STARTING = 2;
+  static const int STATE_ONLINE = 3;
+  static const int STATE_FAULTED = 4;
+
+  // Same enumerations used for Fault and Warning
+  static const int FAULTS_CHARGE_OVERCURRENT = 0;
+  static const int FAULTS_DISCHARGE_OVERCURRENT = 1;
+  static const int FAULTS_OVER_TEMPERATURE = 2;
+  static const int FAULTS_UNDER_TEMPERATURE = 3;
+  static const int FAULTS_OVER_VOLTAGE = 4;
+  static const int FAULTS_UNDER_VOLTAGE = 5;
+  static const int FAULTS_CELL_IMBALANCE = 6;
+  static const int FAULTS_INTERNAL_COM_ERROR = 7;
+  static const int FAULTS_SYSTEM_ERROR = 8;
+
+  // Commands. Bit0 forced charge request. Bit1 charge permitted. Bit2 discharge permitted. Bit3 Stop
+  static const int COMMAND_ONLY_CHARGE_ALLOWED = 0x02;
+  static const int COMMAND_ONLY_DISCHARGE_ALLOWED = 0x04;
+  static const int COMMAND_CHARGE_AND_DISCHARGE_ALLOWED = 0x06;
+  static const int COMMAND_STOP = 0x08;
+
   unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
   unsigned long previousMillis2s = 0;     // will store last time a 2s CAN Message was send
   unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was send

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SMA_BYD_H_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SMA-BYD-H-CAN.h"
@@ -7,80 +8,9 @@
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100ms = 0;
 
-static uint32_t inverter_time = 0;
-static uint16_t inverter_voltage = 0;
-static int16_t inverter_current = 0;
-static uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
-
-//Actual content messages
-CAN_frame SMA_158 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x158,
-                     .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
-CAN_frame SMA_558 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,
-                     .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
-
-static int16_t temperature_average = 0;
-static uint16_t ampere_hours_remaining = 0;
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaBydHInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -210,7 +140,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -250,7 +180,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SmaBydHInverter::transmit_can(unsigned long currentMillis) {
 
   // Send CAN Message every 100ms if inverter allows contactor closing
   if (datalayer.system.status.inverter_allows_contactor_closing) {
@@ -267,7 +197,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void transmit_can_init() {
+void SmaBydHInverter::transmit_can_init() {
   transmit_can_frame(&SMA_558, can_config.inverter);
   transmit_can_frame(&SMA_598, can_config.inverter);
   transmit_can_frame(&SMA_5D8, can_config.inverter);
@@ -282,7 +212,7 @@ void transmit_can_init() {
   transmit_can_frame(&SMA_4D8, can_config.inverter);
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void SmaBydHInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "SMA CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef SMA_BYD_H_CAN
+#include "SMA-BYD-H-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "SMA-BYD-H-CAN.h"
+#include "../include.h"
 
 /* TODO: Map error bits in 0x158 */
 
@@ -222,4 +221,3 @@ void SmaBydHInverter::setup(void) {  // Performs one time setup at startup over 
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
 }
-#endif

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -2,13 +2,96 @@
 #define SMA_BYD_H_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SmaBydHInverter
 
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+class SmaBydHInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  void transmit_can_init();
+
+  unsigned long previousMillis100ms = 0;
+
+  uint32_t inverter_time = 0;
+  uint16_t inverter_voltage = 0;
+  int16_t inverter_current = 0;
+  uint16_t timeWithoutInverterAllowsContactorClosing = 0;
+#define THIRTY_MINUTES 1200
+
+  //Actual content messages
+  CAN_frame SMA_158 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x158,
+                       .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x6A, 0xAA, 0xAA}};
+  CAN_frame SMA_358 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x358,
+                       .data = {0x0F, 0x6C, 0x06, 0x20, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_3D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D8,
+                       .data = {0x04, 0x10, 0x27, 0x10, 0x00, 0x18, 0xF9, 0x00}};
+  CAN_frame SMA_458 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x458,
+                       .data = {0x00, 0x00, 0x06, 0x75, 0x00, 0x00, 0x05, 0xD6}};
+  CAN_frame SMA_4D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x4D8,
+                       .data = {0x09, 0xFD, 0x00, 0x00, 0x00, 0xA8, 0x02, 0x08}};
+  CAN_frame SMA_518 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x518,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
+  CAN_frame SMA_558 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x558,
+                       .data = {0x03, 0x12, 0x00, 0x04, 0x00, 0x59, 0x07, 0x07}};  //7x BYD modules, Vendor ID 7 BYD
+  CAN_frame SMA_598 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x598,
+                       .data = {0x00, 0x00, 0x12, 0x34, 0x5A, 0xDE, 0x07, 0x4F}};  //B0-4 Serial, rest unknown
+  CAN_frame SMA_5D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5D8,
+                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+  CAN_frame SMA_618_1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+  CAN_frame SMA_618_2 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x39}};  //1 - B O X   H
+  CAN_frame SMA_618_3 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x02, 0x2E, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00}};  //2 - 0
+
+  int16_t temperature_average = 0;
+  uint16_t ampere_hours_remaining = 0;
+};
 
 #endif

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -4,11 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SMA_BYD_H_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SmaBydHInverter
-
-#define READY_STATE 0x03
-#define STOP_STATE 0x02
+#endif
 
 class SmaBydHInverter : public CanInverterProtocol {
  public:
@@ -18,6 +17,9 @@ class SmaBydHInverter : public CanInverterProtocol {
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
  private:
+  static const int READY_STATE = 0x03;
+  static const int STOP_STATE = 0x02;
+
   void transmit_can_init();
 
   unsigned long previousMillis100ms = 0;
@@ -26,7 +28,7 @@ class SmaBydHInverter : public CanInverterProtocol {
   uint16_t inverter_voltage = 0;
   int16_t inverter_current = 0;
   uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
+  static const int THIRTY_MINUTES = 1200;
 
   //Actual content messages
   CAN_frame SMA_158 = {.FD = false,

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef SMA_BYD_HVS_CAN
+#include "SMA-BYD-HVS-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "SMA-BYD-HVS-CAN.h"
+#include "../include.h"
 
 /* TODO: Map error bits in 0x158 */
 
@@ -267,4 +266,3 @@ void SmaBydHvsInverter::setup(void) {  // Performs one time setup at startup ove
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
 }
-#endif

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SMA_BYD_HVS_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SMA-BYD-HVS-CAN.h"
@@ -7,85 +8,9 @@
 /* TODO: Map error bits in 0x158 */
 
 /* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100ms = 0;
 
-static uint32_t inverter_time = 0;
-static uint16_t inverter_voltage = 0;
-static int16_t inverter_current = 0;
-static uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
-
-//Actual content messages
-CAN_frame SMA_158 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x158,  // All 0xAA, no faults active
-                     .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x11, 0xA0, 0x07, 0x00, 0x01, 0x5E, 0x00, 0xC8}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x13, 0x2E, 0x27, 0x10, 0x00, 0x45, 0xF9, 0x00}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x11, 0xC8, 0x00, 0x00, 0x0E, 0xF4}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x10, 0x62, 0x00, 0x16, 0x01, 0x68, 0x03, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x01, 0x4A, 0x01, 0x25, 0xFF, 0xFF, 0xFF, 0xFF}};
-
-// Pairing/Battery setup information
-
-CAN_frame SMA_558 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,
-                     .data = {0x03, 0x13, 0x00, 0x03, 0x00, 0x66, 0x04, 0x07}};  //4x BYD modules, Vendor ID 7 BYD
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x00, 0x01, 0x0F, 0x2C, 0x5C, 0x98, 0xB6, 0xEE}};
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x31}};  //- B o x  H 1
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x30, 0x2E, 0x32, 0x00, 0x00, 0x00, 0x00}};  // 0 . 2
-
-static int16_t discharge_current = 0;
-static int16_t charge_current = 0;
-static int16_t temperature_average = 0;
-static uint16_t ampere_hours_remaining = 0;
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaBydHvsInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -214,7 +139,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 */
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -254,7 +179,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SmaBydHvsInverter::transmit_can(unsigned long currentMillis) {
 
   // Send CAN Message every 100ms if inverter allows contactor closing
   if (datalayer.system.status.inverter_allows_contactor_closing) {
@@ -270,7 +195,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void transmit_can_init() {
+void SmaBydHvsInverter::transmit_can_init() {
   transmit_can_frame(&SMA_558, can_config.inverter);
   transmit_can_frame(&SMA_598, can_config.inverter);
   transmit_can_frame(&SMA_5D8, can_config.inverter);
@@ -285,7 +210,7 @@ void transmit_can_init() {
   transmit_can_frame(&SMA_4D8, can_config.inverter);
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void SmaBydHvsInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "BYD Battery-Box HVS over SMA CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -4,11 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SMA_BYD_HVS_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SmaBydHvsInverter
-
-#define READY_STATE 0x03
-#define STOP_STATE 0x02
+#endif
 
 class SmaBydHvsInverter : public CanInverterProtocol {
  public:
@@ -18,6 +17,10 @@ class SmaBydHvsInverter : public CanInverterProtocol {
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
  private:
+  static const int READY_STATE = 0x03;
+  static const int STOP_STATE = 0x02;
+  static const int THIRTY_MINUTES = 1200;
+
   void transmit_can_init();
   unsigned long previousMillis100ms = 0;
 
@@ -25,7 +28,6 @@ class SmaBydHvsInverter : public CanInverterProtocol {
   uint16_t inverter_voltage = 0;
   int16_t inverter_current = 0;
   uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
 
   //Actual content messages
   CAN_frame SMA_158 = {.FD = false,

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -2,13 +2,100 @@
 #define SMA_BYD_HVS_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SmaBydHvsInverter
 
 #define READY_STATE 0x03
 #define STOP_STATE 0x02
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+class SmaBydHvsInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  void transmit_can_init();
+  unsigned long previousMillis100ms = 0;
+
+  uint32_t inverter_time = 0;
+  uint16_t inverter_voltage = 0;
+  int16_t inverter_current = 0;
+  uint16_t timeWithoutInverterAllowsContactorClosing = 0;
+#define THIRTY_MINUTES 1200
+
+  //Actual content messages
+  CAN_frame SMA_158 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x158,  // All 0xAA, no faults active
+                       .data = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}};
+  CAN_frame SMA_358 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x358,
+                       .data = {0x11, 0xA0, 0x07, 0x00, 0x01, 0x5E, 0x00, 0xC8}};
+  CAN_frame SMA_3D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D8,
+                       .data = {0x13, 0x2E, 0x27, 0x10, 0x00, 0x45, 0xF9, 0x00}};
+  CAN_frame SMA_458 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x458,
+                       .data = {0x00, 0x00, 0x11, 0xC8, 0x00, 0x00, 0x0E, 0xF4}};
+  CAN_frame SMA_4D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x4D8,
+                       .data = {0x10, 0x62, 0x00, 0x16, 0x01, 0x68, 0x03, 0x08}};
+  CAN_frame SMA_518 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x518,
+                       .data = {0x01, 0x4A, 0x01, 0x25, 0xFF, 0xFF, 0xFF, 0xFF}};
+
+  // Pairing/Battery setup information
+
+  CAN_frame SMA_558 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x558,
+                       .data = {0x03, 0x13, 0x00, 0x03, 0x00, 0x66, 0x04, 0x07}};  //4x BYD modules, Vendor ID 7 BYD
+  CAN_frame SMA_598 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x598,
+                       .data = {0x00, 0x01, 0x0F, 0x2C, 0x5C, 0x98, 0xB6, 0xEE}};
+  CAN_frame SMA_5D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5D8,
+                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+  CAN_frame SMA_618_1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //0 B A T T E R Y
+  CAN_frame SMA_618_2 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x48, 0x31}};  //- B o x  H 1
+  CAN_frame SMA_618_3 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x02, 0x30, 0x2E, 0x32, 0x00, 0x00, 0x00, 0x00}};  // 0 . 2
+
+  int16_t discharge_current = 0;
+  int16_t charge_current = 0;
+  int16_t temperature_average = 0;
+  uint16_t ampere_hours_remaining = 0;
+};
 
 #endif

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef SMA_LV_CAN
+#include "SMA-LV-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "SMA-LV-CAN.h"
+#include "../include.h"
 
 /* SMA Sunny Island Low Voltage (48V) CAN protocol:
 CAN 2.0A
@@ -113,4 +112,3 @@ void SmaLvInverter::setup(void) {  // Performs one time setup at startup over CA
   strncpy(datalayer.system.info.inverter_protocol, "SMA Low Voltage (48V) protocol via CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SMA_LV_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "SMA-LV-CAN.h"
 
@@ -8,58 +9,8 @@ CAN 2.0A
 500kBit/sec
 11-Bit Identifiers */
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100ms = 0;
-
-#define VOLTAGE_OFFSET_DV 40  //Offset in deciVolt from max charge voltage and min discharge voltage
-#define MAX_VOLTAGE_DV 630
-#define MIN_VOLTAGE_DV 41
-
-//Actual content messages
-CAN_frame SMA_00F = {.FD = false,  // Emergency stop message
-                     .ext_ID = false,
-                     .DLC = 8,  //Documentation unclear, should message even have any content?
-                     .ID = 0x00F,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_351 = {.FD = false,  // Battery charge voltage, charge/discharge limit, min discharge voltage
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x351,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_355 = {.FD = false,  // SOC, SOH, HiResSOC
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x355,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_356 = {.FD = false,  // Battery voltage, current, temperature
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x356,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_35A = {.FD = false,  // Alarms & Warnings
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x35A,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_35B = {.FD = false,  // Events
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x35B,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_35E = {.FD = false,  // Manufacturer ASCII
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x35E,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_35F = {.FD = false,  // Battery Type, version, capacity, ID
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x35F,
-                     .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-static int16_t temperature_average = 0;
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SmaLvInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -114,7 +65,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   //TODO: Map error/warnings in 0x35A
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaLvInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x305:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -136,7 +87,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SmaLvInverter::transmit_can(unsigned long currentMillis) {
 
   if (currentMillis - previousMillis100ms >= INTERVAL_100_MS) {
     previousMillis100ms = currentMillis;
@@ -158,7 +109,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void SmaLvInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "SMA Low Voltage (48V) protocol via CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -2,12 +2,71 @@
 #define SMA_LV_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SmaLvInverter
 
-#define READY_STATE 0x03
-#define STOP_STATE 0x02
+class SmaLvInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+ private:
+  static const int READY_STATE = 0x03;
+  static const int STOP_STATE = 0x02;
+
+  unsigned long previousMillis100ms = 0;
+
+#define VOLTAGE_OFFSET_DV 40  //Offset in deciVolt from max charge voltage and min discharge voltage
+#define MAX_VOLTAGE_DV 630
+#define MIN_VOLTAGE_DV 41
+
+  //Actual content messages
+  CAN_frame SMA_00F = {.FD = false,  // Emergency stop message
+                       .ext_ID = false,
+                       .DLC = 8,  //Documentation unclear, should message even have any content?
+                       .ID = 0x00F,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_351 = {.FD = false,  // Battery charge voltage, charge/discharge limit, min discharge voltage
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x351,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_355 = {.FD = false,  // SOC, SOH, HiResSOC
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x355,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_356 = {.FD = false,  // Battery voltage, current, temperature
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x356,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_35A = {.FD = false,  // Alarms & Warnings
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x35A,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_35B = {.FD = false,  // Events
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x35B,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_35E = {.FD = false,  // Manufacturer ASCII
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x35E,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_35F = {.FD = false,  // Battery Type, version, capacity, ID
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x35F,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  int16_t temperature_average = 0;
+};
 
 #endif

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SMA_LV_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SmaLvInverter
+#endif
 
 class SmaLvInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -22,9 +22,9 @@ class SmaLvInverter : public CanInverterProtocol {
 
   unsigned long previousMillis100ms = 0;
 
-#define VOLTAGE_OFFSET_DV 40  //Offset in deciVolt from max charge voltage and min discharge voltage
-#define MAX_VOLTAGE_DV 630
-#define MIN_VOLTAGE_DV 41
+  static const int VOLTAGE_OFFSET_DV = 40;  //Offset in deciVolt from max charge voltage and min discharge voltage
+  static const int MAX_VOLTAGE_DV = 630;
+  static const int MIN_VOLTAGE_DV = 41;
 
   //Actual content messages
   CAN_frame SMA_00F = {.FD = false,  // Emergency stop message

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SMA_TRIPOWER_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SMA-TRIPOWER-CAN.h"
@@ -12,93 +13,8 @@
 - Figure out how to send the non-cyclic messages when needed
 */
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis250ms = 0;  // will store last time a 250ms CAN Message was send
-static unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was send
-static unsigned long previousMillis2s = 0;     // will store last time a 2s CAN Message was send
-static unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
-static unsigned long previousMillis60s = 0;    // will store last time a 60s CAN Message was send
-
-typedef struct {
-  CAN_frame* frame;
-  void (*callback)();
-} Frame;
-
-static unsigned short listLength = 0;
-static Frame framesToSend[20];
-
-static uint32_t inverter_time = 0;
-static uint16_t inverter_voltage = 0;
-static int16_t inverter_current = 0;
-static bool pairing_completed = false;
-static int16_t temperature_average = 0;
-static uint16_t ampere_hours_remaining = 0;
-static uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
-
-//Actual content messages
-CAN_frame SMA_358 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x358,
-                     .data = {0x12, 0x40, 0x0C, 0x80, 0x01, 0x00, 0x01, 0x00}};
-CAN_frame SMA_3D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x3D8,
-                     .data = {0x04, 0x06, 0x27, 0x10, 0x00, 0x19, 0x00, 0xFA}};
-CAN_frame SMA_458 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x458,
-                     .data = {0x00, 0x00, 0x73, 0xAE, 0x00, 0x00, 0x64, 0x64}};
-CAN_frame SMA_4D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x4D8,
-                     .data = {0x10, 0x62, 0x00, 0x00, 0x00, 0x78, 0x02, 0x08}};
-CAN_frame SMA_518 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x518,
-                     .data = {0x00, 0x96, 0x00, 0x78, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SMA_558 = {.FD = false,  //Pairing first message
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x558,                                                // BYD HVS 10.2 kWh (0x66 might be kWh)
-                     .data = {0x03, 0x24, 0x00, 0x04, 0x00, 0x66, 0x04, 0x09}};  //Amount of modules? Vendor ID?
-CAN_frame SMA_598 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x598,
-                     .data = {0x12, 0xD6, 0x43, 0xA4, 0x00, 0x00, 0x00, 0x00}};  //B0-4 Serial 301100932
-CAN_frame SMA_5D8 = {.FD = false,
-                     .ext_ID = false,
-                     .DLC = 8,
-                     .ID = 0x5D8,
-                     .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
-CAN_frame SMA_618_0 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //BATTERY
-CAN_frame SMA_618_1 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
-CAN_frame SMA_618_2 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
-CAN_frame SMA_618_3 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x618,
-                       .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN
+void SmaTripowerInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the inverter CAN
   // Update values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
@@ -162,7 +78,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   }
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SmaTripowerInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x360:  //Message originating from SMA inverter - Voltage and current
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -193,7 +109,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
+void SmaTripowerInverter::pushFrame(CAN_frame* frame, std::function<void(void)> callback) {
   if (listLength >= 20) {
     return;  //TODO: scream.
   }
@@ -204,7 +120,7 @@ void pushFrame(CAN_frame* frame, void (*callback)() = NULL) {
   listLength++;
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SmaTripowerInverter::transmit_can(unsigned long currentMillis) {
 
   // Send CAN Message only if we're enabled by inverter
   if (!datalayer.system.status.inverter_allows_contactor_closing) {
@@ -216,9 +132,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
     // Send next frame.
     Frame frame = framesToSend[0];
     transmit_can_frame(frame.frame, can_config.inverter);
-    if (frame.callback != NULL) {
-      frame.callback();
-    }
+    frame.callback();
     for (int i = 0; i < listLength - 1; i++) {
       framesToSend[i] = framesToSend[i + 1];
     }
@@ -243,11 +157,11 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void completePairing() {
+void SmaTripowerInverter::completePairing() {
   pairing_completed = true;
 }
 
-void transmit_can_init() {
+void SmaTripowerInverter::transmit_can_init() {
   listLength = 0;  // clear all frames
 
   pushFrame(&SMA_558);    //Pairing start - Vendor
@@ -261,10 +175,10 @@ void transmit_can_init() {
   pushFrame(&SMA_3D8);
   pushFrame(&SMA_458);
   pushFrame(&SMA_4D8);
-  pushFrame(&SMA_518, completePairing);
+  pushFrame(&SMA_518, [this]() { this->completePairing(); });
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void SmaTripowerInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "SMA Tripower CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef SMA_TRIPOWER_CAN
+#include "SMA-TRIPOWER-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "SMA-TRIPOWER-CAN.h"
+#include "../include.h"
 
 /* TODO:
 - Figure out the manufacturer info needed in transmit_can_init() CAN messages
@@ -188,5 +187,3 @@ void SmaTripowerInverter::setup(void) {  // Performs one time setup at startup o
   digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN, LOW);  // Turn LED off, until inverter allows contactor closing
 #endif                                                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
 }
-
-#endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -2,13 +2,110 @@
 #define SMA_CAN_TRIPOWER_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SmaTripowerInverter
 
-#define READY_STATE 0x03
-#define STOP_STATE 0x02
+class SmaTripowerInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void transmit_can_init();
-void setup_inverter(void);
+ private:
+  const int READY_STATE = 0x03;
+  const int STOP_STATE = 0x02;
+
+  void transmit_can_init();
+  void pushFrame(CAN_frame* frame, std::function<void(void)> callback = []() {});
+  void completePairing();
+
+  unsigned long previousMillis250ms = 0;  // will store last time a 250ms CAN Message was send
+  unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was send
+  unsigned long previousMillis2s = 0;     // will store last time a 2s CAN Message was send
+  unsigned long previousMillis10s = 0;    // will store last time a 10s CAN Message was send
+  unsigned long previousMillis60s = 0;    // will store last time a 60s CAN Message was send
+
+  typedef struct {
+    CAN_frame* frame;
+    std::function<void(void)> callback;
+  } Frame;
+
+  unsigned short listLength = 0;
+  Frame framesToSend[20];
+
+  uint32_t inverter_time = 0;
+  uint16_t inverter_voltage = 0;
+  int16_t inverter_current = 0;
+  bool pairing_completed = false;
+  int16_t temperature_average = 0;
+  uint16_t ampere_hours_remaining = 0;
+  uint16_t timeWithoutInverterAllowsContactorClosing = 0;
+#define THIRTY_MINUTES 1200
+
+  //Actual content messages
+  CAN_frame SMA_358 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x358,
+                       .data = {0x12, 0x40, 0x0C, 0x80, 0x01, 0x00, 0x01, 0x00}};
+  CAN_frame SMA_3D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x3D8,
+                       .data = {0x04, 0x06, 0x27, 0x10, 0x00, 0x19, 0x00, 0xFA}};
+  CAN_frame SMA_458 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x458,
+                       .data = {0x00, 0x00, 0x73, 0xAE, 0x00, 0x00, 0x64, 0x64}};
+  CAN_frame SMA_4D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x4D8,
+                       .data = {0x10, 0x62, 0x00, 0x00, 0x00, 0x78, 0x02, 0x08}};
+  CAN_frame SMA_518 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x518,
+                       .data = {0x00, 0x96, 0x00, 0x78, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SMA_558 = {.FD = false,  //Pairing first message
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x558,  // BYD HVS 10.2 kWh (0x66 might be kWh)
+                       .data = {0x03, 0x24, 0x00, 0x04, 0x00, 0x66, 0x04, 0x09}};  //Amount of modules? Vendor ID?
+  CAN_frame SMA_598 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x598,
+                       .data = {0x12, 0xD6, 0x43, 0xA4, 0x00, 0x00, 0x00, 0x00}};  //B0-4 Serial 301100932
+  CAN_frame SMA_5D8 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x5D8,
+                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //B Y D
+  CAN_frame SMA_618_0 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //BATTERY
+  CAN_frame SMA_618_1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
+  CAN_frame SMA_618_2 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
+  CAN_frame SMA_618_3 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x618,
+                         .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
+};
 
 #endif

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SMA_TRIPOWER_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SmaTripowerInverter
+#endif
 
 class SmaTripowerInverter : public CanInverterProtocol {
  public:
@@ -17,6 +19,7 @@ class SmaTripowerInverter : public CanInverterProtocol {
  private:
   const int READY_STATE = 0x03;
   const int STOP_STATE = 0x02;
+  const int THIRTY_MINUTES = 1200;
 
   void transmit_can_init();
   void pushFrame(CAN_frame* frame, std::function<void(void)> callback = []() {});
@@ -43,7 +46,6 @@ class SmaTripowerInverter : public CanInverterProtocol {
   int16_t temperature_average = 0;
   uint16_t ampere_hours_remaining = 0;
   uint16_t timeWithoutInverterAllowsContactorClosing = 0;
-#define THIRTY_MINUTES 1200
 
   //Actual content messages
   CAN_frame SMA_358 = {.FD = false,

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef SOFAR_CAN
+#include "SOFAR-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "SOFAR-CAN.h"
+#include "../include.h"
 
 /* This implementation of the SOFAR can protocol is halfway done. What's missing is implementing the inverter replies, all the CAN messages are listed, but the can sending is missing. */
 
@@ -72,4 +71,3 @@ void SofarInverter::setup(void) {  // Performs one time setup at startup over CA
   strncpy(datalayer.system.info.inverter_protocol, "Sofar BMS (Extended Frame) over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -1,208 +1,13 @@
 #include "../include.h"
 #ifdef SOFAR_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "SOFAR-CAN.h"
 
 /* This implementation of the SOFAR can protocol is halfway done. What's missing is implementing the inverter replies, all the CAN messages are listed, but the can sending is missing. */
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
-
-//Actual content messages
-//Note that these are technically extended frames. If more batteries are put in parallel,the first battery sends 0x351 the next battery sends 0x1351 etc. 16 batteries in parallel supported
-CAN_frame SOFAR_351 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x351,
-                       .data = {0xC6, 0x08, 0xFA, 0x00, 0xFA, 0x00, 0x80, 0x07}};
-CAN_frame SOFAR_355 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x355,
-                       .data = {0x31, 0x00, 0x64, 0x00, 0xFF, 0xFF, 0xF6, 0x00}};
-CAN_frame SOFAR_356 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x356,
-                       .data = {0x36, 0x08, 0x10, 0x00, 0xD0, 0x00, 0x01, 0x00}};
-CAN_frame SOFAR_30F = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x30F,
-                       .data = {0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_359 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x359,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x04, 0x10, 0x27, 0x10}};
-CAN_frame SOFAR_35E = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x35E,
-                       .data = {0x41, 0x4D, 0x41, 0x53, 0x53, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_35F = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x35F,
-                       .data = {0x00, 0x00, 0x24, 0x4E, 0x32, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_35A = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x35A,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-CAN_frame SOFAR_670 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x670,
-                       .data = {0x00, 0x8A, 0x33, 0x11, 0x59, 0x1A, 0x00, 0x00}};
-CAN_frame SOFAR_671 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x671,
-                       .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
-CAN_frame SOFAR_672 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x672,
-                       .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
-CAN_frame SOFAR_673 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x673,
-                       .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
-CAN_frame SOFAR_680 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x680,
-                       .data = {0x00, 0xB7, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame SOFAR_681 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x681,
-                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame SOFAR_682 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x682,
-                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame SOFAR_683 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x683,
-                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame SOFAR_684 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x684,
-                       .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
-CAN_frame SOFAR_685 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x685,
-                       .data = {0x00, 0xB3, 0x0C, 0xBB, 0x0C, 0xB3, 0x0C, 0x00}};
-CAN_frame SOFAR_690 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x690,
-                       .data = {0x00, 0xD7, 0x00, 0xD4, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_691 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x691,
-                       .data = {0x00, 0xD4, 0x00, 0xD1, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_6A0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x6A0,
-                       .data = {0x00, 0xFA, 0x00, 0xDD, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_6B0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x6B0,
-                       .data = {0x00, 0xF6, 0x00, 0x06, 0x02, 0x01, 0x00, 0x00}};
-CAN_frame SOFAR_6C0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x6C0,
-                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_770 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x770,
-                       .data = {0x00, 0x56, 0x0B, 0xF0, 0x58, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_771 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x771,
-                       .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
-CAN_frame SOFAR_772 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x772,
-                       .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
-CAN_frame SOFAR_773 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x773,
-                       .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
-CAN_frame SOFAR_780 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x780,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_781 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x781,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_782 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x782,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_783 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x783,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_784 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x784,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_785 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x785,
-                       .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
-CAN_frame SOFAR_790 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x790,
-                       .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_791 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x791,
-                       .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_7A0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x7A0,
-                       .data = {0x00, 0xFA, 0x00, 0xE1, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SOFAR_7B0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x7B0,
-                       .data = {0x00, 0xF9, 0x00, 0x06, 0x02, 0xE9, 0x5D, 0x00}};
-CAN_frame SOFAR_7C0 = {.FD = false,
-                       .ext_ID = true,
-                       .DLC = 8,
-                       .ID = 0x7C0,
-                       .data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x80, 0x00}};
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SofarInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
   //Maxvoltage (eg 400.0V = 4000 , 16bits long) Charge Cutoff Voltage
   SOFAR_351.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV >> 8);
@@ -230,7 +35,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOFAR_356.data.u8[3] = (datalayer.battery.status.temperature_max_dC & 0x00FF);
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SofarInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter. TODO: make logic
     case 0x605:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -247,7 +52,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SofarInverter::transmit_can(unsigned long currentMillis) {
   // Send 100ms CAN Message
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
@@ -263,7 +68,7 @@ void transmit_can_inverter(unsigned long currentMillis) {
   }
 }
 
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+void SofarInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Sofar BMS (Extended Frame) over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -2,9 +2,214 @@
 #define SOFAR_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SofarInverter
+
+class SofarInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
+
+  //Actual content messages
+  //Note that these are technically extended frames. If more batteries are put in parallel,the first battery sends 0x351 the next battery sends 0x1351 etc. 16 batteries in parallel supported
+  CAN_frame SOFAR_351 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x351,
+                         .data = {0xC6, 0x08, 0xFA, 0x00, 0xFA, 0x00, 0x80, 0x07}};
+  CAN_frame SOFAR_355 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x355,
+                         .data = {0x31, 0x00, 0x64, 0x00, 0xFF, 0xFF, 0xF6, 0x00}};
+  CAN_frame SOFAR_356 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x356,
+                         .data = {0x36, 0x08, 0x10, 0x00, 0xD0, 0x00, 0x01, 0x00}};
+  CAN_frame SOFAR_30F = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x30F,
+                         .data = {0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_359 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x359,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x04, 0x10, 0x27, 0x10}};
+  CAN_frame SOFAR_35E = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x35E,
+                         .data = {0x41, 0x4D, 0x41, 0x53, 0x53, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_35F = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x35F,
+                         .data = {0x00, 0x00, 0x24, 0x4E, 0x32, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_35A = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x35A,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  CAN_frame SOFAR_670 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x670,
+                         .data = {0x00, 0x8A, 0x33, 0x11, 0x59, 0x1A, 0x00, 0x00}};
+  CAN_frame SOFAR_671 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x671,
+                         .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
+  CAN_frame SOFAR_672 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x672,
+                         .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
+  CAN_frame SOFAR_673 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x673,
+                         .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
+  CAN_frame SOFAR_680 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x680,
+                         .data = {0x00, 0xB7, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+  CAN_frame SOFAR_681 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x681,
+                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+  CAN_frame SOFAR_682 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x682,
+                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+  CAN_frame SOFAR_683 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x683,
+                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+  CAN_frame SOFAR_684 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x684,
+                         .data = {0x00, 0xB6, 0x0C, 0xB3, 0x0C, 0xB4, 0x0C, 0x00}};
+  CAN_frame SOFAR_685 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x685,
+                         .data = {0x00, 0xB3, 0x0C, 0xBB, 0x0C, 0xB3, 0x0C, 0x00}};
+  CAN_frame SOFAR_690 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x690,
+                         .data = {0x00, 0xD7, 0x00, 0xD4, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_691 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x691,
+                         .data = {0x00, 0xD4, 0x00, 0xD1, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_6A0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x6A0,
+                         .data = {0x00, 0xFA, 0x00, 0xDD, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_6B0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x6B0,
+                         .data = {0x00, 0xF6, 0x00, 0x06, 0x02, 0x01, 0x00, 0x00}};
+  CAN_frame SOFAR_6C0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x6C0,
+                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_770 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x770,
+                         .data = {0x00, 0x56, 0x0B, 0xF0, 0x58, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_771 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x771,
+                         .data = {0x00, 0x42, 0x48, 0x55, 0x35, 0x31, 0x32, 0x30}};
+  CAN_frame SOFAR_772 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x772,
+                         .data = {0x00, 0x32, 0x35, 0x45, 0x50, 0x43, 0x32, 0x31}};
+  CAN_frame SOFAR_773 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x773,
+                         .data = {0x00, 0x34, 0x32, 0x36, 0x31, 0x36, 0x32, 0x00}};
+  CAN_frame SOFAR_780 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x780,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_781 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x781,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_782 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x782,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_783 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x783,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_784 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x784,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_785 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x785,
+                         .data = {0x00, 0xEB, 0x0C, 0xED, 0x0C, 0xED, 0x0C, 0x00}};
+  CAN_frame SOFAR_790 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x790,
+                         .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_791 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x791,
+                         .data = {0x00, 0xCD, 0x00, 0xCF, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_7A0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x7A0,
+                         .data = {0x00, 0xFA, 0x00, 0xE1, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SOFAR_7B0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x7B0,
+                         .data = {0x00, 0xF9, 0x00, 0x06, 0x02, 0xE9, 0x5D, 0x00}};
+  CAN_frame SOFAR_7C0 = {.FD = false,
+                         .ext_ID = true,
+                         .DLC = 8,
+                         .ID = 0x7C0,
+                         .data = {0x00, 0x00, 0x00, 0x04, 0x00, 0x04, 0x80, 0x00}};
+};
 
 #endif

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SOFAR_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SofarInverter
+#endif
 
 class SofarInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SOLAX_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "SOLAX-CAN.h"
@@ -9,104 +10,13 @@
 // If you are having BattVoltFault issues, configure the above values according to wiki page
 // https://github.com/dalathegreat/Battery-Emulator/wiki/Solax-inverters
 
-/* Do not change code below unless you are sure what you are doing */
-static int16_t temperature_average = 0;
-static uint8_t STATE = BATTERY_ANNOUNCE;
-static unsigned long LastFrameTime = 0;
-static uint8_t number_of_batteries = 1;
-static uint16_t capped_capacity_Wh;
-static uint16_t capped_remaining_capacity_Wh;
-
-//CAN message translations from this amazing repository: https://github.com/rand12345/solax_can_bus
-
-CAN_frame SOLAX_1801 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1801,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_1872 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1872,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Limits
-CAN_frame SOLAX_1873 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1873,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackData
-CAN_frame SOLAX_1874 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1874,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_CellData
-CAN_frame SOLAX_1875 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1875,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Status
-CAN_frame SOLAX_1876 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1876,
-                        .data = {0x0, 0x0, 0xE2, 0x0C, 0x0, 0x0, 0xD7, 0x0C}};  //BMS_PackTemps
-CAN_frame SOLAX_1877 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1877,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_1878 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1878,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackStats
-CAN_frame SOLAX_1879 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1879,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_187E = {.FD = false,  //Needed for Ultra
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x187E,
-                        .data = {0x60, 0xEA, 0x0, 0x0, 0x64, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_187D = {.FD = false,  //Needed for Ultra
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x187D,
-                        .data = {0x8B, 0x01, 0x0, 0x0, 0x8B, 0x1, 0x0, 0x0}};
-CAN_frame SOLAX_187C = {.FD = false,  //Needed for Ultra
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x187C,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_187B = {.FD = false,  //Needed for Ultra
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x187B,
-                        .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_187A = {.FD = false,  //Needed for Ultra
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x187A,
-                        .data = {0x01, 0x50, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-CAN_frame SOLAX_1881 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1881,
-                        .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 6 S B M S F A
-CAN_frame SOLAX_1882 = {.FD = false,
-                        .ext_ID = true,
-                        .DLC = 8,
-                        .ID = 0x1882,
-                        .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 2 3 A B 0 5 2
-CAN_frame SOLAX_100A001 = {.FD = false, .ext_ID = true, .DLC = 0, .ID = 0x100A001, .data = {}};
-
 // __builtin_bswap64 needed to convert to ESP32 little endian format
 // Byte[4] defines the requested contactor state: 1 = Closed , 0 = Open
 #define Contactor_Open_Payload __builtin_bswap64(0x0200010000000000)
 #define Contactor_Close_Payload __builtin_bswap64(0x0200010001000000)
 
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
+void SolaxInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // If not receiveing any communication from the inverter, open contactors and return to battery announce state
   if (millis() - LastFrameTime >= SolaxTimeout) {
     datalayer.system.status.inverter_allows_contactor_closing = false;
@@ -206,11 +116,11 @@ void update_values_can_inverter() {  //This function maps all the values fetched
   SOLAX_187E.data.u8[5] = (uint8_t)(datalayer.battery.status.reported_soc / 100);
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SolaxInverter::transmit_can(unsigned long currentMillis) {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
     datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -297,7 +207,8 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
 #endif
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup
+
+void SolaxInverter::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.inverter_protocol, "SolaX Triple Power LFP over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -1,9 +1,8 @@
-#include "../include.h"
-#ifdef SOLAX_CAN
+#include "SOLAX-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
-#include "SOLAX-CAN.h"
+#include "../include.h"
 
 #define NUMBER_OF_MODULES 0
 #define BATTERY_TYPE 0x50
@@ -213,4 +212,3 @@ void SolaxInverter::setup(void) {  // Performs one time setup at startup
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
 }
-#endif

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SOLAX_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SolaxInverter
+#endif
 
 class SolaxInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -2,19 +2,119 @@
 #define SOLAX_CAN_H
 #include "../include.h"
 
+#include "CanInverterProtocol.h"
+
 #define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SolaxInverter
 
-// Timeout in milliseconds
-#define SolaxTimeout 2000
+class SolaxInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
 
-//SOLAX BMS States Definition
-#define BATTERY_ANNOUNCE 0
-#define WAITING_FOR_CONTACTOR 1
-#define CONTACTOR_CLOSED 2
-#define FAULT_SOLAX 3
-#define UPDATING_FW 4
+ private:
+  // Timeout in milliseconds
+  static const int SolaxTimeout = 2000;
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+  //SOLAX BMS States Definition
+  static const int BATTERY_ANNOUNCE = 0;
+  static const int WAITING_FOR_CONTACTOR = 1;
+  static const int CONTACTOR_CLOSED = 2;
+  static const int FAULT_SOLAX = 3;
+  static const int UPDATING_FW = 4;
+
+  int16_t temperature_average = 0;
+  uint8_t STATE = BATTERY_ANNOUNCE;
+  unsigned long LastFrameTime = 0;
+  uint8_t number_of_batteries = 1;
+  uint16_t capped_capacity_Wh;
+  uint16_t capped_remaining_capacity_Wh;
+
+  //CAN message translations from this amazing repository: https://github.com/rand12345/solax_can_bus
+
+  CAN_frame SOLAX_1801 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1801,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_1872 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1872,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Limits
+  CAN_frame SOLAX_1873 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1873,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackData
+  CAN_frame SOLAX_1874 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1874,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_CellData
+  CAN_frame SOLAX_1875 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1875,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_Status
+  CAN_frame SOLAX_1876 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1876,
+                          .data = {0x0, 0x0, 0xE2, 0x0C, 0x0, 0x0, 0xD7, 0x0C}};  //BMS_PackTemps
+  CAN_frame SOLAX_1877 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1877,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_1878 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1878,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  //BMS_PackStats
+  CAN_frame SOLAX_1879 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1879,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_187E = {.FD = false,  //Needed for Ultra
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x187E,
+                          .data = {0x60, 0xEA, 0x0, 0x0, 0x64, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_187D = {.FD = false,  //Needed for Ultra
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x187D,
+                          .data = {0x8B, 0x01, 0x0, 0x0, 0x8B, 0x1, 0x0, 0x0}};
+  CAN_frame SOLAX_187C = {.FD = false,  //Needed for Ultra
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x187C,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_187B = {.FD = false,  //Needed for Ultra
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x187B,
+                          .data = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_187A = {.FD = false,  //Needed for Ultra
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x187A,
+                          .data = {0x01, 0x50, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+  CAN_frame SOLAX_1881 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1881,
+                          .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 6 S B M S F A
+  CAN_frame SOLAX_1882 = {.FD = false,
+                          .ext_ID = true,
+                          .DLC = 8,
+                          .ID = 0x1882,
+                          .data = {0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};  // E.g.: 0 2 3 A B 0 5 2
+  CAN_frame SOLAX_100A001 = {.FD = false, .ext_ID = true, .DLC = 0, .ID = 0x100A001, .data = {}};
+};
 
 #endif

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -1,8 +1,7 @@
-#include "../include.h"
-#ifdef SUNGROW_CAN
+#include "SUNGROW-CAN.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
-#include "SUNGROW-CAN.h"
+#include "../include.h"
 
 /* TODO: 
 This protocol is still under development. It can not be used yet for Sungrow inverters, 
@@ -358,4 +357,3 @@ void SungrowInverter::setup(void) {  // Performs one time setup at startup over 
   strncpy(datalayer.system.info.inverter_protocol, "Sungrow SBR064 battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }
-#endif

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -1,5 +1,6 @@
 #include "../include.h"
 #ifdef SUNGROW_CAN
+#include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "SUNGROW-CAN.h"
 
@@ -7,253 +8,8 @@
 This protocol is still under development. It can not be used yet for Sungrow inverters, 
 see the Wiki for more info on how to use your Sungrow inverter */
 
-/* Do not change code below unless you are sure what you are doing */
-static unsigned long previousMillis500ms = 0;
-static bool alternate = false;
-static uint8_t mux = 0;
-static uint8_t version_char[14] = {0};
-static uint8_t manufacturer_char[14] = {0};
-static uint8_t model_char[14] = {0};
-static bool inverter_sends_000 = false;
-
-//Actual content messages
-CAN_frame SUNGROW_000 = {.FD = false,  // Sent by inv or BMS?
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x000,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_001 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x001,
-                         .data = {0xF0, 0x05, 0x20, 0x03, 0x2C, 0x01, 0x2C, 0x01}};
-CAN_frame SUNGROW_002 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x002,
-                         .data = {0xA2, 0x05, 0x10, 0x27, 0x9B, 0x03, 0x00, 0x19}};
-CAN_frame SUNGROW_003 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x003,
-                         .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
-CAN_frame SUNGROW_004 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x004,
-                         .data = {0x27, 0x05, 0x00, 0x00, 0x24, 0x05, 0x08, 0x01}};
-CAN_frame SUNGROW_005 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x005,
-                         .data = {0x02, 0x00, 0x01, 0xE6, 0x20, 0x24, 0x05, 0x00}};
-CAN_frame SUNGROW_006 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x006,
-                         .data = {0x0E, 0x01, 0x01, 0x01, 0xDE, 0x0C, 0xD5, 0x0C}};
-CAN_frame SUNGROW_013 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x013,
-                         .data = {0x01, 0x01, 0x01, 0x02, 0x01, 0x02, 0x0E, 0x01}};
-CAN_frame SUNGROW_014 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x014,
-                         .data = {0x05, 0x01, 0xAC, 0x80, 0x10, 0x02, 0x57, 0x80}};
-CAN_frame SUNGROW_015 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x015,
-                         .data = {0x93, 0x80, 0xAC, 0x80, 0x57, 0x80, 0x93, 0x80}};
-CAN_frame SUNGROW_016 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x016,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_017 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x017,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_018 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x018,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_019 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x019,
-                         .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_01A = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x01A,
-                         .data = {0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_01B = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x01B,
-                         .data = {0xBE, 0x8F, 0x61, 0x01, 0xBE, 0x8F, 0x61, 0x01}};
-CAN_frame SUNGROW_01C = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x01C,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_01D = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x01D,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_01E = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x01E,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_400 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x400,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_500 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x500,
-                         .data = {0x01, 0x01, 0x00, 0xFF, 0x00, 0x01, 0x00, 0x32}};
-CAN_frame SUNGROW_501 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x501,
-                         .data = {0xF0, 0x05, 0x20, 0x03, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_502 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x502,
-                         .data = {0xA2, 0x05, 0x00, 0x00, 0x9B, 0x03, 0x00, 0x19}};
-CAN_frame SUNGROW_503 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x503,
-                         .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
-CAN_frame SUNGROW_504 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x504,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_505 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x505,
-                         .data = {0x00, 0x02, 0x01, 0xE6, 0x20, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_506 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x506,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_512 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x512,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_700 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x700,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_701 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x701,
-                         .data = {0xF0, 0x05, 0x20, 0x03, 0x2C, 0x01, 0x2C, 0x01}};
-CAN_frame SUNGROW_702 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x702,
-                         .data = {0xA2, 0x05, 0x10, 0x27, 0x9B, 0x03, 0x00, 0x19}};
-CAN_frame SUNGROW_703 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x703,
-                         .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
-CAN_frame SUNGROW_704 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x704,
-                         .data = {0x27, 0x05, 0x00, 0x00, 0x24, 0x05, 0x08, 0x01}};
-CAN_frame SUNGROW_705 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x705,
-                         .data = {0x02, 0x00, 0x01, 0xE6, 0x20, 0x24, 0x05, 0x00}};
-CAN_frame SUNGROW_706 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x706,
-                         .data = {0x0E, 0x01, 0x01, 0x01, 0xDE, 0x0C, 0xD5, 0x0C}};
-CAN_frame SUNGROW_713 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x713,
-                         .data = {0x01, 0x01, 0x01, 0x02, 0x01, 0x02, 0x0E, 0x01}};
-CAN_frame SUNGROW_714 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x714,
-                         .data = {0x05, 0x01, 0xAC, 0x80, 0x10, 0x02, 0x57, 0x80}};
-CAN_frame SUNGROW_715 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x715,
-                         .data = {0x93, 0x80, 0xAC, 0x80, 0x57, 0x80, 0x93, 0x80}};
-CAN_frame SUNGROW_716 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x716,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_717 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x717,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_718 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x718,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_719 = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x719,
-                         .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_71A = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x71A,
-                         .data = {0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_71B = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x71B,
-                         .data = {0xBE, 0x8F, 0x61, 0x01, 0xBE, 0x8F, 0x61, 0x01}};
-CAN_frame SUNGROW_71C = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x71C,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_71D = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x71D,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-CAN_frame SUNGROW_71E = {.FD = false,
-                         .ext_ID = false,
-                         .DLC = 8,
-                         .ID = 0x71E,
-                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-void update_values_can_inverter() {  //This function maps all the values fetched from battery CAN to the inverter CAN messages
+void SungrowInverter::
+    update_values() {  //This function maps all the values fetched from battery CAN to the inverter CAN messages
 
   //Maxvoltage (eg 400.0V = 4000 , 16bits long)
   SUNGROW_701.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
@@ -411,7 +167,7 @@ void update_values_can_inverter() {  //This function maps all the values fetched
 #endif
 }
 
-void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
+void SungrowInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //In here we need to respond to the inverter
     case 0x000:
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
@@ -557,7 +313,7 @@ void map_can_frame_to_variable_inverter(CAN_frame rx_frame) {
   }
 }
 
-void transmit_can_inverter(unsigned long currentMillis) {
+void SungrowInverter::transmit_can(unsigned long currentMillis) {
   // Send 1s CAN Message
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
@@ -597,7 +353,8 @@ void transmit_can_inverter(unsigned long currentMillis) {
     }
   }
 }
-void setup_inverter(void) {  // Performs one time setup at startup over CAN bus
+
+void SungrowInverter::setup(void) {  // Performs one time setup at startup over CAN bus
   strncpy(datalayer.system.info.inverter_protocol, "Sungrow SBR064 battery over CAN bus", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
 }

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -4,8 +4,10 @@
 
 #include "CanInverterProtocol.h"
 
+#ifdef SUNGROW_CAN
 #define CAN_INVERTER_SELECTED
 #define SELECTED_INVERTER_CLASS SungrowInverter
+#endif
 
 class SungrowInverter : public CanInverterProtocol {
  public:

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -2,9 +2,263 @@
 #define SUNGROW_CAN_H
 #include "../include.h"
 
-#define CAN_INVERTER_SELECTED
+#include "CanInverterProtocol.h"
 
-void transmit_can_frame(CAN_frame* tx_frame, int interface);
-void setup_inverter(void);
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS SungrowInverter
+
+class SungrowInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void update_values();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+
+ private:
+  unsigned long previousMillis500ms = 0;
+  bool alternate = false;
+  uint8_t mux = 0;
+  uint8_t version_char[14] = {0};
+  uint8_t manufacturer_char[14] = {0};
+  uint8_t model_char[14] = {0};
+  bool inverter_sends_000 = false;
+
+  //Actual content messages
+  CAN_frame SUNGROW_000 = {.FD = false,  // Sent by inv or BMS?
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x000,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_001 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x001,
+                           .data = {0xF0, 0x05, 0x20, 0x03, 0x2C, 0x01, 0x2C, 0x01}};
+  CAN_frame SUNGROW_002 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x002,
+                           .data = {0xA2, 0x05, 0x10, 0x27, 0x9B, 0x03, 0x00, 0x19}};
+  CAN_frame SUNGROW_003 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x003,
+                           .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
+  CAN_frame SUNGROW_004 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x004,
+                           .data = {0x27, 0x05, 0x00, 0x00, 0x24, 0x05, 0x08, 0x01}};
+  CAN_frame SUNGROW_005 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x005,
+                           .data = {0x02, 0x00, 0x01, 0xE6, 0x20, 0x24, 0x05, 0x00}};
+  CAN_frame SUNGROW_006 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x006,
+                           .data = {0x0E, 0x01, 0x01, 0x01, 0xDE, 0x0C, 0xD5, 0x0C}};
+  CAN_frame SUNGROW_013 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x013,
+                           .data = {0x01, 0x01, 0x01, 0x02, 0x01, 0x02, 0x0E, 0x01}};
+  CAN_frame SUNGROW_014 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x014,
+                           .data = {0x05, 0x01, 0xAC, 0x80, 0x10, 0x02, 0x57, 0x80}};
+  CAN_frame SUNGROW_015 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x015,
+                           .data = {0x93, 0x80, 0xAC, 0x80, 0x57, 0x80, 0x93, 0x80}};
+  CAN_frame SUNGROW_016 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x016,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_017 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x017,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_018 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x018,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_019 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x019,
+                           .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_01A = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x01A,
+                           .data = {0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_01B = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x01B,
+                           .data = {0xBE, 0x8F, 0x61, 0x01, 0xBE, 0x8F, 0x61, 0x01}};
+  CAN_frame SUNGROW_01C = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x01C,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_01D = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x01D,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_01E = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x01E,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_400 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x400,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_500 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x500,
+                           .data = {0x01, 0x01, 0x00, 0xFF, 0x00, 0x01, 0x00, 0x32}};
+  CAN_frame SUNGROW_501 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x501,
+                           .data = {0xF0, 0x05, 0x20, 0x03, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_502 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x502,
+                           .data = {0xA2, 0x05, 0x00, 0x00, 0x9B, 0x03, 0x00, 0x19}};
+  CAN_frame SUNGROW_503 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x503,
+                           .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
+  CAN_frame SUNGROW_504 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x504,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_505 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x505,
+                           .data = {0x00, 0x02, 0x01, 0xE6, 0x20, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_506 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x506,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_512 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x512,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_700 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x700,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_701 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x701,
+                           .data = {0xF0, 0x05, 0x20, 0x03, 0x2C, 0x01, 0x2C, 0x01}};
+  CAN_frame SUNGROW_702 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x702,
+                           .data = {0xA2, 0x05, 0x10, 0x27, 0x9B, 0x03, 0x00, 0x19}};
+  CAN_frame SUNGROW_703 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x703,
+                           .data = {0x2A, 0x1D, 0x00, 0x00, 0xBF, 0x18, 0x00, 0x00}};
+  CAN_frame SUNGROW_704 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x704,
+                           .data = {0x27, 0x05, 0x00, 0x00, 0x24, 0x05, 0x08, 0x01}};
+  CAN_frame SUNGROW_705 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x705,
+                           .data = {0x02, 0x00, 0x01, 0xE6, 0x20, 0x24, 0x05, 0x00}};
+  CAN_frame SUNGROW_706 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x706,
+                           .data = {0x0E, 0x01, 0x01, 0x01, 0xDE, 0x0C, 0xD5, 0x0C}};
+  CAN_frame SUNGROW_713 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x713,
+                           .data = {0x01, 0x01, 0x01, 0x02, 0x01, 0x02, 0x0E, 0x01}};
+  CAN_frame SUNGROW_714 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x714,
+                           .data = {0x05, 0x01, 0xAC, 0x80, 0x10, 0x02, 0x57, 0x80}};
+  CAN_frame SUNGROW_715 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x715,
+                           .data = {0x93, 0x80, 0xAC, 0x80, 0x57, 0x80, 0x93, 0x80}};
+  CAN_frame SUNGROW_716 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x716,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_717 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x717,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_718 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x718,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_719 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x719,
+                           .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_71A = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x71A,
+                           .data = {0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_71B = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x71B,
+                           .data = {0xBE, 0x8F, 0x61, 0x01, 0xBE, 0x8F, 0x61, 0x01}};
+  CAN_frame SUNGROW_71C = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x71C,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_71D = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x71D,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SUNGROW_71E = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x71E,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+};
 
 #endif


### PR DESCRIPTION
### What and how
This PR converts the remaining inverter protocols to use the common base class and also configures the build to build them all. The activated inverter protocol is still selected based on build-time define.

### Why
This brings the project closer to the goal of having all inverters and batteries in a single image.
