### PR TITLE
Microfeature: Zoe, Refactor and add More Battery Info page

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -24,6 +24,8 @@ static uint32_t LB_Discharge_allowed_W = 0;
 static int16_t LB_Current = 0;
 static int16_t LB_Cell_minimum_temperature = 0;
 static int16_t LB_Cell_maximum_temperature = 0;
+static uint16_t LB_Cell_minimum_voltage = 3700;
+static uint16_t LB_Cell_maximum_voltage = 3700;
 static uint16_t LB_kWh_Remaining = 0;
 static uint16_t LB_Battery_Voltage = 3700;
 static uint8_t LB_Heartbeat = 0;
@@ -110,30 +112,16 @@ void RenaultZoeGen1Battery::
   //Map all cell voltages to the global array
   memcpy(datalayer.battery.status.cell_voltages_mV, cellvoltages, 96 * sizeof(uint16_t));
 
-  // Initialize min and max, lets find which cells are min and max!
-  uint16_t min_cell_mv_value = std::numeric_limits<uint16_t>::max();
-  uint16_t max_cell_mv_value = 0;
-  calculated_total_pack_voltage_mV =
-      datalayer.battery.status.cell_voltages_mV
-          [0];  // cell96 issue, this value should be initialized to 0, but for now it is initialized to cell0
-  // Loop to find the min and max while ignoring zero values
-  for (uint8_t i = 0; i < datalayer.battery.info.number_of_cells; ++i) {
-    uint16_t voltage_mV = datalayer.battery.status.cell_voltages_mV[i];
-    calculated_total_pack_voltage_mV += voltage_mV;
-    if (voltage_mV != 0) {  // Skip unread values (0)
-      min_cell_mv_value = std::min(min_cell_mv_value, voltage_mV);
-      max_cell_mv_value = std::max(max_cell_mv_value, voltage_mV);
+  // Calculate total pack voltage on packs that require this. Only calculate once all cellvotages have been read
+  if (datalayer.battery.status.cell_voltages_mV[95] > 0) {
+    calculated_total_pack_voltage_mV = datalayer.battery.status.cell_voltages_mV[0];
+    for (uint8_t i = 0; i < datalayer.battery.info.number_of_cells; ++i) {
+      calculated_total_pack_voltage_mV += datalayer.battery.status.cell_voltages_mV[i];
     }
   }
-  // If all array values are 0, reset min/max to 3700
-  if (min_cell_mv_value == std::numeric_limits<uint16_t>::max()) {
-    min_cell_mv_value = 3700;
-    max_cell_mv_value = 3700;
-    calculated_total_pack_voltage_mV = 370000;
-  }
 
-  datalayer.battery.status.cell_min_voltage_mV = min_cell_mv_value;
-  datalayer.battery.status.cell_max_voltage_mV = max_cell_mv_value;
+  datalayer.battery.status.cell_min_voltage_mV = LB_Cell_minimum_voltage;
+  datalayer.battery.status.cell_max_voltage_mV = LB_Cell_maximum_voltage;
   datalayer.battery.status.voltage_dV = static_cast<uint32_t>((calculated_total_pack_voltage_mV / 100));  // mV to dV
 }
 
@@ -163,9 +151,10 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       LB_Heartbeat = rx_frame.data.u8[6];  // Alternates between 0x55 and 0xAA every 500ms (Same as on Nissan LEAF)
       LB_Cell_maximum_temperature = (rx_frame.data.u8[7] - 40);
       break;
-    case 0x425:  //100ms Unknown content
+    case 0x425:  //100ms Cellvoltages and kWh remaining
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      //Sent only? by 41kWh battery
+      LB_Cell_maximum_voltage = (((((rx_frame.data.u8[4] & 0x03) << 7) | (rx_frame.data.u8[5] >> 1)) * 10) + 1000);
+      LB_Cell_minimum_voltage = (((((rx_frame.data.u8[6] & 0x01) << 8) | rx_frame.data.u8[7]) * 10) + 1000);
       break;
     case 0x445:  //100ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -723,6 +723,18 @@ typedef struct {
 } DATALAYER_INFO_VOLVO_HYBRID;
 
 typedef struct {
+  /** uint8_t */
+  uint8_t CUV = 0;
+  uint8_t HVBIR = 0;
+  uint8_t HVBUV = 0;
+  uint8_t EOCR = 0;
+  uint8_t HVBOC = 0;
+  uint8_t HVBOT = 0;
+  uint8_t HVBOV = 0;
+  uint8_t COV = 0;
+} DATALAYER_INFO_ZOE;
+
+typedef struct {
   /** User requesting NVROL reset via WebUI*/
   bool UserRequestNVROLReset = false;
   /** uint16_t */
@@ -785,6 +797,7 @@ class DataLayerExtended {
   DATALAYER_INFO_MEB meb;
   DATALAYER_INFO_VOLVO_POLESTAR VolvoPolestar;
   DATALAYER_INFO_VOLVO_HYBRID VolvoHybrid;
+  DATALAYER_INFO_ZOE zoe;
   DATALAYER_INFO_ZOE_PH2 zoePH2;
 };
 

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -1250,6 +1250,17 @@ String advanced_battery_processor(const String& var) {
                " kWh</h4>";
 #endif  //MEB_BATTERY
 
+#ifdef RENAULT_ZOE_GEN1_BATTERY
+    content += "<h4>CUV " + String(datalayer_extended.zoe.CUV) + "</h4>";
+    content += "<h4>HVBIR " + String(datalayer_extended.zoe.HVBIR) + "</h4>";
+    content += "<h4>HVBUV " + String(datalayer_extended.zoe.HVBUV) + "</h4>";
+    content += "<h4>EOCR " + String(datalayer_extended.zoe.EOCR) + "</h4>";
+    content += "<h4>HVBOC " + String(datalayer_extended.zoe.HVBOC) + "</h4>";
+    content += "<h4>HVBOT " + String(datalayer_extended.zoe.HVBOT) + "</h4>";
+    content += "<h4>HVBOV " + String(datalayer_extended.zoe.HVBOV) + "</h4>";
+    content += "<h4>COV " + String(datalayer_extended.zoe.COV) + "</h4>";
+#endif  //RENAULT_ZOE_GEN1_BATTERY
+
 #ifdef RENAULT_ZOE_GEN2_BATTERY
     content += "<button onclick='askTriggerNVROL()'>Perform NVROL reset</button>";
     content += "<h4>soc: " + String(datalayer_extended.zoePH2.battery_soc) + "</h4>";
@@ -1489,7 +1500,8 @@ String advanced_battery_processor(const String& var) {
     !defined(TESLA_BATTERY) && !defined(NISSAN_LEAF_BATTERY) && !defined(BMW_I3_BATTERY) &&          \
     !defined(BYD_ATTO_3_BATTERY) && !defined(RENAULT_ZOE_GEN2_BATTERY) && !defined(CELLPOWER_BMS) && \
     !defined(MEB_BATTERY) && !defined(VOLVO_SPA_BATTERY) && !defined(VOLVO_SPA_HYBRID_BATTERY) &&    \
-    !defined(KIA_HYUNDAI_64_BATTERY) && !defined(CMFA_EV_BATTERY)  //Only the listed types have extra info
+    !defined(KIA_HYUNDAI_64_BATTERY) && !defined(CMFA_EV_BATTERY) &&                                 \
+    !defined(RENAULT_ZOE_GEN1_BATTERY)  //Only the listed types have extra info
     content += "No extra information available for this battery type";
 #endif
 


### PR DESCRIPTION
### What
This PR refactors the Renault Zoe implementation

### Why
This implementation is used by many different Renault vehicles, (Zoe 22/41 , Kangoo 33, Fluence ZE 22/36) , and it is a bit unclear what is sent by what generation of vehicle. This PR aims to make further improvements to the integration easier

### How

- We remove the calculated min/max cellvoltage lookups, and instead use the values sent constantly via CAN
- We add comments on those CAN messages that we are sure is sent by a specific model
- More Battery Info page added for the Zoe integration, so we can look at diagnostic data in more detail
