### PR TITLE
SMA BYD: Split up pairing sending into batches

### DIFF
--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -21,8 +21,12 @@ class SmaBydHvsInverter : public CanInverterProtocol {
   static const int STOP_STATE = 0x02;
   static const int THIRTY_MINUTES = 1200;
 
-  void transmit_can_init();
   unsigned long previousMillis100ms = 0;
+  unsigned long previousMillisBatch = 0;
+  uint8_t batch_send_index = 0;
+  const uint8_t delay_between_batches_ms =
+      7;  //TODO, tweak to as low as possible before performance issues/crashes appear
+  bool transmit_can_init = false;
 
   uint32_t inverter_time = 0;
   uint16_t inverter_voltage = 0;


### PR DESCRIPTION
### What
This PR implements batch sending for the SMA BYD HVS protocol

### Why
Fixes https://github.com/dalathegreat/Battery-Emulator/issues/1131

### How
We send smaller batches to avoid filling the buffer, same as on Foxess implementation
