### PR TITLE
Pylon Battery: Add startup values for SOH and SOC

### DIFF
--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -45,8 +45,8 @@ static uint8_t battery_modules_in_series = 0;
 static uint8_t cell_quantity_in_module = 0;
 static uint8_t voltage_level = 0;
 static uint8_t ah_number = 0;
-static uint8_t SOC = 0;
-static uint8_t SOH = 0;
+static uint8_t SOC = 50;
+static uint8_t SOH = 100;
 static uint8_t charge_forbidden = 0;
 static uint8_t discharge_forbidden = 0;
 


### PR DESCRIPTION
### What
This PR makes the startup of Pylon Battery more smooth

### Why
Prevents two incorrect events from firing at startup before we have values
![image](https://github.com/user-attachments/assets/a7c3aaf6-8961-4454-bd51-6097f3ff3091)

### How
SOH is initialized to 100% instead of 0%
SOC is initialized to 50% instead of 0%
