### PR TITLE
Ferroamp: Bugfix, Now possible to set TOTAL_CELL_AMOUNT over 255

### DIFF
--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -49,14 +49,14 @@ Change the following only if your inverter is generating fault codes about volta
                           .ext_ID = true,
                           .DLC = 8,
                           .ID = 0x7320,
-                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                          .data = {(TOTAL_CELL_AMOUNT & 0xFF), (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
                                    AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_7321 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,
                           .ID = 0x7321,
-                          .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
+                          .data = {(TOTAL_CELL_AMOUNT & 0xFF), (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
                                    AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_4210 = {.FD = false,


### PR DESCRIPTION
### What
This PR makes it possible to set TOTAL_CELL_AMOUNT over 255 on the Ferroamp protocol

### Why
Previously this would result in a compilation error. Fixes #1144 

### How
We now handle the datatype properly
