### PR TITLE
Improvement: Fix const datacast to avoid compiler warning

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -22,7 +22,7 @@ class BydModbusInverter : public ModbusInverterProtocol {
   void handle_update_data_modbusp301_byd();
 
   //BYD Modbus specific value
-  const int MAX_POWER = 40960;
+  const uint16_t MAX_POWER = 40960;
 };
 
 #endif


### PR DESCRIPTION
### What
This PR fixes a compiler warning

### Why
Compiler warnings are bad

![image](https://github.com/user-attachments/assets/e215951f-5b8e-4f9e-8ab6-87d915f87bb0)

### How
During recent refactoring, this line in Modbus BYD was changed;

#define MAX_POWER 40960
Into
const int MAX_POWER = 40960;

This introduced the warning. We now fix this by replacing int with uint16_t
