### PR TITLE
SMA_BYD_H inverter: add content previously added to SMA_BYD_HVS

### DIFF
--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -63,19 +63,22 @@ void SmaBydHInverter::
   }
 
   //Error bits
-  if (datalayer.system.status.inverter_allows_contactor_closing) {
+  if (datalayer.system.status.battery_allows_contactor_closing) {
     SMA_158.data.u8[2] = 0xAA;
-#ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
-    digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN,
-                 HIGH);  // Turn on LED to indicate that SMA inverter allows contactor closing
-#endif                   // INVERTER_CONTACTOR_ENABLE_LED_PIN
   } else {
     SMA_158.data.u8[2] = 0x6A;
-#ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
-    digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN,
-                 LOW);  // Turn off LED to indicate that SMA inverter allows contactor closing
-#endif                  // INVERTER_CONTACTOR_ENABLE_LED_PIN
   }
+
+#ifdef INVERTER_CONTACTOR_ENABLE_LED_PIN
+  // Inverter allows contactor closing
+  if (datalayer.system.status.inverter_allows_contactor_closing) {
+    digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN,
+                 HIGH);  // Turn on LED to indicate that SMA inverter allows contactor closing
+  } else {
+    digitalWrite(INVERTER_CONTACTOR_ENABLE_LED_PIN,
+                 LOW);  // Turn off LED to indicate that SMA inverter does not allow contactor closing
+  }
+#endif  // INVERTER_CONTACTOR_ENABLE_LED_PIN
 
   // Check if Enable line is working. If we go too long without any input, raise an event
   if (!datalayer.system.status.inverter_allows_contactor_closing) {
@@ -166,13 +169,58 @@ void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x560:  //Message originating from SMA inverter - Init
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
+    case 0x561:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x562:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x563:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x564:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x565:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x566:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x567:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
     case 0x5E0:  //Message originating from SMA inverter - String
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       //Inverter brand (frame1-3 = 0x53 0x4D 0x41) = SMA
       break;
+    case 0x5E1:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x5E2:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x5E3:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x5E4:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x5E5:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
+    case 0x5E6:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
     case 0x5E7:  //Pairing request
+#ifdef DEBUG_LOG
+      logging.println("Received 0x5E7: SMA pairing request");
+#endif  // DEBUG_LOG
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can_init();
+      break;
+    case 0x62C:
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     default:
       break;
@@ -180,12 +228,10 @@ void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 }
 
 void SmaBydHInverter::transmit_can(unsigned long currentMillis) {
-
   // Send CAN Message every 100ms if inverter allows contactor closing
   if (datalayer.system.status.inverter_allows_contactor_closing) {
     if (currentMillis - previousMillis100ms >= 100) {
       previousMillis100ms = currentMillis;
-
       transmit_can_frame(&SMA_158, can_config.inverter);
       transmit_can_frame(&SMA_358, can_config.inverter);
       transmit_can_frame(&SMA_3D8, can_config.inverter);
@@ -212,7 +258,7 @@ void SmaBydHInverter::transmit_can_init() {
 }
 
 void SmaBydHInverter::setup(void) {  // Performs one time setup at startup over CAN bus
-  strncpy(datalayer.system.info.inverter_protocol, "SMA CAN", 63);
+  strncpy(datalayer.system.info.inverter_protocol, "BYD over SMA CAN", 63);
   datalayer.system.info.inverter_protocol[63] = '\0';
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
   pinMode(INVERTER_CONTACTOR_ENABLE_PIN, INPUT);


### PR DESCRIPTION
### What
This PR implements the changes done for `SMA_BYD_HVS` in #1129, for `SMA_BYD_H`

### Why
To ensure upgrades are done for all protocols

### How
By adding the content from #1129 to the `SMA_BYD_H` inverter protocol.