### PR TITLE
Improvement: Increase stack size for ACAN2515

### DIFF
--- a/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
+++ b/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
@@ -226,7 +226,7 @@ uint16_t ACAN2515::beginWithoutFilterCheck (const ACAN2515Settings & inSettings,
       #endif
     }
     #ifdef ARDUINO_ARCH_ESP32
-      xTaskCreate (myESP32Task, "ACAN2515Handler", 1024, this, TASK_ACAN2515_PRIORITY, NULL) ;
+      xTaskCreate (myESP32Task, "ACAN2515Handler", 1200, this, TASK_ACAN2515_PRIORITY, NULL) ;
     #endif
   }
 //----------------------------------- Return


### PR DESCRIPTION
### What
This PR increases the stack size for the ACAN2515 library

### Why
Fixes a stack overflow issue for ESP32 S3, which we do not use yet, but maybe soon :) 
https://github.com/pierremolinaro/acan2515/releases/tag/2.1.5

### How
1024 grows to 1200
