### PR TITLE
Feature: Add separate Deye protocol

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -50,9 +50,9 @@
 /* Select inverter communication protocol. See Wiki for which to use with your inverter: https://github.com/dalathegreat/Battery-Emulator/wiki */
 //#define AFORE_CAN        //Enable this line to emulate an "Afore battery" over CAN bus
 //#define BYD_CAN          //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus
-//#define BYD_CAN_DEYE     //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus, with Deye specific fixes
 //#define BYD_KOSTAL_RS485 //Enable this line to emulate a "BYD 11kWh HVM battery" over Kostal RS485
 //#define BYD_MODBUS       //Enable this line to emulate a "BYD 11kWh HVM battery" over Modbus RTU
+//#define DEYE_BYD_CAN     //Enable this line to emulate a "BYD Battery-Box Premium HVS" over CAN Bus, with Deye voltage control
 //#define FERROAMP_CAN     //Enable this line to emulate a "Pylon 4x96V Force H2" over CAN Bus
 //#define FOXESS_CAN       //Enable this line to emulate a "HV2600/ECS4100 battery" over CAN bus
 //#define GROWATT_HV_CAN   //Enable this line to emulate a "Growatt High Voltage v1.10 battery" over CAN bus

--- a/Software/src/inverter/DEYE-BYD-CAN.h
+++ b/Software/src/inverter/DEYE-BYD-CAN.h
@@ -1,0 +1,108 @@
+#ifndef DEYE_BYD_CAN_H
+#define DEYE_BYD_CAN_H
+#include "../include.h"
+
+#ifdef DEYE_BYD_CAN
+#define CAN_INVERTER_SELECTED
+#define SELECTED_INVERTER_CLASS DeyeBydCanInverter
+#endif
+
+#include "CanInverterProtocol.h"
+
+class DeyeBydCanInverter : public CanInverterProtocol {
+ public:
+  void setup();
+  void transmit_can(unsigned long currentMillis);
+  void map_can_frame_to_variable(CAN_frame rx_frame);
+  void update_values();
+
+ private:
+  void send_initial_data();
+  unsigned long previousMillis2s = 0;   // will store last time a 2s CAN Message was send
+  unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was send
+  unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
+
+  static const int FW_MAJOR_VERSION = 0x03;
+  static const int FW_MINOR_VERSION = 0x29;
+  static const int VOLTAGE_OFFSET_DV = 20;
+
+  CAN_frame BYD_250 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x250,
+                       .data = {FW_MAJOR_VERSION, FW_MINOR_VERSION, 0x00, 0x66, (uint8_t)((BATTERY_WH_MAX / 100) >> 8),
+                                (uint8_t)(BATTERY_WH_MAX / 100), 0x02,
+                                0x09}};  //0-1 FW version , Capacity kWh byte4&5 (example 24kWh = 240)
+  CAN_frame BYD_290 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x290,
+                       .data = {0x06, 0x37, 0x10, 0xD9, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BYD_2D0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x2D0,
+                       .data = {0x00, 0x42, 0x59, 0x44, 0x00, 0x00, 0x00, 0x00}};  //BYD
+  CAN_frame BYD_3D0_0 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x3D0,
+                         .data = {0x00, 0x42, 0x61, 0x74, 0x74, 0x65, 0x72, 0x79}};  //Battery
+  CAN_frame BYD_3D0_1 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x3D0,
+                         .data = {0x01, 0x2D, 0x42, 0x6F, 0x78, 0x20, 0x50, 0x72}};  //-Box Pr
+  CAN_frame BYD_3D0_2 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x3D0,
+                         .data = {0x02, 0x65, 0x6D, 0x69, 0x75, 0x6D, 0x20, 0x48}};  //emium H
+  CAN_frame BYD_3D0_3 = {.FD = false,
+                         .ext_ID = false,
+                         .DLC = 8,
+                         .ID = 0x3D0,
+                         .data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00}};  //VS
+  //Actual content messages
+  CAN_frame BYD_110 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x110,
+                       .data = {0x01, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BYD_150 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x150,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x10, 0x27, 0x00, 0x00}};
+  CAN_frame BYD_190 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x190,
+                       .data = {0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BYD_1D0 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x1D0,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x08}};
+  CAN_frame BYD_210 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x210,
+                       .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  int16_t temperature_average = 0;
+  uint16_t inverter_voltage = 0;
+  uint16_t inverter_SOC = 0;
+  int16_t inverter_current = 0;
+  int16_t inverter_temperature = 0;
+  uint16_t remaining_capacity_ah = 0;
+  uint16_t fully_charged_capacity_ah = 0;
+  uint16_t capped_allowed_charge_current_dA = 0;
+  uint16_t capped_allowed_discharge_current_dA = 0;
+  uint16_t capped_SOC_pptt = 0;
+  long inverter_timestamp = 0;
+  bool initialDataSent = false;
+  bool inverterStartedUp = false;
+};
+
+#endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -7,13 +7,9 @@ extern InverterProtocol* inverter;
 #include "../../USER_SETTINGS.h"
 
 #include "AFORE-CAN.h"
-
-#ifdef BYD_CAN_DEYE
-#define BYD_CAN
-#endif
-
 #include "BYD-CAN.h"
 #include "BYD-MODBUS.h"
+#include "DEYE-BYD-CAN.h"
 #include "FERROAMP-CAN.h"
 #include "FOXESS-CAN.h"
 #include "GROWATT-HV-CAN.h"


### PR DESCRIPTION
### What
This PR implements a separate inverter protocol for when using Deye inverters

### Why
Deye inverters are not really compliant with the BYD_CAN protocol, and will start to oscillate when the allowed charge goes below 1A. Deye seems to target a voltage instead, and wants to float charge. To avoid massive modifications to the BYD_CAN protocol, and risk affecting other inverters, we instead branch off a separate DEYE_BYD_CAN protocol.

### How
This implementation introduces DEYE_BYD_CAN, with the following tweaks:

- If charge allowed goes below 1A, we cap it artifically to 1A towards the inverter
- If charge allowed is 0A, we set SOC% to 100% (avoids offgrid Deye overcharging the battery)
- If discharge allowed is 0A, we set SOC% to 0% (avoids offgrid Deye overdischarging the battery)
- TODO: Voltage control needs tweaking
