### PR TITLE
Bugfix: Discharge below 1% SOC not possible

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -428,11 +428,6 @@ void update_calculated_values() {
       scaled_soc = 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
     }
 
-    // Clamp low SOCs to zero for extra safety
-    if (datalayer.battery.status.real_soc < 100) {
-      scaled_soc = 0;
-    }
-
     datalayer.battery.status.reported_soc = scaled_soc;
 
     // If battery info is valid


### PR DESCRIPTION
### What
This PR removes SOC clamping below 1percent

### Why
When using negative SOC scaling, you really want the battery to go down to 0% SOC. This was not possible due to clamping function. Fixes #1176

### How
We now remove this restriction. It was an overcautious safety feature.
