### PR TITLE
Feature: Add balancing status (LEAF & ZoeGen2)

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -456,23 +456,23 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (group_7bb == 0x06)  //Balancing resistor status
       {
         if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 1A 61 06 [14 55 55 51])
-          for (int i = 0; i < 8; i++){
+          for (int i = 0; i < 8; i++) {
             // Byte 4 - 7 (bits 0-31)
-            for (int byte_i = 0; byte_i < 4; byte_i++){
+            for (int byte_i = 0; byte_i < 4; byte_i++) {
               battery_balancing_shunts[byte_i * 8 + i] = (rx_frame.data.u8[4 + byte_i] & (1 << i)) >> i;
             }
           }
         }
         if (rx_frame.data.u8[0] == 0x21) {  // Second frame (21 [50 55 41 2B 56 54 15])
-          for (int i = 0; i < 8; i++){
+          for (int i = 0; i < 8; i++) {
             // Byte 1 to 7 (bits 32-87)
-            for (int byte_i = 0; byte_i < 7; byte_i++){
+            for (int byte_i = 0; byte_i < 7; byte_i++) {
               battery_balancing_shunts[32 + byte_i * 8 + i] = (rx_frame.data.u8[1 + byte_i] & (1 << i)) >> i;
             }
           }
         }
         if (rx_frame.data.u8[0] == 0x22) {  //Third frame (22 51 FF FF FF FF FF FF)
-          for (int i = 0; i < 8; i++){
+          for (int i = 0; i < 8; i++) {
             // Byte 1 (bits 88-95)
             battery_balancing_shunts[88 + i] = (rx_frame.data.u8[1] & (1 << i)) >> i;
           }

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -456,118 +456,26 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (group_7bb == 0x06)  //Balancing resistor status
       {
         if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 1A 61 06 [14 55 55 51])
-          // Byte 4 (bits 0-7)
-          battery_balancing_shunts[0] = (rx_frame.data.u8[4] & 0b00000001);
-          battery_balancing_shunts[1] = (rx_frame.data.u8[4] & 0b00000010) >> 1;
-          battery_balancing_shunts[2] = (rx_frame.data.u8[4] & 0b00000100) >> 2;
-          battery_balancing_shunts[3] = (rx_frame.data.u8[4] & 0b00001000) >> 3;
-          battery_balancing_shunts[4] = (rx_frame.data.u8[4] & 0b00010000) >> 4;
-          battery_balancing_shunts[5] = (rx_frame.data.u8[4] & 0b00100000) >> 5;
-          battery_balancing_shunts[6] = (rx_frame.data.u8[4] & 0b01000000) >> 6;
-          battery_balancing_shunts[7] = (rx_frame.data.u8[4] & 0b10000000) >> 7;
-          // Byte 5 (bits 8-15)
-          battery_balancing_shunts[8] = (rx_frame.data.u8[5] & 0b00000001);
-          battery_balancing_shunts[9] = (rx_frame.data.u8[5] & 0b00000010) >> 1;
-          battery_balancing_shunts[10] = (rx_frame.data.u8[5] & 0b00000100) >> 2;
-          battery_balancing_shunts[11] = (rx_frame.data.u8[5] & 0b00001000) >> 3;
-          battery_balancing_shunts[12] = (rx_frame.data.u8[5] & 0b00010000) >> 4;
-          battery_balancing_shunts[13] = (rx_frame.data.u8[5] & 0b00100000) >> 5;
-          battery_balancing_shunts[14] = (rx_frame.data.u8[5] & 0b01000000) >> 6;
-          battery_balancing_shunts[15] = (rx_frame.data.u8[5] & 0b10000000) >> 7;
-          // Byte 6 (bits 16-23)
-          battery_balancing_shunts[16] = (rx_frame.data.u8[6] & 0b00000001);
-          battery_balancing_shunts[17] = (rx_frame.data.u8[6] & 0b00000010) >> 1;
-          battery_balancing_shunts[18] = (rx_frame.data.u8[6] & 0b00000100) >> 2;
-          battery_balancing_shunts[19] = (rx_frame.data.u8[6] & 0b00001000) >> 3;
-          battery_balancing_shunts[20] = (rx_frame.data.u8[6] & 0b00010000) >> 4;
-          battery_balancing_shunts[21] = (rx_frame.data.u8[6] & 0b00100000) >> 5;
-          battery_balancing_shunts[22] = (rx_frame.data.u8[6] & 0b01000000) >> 6;
-          battery_balancing_shunts[23] = (rx_frame.data.u8[6] & 0b10000000) >> 7;
-          // Byte 7 (bits 24-31)
-          battery_balancing_shunts[24] = (rx_frame.data.u8[7] & 0b00000001);
-          battery_balancing_shunts[25] = (rx_frame.data.u8[7] & 0b00000010) >> 1;
-          battery_balancing_shunts[26] = (rx_frame.data.u8[7] & 0b00000100) >> 2;
-          battery_balancing_shunts[27] = (rx_frame.data.u8[7] & 0b00001000) >> 3;
-          battery_balancing_shunts[28] = (rx_frame.data.u8[7] & 0b00010000) >> 4;
-          battery_balancing_shunts[29] = (rx_frame.data.u8[7] & 0b00100000) >> 5;
-          battery_balancing_shunts[30] = (rx_frame.data.u8[7] & 0b01000000) >> 6;
-          battery_balancing_shunts[31] = (rx_frame.data.u8[7] & 0b10000000) >> 7;
+          for (int i = 0; i < 8; i++){
+            // Byte 4 - 7 (bits 0-31)
+            for (int byte_i = 0; byte_i < 4; byte_i++){
+              battery_balancing_shunts[byte_i * 8 + i] = (rx_frame.data.u8[4 + byte_i] & (1 << i)) >> i;
+            }
+          }
         }
         if (rx_frame.data.u8[0] == 0x21) {  // Second frame (21 [50 55 41 2B 56 54 15])
-          // Byte 1 (bits 32-39)
-          battery_balancing_shunts[32] = (rx_frame.data.u8[1] & 0b00000001);
-          battery_balancing_shunts[33] = (rx_frame.data.u8[1] & 0b00000010) >> 1;
-          battery_balancing_shunts[34] = (rx_frame.data.u8[1] & 0b00000100) >> 2;
-          battery_balancing_shunts[35] = (rx_frame.data.u8[1] & 0b00001000) >> 3;
-          battery_balancing_shunts[36] = (rx_frame.data.u8[1] & 0b00010000) >> 4;
-          battery_balancing_shunts[37] = (rx_frame.data.u8[1] & 0b00100000) >> 5;
-          battery_balancing_shunts[38] = (rx_frame.data.u8[1] & 0b01000000) >> 6;
-          battery_balancing_shunts[39] = (rx_frame.data.u8[1] & 0b10000000) >> 7;
-          // Byte 2 (bits 40-47)
-          battery_balancing_shunts[40] = (rx_frame.data.u8[2] & 0b00000001);
-          battery_balancing_shunts[41] = (rx_frame.data.u8[2] & 0b00000010) >> 1;
-          battery_balancing_shunts[42] = (rx_frame.data.u8[2] & 0b00000100) >> 2;
-          battery_balancing_shunts[43] = (rx_frame.data.u8[2] & 0b00001000) >> 3;
-          battery_balancing_shunts[44] = (rx_frame.data.u8[2] & 0b00010000) >> 4;
-          battery_balancing_shunts[45] = (rx_frame.data.u8[2] & 0b00100000) >> 5;
-          battery_balancing_shunts[46] = (rx_frame.data.u8[2] & 0b01000000) >> 6;
-          battery_balancing_shunts[47] = (rx_frame.data.u8[2] & 0b10000000) >> 7;
-          // Byte 3 (bits 48-55)
-          battery_balancing_shunts[48] = (rx_frame.data.u8[3] & 0b00000001);
-          battery_balancing_shunts[49] = (rx_frame.data.u8[3] & 0b00000010) >> 1;
-          battery_balancing_shunts[50] = (rx_frame.data.u8[3] & 0b00000100) >> 2;
-          battery_balancing_shunts[51] = (rx_frame.data.u8[3] & 0b00001000) >> 3;
-          battery_balancing_shunts[52] = (rx_frame.data.u8[3] & 0b00010000) >> 4;
-          battery_balancing_shunts[53] = (rx_frame.data.u8[3] & 0b00100000) >> 5;
-          battery_balancing_shunts[54] = (rx_frame.data.u8[3] & 0b01000000) >> 6;
-          battery_balancing_shunts[55] = (rx_frame.data.u8[3] & 0b10000000) >> 7;
-          //Byte 4
-          battery_balancing_shunts[56] = (rx_frame.data.u8[4] & 0b00000001);
-          battery_balancing_shunts[57] = (rx_frame.data.u8[4] & 0b00000010) >> 1;
-          battery_balancing_shunts[58] = (rx_frame.data.u8[4] & 0b00000100) >> 2;
-          battery_balancing_shunts[59] = (rx_frame.data.u8[4] & 0b00001000) >> 3;
-          battery_balancing_shunts[60] = (rx_frame.data.u8[4] & 0b00010000) >> 4;
-          battery_balancing_shunts[61] = (rx_frame.data.u8[4] & 0b00100000) >> 5;
-          battery_balancing_shunts[62] = (rx_frame.data.u8[4] & 0b01000000) >> 6;
-          battery_balancing_shunts[63] = (rx_frame.data.u8[4] & 0b10000000) >> 7;
-          //Byte 5
-          battery_balancing_shunts[64] = (rx_frame.data.u8[5] & 0b00000001);
-          battery_balancing_shunts[65] = (rx_frame.data.u8[5] & 0b00000010) >> 1;
-          battery_balancing_shunts[66] = (rx_frame.data.u8[5] & 0b00000100) >> 2;
-          battery_balancing_shunts[67] = (rx_frame.data.u8[5] & 0b00001000) >> 3;
-          battery_balancing_shunts[68] = (rx_frame.data.u8[5] & 0b00010000) >> 4;
-          battery_balancing_shunts[69] = (rx_frame.data.u8[5] & 0b00100000) >> 5;
-          battery_balancing_shunts[70] = (rx_frame.data.u8[5] & 0b01000000) >> 6;
-          battery_balancing_shunts[71] = (rx_frame.data.u8[5] & 0b10000000) >> 7;
-          //Byte 6
-          battery_balancing_shunts[72] = (rx_frame.data.u8[6] & 0b00000001);
-          battery_balancing_shunts[73] = (rx_frame.data.u8[6] & 0b00000010) >> 1;
-          battery_balancing_shunts[74] = (rx_frame.data.u8[6] & 0b00000100) >> 2;
-          battery_balancing_shunts[75] = (rx_frame.data.u8[6] & 0b00001000) >> 3;
-          battery_balancing_shunts[76] = (rx_frame.data.u8[6] & 0b00010000) >> 4;
-          battery_balancing_shunts[77] = (rx_frame.data.u8[6] & 0b00100000) >> 5;
-          battery_balancing_shunts[78] = (rx_frame.data.u8[6] & 0b01000000) >> 6;
-          battery_balancing_shunts[79] = (rx_frame.data.u8[6] & 0b10000000) >> 7;
-          //Byte 7
-          battery_balancing_shunts[80] = (rx_frame.data.u8[7] & 0b00000001);
-          battery_balancing_shunts[81] = (rx_frame.data.u8[7] & 0b00000010) >> 1;
-          battery_balancing_shunts[82] = (rx_frame.data.u8[7] & 0b00000100) >> 2;
-          battery_balancing_shunts[83] = (rx_frame.data.u8[7] & 0b00001000) >> 3;
-          battery_balancing_shunts[84] = (rx_frame.data.u8[7] & 0b00010000) >> 4;
-          battery_balancing_shunts[85] = (rx_frame.data.u8[7] & 0b00100000) >> 5;
-          battery_balancing_shunts[86] = (rx_frame.data.u8[7] & 0b01000000) >> 6;
-          battery_balancing_shunts[87] = (rx_frame.data.u8[7] & 0b10000000) >> 7;
+          for (int i = 0; i < 8; i++){
+            // Byte 1 to 7 (bits 32-87)
+            for (int byte_i = 0; byte_i < 7; byte_i++){
+              battery_balancing_shunts[32 + byte_i * 8 + i] = (rx_frame.data.u8[1 + byte_i] & (1 << i)) >> i;
+            }
+          }
         }
         if (rx_frame.data.u8[0] == 0x22) {  //Third frame (22 51 FF FF FF FF FF FF)
-          //Byte 7
-          battery_balancing_shunts[88] = (rx_frame.data.u8[1] & 0b00000001);
-          battery_balancing_shunts[89] = (rx_frame.data.u8[1] & 0b00000010) >> 1;
-          battery_balancing_shunts[90] = (rx_frame.data.u8[1] & 0b00000100) >> 2;
-          battery_balancing_shunts[91] = (rx_frame.data.u8[1] & 0b00001000) >> 3;
-          battery_balancing_shunts[92] = (rx_frame.data.u8[1] & 0b00010000) >> 4;
-          battery_balancing_shunts[93] = (rx_frame.data.u8[1] & 0b00100000) >> 5;
-          battery_balancing_shunts[94] = (rx_frame.data.u8[1] & 0b01000000) >> 6;
-          battery_balancing_shunts[95] = (rx_frame.data.u8[1] & 0b10000000) >> 7;
+          for (int i = 0; i < 8; i++){
+            // Byte 1 (bits 88-95)
+            battery_balancing_shunts[88 + i] = (rx_frame.data.u8[1] & (1 << i)) >> i;
+          }
           memcpy(datalayer_battery->status.cell_balancing_status, battery_balancing_shunts, 96 * sizeof(bool));
         }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -453,6 +453,128 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
       }
 
+      if (group_7bb == 0x06)  //Balancing resistor status
+      {
+        if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 1A 61 06 [14 55 55 51])
+          // Byte 4 (bits 0-7)
+          battery_balancing_shunts[0] = (rx_frame.data.u8[4] & 0b00000001);
+          battery_balancing_shunts[1] = (rx_frame.data.u8[4] & 0b00000010) >> 1;
+          battery_balancing_shunts[2] = (rx_frame.data.u8[4] & 0b00000100) >> 2;
+          battery_balancing_shunts[3] = (rx_frame.data.u8[4] & 0b00001000) >> 3;
+          battery_balancing_shunts[4] = (rx_frame.data.u8[4] & 0b00010000) >> 4;
+          battery_balancing_shunts[5] = (rx_frame.data.u8[4] & 0b00100000) >> 5;
+          battery_balancing_shunts[6] = (rx_frame.data.u8[4] & 0b01000000) >> 6;
+          battery_balancing_shunts[7] = (rx_frame.data.u8[4] & 0b10000000) >> 7;
+          // Byte 5 (bits 8-15)
+          battery_balancing_shunts[8] = (rx_frame.data.u8[5] & 0b00000001);
+          battery_balancing_shunts[9] = (rx_frame.data.u8[5] & 0b00000010) >> 1;
+          battery_balancing_shunts[10] = (rx_frame.data.u8[5] & 0b00000100) >> 2;
+          battery_balancing_shunts[11] = (rx_frame.data.u8[5] & 0b00001000) >> 3;
+          battery_balancing_shunts[12] = (rx_frame.data.u8[5] & 0b00010000) >> 4;
+          battery_balancing_shunts[13] = (rx_frame.data.u8[5] & 0b00100000) >> 5;
+          battery_balancing_shunts[14] = (rx_frame.data.u8[5] & 0b01000000) >> 6;
+          battery_balancing_shunts[15] = (rx_frame.data.u8[5] & 0b10000000) >> 7;
+          // Byte 6 (bits 16-23)
+          battery_balancing_shunts[16] = (rx_frame.data.u8[6] & 0b00000001);
+          battery_balancing_shunts[17] = (rx_frame.data.u8[6] & 0b00000010) >> 1;
+          battery_balancing_shunts[18] = (rx_frame.data.u8[6] & 0b00000100) >> 2;
+          battery_balancing_shunts[19] = (rx_frame.data.u8[6] & 0b00001000) >> 3;
+          battery_balancing_shunts[20] = (rx_frame.data.u8[6] & 0b00010000) >> 4;
+          battery_balancing_shunts[21] = (rx_frame.data.u8[6] & 0b00100000) >> 5;
+          battery_balancing_shunts[22] = (rx_frame.data.u8[6] & 0b01000000) >> 6;
+          battery_balancing_shunts[23] = (rx_frame.data.u8[6] & 0b10000000) >> 7;
+          // Byte 7 (bits 24-31)
+          battery_balancing_shunts[24] = (rx_frame.data.u8[7] & 0b00000001);
+          battery_balancing_shunts[25] = (rx_frame.data.u8[7] & 0b00000010) >> 1;
+          battery_balancing_shunts[26] = (rx_frame.data.u8[7] & 0b00000100) >> 2;
+          battery_balancing_shunts[27] = (rx_frame.data.u8[7] & 0b00001000) >> 3;
+          battery_balancing_shunts[28] = (rx_frame.data.u8[7] & 0b00010000) >> 4;
+          battery_balancing_shunts[29] = (rx_frame.data.u8[7] & 0b00100000) >> 5;
+          battery_balancing_shunts[30] = (rx_frame.data.u8[7] & 0b01000000) >> 6;
+          battery_balancing_shunts[31] = (rx_frame.data.u8[7] & 0b10000000) >> 7;
+        }
+        if (rx_frame.data.u8[0] == 0x21) {  // Second frame (21 [50 55 41 2B 56 54 15])
+          // Byte 1 (bits 32-39)
+          battery_balancing_shunts[32] = (rx_frame.data.u8[1] & 0b00000001);
+          battery_balancing_shunts[33] = (rx_frame.data.u8[1] & 0b00000010) >> 1;
+          battery_balancing_shunts[34] = (rx_frame.data.u8[1] & 0b00000100) >> 2;
+          battery_balancing_shunts[35] = (rx_frame.data.u8[1] & 0b00001000) >> 3;
+          battery_balancing_shunts[36] = (rx_frame.data.u8[1] & 0b00010000) >> 4;
+          battery_balancing_shunts[37] = (rx_frame.data.u8[1] & 0b00100000) >> 5;
+          battery_balancing_shunts[38] = (rx_frame.data.u8[1] & 0b01000000) >> 6;
+          battery_balancing_shunts[39] = (rx_frame.data.u8[1] & 0b10000000) >> 7;
+          // Byte 2 (bits 40-47)
+          battery_balancing_shunts[40] = (rx_frame.data.u8[2] & 0b00000001);
+          battery_balancing_shunts[41] = (rx_frame.data.u8[2] & 0b00000010) >> 1;
+          battery_balancing_shunts[42] = (rx_frame.data.u8[2] & 0b00000100) >> 2;
+          battery_balancing_shunts[43] = (rx_frame.data.u8[2] & 0b00001000) >> 3;
+          battery_balancing_shunts[44] = (rx_frame.data.u8[2] & 0b00010000) >> 4;
+          battery_balancing_shunts[45] = (rx_frame.data.u8[2] & 0b00100000) >> 5;
+          battery_balancing_shunts[46] = (rx_frame.data.u8[2] & 0b01000000) >> 6;
+          battery_balancing_shunts[47] = (rx_frame.data.u8[2] & 0b10000000) >> 7;
+          // Byte 3 (bits 48-55)
+          battery_balancing_shunts[48] = (rx_frame.data.u8[3] & 0b00000001);
+          battery_balancing_shunts[49] = (rx_frame.data.u8[3] & 0b00000010) >> 1;
+          battery_balancing_shunts[50] = (rx_frame.data.u8[3] & 0b00000100) >> 2;
+          battery_balancing_shunts[51] = (rx_frame.data.u8[3] & 0b00001000) >> 3;
+          battery_balancing_shunts[52] = (rx_frame.data.u8[3] & 0b00010000) >> 4;
+          battery_balancing_shunts[53] = (rx_frame.data.u8[3] & 0b00100000) >> 5;
+          battery_balancing_shunts[54] = (rx_frame.data.u8[3] & 0b01000000) >> 6;
+          battery_balancing_shunts[55] = (rx_frame.data.u8[3] & 0b10000000) >> 7;
+          //Byte 4
+          battery_balancing_shunts[56] = (rx_frame.data.u8[4] & 0b00000001);
+          battery_balancing_shunts[57] = (rx_frame.data.u8[4] & 0b00000010) >> 1;
+          battery_balancing_shunts[58] = (rx_frame.data.u8[4] & 0b00000100) >> 2;
+          battery_balancing_shunts[59] = (rx_frame.data.u8[4] & 0b00001000) >> 3;
+          battery_balancing_shunts[60] = (rx_frame.data.u8[4] & 0b00010000) >> 4;
+          battery_balancing_shunts[61] = (rx_frame.data.u8[4] & 0b00100000) >> 5;
+          battery_balancing_shunts[62] = (rx_frame.data.u8[4] & 0b01000000) >> 6;
+          battery_balancing_shunts[63] = (rx_frame.data.u8[4] & 0b10000000) >> 7;
+          //Byte 5
+          battery_balancing_shunts[64] = (rx_frame.data.u8[5] & 0b00000001);
+          battery_balancing_shunts[65] = (rx_frame.data.u8[5] & 0b00000010) >> 1;
+          battery_balancing_shunts[66] = (rx_frame.data.u8[5] & 0b00000100) >> 2;
+          battery_balancing_shunts[67] = (rx_frame.data.u8[5] & 0b00001000) >> 3;
+          battery_balancing_shunts[68] = (rx_frame.data.u8[5] & 0b00010000) >> 4;
+          battery_balancing_shunts[69] = (rx_frame.data.u8[5] & 0b00100000) >> 5;
+          battery_balancing_shunts[70] = (rx_frame.data.u8[5] & 0b01000000) >> 6;
+          battery_balancing_shunts[71] = (rx_frame.data.u8[5] & 0b10000000) >> 7;
+          //Byte 6
+          battery_balancing_shunts[72] = (rx_frame.data.u8[6] & 0b00000001);
+          battery_balancing_shunts[73] = (rx_frame.data.u8[6] & 0b00000010) >> 1;
+          battery_balancing_shunts[74] = (rx_frame.data.u8[6] & 0b00000100) >> 2;
+          battery_balancing_shunts[75] = (rx_frame.data.u8[6] & 0b00001000) >> 3;
+          battery_balancing_shunts[76] = (rx_frame.data.u8[6] & 0b00010000) >> 4;
+          battery_balancing_shunts[77] = (rx_frame.data.u8[6] & 0b00100000) >> 5;
+          battery_balancing_shunts[78] = (rx_frame.data.u8[6] & 0b01000000) >> 6;
+          battery_balancing_shunts[79] = (rx_frame.data.u8[6] & 0b10000000) >> 7;
+          //Byte 7
+          battery_balancing_shunts[80] = (rx_frame.data.u8[7] & 0b00000001);
+          battery_balancing_shunts[81] = (rx_frame.data.u8[7] & 0b00000010) >> 1;
+          battery_balancing_shunts[82] = (rx_frame.data.u8[7] & 0b00000100) >> 2;
+          battery_balancing_shunts[83] = (rx_frame.data.u8[7] & 0b00001000) >> 3;
+          battery_balancing_shunts[84] = (rx_frame.data.u8[7] & 0b00010000) >> 4;
+          battery_balancing_shunts[85] = (rx_frame.data.u8[7] & 0b00100000) >> 5;
+          battery_balancing_shunts[86] = (rx_frame.data.u8[7] & 0b01000000) >> 6;
+          battery_balancing_shunts[87] = (rx_frame.data.u8[7] & 0b10000000) >> 7;
+        }
+        if (rx_frame.data.u8[0] == 0x22) {  //Third frame (22 51 FF FF FF FF FF FF)
+          //Byte 7
+          battery_balancing_shunts[88] = (rx_frame.data.u8[1] & 0b00000001);
+          battery_balancing_shunts[89] = (rx_frame.data.u8[1] & 0b00000010) >> 1;
+          battery_balancing_shunts[90] = (rx_frame.data.u8[1] & 0b00000100) >> 2;
+          battery_balancing_shunts[91] = (rx_frame.data.u8[1] & 0b00001000) >> 3;
+          battery_balancing_shunts[92] = (rx_frame.data.u8[1] & 0b00010000) >> 4;
+          battery_balancing_shunts[93] = (rx_frame.data.u8[1] & 0b00100000) >> 5;
+          battery_balancing_shunts[94] = (rx_frame.data.u8[1] & 0b01000000) >> 6;
+          battery_balancing_shunts[95] = (rx_frame.data.u8[1] & 0b10000000) >> 7;
+          memcpy(datalayer_battery->status.cell_balancing_status, battery_balancing_shunts, 96 * sizeof(bool));
+        }
+
+        if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23 FF FF FF FF FF FF FF)
+        }
+      }
+
       if (group_7bb == 0x83)  //BatteryPartNumber
       {
         if (rx_frame.data.u8[0] == 0x10) {  //First frame (101A6183334E4B32)
@@ -704,7 +826,7 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       if (!stop_battery_query) {
 
         // Move to the next group
-        PIDindex = (PIDindex + 1) % 6;  // 6 = amount of elements in the PIDgroups[]
+        PIDindex = (PIDindex + 1) % 7;  // 7 = amount of elements in the PIDgroups[]
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
         transmit_can_frame(&LEAF_GROUP_REQUEST, can_interface);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -155,8 +155,8 @@ class NissanLeafBattery : public CanBattery {
   uint8_t group_7bb = 0;
   bool stop_battery_query = true;
   uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
-  uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
-  bool battery_balancing_shunts[97];            //array with all the balancing resistors
+  uint16_t battery_cell_voltages[96];           //array with all the cellvoltages
+  bool battery_balancing_shunts[96];            //array with all the balancing resistors
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
   uint16_t battery_HX = 0;              //Internal resistance

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -82,7 +82,7 @@ class NissanLeafBattery : public CanBattery {
                         .ID = 0x1D4,
                         .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
   // Active polling messages
-  uint8_t PIDgroups[6] = {0x01, 0x02, 0x04, 0x83, 0x84, 0x90};
+  uint8_t PIDgroups[7] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x90};
   uint8_t PIDindex = 0;
   CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
                                   .ext_ID = false,
@@ -156,6 +156,7 @@ class NissanLeafBattery : public CanBattery {
   bool stop_battery_query = true;
   uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
   uint16_t battery_cell_voltages[97];           //array with all the cellvoltages
+  bool battery_balancing_shunts[97];            //array with all the balancing resistors
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
   uint16_t battery_HX = 0;              //Internal resistance

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -112,6 +112,10 @@ void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (rx_frame.data.u8[0] == 0x10) {  //First frame of a group
         transmit_can_frame(&ZOE_POLL_FLOW_CONTROL, can_config.battery);
         //frame 2 & 3 contains which PID is sent
+        reply_poll = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
+      }
+
+      if (rx_frame.data.u8[0] < 0x10) {  //One line responses
         reply_poll = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
       }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -108,8 +108,12 @@ void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
   datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x18DAF1DB:  // LBC Reply from active polling
-      //frame 2 & 3 contains
-      reply_poll = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+
+      if (rx_frame.data.u8[0] == 0x10) {  //First frame of a group
+        transmit_can_frame(&ZOE_POLL_FLOW_CONTROL, can_config.battery);
+        //frame 2 & 3 contains which PID is sent
+        reply_poll = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+      }
 
       switch (reply_poll) {
         case POLL_SOC:
@@ -200,6 +204,29 @@ void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
           battery_bms_state = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           break;
         case POLL_BALANCE_SWITCHES:
+          if (rx_frame.data.u8[0] == 0x10) {
+            for (int i = 0; i < 8; i++) {
+              // Byte 4 - 7 (bits 0-31)
+              for (int byte_i = 0; byte_i < 4; byte_i++) {
+                battery_balancing_shunts[byte_i * 8 + i] = (rx_frame.data.u8[4 + byte_i] & (1 << i)) >> i;
+              }
+            }
+          }
+          if (rx_frame.data.u8[0] == 0x21) {
+            for (int i = 0; i < 8; i++) {
+              // Byte 1 to 7 (bits 32-87)
+              for (int byte_i = 0; byte_i < 7; byte_i++) {
+                battery_balancing_shunts[32 + byte_i * 8 + i] = (rx_frame.data.u8[1 + byte_i] & (1 << i)) >> i;
+              }
+            }
+          }
+          if (rx_frame.data.u8[0] == 0x22) {
+            for (int i = 0; i < 8; i++) {
+              // Byte 1 (bits 88-95)
+              battery_balancing_shunts[88 + i] = (rx_frame.data.u8[1] & (1 << i)) >> i;
+            }
+            memcpy(datalayer.battery.status.cell_balancing_status, battery_balancing_shunts, 96 * sizeof(bool));
+          }
           battery_balance_switches = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           break;
         case POLL_ENERGY_COMPLETE:

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -205,6 +205,7 @@ class RenaultZoeGen2Battery : public CanBattery {
   uint32_t ZOE_376_time_now_s = 1745452800;  // Initialized to make the battery think it is April 24, 2025
   unsigned long kProductionTimestamp_s =
       1614454107;  // Production timestamp in seconds since January 1, 1970. Production timestamp used: February 25, 2021 at 8:08:27 AM GMT
+  bool battery_balancing_shunts[96];
 
   CAN_frame ZOE_373 = {
       .FD = false,
@@ -225,6 +226,11 @@ class RenaultZoeGen2Battery : public CanBattery {
                                  .DLC = 8,
                                  .ID = 0x18DADBF1,
                                  .data = {0x03, 0x22, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ZOE_POLL_FLOW_CONTROL = {.FD = false,
+                                     .ext_ID = true,
+                                     .DLC = 8,
+                                     .ID = 0x18DADBF1,
+                                     .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   //NVROL Reset
   CAN_frame ZOE_NVROL_1_18DADBF1 = {.FD = false,
                                     .ext_ID = true,

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -81,6 +81,11 @@ typedef struct {
    * Use with battery.info.number_of_cells to get valid data.
    */
   uint16_t cell_voltages_mV[MAX_AMOUNT_CELLS];
+  /** All balancing resistors status inside the pack, either on(1) or off(0).
+   * Use with battery.info.number_of_cells to get valid data.
+   * Not available for all battery manufacturers.
+   */
+  bool cell_balancing_status[MAX_AMOUNT_CELLS];
   /** The "real" SOC reported from the battery, in integer-percent x 100. 9550 = 95.50% */
   uint16_t real_soc;
   /** The SOC reported to the inverter, in integer-percent x 100. 9550 = 95.50%.

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -159,7 +159,7 @@ String cellmonitor_processor(const String& var) {
 
         "bar.addEventListener('mouseleave', () => {"
         "valueDisplay.textContent = 'Value: ...';"
-        "bar.style.backgroundColor = `blue`;"
+        "bar.style.backgroundColor = balancing[index] ? '#00FFFF' : 'blue';"  // Restore cyan if balancing, else blue
         "cell.style.removeProperty('background-color');"
         "});"
 
@@ -183,13 +183,13 @@ String cellmonitor_processor(const String& var) {
         "cell.addEventListener('mouseenter', () => {"
         "let bar = document.getElementById(`barIndex${index}`);"
         "valueDisplay.textContent = `Value: ${mV}`;"
-        "bar.style.backgroundColor = `lightblue`;"
-        "cell.style.backgroundColor = `blue`;"
+        "bar.style.backgroundColor = balancing[index] ? '#80FFFF' : 'lightblue';"  // Lighter cyan if balancing
+        "cell.style.backgroundColor = balancing[index] ? '#006666' : 'blue';"      // Darker cyan if balancing
         "});"
 
         "cell.addEventListener('mouseleave', () => {"
         "let bar = document.getElementById(`barIndex${index}`);"
-        "bar.style.backgroundColor = balancing[index] ? '#00FFFF' : 'blue';"
+        "bar.style.backgroundColor = balancing[index] ? '#00FFFF' : 'blue';"  // Restore original color
         "cell.style.removeProperty('background-color');"
         "});"
 
@@ -287,7 +287,7 @@ String cellmonitor_processor(const String& var) {
 
         "bar2.addEventListener('mouseleave', () => {"
         "valueDisplay2.textContent = 'Value: ...';"
-        "bar2.style.backgroundColor = balancing2[index2] ? '#00FFFF' : 'blue';"
+        "bar2.style.backgroundColor = balancing2[index2] ? '#00FFFF' : 'blue';"  // Restore cyan if balancing, else blue
         "cell2.style.removeProperty('background-color');"
         "});"
 
@@ -311,13 +311,13 @@ String cellmonitor_processor(const String& var) {
         "cell2.addEventListener('mouseenter', () => {"
         "let bar2 = document.getElementById(`barIndex2${index2}`);"
         "valueDisplay2.textContent = `Value: ${mV}`;"
-        "bar2.style.backgroundColor = `lightblue`;"
-        "cell2.style.backgroundColor = `blue`;"
+        "bar2.style.backgroundColor = balancing2[index2] ? '#80FFFF' : 'lightblue';"  // Lighter cyan if balancing
+        "cell2.style.backgroundColor = balancing2[index2] ? '#006666' : 'blue';"      // Darker cyan if balancing
         "});"
 
         "cell2.addEventListener('mouseleave', () => {"
         "let bar2 = document.getElementById(`barIndex2${index2}`);"
-        "bar2.style.backgroundColor = `blue`;"
+        "bar2.style.backgroundColor = balancing2[index2] ? '#00FFFF' : 'blue';"  // Restore original color
         "cell2.style.removeProperty('background-color');"
         "});"
 

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -84,7 +84,7 @@ String cellmonitor_processor(const String& var) {
     content +=
         "<span style='color: white; background-color: blue; font-weight: bold; padding: 2px 8px; border-radius: 4px; "
         "margin-right: 15px;'>Idle</span>";
-    
+
     bool battery2_balancing = false;
     for (uint8_t i = 0u; i < datalayer.battery2.info.number_of_cells; i++) {
       battery2_balancing = datalayer.battery2.status.cell_balancing_status[i];

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -50,9 +50,17 @@ String cellmonitor_processor(const String& var) {
     content +=
         "<span style='color: white; background-color: blue; font-weight: bold; padding: 2px 8px; border-radius: 4px; "
         "margin-right: 15px;'>Idle</span>";
-    content +=
-        "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
-        "4px; margin-right: 15px;'>Balancing</span>";
+    bool battery_balancing = false;
+    for (uint8_t i = 0u; i < datalayer.battery.info.number_of_cells; i++) {
+      battery_balancing = datalayer.battery.status.cell_balancing_status[i];
+      if (battery_balancing)
+        break;
+    }
+    if (battery_balancing) {
+      content +=
+          "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
+          "4px; margin-right: 15px;'>Balancing</span>";
+    }
     content +=
         "<span style='color: white; background-color: red; font-weight: bold; padding: 2px 8px; border-radius: "
         "4px;'>Min/Max</span>";
@@ -76,9 +84,18 @@ String cellmonitor_processor(const String& var) {
     content +=
         "<span style='color: white; background-color: blue; font-weight: bold; padding: 2px 8px; border-radius: 4px; "
         "margin-right: 15px;'>Idle</span>";
-    content +=
-        "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
-        "4px; margin-right: 15px;'>Balancing</span>";
+    
+    bool battery2_balancing = false;
+    for (uint8_t i = 0u; i < datalayer.battery2.info.number_of_cells; i++) {
+      battery2_balancing = datalayer.battery2.status.cell_balancing_status[i];
+      if (battery2_balancing)
+        break;
+    }
+    if (battery2_balancing) {
+      content +=
+          "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
+          "4px; margin-right: 15px;'>Balancing</span>";
+    }
     content +=
         "<span style='color: white; background-color: red; font-weight: bold; padding: 2px 8px; border-radius: "
         "4px;'>Min/Max</span>";

--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -46,6 +46,16 @@ String cellmonitor_processor(const String& var) {
     content += "<div id='graph'></div>";
     // Display single hovered value
     content += "<div id='valueDisplay'>Value: ...</div>";
+    //Legend for graph
+    content +=
+        "<span style='color: white; background-color: blue; font-weight: bold; padding: 2px 8px; border-radius: 4px; "
+        "margin-right: 15px;'>Idle</span>";
+    content +=
+        "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
+        "4px; margin-right: 15px;'>Balancing</span>";
+    content +=
+        "<span style='color: white; background-color: red; font-weight: bold; padding: 2px 8px; border-radius: "
+        "4px;'>Min/Max</span>";
 
     // Close the block
     content += "</div>";
@@ -62,6 +72,16 @@ String cellmonitor_processor(const String& var) {
     content += "<div id='graph2'></div>";
     // Display single hovered value
     content += "<div id='valueDisplay2'>Value: ...</div>";
+    //Legend for graph
+    content +=
+        "<span style='color: white; background-color: blue; font-weight: bold; padding: 2px 8px; border-radius: 4px; "
+        "margin-right: 15px;'>Idle</span>";
+    content +=
+        "<span style='color: black; background-color: #00FFFF; font-weight: bold; padding: 2px 8px; border-radius: "
+        "4px; margin-right: 15px;'>Balancing</span>";
+    content +=
+        "<span style='color: white; background-color: red; font-weight: bold; padding: 2px 8px; border-radius: "
+        "4px;'>Min/Max</span>";
 
     // Close the block
     content += "</div>";
@@ -77,6 +97,15 @@ String cellmonitor_processor(const String& var) {
         continue;
       }
       content += String(datalayer.battery.status.cell_voltages_mV[i]) + ",";
+    }
+    content += "];";
+
+    content += "const balancing = [";
+    for (uint8_t i = 0u; i < datalayer.battery.info.number_of_cells; i++) {
+      if (datalayer.battery.status.cell_voltages_mV[i] == 0) {
+        continue;
+      }
+      content += datalayer.battery.status.cell_balancing_status[i] ? "true," : "false,";
     }
     content += "];";
 
@@ -110,15 +139,22 @@ String cellmonitor_processor(const String& var) {
         "bar.id = `barIndex${index}`;"
         "bar.style.height = `${mV_limited}px`;"
         "bar.style.width = `${750/data.length}px`;"
+        "if (balancing[index]) {"
+        "  bar.style.backgroundColor = '#00FFFF';"  // Cyan color for balancing
+        "  bar.style.borderColor = '#00FFFF';"
+        "} else {"
+        "  bar.style.backgroundColor = 'blue';"  // Normal blue for non-balancing
+        "  bar.style.borderColor = 'white';"
+        "}"
 
         "const cell = document.getElementById(`cellIndex${index}`);"
 
         "checkMinMax(cell, bar, index);"
 
         "bar.addEventListener('mouseenter', () => {"
-        "valueDisplay.textContent = `Value: ${mV}`;"
-        "bar.style.backgroundColor = `lightblue`;"
-        "cell.style.backgroundColor = `blue`;"
+        "    valueDisplay.textContent = `Value: ${mV}` + (balancing[index] ? ' (balancing)' : '');"
+        "    bar.style.backgroundColor = balancing[index] ? '#80FFFF' : 'lightblue';"
+        "    cell.style.backgroundColor = balancing[index] ? '#006666' : 'blue';"
         "});"
 
         "bar.addEventListener('mouseleave', () => {"
@@ -140,7 +176,7 @@ String cellmonitor_processor(const String& var) {
         "cell.id = `cellIndex${index}`;"
         "let cellContent = `Cell ${index + 1}<br>${mV} mV`;"
         "if (mV < 3000) {"
-        "cellContent = `<span class='low-voltage'>${cellContent}</span>`;"
+        "  cellContent = `<span class='low-voltage'>${cellContent}</span>`;"
         "}"
         "cell.innerHTML = cellContent;"
 
@@ -153,7 +189,7 @@ String cellmonitor_processor(const String& var) {
 
         "cell.addEventListener('mouseleave', () => {"
         "let bar = document.getElementById(`barIndex${index}`);"
-        "bar.style.backgroundColor = `blue`;"
+        "bar.style.backgroundColor = balancing[index] ? '#00FFFF' : 'blue';"
         "cell.style.removeProperty('background-color');"
         "});"
 
@@ -195,6 +231,15 @@ String cellmonitor_processor(const String& var) {
     }
     content += "];";
 
+    content += "const balancing2 = [";
+    for (uint8_t i = 0u; i < datalayer.battery2.info.number_of_cells; i++) {
+      if (datalayer.battery2.status.cell_voltages_mV[i] == 0) {
+        continue;
+      }
+      content += datalayer.battery2.status.cell_balancing_status[i] ? "true," : "false,";
+    }
+    content += "];";
+
     content += "const min_mv2 = Math.min(...data2) - 20;";
     content += "const max_mv2 = Math.max(...data2) + 20;";
     content += "const min_index2 = data2.indexOf(Math.min(...data2));";
@@ -223,20 +268,26 @@ String cellmonitor_processor(const String& var) {
         "bar2.id = `barIndex2${index2}`;"
         "bar2.style.height = `${mV_limited2}px`;"
         "bar2.style.width = `${750/data2.length}px`;"
-
+        "if (balancing2[index2]) {"
+        "  bar2.style.backgroundColor = '#00FFFF';"  // Cyan color for balancing
+        "  bar2.style.borderColor = '#00FFFF';"
+        "} else {"
+        "  bar2.style.backgroundColor = 'blue';"  // Normal blue for non-balancing
+        "  bar2.style.borderColor = 'white';"
+        "}"
         "const cell2 = document.getElementById(`cellIndex2${index2}`);"
 
         "checkMinMax2(cell2, bar2, index2);"
 
         "bar2.addEventListener('mouseenter', () => {"
-        "valueDisplay2.textContent = `Value: ${mV}`;"
-        "bar2.style.backgroundColor = `lightblue`;"
-        "cell2.style.backgroundColor = `blue`;"
+        "    valueDisplay2.textContent = `Value: ${mV}` + (balancing[index2] ? ' (balancing)' : '');"
+        "    bar2.style.backgroundColor = balancing2[index2] ? '#80FFFF' : 'lightblue';"
+        "    cell2.style.backgroundColor = balancing2[index2] ? '#006666' : 'blue';"
         "});"
 
         "bar2.addEventListener('mouseleave', () => {"
         "valueDisplay2.textContent = 'Value: ...';"
-        "bar2.style.backgroundColor = `blue`;"
+        "bar2.style.backgroundColor = balancing2[index2] ? '#00FFFF' : 'blue';"
         "cell2.style.removeProperty('background-color');"
         "});"
 
@@ -281,7 +332,8 @@ String cellmonitor_processor(const String& var) {
         "const max_mv2 = Math.max(...data2);"
         "const cell_dev2 = max_mv2 - min_mv2;"
         "const voltVal2 = document.getElementById('voltageValues2');"
-        "voltVal2.innerHTML = `Max Voltage : ${max_mv2} mV<br>Min Voltage: ${min_mv2} mV<br>Voltage Deviation: "
+        "voltVal2.innerHTML = `Battery #2<br>Max Voltage : ${max_mv2} mV<br>Min Voltage: ${min_mv2} mV<br>Voltage "
+        "Deviation: "
         "${cell_dev2} mV`"
         "}";
 


### PR DESCRIPTION
### What
This PR implements balancing status, initially for Nissan LEAF and ZoeGen2 batteries, and also sets the foundation on how to implement the same on other battery types

### Why
To be able to see that battery is balancing properly long term

### How
LEAF: We now read Group6 from the Nissan LEAF BMS, which contain the balancing resistor status (aka shunt status). We map this to the datalayer, into the newly created cell_balancing_status[]

The cellmonitor view now also shows the balancing status in the graph view:

![image](https://github.com/user-attachments/assets/66831698-57ba-427c-b4c7-d53cc2501e98)

