### PR TITLE
Update PYLON-CAN.h to allow high capacity >255Ah

### DIFF
--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -52,14 +52,14 @@ class PylonInverter : public CanInverterProtocol {
                           .ID = 0x7320,
                           .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   (uint8_t) (AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t)(AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_7321 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,
                           .ID = 0x7321,
                           .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   (uint8_t) (AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t)(AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_4210 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -52,14 +52,14 @@ class PylonInverter : public CanInverterProtocol {
                           .ID = 0x7320,
                           .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t) (AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_7321 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,
                           .ID = 0x7321,
                           .data = {TOTAL_CELL_AMOUNT, (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t) (AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_4210 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,


### PR DESCRIPTION

What

This PR fixes a bug that prevents a config for a high capacity battery to compile
Why

As the low-byte of the 732x Pylon frame isn't correctly cast from int -> uint8_t, the compiler won't accept values > 255.
How

Correct masking and casting of low-byte of the AH_Capacity fixes the issues.
Implemented twice for the frame 7320 and 7321

