### PR TITLE
Bugfix - Update Ferroamp-Can.h to allow large capacity > 255Ah

### DIFF
--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -51,14 +51,14 @@ Change the following only if your inverter is generating fault codes about volta
                           .ID = 0x7320,
                           .data = {(TOTAL_CELL_AMOUNT & 0xFF), (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t)(AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_7321 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,
                           .ID = 0x7321,
                           .data = {(TOTAL_CELL_AMOUNT & 0xFF), (uint8_t)(TOTAL_CELL_AMOUNT >> 8), MODULES_IN_SERIES,
                                    CELLS_PER_MODULE, (uint8_t)(VOLTAGE_LEVEL & 0x00FF), (uint8_t)(VOLTAGE_LEVEL >> 8),
-                                   AH_CAPACITY, (uint8_t)(AH_CAPACITY >> 8)}};
+                                   (uint8_t)(AH_CAPACITY & 0x00FF), (uint8_t)(AH_CAPACITY >> 8)}};
   CAN_frame PYLON_4210 = {.FD = false,
                           .ext_ID = true,
                           .DLC = 8,


### PR DESCRIPTION
### What
This PR implements same change as for Pylon-Can HV

### Why
As both implementations share the same code-base, it's better to align them and fix both implementations

### How
Copy the same code for Frame 7320/7321
