### PR TITLE
Fix Ferroamp/Pylon CAN send conflict

### DIFF
--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -3,6 +3,12 @@
 #include "../datalayer/datalayer.h"
 #include "../include.h"
 
+//#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
+#define SEND_1                 //If defined, the messages will have ID ending with 1 (useful for some inverters)
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
+                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
+#define SET_30K_OFFSET         //If defined, current values are sent with a 30k offest (useful for ferroamp)
+
 void FerroampCanInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   //There are more mappings that could be added, but this should be enough to use as a starting point

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -20,12 +20,6 @@ class FerroampCanInverter : public CanInverterProtocol {
   void send_system_data();
   void send_setup_info();
 
-//#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
-#define SEND_1                 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
-                               //useful for some inverters like Sofar that report the voltages incorrect otherwise
-#define SET_30K_OFFSET         //If defined, current values are sent with a 30k offest (useful for ferroamp)
-
   /* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
 Change the following only if your inverter is generating fault codes about voltage range */
   static const int TOTAL_CELL_AMOUNT = 120;  //Adjust this parameter in steps of 120 to add another 14,2kWh of capacity

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -3,6 +3,12 @@
 #include "../datalayer/datalayer.h"
 #include "../include.h"
 
+#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
+//#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
+#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
+                                    //useful for some inverters like Sofar that report the voltages incorrect otherwise
+//#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
+
 void PylonInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -20,12 +20,6 @@ class PylonInverter : public CanInverterProtocol {
   void send_system_data();
   void send_setup_info();
 
-#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
-//#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
-#define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
-                                    //useful for some inverters like Sofar that report the voltages incorrect otherwise
-  //#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
-
   /* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
      Change the following only if your inverter is generating fault codes about voltage range */
   static const int TOTAL_CELL_AMOUNT = 120;


### PR DESCRIPTION
### What and why
This PR fixes the bug of Ferroamp/Pylon inverter codes sending both 0 and 1 -ending messages incorrectly.

### How
Preprocessor defines are moved back to cpp file where they can't conflict with other inverters and only have effect on a single inverter.
