### PR TITLE
fix RS485Battery::transmit_rs485 not being defined/used correctly

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -73,8 +73,8 @@ void handle_incoming_can_frame_battery2(CAN_frame rx_frame) {
 #endif
 
 #ifdef RS485_BATTERY_SELECTED
-void transmit_rs485() {
-  ((RS485Battery*)battery)->transmit_rs485();
+void transmit_rs485(unsigned long currentMillis) {
+  ((RS485Battery*)battery)->transmit_rs485(currentMillis);
 }
 
 void receive_RS485() {

--- a/Software/src/battery/RS485Battery.h
+++ b/Software/src/battery/RS485Battery.h
@@ -9,7 +9,7 @@
 class RS485Battery : public Battery {
  public:
   virtual void receive_RS485() = 0;
-  virtual void transmit_rs485() = 0;
+  virtual void transmit_rs485(unsigned long currentMillis) = 0;
 };
 
 #endif


### PR DESCRIPTION
### What
This PR fixes compiling with battery set to PYLON LV

### Why
The [call to `transmit_rs485` here](https://github.com/dalathegreat/Battery-Emulator/blob/main/Software/Software.ino#L276), supplies a parameter, however [the callee](https://github.com/dalathegreat/Battery-Emulator/blob/main/Software/src/battery/BATTERIES.cpp#L76) is currently defined without the parameter, leading to compilation errors.

### How
Add the missing parameter.
