### PR TITLE
Bugfix: Add Daly to build system

### DIFF
--- a/.github/workflows/compile-all-batteries.yml
+++ b/.github/workflows/compile-all-batteries.yml
@@ -56,6 +56,7 @@ jobs:
           - CELLPOWER_BMS
           - CHADEMO_BATTERY
           - CMFA_EV_BATTERY
+          - DALY_BMS
           - FOXESS_BATTERY
           - IMIEV_CZERO_ION_BATTERY
           - JAGUAR_IPACE_BATTERY


### PR DESCRIPTION
### What
This PR adds the Daly BMS to the build system

### Why
To avoid anyone breaking it during other code maintenance, like previously noticed in #1201

### How
We add it to the Github workflow
