### PR TITLE
Add feature to changing SOC method in UI on BYD Atto3

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -151,21 +151,22 @@ void BydAttoBattery::
     datalayer_battery->status.voltage_dV = BMS_voltage * 10;
   }
 
-#ifdef USE_ESTIMATED_SOC
-  // When the battery is crashed hard, it locks itself and SOC becomes unavailable.
-  // We instead estimate the SOC% based on the battery voltage.
-  // This is a bad solution, you wont be able to use 100% of the battery
-  if (battery_type == EXTENDED_RANGE) {
-    datalayer_battery->status.real_soc = estimateSOCextended(datalayer_battery->status.voltage_dV);
+  if (SOC_method == MEASURED) {
+    // Pack is not crashed, we can use periodically transmitted SOC
+    datalayer_battery->status.real_soc = battery_highprecision_SOC * 10;
   }
-  if (battery_type == STANDARD_RANGE) {
-    datalayer_battery->status.real_soc = estimateSOCstandard(datalayer_battery->status.voltage_dV);
+  else
+  {
+    // When the battery is crashed hard, it locks itself and SOC becomes unavailable.
+    // We instead estimate the SOC% based on the battery voltage.
+    // This is a bad solution, you wont be able to use 100% of the battery
+    if (battery_type == EXTENDED_RANGE) {
+      datalayer_battery->status.real_soc = estimateSOCextended(datalayer_battery->status.voltage_dV);
+    }
+    if (battery_type == STANDARD_RANGE) {
+      datalayer_battery->status.real_soc = estimateSOCstandard(datalayer_battery->status.voltage_dV);
+    }
   }
-  SOC_method = ESTIMATED;
-#else  // Pack is not crashed, we can use periodically transmitted SOC
-  datalayer_battery->status.real_soc = battery_highprecision_SOC * 10;
-  SOC_method = MEASURED;
-#endif
 
   datalayer_battery->status.current_dA = -BMS_current;
 
@@ -291,6 +292,12 @@ void BydAttoBattery::
     if (datalayer_bydatto->UserRequestCrashReset && stateMachineClearCrash == NOT_RUNNING) {
       stateMachineClearCrash = STARTED;
       datalayer_bydatto->UserRequestCrashReset = false;
+    }
+
+    // Change SOC method if requested from webserver datalayer
+    if (datalayer_bydatto->ChangeSOCMethod) {
+      SOC_method = !SOC_method;  // Toggle the SOC method
+      datalayer_bydatto->ChangeSOCMethod = false;
     }
   }
 }
@@ -691,6 +698,11 @@ void BydAttoBattery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  #ifdef USE_ESTIMATED_SOC // Initial setup for selected SOC method
+    SOC_method = ESTIMATED;
+  #else
+    SOC_method = MEASURED;
+  #endif
 }
 
 #endif

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -57,6 +57,13 @@ class BydAttoBattery : public CanBattery {
 
   void reset_crash() { datalayer_bydatto->UserRequestCrashReset = true; }
 
+  #ifndef USE_ESTIMATED_SOC
+    // Changing SOC method in UI is only enabled if we initially use measured SOC
+    bool supports_change_SOC_method() { return true; }
+  #endif
+
+  void change_SOC_method() { datalayer_bydatto->ChangeSOCMethod = true; }
+
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
  private:
@@ -81,6 +88,7 @@ class BydAttoBattery : public CanBattery {
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was send
   bool SOC_method = false;
+  bool ChangeSOCMethod = false;
   uint8_t counter_50ms = 0;
   uint8_t counter_100ms = 0;
   uint8_t frame6_counter = 0xB;

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -29,6 +29,7 @@ class Battery {
   virtual bool supports_set_fake_voltage() { return false; }
   virtual bool supports_manual_balancing() { return false; }
   virtual bool supports_real_BMS_status() { return false; }
+  virtual bool supports_change_SOC_method() { return false; }
 
   virtual void clear_isolation() {}
   virtual void reset_BMS() {}
@@ -40,6 +41,7 @@ class Battery {
   virtual void reset_BECM() {}
   virtual void request_open_contactors() {}
   virtual void request_close_contactors() {}
+  virtual void change_SOC_method() {}
 
   virtual void set_fake_voltage(float v) {}
   virtual float get_voltage() { static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0; }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -171,6 +171,9 @@ typedef struct {
   /** User requesting crash reset via WebUI*/
   bool UserRequestCrashReset = false;
   /** bool */
+  /** User changing SOC method via WebUI*/
+  bool ChangeSOCMethod = false;
+  /** bool */
   /** Which SOC method currently used. 0 = Estimated, 1 = Measured */
   bool SOC_method = 0;
   /** uint16_t */

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -56,6 +56,12 @@ std::vector<BatteryCommand> battery_commands = {
      [](Battery* b) {
        b->reset_SOH();
      }},
+    {"changeSOC", "Change SOC method",
+     "change SOC method? This will toggle between ESTIMATED and MEASURED SOC methods.",
+     [](Battery* b) { return b && b->supports_change_SOC_method(); },
+     [](Battery* b) {
+       b->change_SOC_method();
+     }},
 };
 
 String advanced_battery_processor(const String& var) {


### PR DESCRIPTION
### What
Makes it possible to change between measured and estimated SOC on BYD Atto3 batteries.

### Why
To easier switch between the modes if the SOC drifts and the battery needs deeper discharge.

### How
Adding a button on the more info page and dynamically switch between the modes.