### PR TITLE
SMA: Add event for pairing event to aid troubleshooting

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -101,6 +101,7 @@ void init_events(void) {
   events.entries[EVENT_SERIAL_RX_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_SERIAL_TX_FAILURE].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_SERIAL_TRANSMITTER_FAILURE].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_SMA_PAIRING].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_RESET_UNKNOWN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_RESET_POWERON].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_RESET_EXT].level = EVENT_LEVEL_INFO;
@@ -305,6 +306,8 @@ const char* get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Error in serial function: No ACK from receiver!";
     case EVENT_SERIAL_TRANSMITTER_FAILURE:
       return "Error in serial function: Some ERROR level fault in transmitter, received by receiver";
+    case EVENT_SMA_PAIRING:
+      return "SMA inverter trying to pair, contactors will close and open according to Enable line";
     case EVENT_OTA_UPDATE:
       return "OTA update started!";
     case EVENT_OTA_UPDATE_TIMEOUT:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -74,6 +74,7 @@
   XX(EVENT_SERIAL_RX_FAILURE)                  \
   XX(EVENT_SERIAL_TX_FAILURE)                  \
   XX(EVENT_SERIAL_TRANSMITTER_FAILURE)         \
+  XX(EVENT_SMA_PAIRING)                        \
   XX(EVENT_TASK_OVERRUN)                       \
   XX(EVENT_RESET_UNKNOWN)                      \
   XX(EVENT_RESET_POWERON)                      \

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -216,6 +216,8 @@ void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 #ifdef DEBUG_LOG
       logging.println("Received 0x5E7: SMA pairing request");
 #endif  // DEBUG_LOG
+      pairing_events++;
+      set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can_init();
       break;

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -24,6 +24,7 @@ class SmaBydHInverter : public CanInverterProtocol {
 
   unsigned long previousMillis100ms = 0;
 
+  uint8_t pairing_events = 0;
   uint32_t inverter_time = 0;
   uint16_t inverter_voltage = 0;
   int16_t inverter_current = 0;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -206,6 +206,8 @@ void SmaBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 #ifdef DEBUG_LOG
       logging.println("Received 0x5E7: SMA pairing request");
 #endif  // DEBUG_LOG
+      pairing_events++;
+      set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can_init = true;
       break;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -28,6 +28,7 @@ class SmaBydHvsInverter : public CanInverterProtocol {
       7;  //TODO, tweak to as low as possible before performance issues/crashes appear
   bool transmit_can_init = false;
 
+  uint8_t pairing_events = 0;
   uint32_t inverter_time = 0;
   uint16_t inverter_voltage = 0;
   int16_t inverter_current = 0;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.cpp
@@ -100,6 +100,11 @@ void SmaTripowerInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       //Inverter brand (frame1-3 = 0x53 0x4D 0x41) = SMA
       break;
     case 0x660:  //Message originating from SMA inverter - Pairing request
+#ifdef DEBUG_LOG
+      logging.println("Received 0x660: SMA pairing request");
+#endif  // DEBUG_LOG
+      pairing_events++;
+      set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       transmit_can_init();
       break;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -42,6 +42,7 @@ class SmaTripowerInverter : public CanInverterProtocol {
   uint32_t inverter_time = 0;
   uint16_t inverter_voltage = 0;
   int16_t inverter_current = 0;
+  uint8_t pairing_events = 0;
   bool pairing_completed = false;
   int16_t temperature_average = 0;
   uint16_t ampere_hours_remaining = 0;


### PR DESCRIPTION
### What
This PR adds an info event when SMA pairing attempts are made 

### Why
For easier troubleshooting of SMA installs

### How
We now fire an Info event, every time the SMA inverter tries to initiate a pairing event. We send this text to let the user know that now it will be up to the Enable line sensing if this will succeed or not:

"SMA inverter trying to pair, contactors will close and open according to Enable line"
