### PR TITLE
Bugfix: Make Kia/Hyundai 90S celldetection more reliable

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -114,8 +114,9 @@ void KiaHyundai64Battery::
 void KiaHyundai64Battery::update_number_of_cells() {
   //If we have cell values and number_of_cells not initialized yet
   if (cellvoltages_mv[0] > 0 && datalayer_battery->info.number_of_cells == 0) {
-    // Check if we have 98S or 90S battery
-    if (datalayer_battery->status.cell_voltages_mV[97] > 0) {
+    // Check if we have 98S or 90S battery. If the 98th cell is valid range, we are on a 98S battery
+    if ((datalayer_battery->status.cell_voltages_mV[97] > 2000) &&
+        (datalayer_battery->status.cell_voltages_mV[97] < 4300)) {
       datalayer_battery->info.number_of_cells = 98;
       datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_98S_DV;
       datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_98S_DV;


### PR DESCRIPTION
### What
This PR makes the determination between 90S and 98S Kia/Hyundai batteries more robust

### Why
One user on the Discord had this happen to them:

![image](https://github.com/user-attachments/assets/5acb6e1d-c372-4382-9886-8e656ef45c8a)

90S battery incorrectly setup as 98S

### How
We now check if the cell98 is between 2000-4300mV, and if it is, we are on a 98S battery. Otherwise 90S.
