### PR TITLE
Bugfix: Zoe PH2, Make NVROL reset survive WDT trigger

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -167,7 +167,8 @@ class RenaultZoeGen2Battery : public CanBattery {
   static const int POLL_CELL_93 = 0x9081;
   static const int POLL_CELL_94 = 0x9082;
   static const int POLL_CELL_95 = 0x9083;
-
+  volatile unsigned long startTimeNVROL = 0;
+  uint8_t NVROLstateMachine = 0;
   uint16_t battery_soc = 0;
   uint16_t battery_usable_soc = 5000;
   uint16_t battery_soh = 10000;

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -34,6 +34,7 @@ enum PrechargeState {
 #define INTERVAL_2_S 2000
 #define INTERVAL_5_S 5000
 #define INTERVAL_10_S 10000
+#define INTERVAL_30_S 30000
 #define INTERVAL_60_S 60000
 
 #define INTERVAL_10_MS_DELAYED 15


### PR DESCRIPTION
### What
This PR makes the NVROL reset usable on the Zoe PH2. Running it would cause a watchdog reset

### Why
Fixes #1235 

### How
How does it do it? Instead of using wait_ms, we use a state machine.

![image](https://github.com/user-attachments/assets/fc95698a-ca33-4d38-a1b5-104cb5c23b1f)
