### PR TITLE
Chademo: Improve startup to throw less events

### DIFF
--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -204,7 +204,7 @@ void ChademoBattery::process_vehicle_charging_session(CAN_frame rx_frame) {
   }
 
 #ifdef DEBUG_LOG
-  logging.println("UNHANDLED STATE IN process_vehicle_charging_session()");
+  logging.println("UNHANDLED CHADEMO STATE, try unplugging chademo cable, reboot emulator, and retry!");
 #endif
   return;
 }

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -21,7 +21,9 @@ void ChademoBattery::update_values() {
   datalayer.battery.status.max_discharge_power_W =
       (x200_discharge_limits.MaximumDischargeCurrent * x100_chg_lim.MaximumBatteryVoltage);  //In Watts, Convert A to P
 
-  datalayer.battery.status.voltage_dV = get_measured_voltage() * 10;
+  if (vehicle_can_received) {  // Only update the value sent towards inverter if vehicle is connected (avoids false positive events)
+    datalayer.battery.status.voltage_dV = get_measured_voltage() * 10;
+  }
 
   datalayer.battery.info.total_capacity_Wh = (x101_chg_est.RatedBatteryCapacity * 100);
   //(Added in CHAdeMO v1.0.1), maybe handle hardcoded on lower protocol version?

--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -231,6 +231,10 @@ void ChademoBattery::process_vehicle_charging_limits(CAN_frame rx_frame) {
   if (get_measured_voltage() <= x200_discharge_limits.MinimumDischargeVoltage && CHADEMO_Status > CHADEMO_NEGOTIATE) {
 #ifdef DEBUG_LOG
     logging.println("x200 minimum discharge voltage met or exceeded, stopping.");
+    logging.print("Measured: ");
+    logging.print(get_measured_voltage());
+    logging.print("Minimum voltage: ");
+    logging.print(x200_discharge_limits.MinimumDischargeVoltage);
 #endif
     CHADEMO_Status = CHADEMO_STOP;
   }

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -180,7 +180,7 @@ uint8_t CHADEMO_seq = 0x0;
   //H200 - Vehicle - Discharge limits
   struct x200_Vehicle_Discharge_Limits {
     uint8_t MaximumDischargeCurrent = 0xFF;
-    uint16_t MinimumDischargeVoltage = 0;
+    uint16_t MinimumDischargeVoltage = 260;  //Initialized to a semi-sane value, updates via CAN later
     uint16_t MinimumBatteryDischargeLevel = 0;
     uint16_t MaxRemainingCapacityForCharging = 0;
   };

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -127,7 +127,7 @@ uint8_t CHADEMO_seq = 0x0;
       } status;
     } s;
 
-    uint8_t StateOfCharge = 0;  //6 state of charge?
+    uint8_t StateOfCharge = 50;  //6 state of charge?
   };
 
   /* ---------- CHARGING: EVSE Data structures */


### PR DESCRIPTION
### What
This PR improves the Chademo start, to generate less false-positive events

### Why
Fixes #1239 

### How
We only update voltage after car has started communicating. We also init SOC% to 50%, as on other integrations to avoid fake battery empty messages
