### PR TITLE
Improvement: Make webserver more compact

### DIFF
--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -84,6 +84,7 @@ String advanced_battery_processor(const String& var) {
         "button { background-color: #505E67; color: white; border: none; padding: 10px 20px; margin-bottom: 20px; "
         "cursor: pointer; border-radius: 10px; }";
     content += "button:hover { background-color: #3A4A52; }";
+    content += "h4 { margin: 0.6em 0; line-height: 1.2; }";
     content += "</style>";
     content += "<button onclick='goToMainPage()'>Back to main page</button>";
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -14,6 +14,7 @@ String settings_processor(const String& var) {
         "button { background-color: #505E67; color: white; border: none; padding: 10px 20px; margin-bottom: 20px; "
         "cursor: pointer; border-radius: 10px; }";
     content += "button:hover { background-color: #3A4A52; }";
+    content += "h4 { margin: 0.6em 0; line-height: 1.2; }";
     content += "</style>";
 
     content += "<button onclick='goToMainPage()'>Back to main page</button>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -883,20 +883,21 @@ String get_firmware_info_processor(const String& var) {
 String processor(const String& var) {
   if (var == "X") {
     String content = "";
-    content += "<h2>" + String(ssidAP) + "</h2>";  // ssidAP name is used as header name
-    //Page format
     content += "<style>";
     content += "body { background-color: black; color: white; }";
     content +=
         "button { background-color: #505E67; color: white; border: none; padding: 10px 20px; margin-bottom: 20px; "
         "cursor: pointer; border-radius: 10px; }";
     content += "button:hover { background-color: #3A4A52; }";
+    content += "h2 { font-size: 1.2em; margin: 0.3em 0 0.5em 0; }";
+    content += "h4 { margin: 0.6em 0; line-height: 1.2; }";
     content += "</style>";
 
-    // Start a new block with a specific background color
-    content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+    // Compact header
+    content += "<h2>" + String(ssidAP) + "</h2>";
 
-    // Show version number
+    // Start content block
+    content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
     content += "<h4>Software: " + String(version_number);
 // Show hardware used:
 #ifdef HW_LILYGO
@@ -1442,14 +1443,14 @@ String processor(const String& var) {
       content += "<button onclick='logout()'>Logout</button>";
     if (!datalayer.system.settings.equipment_stop_active)
       content +=
-          "<br/><br/><button style=\"background:red;color:white;cursor:pointer;\""
+          "<br/><button style=\"background:red;color:white;cursor:pointer;\""
           " onclick=\""
           "if(confirm('This action will attempt to open contactors on the battery. Are you "
           "sure?')) { estop(true); }\""
           ">Open Contactors</button><br/>";
     else
       content +=
-          "<br/><br/><button style=\"background:green;color:white;cursor:pointer;\""
+          "<br/><button style=\"background:green;color:white;cursor:pointer;\""
           "20px;font-size:16px;font-weight:bold;cursor:pointer;border-radius:5px; margin:10px;"
           " onclick=\""
           "if(confirm('This action will attempt to close contactors and enable power transfer. Are you sure?')) { "


### PR DESCRIPTION
### What
This PR makes the UI fit to a single screen without scrolling.

### Why
User requested idea, fixes #1204

### How

1. We modify existing h4 styling to have smaller margins
2. We also make the h2 header showing the access point name (typically Battery-Emulator), also have a smaller size
3. We remove a line break for the contactor opening button to make the page smaller
4. We also apply the same to More Battery Info and Settings page

![image](https://github.com/user-attachments/assets/d179cf70-8967-4ac9-8bfc-ccef407b237a)

