### PR TITLE
Feature: BYD Atto 3 mapping unknown polls to support charged/discharged energy

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -22,8 +22,8 @@ After battery has been unlocked, you can remove the "USE_ESTIMATED_SOC" from the
 #define UNKNOWN_POLL_0 0x1FFE  //0x64 19 C4 3B
 #define UNKNOWN_POLL_1 0x1FFC  //0x72 1F C4 3B
 #define POLL_MAX_CHARGE_POWER 0x000A
-#define UNKNOWN_POLL_3 0x000B   //0x00B1 (177 interesting!)
-#define UNKNOWN_POLL_4 0x000E   //0x0B27 (2855 interesting!)
+#define UNKNOWN_POLL_3 0x000B  //0x00B1 (177 interesting!)
+#define UNKNOWN_POLL_4 0x000E  //0x0B27 (2855 interesting!)
 #define POLL_TOTAL_CHARGED_AH 0x000F
 #define POLL_TOTAL_DISCHARGED_AH 0x0010
 #define POLL_TOTAL_CHARGED_KWH 0x0011

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -24,10 +24,10 @@ After battery has been unlocked, you can remove the "USE_ESTIMATED_SOC" from the
 #define POLL_MAX_CHARGE_POWER 0x000A
 #define UNKNOWN_POLL_3 0x000B   //0x00B1 (177 interesting!)
 #define UNKNOWN_POLL_4 0x000E   //0x0B27 (2855 interesting!)
-#define UNKNOWN_POLL_5 0x000F   //0x00237B (9083 interesting!)
-#define UNKNOWN_POLL_6 0x0010   //0x00231B (8987 interesting!)
-#define UNKNOWN_POLL_7 0x0011   //0x0E4E (3662 interesting!)
-#define UNKNOWN_POLL_8 0x0012   //0x0E27 (3623 interesting)
+#define POLL_TOTAL_CHARGED_AH 0x000F
+#define POLL_TOTAL_DISCHARGED_AH 0x0010
+#define POLL_TOTAL_CHARGED_KWH 0x0011
+#define POLL_TOTAL_DISCHARGED_KWH 0x0012
 #define UNKNOWN_POLL_9 0x0004   //0x0034 (52 interesting!)
 #define UNKNOWN_POLL_10 0x002A  //0x5B
 #define UNKNOWN_POLL_11 0x002E  //0x08 (probably module number, or cell number?)
@@ -181,6 +181,9 @@ void BydAttoBattery::
 
   datalayer_battery->status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;
 
+  datalayer_battery->status.total_discharged_battery_Wh = BMS_total_discharged_kwh * 1000;
+  datalayer_battery->status.total_charged_battery_Wh = BMS_total_charged_kwh * 1000;
+
   //Map all cell voltages to the global array
   memcpy(datalayer_battery->status.cell_voltages_mV, battery_cellvoltages, CELLCOUNT_EXTENDED * sizeof(uint16_t));
 
@@ -277,10 +280,10 @@ void BydAttoBattery::
     datalayer_bydatto->chargePower = BMS_allowed_charge_power;
     datalayer_bydatto->unknown3 = BMS_unknown3;
     datalayer_bydatto->unknown4 = BMS_unknown4;
-    datalayer_bydatto->unknown5 = BMS_unknown5;
-    datalayer_bydatto->unknown6 = BMS_unknown6;
-    datalayer_bydatto->unknown7 = BMS_unknown7;
-    datalayer_bydatto->unknown8 = BMS_unknown8;
+    datalayer_bydatto->total_charged_ah = BMS_total_charged_ah;
+    datalayer_bydatto->total_discharged_ah = BMS_total_discharged_ah;
+    datalayer_bydatto->total_charged_kwh = BMS_total_charged_kwh;
+    datalayer_bydatto->total_discharged_kwh = BMS_total_discharged_kwh;
     datalayer_bydatto->unknown9 = BMS_unknown9;
     datalayer_bydatto->unknown10 = BMS_unknown10;
     datalayer_bydatto->unknown11 = BMS_unknown11;
@@ -443,17 +446,17 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case UNKNOWN_POLL_4:
           BMS_unknown4 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case UNKNOWN_POLL_5:
-          BMS_unknown5 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+        case POLL_TOTAL_CHARGED_AH:
+          BMS_total_charged_ah = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case UNKNOWN_POLL_6:
-          BMS_unknown6 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+        case POLL_TOTAL_DISCHARGED_AH:
+          BMS_total_discharged_ah = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case UNKNOWN_POLL_7:
-          BMS_unknown7 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+        case POLL_TOTAL_CHARGED_KWH:
+          BMS_total_charged_kwh = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case UNKNOWN_POLL_8:
-          BMS_unknown8 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+        case POLL_TOTAL_DISCHARGED_KWH:
+          BMS_total_discharged_kwh = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
         case UNKNOWN_POLL_9:
           BMS_unknown9 = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
@@ -623,26 +626,26 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case UNKNOWN_POLL_4:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((UNKNOWN_POLL_4 & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(UNKNOWN_POLL_4 & 0x00FF);
-        poll_state = UNKNOWN_POLL_5;
+        poll_state = POLL_TOTAL_CHARGED_AH;
         break;
-      case UNKNOWN_POLL_5:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((UNKNOWN_POLL_5 & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(UNKNOWN_POLL_5 & 0x00FF);
-        poll_state = UNKNOWN_POLL_6;
+      case POLL_TOTAL_CHARGED_AH:
+        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TOTAL_CHARGED_AH & 0xFF00) >> 8);
+        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TOTAL_CHARGED_AH & 0x00FF);
+        poll_state = POLL_TOTAL_DISCHARGED_AH;
         break;
-      case UNKNOWN_POLL_6:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((UNKNOWN_POLL_6 & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(UNKNOWN_POLL_6 & 0x00FF);
-        poll_state = UNKNOWN_POLL_7;
+      case POLL_TOTAL_DISCHARGED_AH:
+        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TOTAL_DISCHARGED_AH & 0xFF00) >> 8);
+        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TOTAL_DISCHARGED_AH & 0x00FF);
+        poll_state = POLL_TOTAL_CHARGED_KWH;
         break;
-      case UNKNOWN_POLL_7:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((UNKNOWN_POLL_7 & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(UNKNOWN_POLL_7 & 0x00FF);
-        poll_state = UNKNOWN_POLL_8;
+      case POLL_TOTAL_CHARGED_KWH:
+        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TOTAL_CHARGED_KWH & 0xFF00) >> 8);
+        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TOTAL_CHARGED_KWH & 0x00FF);
+        poll_state = POLL_TOTAL_DISCHARGED_KWH;
         break;
-      case UNKNOWN_POLL_8:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((UNKNOWN_POLL_8 & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(UNKNOWN_POLL_8 & 0x00FF);
+      case POLL_TOTAL_DISCHARGED_KWH:
+        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TOTAL_DISCHARGED_KWH & 0xFF00) >> 8);
+        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TOTAL_DISCHARGED_KWH & 0x00FF);
         poll_state = UNKNOWN_POLL_9;
         break;
       case UNKNOWN_POLL_9:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -53,6 +53,7 @@ class BydAttoBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
+  bool supports_charged_energy() { return true; }
   bool supports_reset_crash() { return true; }
 
   void reset_crash() { datalayer_bydatto->UserRequestCrashReset = true; }
@@ -114,10 +115,10 @@ class BydAttoBattery : public CanBattery {
   uint16_t BMS_allowed_charge_power = 0;
   uint16_t BMS_unknown3 = 0;
   uint16_t BMS_unknown4 = 0;
-  uint16_t BMS_unknown5 = 0;
-  uint16_t BMS_unknown6 = 0;
-  uint16_t BMS_unknown7 = 0;
-  uint16_t BMS_unknown8 = 0;
+  uint16_t BMS_total_charged_ah = 0;
+  uint16_t BMS_total_discharged_ah = 0;
+  uint16_t BMS_total_charged_kwh = 0;
+  uint16_t BMS_total_discharged_kwh = 0;
   uint16_t BMS_unknown9 = 0;
   uint8_t BMS_unknown10 = 0;
   uint8_t BMS_unknown11 = 0;

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -34,10 +34,10 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Charge power raw: " + String(byd_datalayer->chargePower) + "</h4>";
     content += "<h4>Unknown3: " + String(byd_datalayer->unknown3) + "</h4>";
     content += "<h4>Unknown4: " + String(byd_datalayer->unknown4) + "</h4>";
-    content += "<h4>Unknown5: " + String(byd_datalayer->unknown5) + "</h4>";
-    content += "<h4>Unknown6: " + String(byd_datalayer->unknown6) + "</h4>";
-    content += "<h4>Unknown7: " + String(byd_datalayer->unknown7) + "</h4>";
-    content += "<h4>Unknown8: " + String(byd_datalayer->unknown8) + "</h4>";
+    content += "<h4>Total charged Ah: " + String(byd_datalayer->total_charged_ah) + "</h4>";
+    content += "<h4>Total discharged Ah: " + String(byd_datalayer->total_discharged_ah) + "</h4>";
+    content += "<h4>Total charged kWh: " + String(byd_datalayer->total_charged_kwh) + "</h4>";
+    content += "<h4>Total discharged kWh: " + String(byd_datalayer->total_discharged_kwh) + "</h4>";
     content += "<h4>Unknown9: " + String(byd_datalayer->unknown9) + "</h4>";
     content += "<h4>Unknown10: " + String(byd_datalayer->unknown10) + "</h4>";
     content += "<h4>Unknown11: " + String(byd_datalayer->unknown11) + "</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -197,10 +197,10 @@ typedef struct {
   uint16_t chargePower = 0;
   uint16_t unknown3 = 0;
   uint16_t unknown4 = 0;
-  uint16_t unknown5 = 0;
-  uint16_t unknown6 = 0;
-  uint16_t unknown7 = 0;
-  uint16_t unknown8 = 0;
+  uint16_t total_charged_ah = 0;
+  uint16_t total_discharged_ah = 0;
+  uint16_t total_charged_kwh = 0;
+  uint16_t total_discharged_kwh = 0;
   uint16_t unknown9 = 0;
   uint8_t unknown10 = 0;
   uint8_t unknown11 = 0;


### PR DESCRIPTION
### What
This one maps some of the previous unknown polls to total charged and discharged kWh and Ah.

### Why
To see how many cycles your battery has done.

### How
Maps the unknown polls and also enables the feature to have it published to MQTT.