### PR TITLE
Fix Volvo Spa more battery info page

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -25,7 +25,11 @@ class VolvoSpaBattery : public CanBattery {
   bool supports_reset_BECM() { return true; }
   void reset_BECM() { datalayer_extended.VolvoPolestar.UserRequestBECMecuReset = true; }
 
+  BatteryHtmlRenderer& get_status_renderer() { return renderer; }
+
  private:
+  VolvoSpaHtmlRenderer renderer;
+
   void readCellVoltages();
 
   static const int MAX_PACK_VOLTAGE_108S_DV = 4540;


### PR DESCRIPTION
### What
This fixes bug #1266.

### How
The battery class for Volvo Spa had a method missing to return the HTML renderer for battery specific page.
