### PR TITLE
Use const to eliminate compiler warnings

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -38,7 +38,7 @@ class BmwI3Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "BMW i3";
+  static constexpr const char* Name = "BMW i3";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -22,7 +22,7 @@ class BmwIXBattery : public CanBattery {
   void request_open_contactors() { datalayer_extended.bmwix.UserRequestContactorOpen = true; }
   void request_close_contactors() { datalayer_extended.bmwix.UserRequestContactorClose = true; }
 
-  static constexpr char* Name = "BMW iX and i4-7 platform";
+  static constexpr const char* Name = "BMW iX and i4-7 platform";
 
  private:
   BmwIXHtmlRenderer renderer;

--- a/Software/src/battery/BMW-SBOX.h
+++ b/Software/src/battery/BMW-SBOX.h
@@ -13,7 +13,7 @@ class BmwSbox : public CanShunt {
   void setup();
   void transmit_can(unsigned long currentMillis);
   void handle_incoming_can_frame(CAN_frame rx_frame);
-  static constexpr char* Name = "BMW SBOX";
+  static constexpr const char* Name = "BMW SBOX";
 
  private:
   /** Minimum input voltage required to enable relay control **/

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -17,7 +17,7 @@ class BoltAmperaBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
-  static constexpr char* Name = "Chevrolet Bolt EV/Opel Ampera-e";
+  static constexpr const char* Name = "Chevrolet Bolt EV/Opel Ampera-e";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -44,7 +44,7 @@ class BydAttoBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
-  static constexpr char* Name = "BYD Atto 3";
+  static constexpr const char* Name = "BYD Atto 3";
 
   bool supports_charged_energy() { return true; }
   bool supports_reset_crash() { return true; }

--- a/Software/src/battery/CELLPOWER-BMS.h
+++ b/Software/src/battery/CELLPOWER-BMS.h
@@ -16,7 +16,7 @@ class CellPowerBms : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
-  static constexpr char* Name = "Cellpower BMS";
+  static constexpr const char* Name = "Cellpower BMS";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -18,7 +18,7 @@ class ChademoBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
-  static constexpr char* Name = "Chademo V2X mode";
+  static constexpr const char* Name = "Chademo V2X mode";
 
  private:
   void process_vehicle_charging_minimums(CAN_frame rx_frame);

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -32,7 +32,7 @@ class CmfaEvBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "CMFA platform, 27 kWh battery";
+  static constexpr const char* Name = "CMFA platform, 27 kWh battery";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -13,7 +13,7 @@ class DalyBms : public RS485Battery {
   void update_values();
   void transmit_rs485(unsigned long currentMillis);
   void receive();
-  static constexpr char* Name = "DALY RS485";
+  static constexpr const char* Name = "DALY RS485";
 
  private:
   /* Tweak these according to your battery build */

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -16,7 +16,7 @@ class EcmpBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Stellantis ECMP battery";
+  static constexpr const char* Name = "Stellantis ECMP battery";
 
   bool supports_clear_isolation() { return true; }
   void clear_isolation() { datalayer_extended.stellantisECMP.UserRequestIsolationReset = true; }

--- a/Software/src/battery/FOXESS-BATTERY.h
+++ b/Software/src/battery/FOXESS-BATTERY.h
@@ -15,7 +15,7 @@ class FoxessBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "FoxESS HV2600/ECS4100 OEM battery";
+  static constexpr const char* Name = "FoxESS HV2600/ECS4100 OEM battery";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 4672;  //467.2V for HS20.8 (used during startup, refined later)

--- a/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
+++ b/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
@@ -16,7 +16,7 @@ class GeelyGeometryCBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Geely Geometry C";
+  static constexpr const char* Name = "Geely Geometry C";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -15,7 +15,7 @@ class ImievCZeroIonBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "I-Miev / C-Zero / Ion Triplet";
+  static constexpr const char* Name = "I-Miev / C-Zero / Ion Triplet";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 3696;  //5000 = 500.0V

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -13,7 +13,7 @@ class JaguarIpaceBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Jaguar I-PACE";
+  static constexpr const char* Name = "Jaguar I-PACE";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 4546;  //5000 = 500.0V

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -19,7 +19,7 @@ class KiaEGmpBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Kia/Hyundai EGMP platform";
+  static constexpr const char* Name = "Kia/Hyundai EGMP platform";
 
  private:
   uint16_t estimateSOC(uint16_t packVoltage, uint16_t cellCount, int16_t currentAmps);

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -35,7 +35,7 @@ class KiaHyundai64Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Kia/Hyundai 64/40kWh battery";
+  static constexpr const char* Name = "Kia/Hyundai 64/40kWh battery";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -15,7 +15,7 @@ class KiaHyundaiHybridBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Kia/Hyundai Hybrid";
+  static constexpr const char* Name = "Kia/Hyundai Hybrid";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 2550;  //5000 = 500.0V

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -17,7 +17,7 @@ class MebBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   bool supports_real_BMS_status() { return true; }
   bool supports_charged_energy() { return true; }
-  static constexpr char* Name = "Volkswagen Group MEB platform via CAN-FD";
+  static constexpr const char* Name = "Volkswagen Group MEB platform via CAN-FD";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -15,7 +15,7 @@ class Mg5Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "MG 5 battery";
+  static constexpr const char* Name = "MG 5 battery";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -46,7 +46,7 @@ class NissanLeafBattery : public CanBattery {
   }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
-  static constexpr char* Name = "Nissan LEAF battery";
+  static constexpr const char* Name = "Nissan LEAF battery";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V

--- a/Software/src/battery/ORION-BMS.h
+++ b/Software/src/battery/ORION-BMS.h
@@ -15,7 +15,7 @@ class OrionBms : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "DIY battery with Orion BMS (Victron setting)";
+  static constexpr const char* Name = "DIY battery with Orion BMS (Victron setting)";
 
  private:
   /* Change the following to suit your battery */

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -31,7 +31,7 @@ class PylonBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Pylon compatible battery";
+  static constexpr const char* Name = "Pylon compatible battery";
 
  private:
   /* Change the following to suit your battery */

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -15,7 +15,7 @@ class RangeRoverPhevBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Range Rover 13kWh PHEV battery (L494/L405)";
+  static constexpr const char* Name = "Range Rover 13kWh PHEV battery (L494/L405)";
 
  private:
   /* Change the following to suit your battery */

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -15,7 +15,7 @@ class RenaultKangooBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Renault Kangoo";
+  static constexpr const char* Name = "Renault Kangoo";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 4150;  //5000 = 500.0V

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -13,7 +13,7 @@ class RenaultTwizyBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Renault Twizy";
+  static constexpr const char* Name = "Renault Twizy";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 579;  // 57.9V at 100% SOC (with 70% SOH, new one might be higher)

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -31,7 +31,7 @@ class RenaultZoeGen1Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Renault Zoe Gen1 22/40kWh";
+  static constexpr const char* Name = "Renault Zoe Gen1 22/40kWh";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -15,7 +15,7 @@ class RenaultZoeGen2Battery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Renault Zoe Gen2 50kWh";
+  static constexpr const char* Name = "Renault Zoe Gen2 50kWh";
 
   bool supports_reset_NVROL() { return true; }
 

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -15,7 +15,7 @@ class RjxzsBms : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "RJXZS BMS, DIY battery";
+  static constexpr const char* Name = "RJXZS BMS, DIY battery";
 
  private:
   /* Tweak these according to your battery build */

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -27,7 +27,7 @@ class SantaFePhevBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Santa Fe PHEV";
+  static constexpr const char* Name = "Santa Fe PHEV";
 
  private:
   DATALAYER_BATTERY_TYPE* datalayer_battery;

--- a/Software/src/battery/SIMPBMS-BATTERY.h
+++ b/Software/src/battery/SIMPBMS-BATTERY.h
@@ -15,7 +15,7 @@ class SimpBmsBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "SIMPBMS battery";
+  static constexpr const char* Name = "SIMPBMS battery";
 
  private:
   /* DEFAULT VALUES BMS will send configured */

--- a/Software/src/battery/SONO-BATTERY.h
+++ b/Software/src/battery/SONO-BATTERY.h
@@ -15,7 +15,7 @@ class SonoBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Sono Motors Sion 64kWh LFP ";
+  static constexpr const char* Name = "Sono Motors Sion 64kWh LFP ";
 
  private:
   static const int MAX_PACK_VOLTAGE_DV = 5000;  //5000 = 500.0V

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -513,14 +513,14 @@ class TeslaModel3YBattery : public TeslaBattery {
     operate_contactors = true;
 #endif
   }
-  static constexpr char* Name = "Tesla Model 3/Y";
+  static constexpr const char* Name = "Tesla Model 3/Y";
   virtual void setup(void);
 };
 
 class TeslaModelSXBattery : public TeslaBattery {
  public:
   TeslaModelSXBattery() { operate_contactors = true; }
-  static constexpr char* Name = "Tesla Model S/X";
+  static constexpr const char* Name = "Tesla Model S/X";
   virtual void setup(void);
 };
 

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -22,7 +22,7 @@ class TestFakeBattery : public CanBattery {
     allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
   }
 
-  static constexpr char* Name = "Fake battery for testing purposes";
+  static constexpr const char* Name = "Fake battery for testing purposes";
 
   virtual void setup();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -16,7 +16,7 @@ class VolvoSpaBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Volvo / Polestar 69/78kWh SPA battery";
+  static constexpr const char* Name = "Volvo / Polestar 69/78kWh SPA battery";
 
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { datalayer_extended.VolvoPolestar.UserRequestDTCreset = true; }

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
@@ -16,7 +16,7 @@ class VolvoSpaHybridBattery : public CanBattery {
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
-  static constexpr char* Name = "Volvo PHEV battery";
+  static constexpr const char* Name = "Volvo PHEV battery";
 
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { datalayer_extended.VolvoHybrid.UserRequestDTCreset = true; }

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -14,7 +14,7 @@ class ChevyVoltCharger : public CanCharger {
   ChevyVoltCharger() : CanCharger(ChargerType::ChevyVolt) {}
 
   const char* name() { return Name; }
-  static constexpr char* Name = "Chevy Volt Gen1 Charger";
+  static constexpr const char* Name = "Chevy Volt Gen1 Charger";
 
   void map_can_frame_to_variable(CAN_frame rx_frame);
   void transmit_can(unsigned long currentMillis);

--- a/Software/src/charger/NISSAN-LEAF-CHARGER.h
+++ b/Software/src/charger/NISSAN-LEAF-CHARGER.h
@@ -14,7 +14,7 @@ class NissanLeafCharger : public CanCharger {
   NissanLeafCharger() : CanCharger(ChargerType::NissanLeaf) {}
 
   const char* name() { return Name; }
-  static constexpr char* Name = "Nissan LEAF 2013-2024 PDM charger";
+  static constexpr const char* Name = "Nissan LEAF 2013-2024 PDM charger";
 
   void map_can_frame_to_variable(CAN_frame rx_frame);
   void transmit_can(unsigned long currentMillis);

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -14,7 +14,7 @@ class AforeCanInverter : public CanInverterProtocol {
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
   void update_values();
-  static constexpr char* Name = "Afore battery over CAN";
+  static constexpr const char* Name = "Afore battery over CAN";
 
  private:
   /* The code is following the Afore 2.3 CAN standard, little-endian, 500kbps, from 2023.08.07 */

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -14,7 +14,7 @@ class BydCanInverter : public CanInverterProtocol {
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
   void update_values();
-  static constexpr char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
+  static constexpr const char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
 
  private:
   void send_initial_data();

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -12,7 +12,7 @@ class BydModbusInverter : public ModbusInverterProtocol {
  public:
   void setup();
   void update_values();
-  static constexpr char* Name = "BYD 11kWh HVM battery over Modbus RTU";
+  static constexpr const char* Name = "BYD 11kWh HVM battery over Modbus RTU";
 
  private:
   void handle_static_data();

--- a/Software/src/inverter/FERROAMP-CAN.h
+++ b/Software/src/inverter/FERROAMP-CAN.h
@@ -15,7 +15,7 @@ class FerroampCanInverter : public CanInverterProtocol {
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
 
-  static constexpr char* Name = "Ferroamp Pylon battery over CAN bus";
+  static constexpr const char* Name = "Ferroamp Pylon battery over CAN bus";
 
  private:
   void send_system_data();

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -14,7 +14,7 @@ class FoxessCanInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "FoxESS compatible HV2600/ECS4100 battery";
+  static constexpr const char* Name = "FoxESS compatible HV2600/ECS4100 battery";
 
  private:
   int16_t temperature_average = 0;

--- a/Software/src/inverter/GROWATT-HV-CAN.h
+++ b/Software/src/inverter/GROWATT-HV-CAN.h
@@ -14,7 +14,7 @@ class GrowattHvInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Growatt High Voltage protocol via CAN";
+  static constexpr const char* Name = "Growatt High Voltage protocol via CAN";
 
  private:
   //Total number of Cells (1-512)

--- a/Software/src/inverter/GROWATT-LV-CAN.h
+++ b/Software/src/inverter/GROWATT-LV-CAN.h
@@ -14,7 +14,7 @@ class GrowattLvInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Growatt Low Voltage (48V) protocol via CAN";
+  static constexpr const char* Name = "Growatt Low Voltage (48V) protocol via CAN";
 
  private:
   //Actual content messages

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -22,7 +22,7 @@ class KostalInverterProtocol : public Rs485InverterProtocol {
   void setup();
   void receive();
   void update_values();
-  static constexpr char* Name = "BYD battery via Kostal RS485";
+  static constexpr const char* Name = "BYD battery via Kostal RS485";
 
  private:
   int baud_rate() { return 57600; }

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -14,7 +14,7 @@ class PylonInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Pylontech battery over CAN bus";
+  static constexpr const char* Name = "Pylontech battery over CAN bus";
 
  private:
   void send_system_data();

--- a/Software/src/inverter/PYLON-LV-CAN.h
+++ b/Software/src/inverter/PYLON-LV-CAN.h
@@ -14,7 +14,7 @@ class PylonLvInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Pylontech LV battery over CAN bus";
+  static constexpr const char* Name = "Pylontech LV battery over CAN bus";
 
  private:
   void send_system_data();

--- a/Software/src/inverter/SCHNEIDER-CAN.h
+++ b/Software/src/inverter/SCHNEIDER-CAN.h
@@ -14,7 +14,7 @@ class SchneiderInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Schneider V2 SE BMS CAN";
+  static constexpr const char* Name = "Schneider V2 SE BMS CAN";
 
  private:
   static const int STATE_OFFLINE = 0;

--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -15,7 +15,7 @@ class SmaBydHInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "BYD over SMA CAN";
+  static constexpr const char* Name = "BYD over SMA CAN";
 
   virtual bool controls_contactor() { return true; }
   virtual bool allows_contactor_closing() { return digitalRead(INVERTER_CONTACTOR_ENABLE_PIN) == 1; }

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -15,7 +15,7 @@ class SmaBydHvsInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "BYD Battery-Box HVS over SMA CAN";
+  static constexpr const char* Name = "BYD Battery-Box HVS over SMA CAN";
 
   virtual bool controls_contactor() { return true; }
   virtual bool allows_contactor_closing() { return digitalRead(INVERTER_CONTACTOR_ENABLE_PIN) == 1; }

--- a/Software/src/inverter/SMA-LV-CAN.h
+++ b/Software/src/inverter/SMA-LV-CAN.h
@@ -14,7 +14,7 @@ class SmaLvInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "SMA Low Voltage (48V) protocol via CAN";
+  static constexpr const char* Name = "SMA Low Voltage (48V) protocol via CAN";
 
  private:
   static const int READY_STATE = 0x03;

--- a/Software/src/inverter/SMA-TRIPOWER-CAN.h
+++ b/Software/src/inverter/SMA-TRIPOWER-CAN.h
@@ -15,7 +15,7 @@ class SmaTripowerInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "SMA Tripower CAN";
+  static constexpr const char* Name = "SMA Tripower CAN";
 
   virtual bool controls_contactor() { return true; }
   virtual bool allows_contactor_closing() { return digitalRead(INVERTER_CONTACTOR_ENABLE_PIN) == 1; }

--- a/Software/src/inverter/SOFAR-CAN.h
+++ b/Software/src/inverter/SOFAR-CAN.h
@@ -14,7 +14,7 @@ class SofarInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Sofar BMS (Extended Frame) over CAN bus";
+  static constexpr const char* Name = "Sofar BMS (Extended Frame) over CAN bus";
 
  private:
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,7 +14,7 @@ class SolaxInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "SolaX Triple Power LFP over CAN bus";
+  static constexpr const char* Name = "SolaX Triple Power LFP over CAN bus";
 
  private:
   // Timeout in milliseconds

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -14,7 +14,7 @@ class SungrowInverter : public CanInverterProtocol {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr char* Name = "Sungrow SBR064 battery over CAN bus";
+  static constexpr const char* Name = "Sungrow SBR064 battery over CAN bus";
 
  private:
   unsigned long previousMillis500ms = 0;


### PR DESCRIPTION
### What & How
This PR adds a const keyword for all battery and inverter name constants to eliminate compiler warnings.

### Why
Compiler warnings should be minimized.
