### PR TITLE
Preliminary changes for better MG HS PHEV integration

### DIFF
--- a/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
@@ -1,6 +1,7 @@
 #include "../include.h"
 #ifdef MG_HS_PHEV_BATTERY_H
 #include "../communication/can/comm_can.h"
+#include "../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "MG-HS-PHEV-BATTERY.h"
@@ -38,231 +39,57 @@ void MgHsPHEVBattery::
   datalayer.battery.status.temperature_max_dC;
 }
 
+void MgHsPHEVBattery::update_soc(uint16_t soc_times_ten) {
+
+  // Set the state of charge in the datalayer
+  datalayer.battery.status.real_soc = soc_times_ten * 10;
+
+  RealSoC = datalayer.battery.status.real_soc / 100;
+
+  // Calculate the remaining capacity.
+  tempfloat = datalayer.battery.info.total_capacity_Wh * (RealSoC - MinSoC) / 100;
+  if (tempfloat > 0) {
+    datalayer.battery.status.remaining_capacity_Wh = tempfloat;
+  } else {
+    datalayer.battery.status.remaining_capacity_Wh = 0;
+  }
+
+  // Calculate the maximum charge power. Taper the charge power between 90% and 100% SoC, as 100% SoC is approached
+  if (RealSoC < StartChargeTaper) {
+    datalayer.battery.status.max_charge_power_W = MaxChargePower;
+  } else if (RealSoC >= 100) {
+    datalayer.battery.status.max_charge_power_W = TricklePower;
+  } else {
+    //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
+    datalayer.battery.status.max_charge_power_W =
+        (MaxChargePower * pow(((100 - RealSoC) / (100 - StartChargeTaper)), ChargeTaperExponent)) + TricklePower;
+  }
+
+  // Calculate the maximum discharge power. Taper the discharge power between 35% and Min% SoC, as Min% SoC is approached
+  if (RealSoC > StartDischargeTaper) {
+    datalayer.battery.status.max_discharge_power_W = MaxDischargePower;
+  } else if (RealSoC < MinSoC) {
+    datalayer.battery.status.max_discharge_power_W = TricklePower;
+  } else {
+    //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
+    datalayer.battery.status.max_discharge_power_W =
+        (MaxDischargePower * pow(((RealSoC - MinSoC) / (StartDischargeTaper - MinSoC)), DischargeTaperExponent)) +
+        TricklePower;
+  }
+}
+
 void MgHsPHEVBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
+  uint16_t soc1, soc2, cell_id, v;
   switch (rx_frame.ID) {
-    case 0x171:  //Following messages were detected on a MG5 battery BMS
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x172:
-      break;
     case 0x173:
-      break;
-    case 0x293:
-      break;
-    case 0x295:
-      break;
-    case 0x297:
-      break;
-    case 0x29B:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x29C:
-      break;
-    case 0x2A0:
-      break;
-    case 0x2A2:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x322:
-      break;
-    case 0x334:
-      break;
-    case 0x33F:
-      break;
-    case 0x391:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x393:
-      break;
-    case 0x3AB:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x3AC:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x3B8:
-      break;
-    case 0x3BA:
-      break;
-    case 0x3BC:
-      break;
-    case 0x3BE:
-      break;
-    case 0x3C0:
-      break;
-    case 0x3C2:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x400:
-      break;
-    case 0x402:
-      break;
-    case 0x418:
-      break;
-    case 0x44C:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x620:
-      break;     //This is the last on the list in the MG5 template.
-    case 0x3a8:  //This ID is on the MG HS RX WITHOUT ANY TX PRESENT
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x508:  //This ID is a new one MG HS RX WHEN TRANSMITTING 03 22 B0 41 00 00 00 00. Rx data is 00 00 00 00 00 00 00 00
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      break;
-    case 0x7ED:  //This ID is the battery BMS
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      //Process rx data for incoming responses to "Read data by ID" Tx
-      if (rx_frame.data.u8[1] == 0x62) {
-        if (rx_frame.data.u8[2] == 0xB0) {                                   //Battery information
-          if (rx_frame.data.u8[3] == 0x41 && rx_frame.data.u8[0] == 0x05) {  // Battery bus voltage
-            //				Serial.print ("Battery Bus voltage frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) * 2.5;
-            //				Serial.print ("Battery Bus Voltage = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-          if (rx_frame.data.u8[3] == 0x42 && rx_frame.data.u8[0] == 0x05) {  // Battery voltage
-            //				Serial.print ("Battery voltage frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.voltage_dV = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) * 2.5;
-            //				Serial.print ("Battery voltage = ");
-            //				Serial.println (datalayer.battery.status.voltage_dV);
-          }
-          if (rx_frame.data.u8[3] == 0x43 && rx_frame.data.u8[0] == 0x05) {  // Battery current
-            //				Serial.print ("Battery current frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.current_dA = ((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) - 40000) / -4;
-            //				Serial.print ("Battery current = ");
-            //				Serial.println (datalayer.battery.status.current_dA);
-          }
+      // Contains cell min/max voltages
 
-          if (rx_frame.data.u8[3] == 0x45 && rx_frame.data.u8[0] == 0x05) {  // Battery resistance
-            //				Serial.print ("Battery resistance frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);
-            //				Serial.print ("Battery resistance = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-          if (rx_frame.data.u8[3] == 0x46 && rx_frame.data.u8[0] == 0x05) {  // Battery SoC
-            //				Serial.print ("Battery SoC frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.real_soc = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) * 10;
-            //				Serial.print ("Battery SoC = ");
-            //				Serial.println (datalayer.battery.status.real_soc);
-            RealSoC = datalayer.battery.status.real_soc / 100;  // For calculation of charge and discharge rates
-          }
-
-          if (rx_frame.data.u8[3] == 0x47) {  //    && rx_frame.data.u8[0] == 0x05) {	   // BMS error code
-                                              //				Serial.print ("BMS error code frame = ");
-                                              //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
-            //				Serial.print ("Battery error = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-
-          if (rx_frame.data.u8[3] == 0x48) {  //    && rx_frame.data.u8[0] == 0x05) {	   // BMS status code
-                                              //				Serial.print ("BMS status code frame = ");
-                                              //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
-            //				Serial.print ("Battery Status = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-
-          if (rx_frame.data.u8[3] == 0x49) {  //    && rx_frame.data.u8[0] == 0x05) {	   // System main relay B status
-                                              //				Serial.print ("System main relay B status frame = ");
-                                              //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
-            //				Serial.print ("Main relay B status = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-
-          if (rx_frame.data.u8[3] == 0x4A) {  //    && rx_frame.data.u8[0] == 0x05) {	   // System main relay G status
-                                              //				Serial.print ("System main relay G status frame = ");
-                                              //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
-            //				Serial.print ("Main relay G status = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-
-          if (rx_frame.data.u8[3] == 0x52) {  //    && rx_frame.data.u8[0] == 0x05) {	   // System main relay P status
-                                              //				Serial.print ("System main relay P status frame = ");
-                                              //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            //				datalayer.battery.status.PARAMETER = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
-            //				Serial.print ("BMain relay P status = ");
-            //				Serial.println (datalayer.battery.status.PARAMETER);
-          }
-
-          if (rx_frame.data.u8[3] == 0x56 && rx_frame.data.u8[0] == 0x05) {  // Max cell temperature
-            //				Serial.print ("Max cell temperature frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.temperature_max_dC =
-                (((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) / 500) - 40) * 10;
-            //				Serial.print ("Max cell temperature = ");
-            //				Serial.println (datalayer.battery.status.temperature_max_dC);
-          }
-
-          if (rx_frame.data.u8[3] == 0x57 && rx_frame.data.u8[0] == 0x05) {  // Min cell temperature
-            //				Serial.print ("Min cell temperature frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.temperature_min_dC =
-                (((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) / 500) - 40) * 10;
-            //				Serial.print ("Min cell temperature = ");
-            //				Serial.println (datalayer.battery.status.temperature_min_dC);
-          }
-
-          if (rx_frame.data.u8[3] == 0x58 && rx_frame.data.u8[0] == 0x06) {  // Max cell voltage
-            //				Serial.print ("Max cell voltage frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.cell_max_voltage_mV =
-                (rx_frame.data.u8[4] << 16 | rx_frame.data.u8[5] << 8 | rx_frame.data.u8[6]) / 250;
-            //				Serial.print ("Max cell voltage = ");
-            //				Serial.println (datalayer.battery.status.cell_max_voltage_mV);
-          }
-
-          if (rx_frame.data.u8[3] == 0x59 && rx_frame.data.u8[0] == 0x06) {  // Min cell voltage
-            //				Serial.print ("Min cell voltage frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.cell_min_voltage_mV =
-                (rx_frame.data.u8[4] << 16 | rx_frame.data.u8[5] << 8 | rx_frame.data.u8[6]) / 250;
-            //				Serial.print ("Min cell voltage = ");
-            //				Serial.println (datalayer.battery.status.cell_min_voltage_mV);
-          }
-
-          if (rx_frame.data.u8[3] == 0x61 && rx_frame.data.u8[0] == 0x05) {  // Battery SoH
-            //				Serial.print ("Battery SoH frame = ");
-            //				print_can_frame_MG5(rx_frame, frameDirection(MSG_RX));
-            datalayer.battery.status.soh_pptt = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);
-            //				Serial.print ("Battery SoH = ");
-            //				Serial.println (datalayer.battery.status.soh_pptt);
-          }
-
-        }  // data.u8[2]=0xB0
-      }  // data.u8[1] = 0x62)
-
-      //Set calculated and derived parameters
-
-      // Calculate the remaining capacity.
-      tempfloat = datalayer.battery.info.total_capacity_Wh * (RealSoC - MinSoC) / 100;
-      //	Serial.print ("Remaining capacity calculated = ");
-      //	Serial.println (tempfloat);
-      if (tempfloat > 0) {
-        datalayer.battery.status.remaining_capacity_Wh = tempfloat;
-      } else {
-        datalayer.battery.status.remaining_capacity_Wh = 0;
-      }
-
-      // Calculate the maximum charge power. Taper the charge power between 90% and 100% SoC, as 100% SoC is approached
-      if (RealSoC < StartChargeTaper) {
-        datalayer.battery.status.max_charge_power_W = MaxChargePower;
-      } else if (RealSoC >= 100) {
-        datalayer.battery.status.max_charge_power_W = TricklePower;
-      } else {
-        //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
-        datalayer.battery.status.max_charge_power_W =
-            (MaxChargePower * pow(((100 - RealSoC) / (100 - StartChargeTaper)), ChargeTaperExponent)) + TricklePower;
-      }
-
+      v = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+      if (v > 0 && v < 0x2000) {
+        datalayer.battery.status.cell_max_voltage_mV = v;
+        v = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
+        if (v > 0 && v < 0x2000) {
+          datalayer.battery.status.cell_min_voltage_mV = v;
       // Calculate the maximum discharge power. Taper the discharge power between 35% and Min% SoC, as Min% SoC is approached
       if (RealSoC > StartDischargeTaper) {
         datalayer.battery.status.max_discharge_power_W = MaxDischargePower;
@@ -274,6 +101,193 @@ void MgHsPHEVBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             (MaxDischargePower * pow(((RealSoC - MinSoC) / (StartDischargeTaper - MinSoC)), DischargeTaperExponent)) +
             TricklePower;
       }
+        }
+      }
+
+      break;
+    case 0x297:
+      // Contains battery status in rx_frame.data.u8[1]
+      // Presumed mapping:
+      // 1 = disconnected
+      // 2 = precharge
+      // 3 = connected
+      // 15 = isolation fault
+      // 0/8 = checking
+
+#ifdef DEBUG_LOG
+      if(rx_frame.data.u8[1] != previousState) {
+        logging.printf("MG_HS_PHEV: Battery status changed to %d (%d)\n", rx_frame.data.u8[1], rx_frame.data.u8[0]);
+      }
+#endif
+
+      if (rx_frame.data.u8[1] == 0xf && previousState != 0xf) {
+        // Isolation fault, set event
+        set_event(EVENT_BATTERY_ISOLATION, rx_frame.data.u8[0]);
+      } else if (rx_frame.data.u8[1] != 0xf && previousState == 0xf) {
+        // Isolation fault has cleared, clear event
+        clear_event(EVENT_BATTERY_ISOLATION);
+      }
+
+      if (datalayer.battery.status.bms_status == FAULT) {
+        // If in fault state, don't try resetting things yet as it'll turn the
+        // BMS off and we'll lose CAN info
+      } else if((rx_frame.data.u8[0] == 0x02 || rx_frame.data.u8[0] == 0x06) && rx_frame.data.u8[1] == 0x01) {
+        // A weird 'stuck' state where the battery won't reconnect
+        datalayer.system.status.battery_allows_contactor_closing = false;
+        if(!datalayer.system.status.BMS_startup_in_progress) {
+#ifdef DEBUG_LOG
+          logging.printf("MG_HS_PHEV: Stuck, resetting.\n");
+#endif
+          start_bms_reset();
+        }
+      } else if(rx_frame.data.u8[1] == 0xf) {
+        // A fault state (likely isolation failure)
+        datalayer.system.status.battery_allows_contactor_closing = false;
+        if(!datalayer.system.status.BMS_startup_in_progress) {
+#ifdef DEBUG_LOG
+          logging.printf("MG_HS_PHEV: Fault, resetting.\n");
+#endif
+          start_bms_reset();
+        }
+      } else {
+        datalayer.system.status.battery_allows_contactor_closing = true;
+      }
+
+      previousState = rx_frame.data.u8[1];
+
+      break;
+    case 0x2A2:
+      // Contains temperatures.
+
+      if (rx_frame.data.u8[0] < 0xfe) {
+        // Max cell temp
+        datalayer.battery.status.temperature_max_dC = ((rx_frame.data.u8[0] << 8) / 50) - 400;
+      }
+      if (rx_frame.data.u8[5] < 0xfe) {
+        // Min cell temp
+        datalayer.battery.status.temperature_min_dC = ((rx_frame.data.u8[5] << 8) / 50) - 400;
+      }
+      // Coolant temp
+      // ((rx_frame.data.u8[1] << 8)/50) - 400;
+
+      // There is another unknown temp in [6]/[7]
+
+      break;
+    case 0x3AC:
+      // Contains SoCs, voltage, current. Is emitted by both CAN1 and CAN2, but
+      // the CAN2 version only has one SoC (soc2), the CAN1 version has all four
+      // values.
+
+      // Both SoCs top out at about ~4.1V/cell, the first SoC at 92%, and the
+      // second at 100%.
+
+      // They are scaled differently, the relationship seems to be:
+      // soc2 = (1.392*soc1) - 28.064
+
+      soc1 = (rx_frame.data.u8[0] << 8 | rx_frame.data.u8[1]);
+      soc2 = (rx_frame.data.u8[2] << 8 | rx_frame.data.u8[3]);
+
+      // soc2 is present in both CAN1 and CAN2 messages
+      if (soc2 < 1022) {
+        update_soc(soc2);
+        datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      }
+
+      if (((rx_frame.data.u8[4] << 8) & 0xf00 | rx_frame.data.u8[5]) != 0) {
+        // 3AC message contains a nonzero voltage (so must have come from CAN1)
+        v = (rx_frame.data.u8[4] << 8) & 0xf00 | rx_frame.data.u8[5];
+        if (v > 0 && v < 4000) {
+          datalayer.battery.status.voltage_dV = v * 2.5;
+        }
+        // Current
+        v = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);
+        if (v > 0 && v < 0xf000) {
+          datalayer.battery.status.current_dA = -(v - 20000) * 0.5;
+        }
+      }
+
+      break;
+    case 0x3BE:
+      // Per-cell voltages and temps
+      cell_id = rx_frame.data.u8[5];
+      if (cell_id < 90) {
+        v = 1000 + (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+        datalayer.battery.status.cell_voltages_mV[cell_id] = v < 10000 ? v : 0;
+        // cell temperature is rx_frame.data.u8[1]-40 but BE doesn't use it
+      }
+
+      break;
+    case 0x7ED:
+      // A response from our CAN2 OBD requests
+      // We mostly ignore these, apart from SoH, and also the voltage as a
+      // safety measure (in case CAN1 misbehaves).
+      if (rx_frame.data.u8[1] == 0x62) {
+        if (rx_frame.data.u8[2] == 0xB0) {                                   //Battery information
+          if (rx_frame.data.u8[3] == 0x41 && rx_frame.data.u8[0] == 0x05) {  // Battery bus voltage
+            // Battery bus voltage
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) * 2.5;
+          } else if (rx_frame.data.u8[3] == 0x42 && rx_frame.data.u8[0] == 0x05) {
+            // Battery voltage
+            datalayer.battery.status.voltage_dV = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) * 2.5;
+          } else if (rx_frame.data.u8[3] == 0x43 && rx_frame.data.u8[0] == 0x05) {
+            // Battery current
+            // we won't update this as it differs in rounding from the CAN1 version
+            //datalayer.battery.status.current_dA = ((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) - 40000) / -4;
+          } else if (rx_frame.data.u8[3] == 0x45 && rx_frame.data.u8[0] == 0x05) {
+            // Battery resistance
+            // rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);
+          } else if (rx_frame.data.u8[3] == 0x46 && rx_frame.data.u8[0] == 0x05) {
+            // The battery SoC, the same as soc1 in 3AC.
+            soc1 = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);
+            // We won't use since we're using soc2
+          } else if (rx_frame.data.u8[3] == 0x47) {
+            // BMS error code
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
+          } else if (rx_frame.data.u8[3] == 0x48) {
+            // BMS status coded
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
+            // This is the same as 297[1]
+          } else if (rx_frame.data.u8[3] == 0x49) {
+            // System main relay B status
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
+          } else if (rx_frame.data.u8[3] == 0x4A) {
+            // System main relay G status
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
+          } else if (rx_frame.data.u8[3] ==
+                     0x52) {  //    && rx_frame.data.u8[0] == 0x05) {	   // System main relay P status
+            // System main relay P status
+            // (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);	// HOLD: What to do with this data
+          } else if (rx_frame.data.u8[3] == 0x56 && rx_frame.data.u8[0] == 0x05) {
+            // Max cell temperature
+            // datalayer.battery.status.temperature_max_dC =
+            //     (((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) / 500) - 40) * 10;
+          } else if (rx_frame.data.u8[3] == 0x57 && rx_frame.data.u8[0] == 0x05) {
+            // Min cell temperature
+            // datalayer.battery.status.temperature_min_dC =
+            //     (((rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]) / 500) - 40) * 10;
+          } else if (rx_frame.data.u8[3] == 0x58 && rx_frame.data.u8[0] == 0x06) {
+            // Max cell voltage
+            // datalayer.battery.status.cell_max_voltage_mV = rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5];
+      // Calculate the maximum discharge power. Taper the discharge power between 35% and Min% SoC, as Min% SoC is approached
+      if (RealSoC > StartDischargeTaper) {
+        datalayer.battery.status.max_discharge_power_W = MaxDischargePower;
+      } else if (RealSoC < MinSoC) {
+        datalayer.battery.status.max_discharge_power_W = TricklePower;
+      } else {
+        //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
+        datalayer.battery.status.max_discharge_power_W =
+            (MaxDischargePower * pow(((RealSoC - MinSoC) / (StartDischargeTaper - MinSoC)), DischargeTaperExponent)) +
+            TricklePower;
+      }
+          } else if (rx_frame.data.u8[3] == 0x59 && rx_frame.data.u8[0] == 0x06) {
+            // Min cell voltage
+            // datalayer.battery.status.cell_min_voltage_mV = rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5];
+          } else if (rx_frame.data.u8[3] == 0x61 && rx_frame.data.u8[0] == 0x05) {
+            // Battery SoH
+            datalayer.battery.status.soh_pptt = (rx_frame.data.u8[4] << 8 | rx_frame.data.u8[5]);
+          }
+        }  // data.u8[2]=0xB0
+      }  // data.u8[1] = 0x62)
 
       break;
     default:

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
@@ -324,53 +324,20 @@ void MgHsPHEVBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
     previousMillis200 = currentMillis;
 
-    switch (messageindex) {
+    switch (transmitIndex) {
       case 1:
         transmit_can_frame(&MG_HS_7E5_B0_42, can_config.battery);  //Battery voltage
         break;
       case 2:
-        transmit_can_frame(&MG_HS_7E5_B0_43, can_config.battery);  //Battery current
-        break;
-      case 3:
-        transmit_can_frame(&MG_HS_7E5_B0_46, can_config.battery);  //Battery SoC
-        break;
-      case 4:
-        transmit_can_frame(&MG_HS_7E5_B0_47, can_config.battery);  // Get BMS error code
-        break;
-      case 5:
-        transmit_can_frame(&MG_HS_7E5_B0_48, can_config.battery);  // Get BMS status
-        break;
-      case 6:
-        transmit_can_frame(&MG_HS_7E5_B0_49, can_config.battery);  // Get System main relay B status
-        break;
-      case 7:
-        transmit_can_frame(&MG_HS_7E5_B0_4A, can_config.battery);  // Get System main relay G status
-        break;
-      case 8:
-        transmit_can_frame(&MG_HS_7E5_B0_52, can_config.battery);  // Get System main relay P status
-        break;
-      case 9:
-        transmit_can_frame(&MG_HS_7E5_B0_56, can_config.battery);  //Max cell temperature
-        break;
-      case 10:
-        transmit_can_frame(&MG_HS_7E5_B0_57, can_config.battery);  //Min cell temperature
-        break;
-      case 11:
-        transmit_can_frame(&MG_HS_7E5_B0_58, can_config.battery);  //Max cell voltage
-        break;
-      case 12:
-        transmit_can_frame(&MG_HS_7E5_B0_59, can_config.battery);  //Min cell voltage
-        break;
-      case 13:
         transmit_can_frame(&MG_HS_7E5_B0_61, can_config.battery);  //Battery SoH
-        messageindex = 0;  //Return to the first message index. This goes in the last message entry
+        transmitIndex = 0;  //Return to the first message index. This goes in the last message entry
         break;
       default:
         break;
 
     }  //switch
 
-    messageindex++;  //Increment the message index
+    transmitIndex++;  //Increment the message index
 
   }  //endif
 }

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
@@ -149,7 +149,7 @@ void MgHsPHEVBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       // 0/8 = checking
 
 #ifdef DEBUG_LOG
-      if(rx_frame.data.u8[1] != previousState) {
+      if (rx_frame.data.u8[1] != previousState) {
         logging.printf("MG_HS_PHEV: Battery status changed to %d (%d)\n", rx_frame.data.u8[1], rx_frame.data.u8[0]);
       }
 #endif
@@ -165,19 +165,19 @@ void MgHsPHEVBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (datalayer.battery.status.bms_status == FAULT) {
         // If in fault state, don't try resetting things yet as it'll turn the
         // BMS off and we'll lose CAN info
-      } else if((rx_frame.data.u8[0] == 0x02 || rx_frame.data.u8[0] == 0x06) && rx_frame.data.u8[1] == 0x01) {
+      } else if ((rx_frame.data.u8[0] == 0x02 || rx_frame.data.u8[0] == 0x06) && rx_frame.data.u8[1] == 0x01) {
         // A weird 'stuck' state where the battery won't reconnect
         datalayer.system.status.battery_allows_contactor_closing = false;
-        if(!datalayer.system.status.BMS_startup_in_progress) {
+        if (!datalayer.system.status.BMS_startup_in_progress) {
 #ifdef DEBUG_LOG
           logging.printf("MG_HS_PHEV: Stuck, resetting.\n");
 #endif
           start_bms_reset();
         }
-      } else if(rx_frame.data.u8[1] == 0xf) {
+      } else if (rx_frame.data.u8[1] == 0xf) {
         // A fault state (likely isolation failure)
         datalayer.system.status.battery_allows_contactor_closing = false;
-        if(!datalayer.system.status.BMS_startup_in_progress) {
+        if (!datalayer.system.status.BMS_startup_in_progress) {
 #ifdef DEBUG_LOG
           logging.printf("MG_HS_PHEV: Fault, resetting.\n");
 #endif

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
@@ -6,15 +6,44 @@
 #include "../devboard/utils/events.h"
 #include "MG-HS-PHEV-BATTERY.h"
 
-/* TODO:
-- Get contactor closing working
-- Figure out which CAN messages need to be sent towards the battery to keep it alive
-- Map all values from battery CAN messages
-- Note: Charge power/discharge power is estimated for now
+/*
+MG HS PHEV 16.6kWh battery integration
 
-# row3 pin2 needs strobing to 12V (via a 1k) to wake up the BMU
-# but contactor won't come on until deasserted
-# BMU goes to sleep after after ~18s of no CAN
+This may work on other MG batteries, but will need some hardcoded constants
+changing.
+
+
+OPTIONAL SETTINGS
+
+Put these in your USER_SETTINGS.h:
+
+// This will scale the SoC so the batteries top out at 4.2V/cell instead of
+4.1V/cell. The car only seems to use up to 4.1V/cell in service. 
+#define MG_HS_PHEV_USE_FULL_CAPACITY true
+
+// If you have bypassed the contactors, you can avoid them being activated //
+(which also disables isolation resistance measuring). 
+#define MG_HS_PHEV_DISABLE_CONTACTORS true
+
+
+CAN CONNECTIONS
+
+Battery Emulator should be connected via CAN to either:
+
+- CAN1 (pins 1+2 on the LV connector)
+
+This provides efficient data updates including individual cell voltages, and
+allows control over the contactors.
+
+- CAN1 and CAN2 (pins 3+4) in parallel
+
+This adds extra information (currently just SoH), and works in practice despite
+the potential problems with connecting CAN buses in parallel.
+
+NOTES
+
+- Charge power/discharge power is estimated for now
+
 */
 
 void MgHsPHEVBattery::
@@ -350,6 +379,8 @@ void MgHsPHEVBattery::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer.battery.info.total_capacity_Wh = BATTERY_WH_MAX;
+  datalayer.battery.info.number_of_cells = 90;
 }
 
 #endif

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -34,7 +34,7 @@ class MgHsPHEVBattery : public CanBattery {
   float RealVoltage;
   float RealSoC;
   float tempfloat;
-  
+
   uint8_t previousState = 0;
 
   static const uint16_t CELL_VOLTAGE_TIMEOUT = 10;  // in seconds

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -21,14 +21,15 @@ class MgHsPHEVBattery : public CanBattery {
  private:
   void update_soc(uint16_t soc_times_ten);
 
+  static const int MAX_PACK_VOLTAGE_DV = 3780;  //5000 = 500.0V
+  static const int MIN_PACK_VOLTAGE_DV = 2790;
   static const int MAX_CELL_DEVIATION_MV = 150;
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
-  static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
+  static const int MIN_CELL_VOLTAGE_MV = 2610;  //Battery is put into emergency stop if one cell goes below this value
 
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was send
 
-  int BMS_SOC = 0;
   // For calculating charge and discharge power
   float RealVoltage;
   float RealSoC;

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -36,7 +36,9 @@ class MgHsPHEVBattery : public CanBattery {
   
   uint8_t previousState = 0;
 
-  uint8_t messageindex = 0;  //For polling switchcase
+  static const uint16_t CELL_VOLTAGE_TIMEOUT = 10;  // in seconds
+  uint16_t cellVoltageValidTime = 0;
+
 
   const int MaxChargePower = 3000;  // Maximum allowable charge power, excluding the taper
   const int StartChargeTaper = 90;  // Battery percentage above which the charge power will taper to zero

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -25,7 +25,7 @@ class MgHsPHEVBattery : public CanBattery {
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
 
-  unsigned long previousMillis70 = 0;   // will store last time a 70ms CAN Message was send
+  unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was send
 
   int BMS_SOC = 0;
@@ -52,7 +52,7 @@ class MgHsPHEVBattery : public CanBattery {
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x08A,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x36, 0xB0}};
+                        .data = {0x80, 0x00, 0x00, 0x04, 0x00, 0x02, 0x36, 0xB0}};
   CAN_frame MG_HS_1F1 = {.FD = false,
                          .ext_ID = false,
                          .DLC = 8,

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -39,6 +39,7 @@ class MgHsPHEVBattery : public CanBattery {
   static const uint16_t CELL_VOLTAGE_TIMEOUT = 10;  // in seconds
   uint16_t cellVoltageValidTime = 0;
 
+  uint8_t transmitIndex = 0;  //For polling switchcase
 
   const int MaxChargePower = 3000;  // Maximum allowable charge power, excluding the taper
   const int StartChargeTaper = 90;  // Battery percentage above which the charge power will taper to zero

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -19,8 +19,8 @@ class MgHsPHEVBattery : public CanBattery {
   static constexpr const char* Name = "MG HS PHEV 16.6kWh battery";
 
  private:
-  static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
-  static const int MIN_PACK_VOLTAGE_DV = 3100;
+  void update_soc(uint16_t soc_times_ten);
+
   static const int MAX_CELL_DEVIATION_MV = 150;
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
@@ -33,6 +33,8 @@ class MgHsPHEVBattery : public CanBattery {
   float RealVoltage;
   float RealSoC;
   float tempfloat;
+  
+  uint8_t previousState = 0;
 
   uint8_t messageindex = 0;  //For polling switchcase
 


### PR DESCRIPTION
### What
This PR improves MG HS PHEV battery integration:
- Uses CAN1 broadcast messages for SoC, voltages, current and temperatures, rather than relying on OBD
- Implements optional voltage-based SoC scaling to allow the (NMC) cells to be charged over 4.1V/cell.
- Tidies various things up.

### Implementation details
- It uses update_values as a 1Hz tick (is this acceptable?)
- It will only allow voltage-based SoC scaling if the voltage reading is less than 10s old, to avoid a being stuck on a stale voltage due to a partial CAN connection failure.
