### PR TITLE
MEB: Fixed rollover millis bug

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -1290,7 +1290,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
 void MebBattery::transmit_can(unsigned long currentMillis) {
 
-  if (currentMillis > last_can_msg_timestamp + 500) {
+  if (currentMillis - last_can_msg_timestamp > 500) {
 #ifdef DEBUG_LOG
     if (first_can_msg)
       logging.printf("MEB: No CAN msg received for 500ms\n");


### PR DESCRIPTION
### What
This PR fixes an issue with MEB batteries opening contactors after 49 days of operation

### Why
Bugs are bad. Emulator should be able to continue operation nonstop.

### How
The bug is related to millis() rollover (which happens approximately every 49.7 days) in the first timing comparison. Here's the issue:

`if (currentMillis > last_can_msg_timestamp + 500)`

This comparison is unsafe when millis() rolls over because of how unsigned arithmetic works. When last_can_msg_timestamp is close to the maximum value (ULONG_MAX), adding 500 to it will cause an overflow, making the comparison behave incorrectly.

The safer way is to use:

`if (currentMillis - last_can_msg_timestamp > 500)`
