### PR TITLE
Atto 3: Add ramp down of discharge power

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -176,6 +176,14 @@ void BydAttoBattery::
 
   datalayer_battery->status.max_charge_power_W = BMS_allowed_charge_power * 10;  //TODO: Scaling unknown, *10 best guess
 
+  if (SOC_method ==
+      ESTIMATED) {  // If we are using estimated SOC, maximum discharge power is ramped down towards the end.
+    if (battery_estimated_SOC * 0.1 < RAMPDOWN_SOC) {
+      datalayer.battery.status.max_discharge_power_W =
+          RAMPDOWN_POWER_ALLOWED * ((battery_estimated_SOC * 0.1) / RAMPDOWN_SOC);
+    }
+  }
+
   datalayer_battery->status.cell_max_voltage_mV = BMS_highest_cell_voltage_mV;
 
   datalayer_battery->status.cell_min_voltage_mV = BMS_lowest_cell_voltage_mV;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -17,6 +17,11 @@
 //Make sure you understand risks associated with disabling. Values can be read via "More Battery info"
 //#define SKIP_TEMPERATURE_SENSOR_NUMBER 1
 
+// Ramp down settings that are used when SOC is estimated from voltage
+static const int RAMPDOWN_SOC = 100;  // SOC to start ramping down from. Value set here is scaled by 10 (100 = 10.0%)
+static const int RAMPDOWN_POWER_ALLOWED =
+    10000;  // The power to start ramping down from, can be set to a lower value if you want to limit the power at the end of discharge even further
+
 /* Do not modify the rows below */
 #ifdef BYD_ATTO_3_BATTERY
 #define SELECTED_BATTERY_CLASS BydAttoBattery

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -20,7 +20,7 @@
 // Ramp down settings that are used when SOC is estimated from voltage
 static const int RAMPDOWN_SOC = 100;  // SOC to start ramping down from. Value set here is scaled by 10 (100 = 10.0%)
 static const int RAMPDOWN_POWER_ALLOWED =
-    10000;  // The power to start ramping down from, can be set to a lower value if you want to limit the power at the end of discharge even further
+    10000;  // Power to start ramp down from, set a lower value to limit the power even further as SOC decreases
 
 /* Do not modify the rows below */
 #ifdef BYD_ATTO_3_BATTERY
@@ -134,6 +134,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t BMS_unknown13 = 0;
   uint8_t battery_frame_index = 0;
   uint16_t battery_cellvoltages[CELLCOUNT_EXTENDED] = {0};
+  uint16_t rampdown_power = 0;
 
   uint16_t poll_state = POLL_FOR_BATTERY_SOC;
   uint16_t pid_reply = 0;


### PR DESCRIPTION
### What
This adds a ramp down of the maximum discharge power when SOC is estimated by voltage.

### Why
To avoid false estimation of SOC due to voltage drops cased by heavy discharge.

### How
By ramping down max discharge power from 10% estimated SOC.
