### PR TITLE
Fix RS485 inverters by proper registration of a receiver

### DIFF
--- a/Software/src/inverter/Rs485InverterProtocol.h
+++ b/Software/src/inverter/Rs485InverterProtocol.h
@@ -10,6 +10,8 @@ class Rs485InverterProtocol : public InverterProtocol, Rs485Receiver {
   virtual const char* interface_name() { return "RS485"; }
   InverterInterfaceType interface_type() { return InverterInterfaceType::Rs485; }
   virtual int baud_rate() = 0;
+
+  Rs485InverterProtocol() { register_receiver(this); }
 };
 
 #endif


### PR DESCRIPTION
### What
This fixes Kostal RS485 inverter communication.

### How
RS485 inverter object needs to be registered as a receiver for the communication to work.
