### PR TITLE
MEB: Add Init/Error display for temperatre to more battery info page

### DIFF
--- a/Software/src/battery/MEB-HTML.h
+++ b/Software/src/battery/MEB-HTML.h
@@ -253,8 +253,15 @@ class MebHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Cell imbalance: " + String(rt_enum[datalayer_extended.meb.rt_cell_imbalance & 0x03]) + "</h4>";
     content +=
         "<h4>Battery unathorized: " + String(rt_enum[datalayer_extended.meb.rt_battery_unathorized & 0x03]) + "</h4>";
-    content +=
-        "<h4>Battery temperature: " + String(datalayer_extended.meb.battery_temperature_dC / 10.f, 1) + " &deg;C</h4>";
+    content += "<h4>Battery temperature: ";
+    if (datalayer_extended.meb.battery_temperature_dC == 875) {  //Raw value 255
+      content += "ERROR</h4>";
+    } else if (datalayer_extended.meb.battery_temperature_dC == 870) {  //Raw value 254
+      content += "INIT</h4>";
+    } else {
+      content += String(datalayer_extended.meb.battery_temperature_dC / 10.f, 1) + " &deg;C</h4>";
+    }
+
     for (int i = 0; i < 3; i++) {
       content += "<h4>Temperature points " + String(i * 6 + 1) + "-" + String(i * 6 + 6) + " :";
       for (int j = 0; j < 6; j++)


### PR DESCRIPTION
### What
This PR makes the temperature value shown in the "More Battery Info" page for MEB make more sense

### Why
Before this PR, having the Init/error state would show temperature as 87.0 and 87.5*C, which confuses users

<img width="514" height="153" alt="image" src="https://github.com/user-attachments/assets/abe7bbde-41ac-49b5-b5d5-40d09b35f325" />

### How
We now show the text Init / Error incase the temperature measurement fails
