### PR TITLE
Fix compiler warning for overflow on Sono

### DIFF
--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -128,7 +128,7 @@ void SonoBattery::transmit_can(unsigned long currentMillis) {
 
     //Time and date
     //Let's see if the battery is happy with just getting seconds incrementing
-    SONO_401.data.u8[0] = 2025;     //Year
+    SONO_401.data.u8[0] = 25;       //Year
     SONO_401.data.u8[1] = 1;        //Month
     SONO_401.data.u8[2] = 1;        //Day
     SONO_401.data.u8[3] = 12;       //Hour


### PR DESCRIPTION
### What
This PR fixes a compiler warning on Sono

### Why
Not nice to have to see compiler warnings. It was an actual issue.

### How
2025 does not fit in an u8, but 25 does :) 
