### PR TITLE
Fix: Ignore erroneous 53.3c CPU temperature value that ESP32 often returns

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -361,7 +361,14 @@ void check_interconnect_available() {
 
 void update_calculated_values() {
   /* Update CPU temperature*/
-  datalayer.system.info.CPU_temperature = temperatureRead();
+  union {
+    float temp;
+    uint32_t hex;
+  } temp = {.temp = temperatureRead()};
+  if (temp.hex != 0x42555555) {
+    // Ignoring erroneous temperature value that ESP32 sometimes returns
+    datalayer.system.info.CPU_temperature = temp.temp;
+  }
 
   /* Calculate allowed charge/discharge currents*/
   if (datalayer.battery.status.voltage_dV > 10) {


### PR DESCRIPTION
### What
Ignore the specific float value 53.3c (hex value 0x42555555) that temperatureRead often returns.

### Why
With a ESP32 lilygo at 78c, the temperature keeps bouncing between 53.3c and 78c - the lower value is incorrect. Ignoring it results in a smoothly changing temperature.

Hopefully this is not device specific, but is a common issue with all ESP32s (https://github.com/esphome/issues/issues/6543 suggests that it is).