### PR TITLE
Feature: Allow BMS_POWER to be used on a Lilygo if CONTACTOR_CONTROL isn't used

### DIFF
--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -51,7 +51,11 @@
 #define POSITIVE_CONTACTOR_PIN 32
 #define NEGATIVE_CONTACTOR_PIN 33
 #define PRECHARGE_PIN 25
-#define BMS_POWER 18                      // Note, this pin collides with CAN add-ons and Chademo
+#ifdef CONTACTOR_CONTROL
+#define BMS_POWER 18  // Note, this pin collides with CAN add-ons and Chademo
+#else
+#define BMS_POWER 32  // If not using contactor control, we can reuse a pin
+#endif
 #define SECOND_BATTERY_CONTACTORS_PIN 15  //Note, this pin collides with SD card pins
 
 // Automatic precharging

--- a/Software/src/include.h
+++ b/Software/src/include.h
@@ -33,8 +33,10 @@
 #ifdef HW_LILYGO
 #if defined(PERIODIC_BMS_RESET) || defined(REMOTE_BMS_RESET)
 #if defined(CAN_ADDON) || defined(CANFD_ADDON) || defined(CHADEMO_BATTERY)
+#if defined(CONTACTOR_CONTROL)
 //Check that BMS reset is not used at the same time as Chademo and CAN addons
 #error BMS RESET CANNOT BE USED AT SAME TIME AS CAN-ADDONS / CHADMEO! NOT ENOUGH GPIO!
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
### What
Add an extra check so that it does not error if you have enabled BMS_RESET as well as CAN_ADDON on a Lilygo, but not CONTACTOR_CONTROL. Normally there would not be enough GPIOs for three contactors as well as BMS_RESET, but you might not need the contactors.

In this instance, also set BMS_POWER to reuse the positive contactor pin by default.

### Why
This allows BMS_RESET to be used with CAN_ADDON on a Lilygo, if you are using a battery with CAN-driven contactors.