### PR TITLE
WIP: Add a DISCOURAGE_CONTACTOR_OPENING define to stop Solax integration opening battery contactors during idle

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -18,7 +18,9 @@ void SolaxInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // If not receiveing any communication from the inverter, open contactors and return to battery announce state
   if (millis() - LastFrameTime >= SolaxTimeout) {
+#ifndef DISCOURAGE_CONTACTOR_OPENING
     datalayer.system.status.inverter_allows_contactor_closing = false;
+#endif
     STATE = BATTERY_ANNOUNCE;
   }
   //Calculate the required values
@@ -133,7 +135,9 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 #ifdef DEBUG_LOG
         logging.println("Solax Battery State: Announce");
 #endif
+#ifndef DISCOURAGE_CONTACTOR_OPENING
         datalayer.system.status.inverter_allows_contactor_closing = false;
+#endif
         SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
         for (uint8_t i = 0; i <= number_of_batteries; i++) {
           transmit_can_frame(&SOLAX_187E, can_config.inverter);
@@ -151,6 +155,13 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
         // Byte 4 changes from 0 to 1
         if (rx_frame.data.u64 == Contactor_Close_Payload)
           STATE = WAITING_FOR_CONTACTOR;
+
+#ifdef DISCOURAGE_CONTACTOR_OPENING
+        // The Solax will wait for contactors to open, but they never will, so
+        // jump straight to closing states.
+        STATE = WAITING_FOR_CONTACTOR;
+#endif
+
         break;
 
       case (WAITING_FOR_CONTACTOR):
@@ -208,6 +219,8 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 }
 
 bool SolaxInverter::setup(void) {                                     // Performs one time setup at startup
+#ifndef DISCOURAGE_CONTACTOR_OPENING
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
+#endif
   return true;
 }

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -218,7 +218,7 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   }
 }
 
-bool SolaxInverter::setup(void) {                                     // Performs one time setup at startup
+bool SolaxInverter::setup(void) {  // Performs one time setup at startup
 #ifndef DISCOURAGE_CONTACTOR_OPENING
   datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
 #endif


### PR DESCRIPTION
**Edit - am still having issues with this!**

Note - is DISCOURAGE_CONTACTOR_OPENING a good name? It could be:

AVOID_CONTACTOR_OPENING
PREVENT_IDLE_CONTACTOR_OPENING

or something...

### What
Add an optional DISCOURAGE_CONTACTOR_OPENING define, which if set, stops the Solax integration asking for battery contactors to be opened during idle or CAN timeout.

There is also a change to the state machine, that will jump straight from ANNOUNCE to WAITING_FOR_CONTACTOR/CONTACTOR_CLOSED if the define is set. This is necessary if the battery contactors are not going to be opening (or have been bypassed), since the Solax will otherwise wait forever to see 0V on the battery input, which will never come.

### Why
Some batteries hate contactor opening requests, which can cause the battery to go into fault state and require a power cycle to recover. We don't change the FAULT handling, which can open the contactors if the battery implements that.

Also, with bypassed contactors, the Solax integration is currently unusable (with an X1-AC, at least).

### TODO

Other inverter integrations (Kostal, SMA?) may need updating too (although we would need to check that they are OK with having the contactors closed all the time - the Solax X1-AC doesn't mind, at least).