### PR TITLE
Feature: Add user configurable BMS reset off time

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -73,7 +73,6 @@ unsigned long currentTime = 0;
 unsigned long lastPowerRemovalTime = 0;
 unsigned long bmsPowerOnTime = 0;
 const unsigned long powerRemovalInterval = 24 * 60 * 60 * 1000;  // 24 hours in milliseconds
-const unsigned long powerRemovalDuration = 30000;                // 30 seconds in milliseconds
 const unsigned long bmsWarmupDuration = 3000;
 
 void set(uint8_t pin, bool direction, uint32_t pwm_freq = 0xFFFF) {
@@ -304,8 +303,9 @@ void handle_BMSpower() {
       }
     }
 
-    // If power has been removed for 30 seconds, restore the power
-    if (datalayer.system.status.BMS_reset_in_progress && currentTime - lastPowerRemovalTime >= powerRemovalDuration) {
+    // If power has been removed for user configured interval (1-59 seconds), restore the power
+    if (datalayer.system.status.BMS_reset_in_progress &&
+        currentTime - lastPowerRemovalTime >= datalayer.battery.settings.user_set_bms_reset_duration_ms) {
       // Reapply power to the BMS
       digitalWrite(bms_power_pin, HIGH);
       bmsPowerOnTime = currentTime;

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -76,6 +76,10 @@ void init_stored_settings() {
   if (temp < 16) {
     datalayer.battery.settings.sofar_user_specified_battery_id = temp;
   }
+  temp = settings.getUInt("BMSRESETDUR", false);
+  if (temp != 0) {
+    datalayer.battery.settings.user_set_bms_reset_duration_ms = temp;
+  }
 
 #ifdef COMMON_IMAGE
   user_selected_battery_type = (BatteryType)settings.getUInt("BATTTYPE", (int)BatteryType::None);
@@ -183,6 +187,9 @@ void store_settings() {
   }
   if (!settings.putUInt("SOFAR_ID", datalayer.battery.settings.sofar_user_specified_battery_id)) {
     set_event(EVENT_PERSISTENT_SAVE_INFO, 12);
+  }
+  if (!settings.putUInt("BMSRESETDUR", datalayer.battery.settings.sofar_user_specified_battery_id)) {
+    set_event(EVENT_PERSISTENT_SAVE_INFO, 13);
   }
 
   settings.end();  // Close preferences handle

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -139,6 +139,9 @@ typedef struct {
   /** The user specified maximum allowed discharge voltage, in deciVolt. 3000 = 300.0 V */
   uint16_t max_user_set_discharge_voltage_dV = BATTERY_MAX_DISCHARGE_VOLTAGE;
 
+  /** The user specified BMS reset period. Keeps track on how many milliseconds should we keep power off during daily BMS reset */
+  uint16_t user_set_bms_reset_duration_ms = 30000;
+
   /** Parameters for keeping track of the limiting factor in the system */
   bool user_settings_limit_discharge = false;
   bool user_settings_limit_charge = false;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -401,6 +401,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return String(datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV / 1.0, 0);
   }
 
+  if (var == "BMS_RESET_DURATION") {
+    return String(datalayer.battery.settings.user_set_bms_reset_duration_ms / 1000.0, 0);
+  }
+
   if (var == "CHARGER_CLASS") {
     if (!charger) {
       return "hidden";
@@ -542,6 +546,9 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         function editMaxDischargeVoltage(){var value=prompt('Some inverters needs to be artificially limited. Enter new voltage setpoint batttery should discharge to (0-1000.0):');if(value!==null){if(value>=0&&value<=1000){var 
         xhr=new 
         XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/updateMaxDischargeVoltage?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 and 1000.0');}}}
+
+        function editBMSresetDuration(){var value=prompt('Amount of seconds BMS power should be off during periodic daily resets. Requires "Periodic BMS reset" to be enabled. Enter value in seconds (1-59):');if(value!==null){if(value>=1&&value<=59){var 
+        xhr=new XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/updateBMSresetDuration?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 1 and 59');}}}
 
         function editTeslaBalAct(){var value=prompt('Enable or disable forced LFP balancing. Makes the battery charge to 101percent. This should be performed once every month, to keep LFP batteries balanced. Ensure battery is fully charged before enabling, and also that you have enough sun or grid power to feed power into the battery while balancing is active. Enter 1 for enabled, 0 for disabled');if(value!==null){if(value==0||value==1){var xhr=new 
         XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/TeslaBalAct?value='+value,true);xhr.send();}}else{alert('Invalid value. Please enter 1 or 0');}}
@@ -790,6 +797,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       <h4 class='%VOLTAGE_LIMITS_ACTIVE_CLASS%'>Target charge voltage: %CHARGE_VOLTAGE% V </span> <button onclick='editMaxChargeVoltage()'>Edit</button></h4>
 
       <h4 class='%VOLTAGE_LIMITS_ACTIVE_CLASS%'>Target discharge voltage: %DISCHARGE_VOLTAGE% V </span> <button onclick='editMaxDischargeVoltage()'>Edit</button></h4>
+
+      <h4 style='color: white;'>Periodic BMS reset off time: %BMS_RESET_DURATION% s </span><button onclick='editBMSresetDuration()'>Edit</button></h4>
 
     </div>
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -656,6 +656,11 @@ void init_webserver() {
     datalayer.battery.settings.max_user_set_discharge_voltage_dV = static_cast<uint16_t>(value.toFloat() * 10);
   });
 
+  // Route for editing BMSresetDuration
+  update_string_setting("/updateBMSresetDuration", [](String value) {
+    datalayer.battery.settings.user_set_bms_reset_duration_ms = static_cast<uint16_t>(value.toFloat() * 1000);
+  });
+
   // Route for editing FakeBatteryVoltage
   update_string_setting("/updateFakeBatteryVoltage", [](String value) { battery->set_fake_voltage(value.toFloat()); });
 


### PR DESCRIPTION
### What
This PR implements user configurable BMS reset off duration

### Why
Some BMS does not require a long cooldown when the reset occurs. Another usecase for setting a short off duration is frequency control, when user might require battery to be online as much as possible in order to not miss any frequency stabilization requests from the grid provider

### How
Value is now configurable in Webserver. 1-59 seconds. Default 30s.

<img width="363" height="95" alt="image" src="https://github.com/user-attachments/assets/de93d43f-b86f-4d70-b91d-c219aefa0524" />
