### PR TITLE
Fix crash when saving settings

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -534,7 +534,7 @@ void init_webserver() {
 
   auto update_string = [](const char* route, std::function<void(String)> setter,
                           std::function<bool(String)> validator = nullptr) {
-    def_route_with_auth(route, server, HTTP_GET, [&](AsyncWebServerRequest* request) {
+    def_route_with_auth(route, server, HTTP_GET, [=](AsyncWebServerRequest* request) {
       if (request->hasParam("value")) {
         String value = request->getParam("value")->value();
 


### PR DESCRIPTION
### What
This PR fixes a crash when saving settings.

### How
A lambda function that saves string settings incorrectly captured arguments by ref instead of value.