### PR TITLE
Fix: Solax (sending too many CAN messages and overflowing buffers)

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -135,7 +135,7 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 #endif
         datalayer.system.status.inverter_allows_contactor_closing = false;
         SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
-        for (uint8_t i = 0; i <= number_of_batteries; i++) {
+        for (uint8_t i = 0; i < number_of_batteries; i++) {
           transmit_can_frame(&SOLAX_187E, can_config.inverter);
           transmit_can_frame(&SOLAX_187A, can_config.inverter);
           transmit_can_frame(&SOLAX_1872, can_config.inverter);


### PR DESCRIPTION
### What
The Solax integration (with a MCP2515 and a Solax X1-AC) was setting a MCP buffer overflow event every time it connected. This seems to be due to a typo, where it sent an extra full set of CAN messages when in the ANNOUNCE state, and the inverter did not receive them quickly enough.

The fix causes it to only send them once (when number_of_batteries==1).

### Why
The generated events are a nuisance.
