### PR TITLE
Fix KIA-E-GMP-HTML imports

### DIFF
--- a/Software/src/battery/KIA-E-GMP-HTML.cpp
+++ b/Software/src/battery/KIA-E-GMP-HTML.cpp
@@ -1,5 +1,4 @@
 #include "KIA-E-GMP-HTML.h"
-#include "../include.h"
 #include "KIA-E-GMP-BATTERY.h"
 
 String KiaEGMPHtmlRenderer::get_status_html() {


### PR DESCRIPTION
### What
A recent KIA-E-GMP-HTML PR merge had an `include.h` #include, removed.
