### PR TITLE
Fix WiFi to use settings

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -2,6 +2,7 @@
 #include <ESPmDNS.h>
 #include "../utils/events.h"
 #include "../utils/logging.h"
+#include "USER_SETTINGS.h"
 
 #if defined(WIFI) || defined(WEBSERVER)
 const bool wifi_enabled_default = true;


### PR DESCRIPTION
### What
This PR fixes Wifi by making sure the module uses the compile-time settings.

### Why
We're still supporting compile-time configuration.
