### PR TITLE
Stark and Wifi fixes

### DIFF
--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -2,6 +2,7 @@
 #define __LOGGING_H__
 
 #include <inttypes.h>
+#include "../../../USER_SETTINGS.h"
 #include "Print.h"
 #include "types.h"
 


### PR DESCRIPTION
### What
This PR fixes a bug that prevented startup on Stark HW and a Wifi-reconnection issue.

### Why
Both issues are critical to fix.

### How
GPIO allocation was fixed to handle the Stark case with duplicate NC-pin-values properly.
WiFi reconnection logic did not correctly handle the case when ESP WiFi stack returns IDLE state right after connected.
