### PR TITLE
Safety: Improve stopping charge/discharge when battery is full/empty

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -130,7 +130,8 @@ void update_machineryprotection() {
 
     // Battery is fully charged. Dont allow any more power into it
     // Normally the BMS will send 0W allowed, but this acts as an additional layer of safety
-    if (datalayer.battery.status.reported_soc == 10000)  //Scaled SOC% value is 100.00%
+    if (datalayer.battery.status.reported_soc == 10000 ||
+        datalayer.battery.status.real_soc == 10000)  //Either Scaled OR Real SOC% value is 100.00%
     {
       if (!battery_full_event_fired) {
         set_event(EVENT_BATTERY_FULL, 0);
@@ -145,7 +146,8 @@ void update_machineryprotection() {
     // Battery is empty. Do not allow further discharge.
     // Normally the BMS will send 0W allowed, but this acts as an additional layer of safety
     if (datalayer.battery.status.bms_status == ACTIVE) {
-      if (datalayer.battery.status.reported_soc == 0) {  //Scaled SOC% value is 0.00%
+      if (datalayer.battery.status.reported_soc == 0 ||
+          datalayer.battery.status.real_soc == 0) {  //Either Scaled OR Real SOC% value is 0.00%, time to stop
         if (!battery_empty_event_fired) {
           set_event(EVENT_BATTERY_EMPTY, 0);
           battery_empty_event_fired = true;


### PR DESCRIPTION
### What
This PR implements a new safety check for stopping charge/discharge

### Why
With the introduction of negative scaled SOC (to be able to discharge to true 0%), we now only checked the safety on the reported SOC, and stopped if that was 0. This is a bit risky, so we now also stop if the real SOC% value is 0

This prevents undercharging batteries.

### How
Instead of stopping when
//Scaled SOC% value is 100.00%

We now stop when
//Either Scaled OR Real SOC% value is 100.00%
