### PR TITLE
Volvo SPA: Correct datatype for current value in More Battery Info

### DIFF
--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -750,7 +750,7 @@ typedef struct {
   uint16_t BECMsupplyVoltage = 0;
 
   uint16_t BECMBatteryVoltage = 0;
-  uint16_t BECMBatteryCurrent = 0;
+  int16_t BECMBatteryCurrent = 0;
   uint16_t BECMUDynMaxLim = 0;
   uint16_t BECMUDynMinLim = 0;
 


### PR DESCRIPTION
### What
This PR corrects the datatype for current value in More Battery Info

### Why
User reported bug on the Discord

<img width="239" height="90" alt="image" src="https://github.com/user-attachments/assets/2d6ee5d3-d022-4d54-b5dc-a8dc65339458" />

### How
We now use int16_t instead of uint16_t