### PR TITLE
Add kostal contactor sequence, and secondary contactor option.

### DIFF
--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -90,6 +90,7 @@
 
 /* Shunt/Contactor settings (Optional) */
 //#define BMW_SBOX  // SBOX relay control & battery current/voltage measurement
+//#define KOSTAL_SECONDARY_CONTACTOR // Enable this line to use  (GPIO33) for controlling the secondary NC contactor. If you use battery with can controlled contactor like BMW I3 or tesla.
 
 /* Select charger used (Optional) */
 //#define CHEVYVOLT_CHARGER  //Enable this line to control a Chevrolet Volt charger connected to battery - for example, when generator charging or using an inverter without a charging function.

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -210,7 +210,7 @@ void KostalInverterProtocol::update_values() {
   }
 }
 
-void KostalInverterProtocol::receive()  // Runs as fast as possible to handle the serial stream
+void KostalInverterProtocol::receive()   // Runs as fast as possible to handle the serial stream
 {
   currentMillis = millis();
 

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -210,7 +210,7 @@ void KostalInverterProtocol::update_values() {
   }
 }
 
-void KostalInverterProtocol::receive()   // Runs as fast as possible to handle the serial stream
+void KostalInverterProtocol::receive()  // Runs as fast as possible to handle the serial stream
 {
   currentMillis = millis();
 

--- a/Software/src/inverter/KOSTAL-RS485.h
+++ b/Software/src/inverter/KOSTAL-RS485.h
@@ -12,6 +12,10 @@
 //#define DEBUG_KOSTAL_RS485_DATA  // Enable this line to get TX / RX printed out via logging
 //#define DEBUG_KOSTAL_RS485_DATA_USB  // Enable this line to get TX / RX printed out via USB
 
+#ifdef KOSTAL_SECONDARY_CONTACTOR
+#define SECONDARY_CONTACTOR_PIN 33
+#endif
+
 #if defined(DEBUG_KOSTAL_RS485_DATA) && !defined(DEBUG_LOG)
 #error "enable LOG_TO_SD, DEBUG_VIA_USB or DEBUG_VIA_WEB in order to use DEBUG_KOSTAL_RS485_DATA"
 #endif
@@ -44,6 +48,10 @@ class KostalInverterProtocol : public Rs485InverterProtocol {
   unsigned long currentMillis;
   unsigned long startupMillis = 0;
   unsigned long contactorMillis = 0;
+  unsigned long contactortestTimerStart = 0;
+  bool contactortestTimerActive = false;
+  unsigned long startupTimerStart = 0;
+  bool startupTimerActive = false;
 
   uint16_t rx_index = 0;
   boolean RX_allow = false;


### PR DESCRIPTION
### What
This PR implements secondary contactor to kostal inverter, when batteries with can contactor is used. This PR also implements contactor control by BE when kostal inverter wants to perform contactor test. this can be done both with the secondary contactor, or if this not is define it will do with automatic contactor control define. 

Maybe GPIO need to be implements better to Stark CMR and other, this is only done with lilygo
### Why
To get inverter to connect to battery and start up using battery correctly.
I also use secondary NC contactor, because off double BMW I3 battery. The second battery not always close contactor so i don't want inverter to control this can contactor. 

Mqtt gpio press is add to have ability to open secondary contactor from Home assistant, because plenticore G3 have some problem to recover battery after restart in night.

###How
contactor stays open when battery info is sent, when message 5E 02 is received contactor allow closing.
when message 5E 04 is received BE do contactor sequence. open contactor for 5 sec and close again, inverter pass this test and start charging or discharging,
