### PR TITLE
Volvo SPA: Improve robustness of reading of values

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -158,13 +158,8 @@ void VolvoSpaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         //logging.println("MIN_U not valid");	// Value toggles between true/false from BMS
       }
 
-      if ((rx_frame.data.u8[0] & 0x08) == 0x08)
+      if ((rx_frame.data.u8[0] & 0x08) == 0x08) {
         BATT_U = (((rx_frame.data.u8[0] & 0x07) * 256.0 + rx_frame.data.u8[1]) * 0.25);
-      else {
-        BATT_U = 0;
-#ifdef DEBUG_LOG
-        logging.println("BATT_U not valid");
-#endif
       }
 
       if ((rx_frame.data.u8[0] & 0x40) == 0x40)
@@ -255,31 +250,16 @@ void VolvoSpaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 #endif
       }
 
-      if ((rx_frame.data.u8[0] & 0x04) == 0x04)
+      if ((rx_frame.data.u8[0] & 0x04) == 0x04) {
         CELL_U_MAX = ((rx_frame.data.u8[2] & 0x01) * 256 + rx_frame.data.u8[3]);
-      else {
-        CELL_U_MAX = 0;
-#ifdef DEBUG_LOG
-        logging.println("CELL_U_MAX not valid");
-#endif
       }
 
-      if ((rx_frame.data.u8[0] & 0x02) == 0x02)
+      if ((rx_frame.data.u8[0] & 0x02) == 0x02) {
         CELL_U_MIN = ((rx_frame.data.u8[0] & 0x01) * 256.0 + rx_frame.data.u8[1]);
-      else {
-        CELL_U_MIN = 0;
-#ifdef DEBUG_LOG
-        logging.println("CELL_U_MIN not valid");
-#endif
       }
 
-      if ((rx_frame.data.u8[0] & 0x08) == 0x08)
+      if ((rx_frame.data.u8[0] & 0x08) == 0x08) {
         CELL_ID_U_MAX = ((rx_frame.data.u8[4] & 0x01) * 256.0 + rx_frame.data.u8[5]);
-      else {
-        CELL_ID_U_MAX = 0;
-#ifdef DEBUG_LOG
-        logging.println("CELL_ID_U_MAX not valid");
-#endif
       }
       break;
     case 0x635:  // Diag request response

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -55,8 +55,8 @@ class VolvoSpaBattery : public CanBattery {
   float BATT_T_AVG = 0;             //0x413
   uint16_t SOC_BMS = 0;             //0X37D
   uint16_t SOC_CALC = 0;
-  uint16_t CELL_U_MAX = 3700;            //0x37D
-  uint16_t CELL_U_MIN = 3700;            //0x37D
+  uint16_t CELL_U_MAX = 370;             //0x37D
+  uint16_t CELL_U_MIN = 370;             //0x37D
   uint8_t CELL_ID_U_MAX = 0;             //0x37D
   uint16_t HvBattPwrLimDchaSoft = 0;     //0x369
   uint16_t HvBattPwrLimDcha1 = 0;        //0x175


### PR DESCRIPTION
### What
This PR makes the Volvo SPA integration more stable and less likely to error out

### Why
Bug reported on the Discord server. Volvo integration can incorrectly go into faulted state while starting up

### How
- We init cellvoltages to 3700mV instead of 37000mV to avoid code going right into FAULTED state
- We now only read cellvoltages if the value is available, and stop writing them to 0mV in case of value not available
- We now only read total pack voltage if the value is available, and stop writing the value to 0V in case of value not available
