### PR TITLE
Back to using GITHUB_TOKEN but with more permissions

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Set release tag
       id: vars
@@ -67,4 +69,4 @@ jobs:
         files: |
           output/*
       env:
-        GITHUB_TOKEN: ${{ secrets.WORKFLOW_SECRET }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What
We actually should use GITHUB_TOKEN but with correct permissions which are added in this PR.