### PR TITLE
BMW iX, i4‐i7: Reduce startup events

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -95,6 +95,10 @@ void BmwIXBattery::update_values() {  //This function maps all the values fetche
     datalayer.battery.status.cell_max_voltage_mV = max_cell_voltage;  //Value is alive
   }
 
+  if (terminal30_12v_voltage < 1100) {  //11.000V
+    set_event(EVENT_12V_LOW, terminal30_12v_voltage);
+  }
+
   datalayer.battery.info.max_design_voltage_dV = max_design_voltage;
 
   datalayer.battery.info.min_design_voltage_dV = min_design_voltage;

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -533,7 +533,7 @@ CAN_frame BMWiX_49C = {.FD = true,
   uint32_t battery_serial_number = 0;
   int32_t battery_current = 0;
   uint16_t battery_voltage = 3700;  //Startup with valid values - needs fixing in future
-  uint16_t terminal30_12v_voltage = 0;
+  uint16_t terminal30_12v_voltage = 1200;
   uint16_t battery_voltage_after_contactor = 0;
   uint16_t min_soc_state = 5000;
   uint16_t avg_soc_state = 5000;


### PR DESCRIPTION
### What
This PR makes the BMW iX, i4‐i7 integration startup without voltage warning events active

### Why
User reported bug on Discord server

### How
We initialize sane values (370.0V instead of 37.0V)

BONUS:
- We use correct datatypes
- Event for low 12V battery added
