### PR TITLE
Improvement: Add voltage limits to RangeRoverPHEV

### DIFF
--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -17,12 +17,12 @@ class RangeRoverPhevBattery : public CanBattery {
 
  private:
   /* Change the following to suit your battery */
-  static const int MAX_PACK_VOLTAGE_DV = 5000;  //TODO: Configure
-  static const int MIN_PACK_VOLTAGE_DV = 0;     //TODO: Configure
+  static const int MAX_PACK_VOLTAGE_DV = 4710;
+  static const int MIN_PACK_VOLTAGE_DV = 3000;
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
   static const int MAX_CELL_DEVIATION_MV = 150;
-  ;
+
   unsigned long previousMillis50ms = 0;  // will store last time a 50ms CAN Message was sent
 
   //CAN content from battery


### PR DESCRIPTION
### What
This PR adds voltage limits to 

Range Rover Sport (L494) [2013–2022] integration

### Why
Safer operation

### How
Max voltage taken from log from CCS charging session
