### PR TITLE
Keep factory images out of release assets

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -74,8 +74,9 @@ jobs:
     - name: 🌐 Deploy to Web Installer repo
       env:
         WEB_INSTALLER_PUSH_TOKEN: ${{ secrets.WEB_INSTALLER_PUSH_TOKEN }}
+        REPO_OWNER: ${{ github.repository_owner }}
       run: |
-        git clone https://$WEB_INSTALLER_PUSH_TOKEN@github.com/dalathegreat/BE-Web-Installer web-installer
+        git clone https://$WEB_INSTALLER_PUSH_TOKEN@github.com/$REPO_OWNER/BE-Web-Installer web-installer
         cd web-installer
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -90,6 +91,6 @@ jobs:
       with:
         tag_name: ${{ steps.vars.outputs.tag }}
         files: |
-          output/*
+          output/*.ota.bin
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What
Avoid uploading `.factory.bin` files to GitHub release assets, as these will confuse people.

We could provide the factory files via some other mechanism for people that can't get the web installer to work (maybe a link on the web installer page).
