### PR TITLE
Revert AsyncTCP extra taskYIELD (unnecessary)

### DIFF
--- a/Software/src/lib/mathieucarbou-AsyncTCPSock/src/AsyncTCP.cpp
+++ b/Software/src/lib/mathieucarbou-AsyncTCPSock/src/AsyncTCP.cpp
@@ -228,11 +228,6 @@ void _asynctcpsock_task(void *)
         sockList.clear();
 
         xSemaphoreGiveRecursive(_asyncsock_mutex);
-
-        // Battery-Emulator modification: Yield so that other same-priority
-        // tasks on the same core get a turn, otherwise heavy HTTP traffic will
-        // exclude them.
-        taskYIELD();
     }
 
     vTaskDelete(NULL);


### PR DESCRIPTION
### What
Remove the `taskYIELD()` recently added to the AsyncTCP class.

### Why
I thought that this was necessary to prevent starvation of the same-prio tasks with watchdogs, but as Kyberias points out, FreeRTOS has `configUSE_TIME_SLICING` set, and has a fair scheduling algorithm, so this can't have been a problem.

Indeed I can no longer recreate it!