### PR TITLE
Make custom-BMS voltage limits configurable via settings

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -152,6 +152,11 @@ battery_chemistry_enum user_selected_battery_chemistry = battery_chemistry_defau
 
 BatteryType user_selected_battery_type = BatteryType::NissanLeaf;
 bool user_selected_second_battery = false;
+// Defaults for the battery voltage limits, only applied with custom-BMS batteries
+uint16_t user_selected_max_pack_voltage_dV = 0;
+uint16_t user_selected_min_pack_voltage_dV = 0;
+uint16_t user_selected_max_cell_voltage_mV = 0;
+uint16_t user_selected_min_cell_voltage_mV = 0;
 
 Battery* create_battery(BatteryType type) {
   switch (type) {

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -55,4 +55,11 @@ void setup_can_shunt();
 
 void setup_battery(void);
 
+#ifdef COMMON_IMAGE
+extern uint16_t user_selected_max_pack_voltage_dV;
+extern uint16_t user_selected_min_pack_voltage_dV;
+extern uint16_t user_selected_max_cell_voltage_mV;
+extern uint16_t user_selected_min_cell_voltage_mV;
+#endif
+
 #endif

--- a/Software/src/battery/CELLPOWER-BMS.cpp
+++ b/Software/src/battery/CELLPOWER-BMS.cpp
@@ -1,4 +1,5 @@
 #include "CELLPOWER-BMS.h"
+#include "../battery/BATTERIES.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For "More battery info" webpage
@@ -231,8 +232,15 @@ void CellPowerBms::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
 }

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -1,6 +1,7 @@
 #include "DALY-BMS.h"
 #include <Arduino.h>
 #include <cstdint>
+#include "../battery/BATTERIES.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
@@ -64,10 +65,17 @@ void DalyBms::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = CELL_COUNT;
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
   datalayer.battery.info.total_capacity_Wh = BATTERY_WH_MAX;
   datalayer.system.status.battery_allows_contactor_closing = true;
 

--- a/Software/src/battery/ORION-BMS.cpp
+++ b/Software/src/battery/ORION-BMS.cpp
@@ -1,4 +1,5 @@
 #include "ORION-BMS.h"
+#include "../battery/BATTERIES.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
@@ -116,9 +117,16 @@ void OrionBms::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = NUMBER_OF_CELLS;
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
   datalayer.system.status.battery_allows_contactor_closing = true;
 }

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -1,4 +1,5 @@
 #include "PYLON-BATTERY.h"
+#include "../battery/BATTERIES.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
@@ -131,10 +132,17 @@ void PylonBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, "Pylon compatible battery", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer_battery->info.number_of_cells = 2;
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
 
   datalayer.battery2.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -1,4 +1,5 @@
 #include "RJXZS-BMS.h"
+#include "../battery/BATTERIES.h"
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
@@ -517,9 +518,16 @@ void RjxzsBms::transmit_can(unsigned long currentMillis) {
 void RjxzsBms::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
   datalayer.system.status.battery_allows_contactor_closing = true;
 }

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -1,4 +1,5 @@
 #include "SIMPBMS-BATTERY.h"
+#include "../battery/BATTERIES.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 
@@ -94,9 +95,16 @@ void SimpBmsBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = CELL_COUNT;
+#ifdef COMMON_IMAGE
+  datalayer.battery.info.max_design_voltage_dV = user_selected_max_pack_voltage_dV;
+  datalayer.battery.info.min_design_voltage_dV = user_selected_min_pack_voltage_dV;
+  datalayer.battery.info.max_cell_voltage_mV = user_selected_max_cell_voltage_mV;
+  datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
+#else
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+#endif
   datalayer.system.status.battery_allows_contactor_closing = true;
 }

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -1,4 +1,5 @@
 #include "comm_nvm.h"
+#include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
 #include "../../battery/Shunt.h"
 #include "../../charger/CanCharger.h"
@@ -91,6 +92,10 @@ void init_stored_settings() {
   user_selected_inverter_protocol = (InverterProtocolType)settings.getUInt("INVTYPE", (int)InverterProtocolType::None);
   user_selected_charger_type = (ChargerType)settings.getUInt("CHGTYPE", (int)ChargerType::None);
   user_selected_shunt_type = (ShuntType)settings.getUInt("SHUNTTYPE", (int)ShuntType::None);
+  user_selected_max_pack_voltage_dV = settings.getUInt("BATTPVMAX", 0);
+  user_selected_min_pack_voltage_dV = settings.getUInt("BATTPVMIN", 0);
+  user_selected_max_cell_voltage_mV = settings.getUInt("BATTCVMAX", 0);
+  user_selected_min_cell_voltage_mV = settings.getUInt("BATTCVMIN", 0);
 
   auto readIf = [](const char* settingName) {
     auto batt1If = (comm_interface)settings.getUInt(settingName, (int)comm_interface::CanNative);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -306,6 +306,22 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     }
   }
 
+  if (var == "BATTPVMAX") {
+    return String(static_cast<float>(settings.getUInt("BATTPVMAX", 0)) / 10.0, 1);
+  }
+
+  if (var == "BATTPVMIN") {
+    return String(static_cast<float>(settings.getUInt("BATTPVMIN", 0)) / 10.0, 1);
+  }
+
+  if (var == "BATTCVMAX") {
+    return String(settings.getUInt("BATTCVMAX", 0));
+  }
+
+  if (var == "BATTCVMIN") {
+    return String(settings.getUInt("BATTCVMIN", 0));
+  }
+
   if (var == "BATTERY_WH_MAX") {
     return String(datalayer.battery.info.total_capacity_Wh);
   }
@@ -593,23 +609,13 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
           function goToMainPage() { window.location.href = '/'; }
 
-          function toggleMqtt() {
-            var mqttEnabled = document.querySelector('input[name="MQTTENABLED"]').checked;
-            document.querySelectorAll('.mqtt-settings').forEach(function (el) {
-              el.style.display = mqttEnabled ? 'contents' : 'none';
-            });
-          }
-
-          document.addEventListener('DOMContentLoaded', toggleMqtt);
-
-          function toggleTopics() {
-            var topicsEnabled = document.querySelector('input[name="MQTTTOPICS"]').checked;
-            document.querySelectorAll('.mqtt-topics').forEach(function (el) {
-              el.style.display = topicsEnabled ? 'contents' : 'none';
-            });
-          }
-
-          document.addEventListener('DOMContentLoaded', toggleTopics);
+          document.querySelectorAll('select,input').forEach(function(sel) {
+            function ch() {
+              sel.closest('form').setAttribute('data-' + sel.name?.toLowerCase(), sel.type=='checkbox'?sel.checked:sel.value);
+            }
+            sel.addEventListener('change', ch);
+            ch();
+          });
     </script>
 )rawliteral"
 
@@ -621,7 +627,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         cursor: pointer; border-radius: 10px; }
     button:hover { background-color: #3A4A52; }
     h4 { margin: 0.6em 0; line-height: 1.2; }
-    select { max-width: 250px; }
+    select, input { max-width: 250px; box-sizing: border-box; }
     .hidden {
       display: none;
     }
@@ -641,6 +647,32 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       grid-column: span 2;
     }
 
+    form .if-battery, form .if-inverter, form .if-charger, form .if-shunt { display: contents; }
+    form[data-battery="0"] .if-battery { display: none; }
+    form[data-inverter="0"] .if-inverter { display: none; }    
+    form[data-charger="0"] .if-charger { display: none; }
+    form[data-shunt="0"] .if-shunt { display: none; }
+
+    form .if-cbms { display: none; }
+    form[data-battery="6"] .if-cbms, form[data-battery="11"] .if-cbms, form[data-battery="22"] .if-cbms, form[data-battery="23"] .if-cbms, form[data-battery="24"] .if-cbms, form[data-battery="31"] .if-cbms {
+      display: contents;
+    }
+
+    form .if-dblbtr { display: none; }
+    form[data-dblbtr="true"] .if-dblbtr {
+      display: contents;
+    }
+
+    form .if-mqtt { display: none; }
+    form[data-mqttenabled="true"] .if-mqtt {
+      display: contents;
+    }
+
+    form .if-topics { display: none; }
+    form[data-mqtttopics="true"] .if-topics {
+      display: contents;
+    }
+
     </style>
 )rawliteral"
 
@@ -654,13 +686,13 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     
     <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px;border-radius: 50px; class="%COMMONIMAGEDIVCLASS%">
     <div style='max-width: 500px;'>
-        <form action='saveSettings' method='post' style='display: grid; grid-template-columns: 1fr 2fr; gap: 10px;
-        align-items: center;'>
+        <form action='saveSettings' method='post' style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>
 
         <label for='battery'>Battery: </label><select name='battery' if='battery'>
         %BATTTYPE%
         </select>
 
+        <div class="if-battery">
         <label for='BATTCOMM'>Battery comm I/F: </label><select name='BATTCOMM' id='BATTCOMM'>
         %BATTCOMM%
         </select>
@@ -668,30 +700,51 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label>Battery chemistry: </label><select name='BATTCHEM'>
         %BATTCHEM%
         </select>
+        </div>
+
+        <div class="if-cbms">
+        <label>Battery max design voltage (V): </label>
+        <input name='BATTPVMAX' pattern="^[0-9]+(\.[0-9]+)?$" type='text' value='%BATTPVMAX%' />
+
+        <label>Battery min design voltage (V): </label>
+        <input name='BATTPVMIN' pattern="^[0-9]+(\.[0-9]+)?$" type='text' value='%BATTPVMIN%' />
+
+        <label>Cell max design voltage (mV): </label>
+        <input name='BATTCVMAX' pattern="^[0-9]+$" type='text' value='%BATTCVMAX%' />
+
+        <label>Cell min design voltage (mV): </label>
+        <input name='BATTCVMIN' pattern="^[0-9]+$" type='text' value='%BATTCVMIN%' />
+        </div>
 
         <label>Inverter protocol: </label><select name='inverter'>
         %INVTYPE%
         </select>
 
+        <div class="if-inverter">        
         <label>Inverter comm I/F: </label><select name='INVCOMM'>
         %INVCOMM%     
         </select>
+        </div>
 
         <label>Charger: </label><select name='charger'>
         %CHGTYPE%
         </select>
 
+        <div class="if-charger">
         <label>Charger comm I/F: </label><select name='CHGCOMM'>
         %CHGCOMM%
         </select>
+        </div>
 
         <label>Shunt: </label><select name='SHUNT'>
         %SHUNTTYPE%
         </select>
 
+        <div class="if-shunt">
         <label>Shunt comm I/F: </label><select name='SHUNTCOMM'>
         %SHUNTCOMM%
         </select>
+        </div>
 
         <label>Equipment stop button: </label><select name='EQSTOP'>
         %EQSTOP%  
@@ -700,15 +753,19 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label>Double battery: </label>
         <input type='checkbox' name='DBLBTR' value='on' style='margin-left: 0;' %DBLBTR% />
 
+        <div class="if-dblbtr">
         <label>Battery 2 comm I/F: </label><select name='BATT2COMM'>
         %BATT2COMM%
         </select>
+        </div>
 
         <label>Contactor control: </label>
         <input type='checkbox' name='CNTCTRL' value='on' style='margin-left: 0;' %CNTCTRL% />
 
+        <div class="if-dblbtr">
         <label>Contactor control double battery: </label>
         <input type='checkbox' name='CNTCTRLDBL' value='on' style='margin-left: 0;' %CNTCTRLDBL% />
+        </div>
 
         <label>PWM contactor control: </label>
         <input type='checkbox' name='PWMCNTCTRL' value='on' style='margin-left: 0;' %PWMCNTCTRL% />
@@ -726,26 +783,26 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='checkbox' name='WIFIAPENABLED' value='on' style='margin-left: 0;' %WIFIAPENABLED% />
 
         <label>Custom hostname: </label>
-        <input style='max-width: 250px;' type='text' name='HOSTNAME' value="%HOSTNAME%" />
+        <input type='text' name='HOSTNAME' value="%HOSTNAME%" />
 
         <label>Enable MQTT: </label>
-        <input type='checkbox' name='MQTTENABLED' value='on' onchange='toggleMqtt()' style='margin-left: 0;' %MQTTENABLED% />
+        <input type='checkbox' name='MQTTENABLED' value='on' style='margin-left: 0;' %MQTTENABLED% />
 
-        <div class='mqtt-settings'>
-        <label>MQTT server: </label><input style='max-width: 250px;' type='text' name='MQTTSERVER' value="%MQTTSERVER%" />
-        <label>MQTT port: </label><input style='max-width: 250px;' type='text' name='MQTTPORT' value="%MQTTPORT%" />
-        <label>MQTT user: </label><input style='max-width: 250px;' type='text' name='MQTTUSER' value="%MQTTUSER%" />
-        <label>MQTT password: </label><input style='max-width: 250px;' type='password' name='MQTTPASSWORD' value="%MQTTPASSWORD%" />
+        <div class='if-mqtt'>
+        <label>MQTT server: </label><input type='text' name='MQTTSERVER' value="%MQTTSERVER%" />
+        <label>MQTT port: </label><input type='text' name='MQTTPORT' value="%MQTTPORT%" />
+        <label>MQTT user: </label><input type='text' name='MQTTUSER' value="%MQTTUSER%" />
+        <label>MQTT password: </label><input type='password' name='MQTTPASSWORD' value="%MQTTPASSWORD%" />
 
         <label>Customized MQTT topics: </label>
-        <input type='checkbox' name='MQTTTOPICS' value='on' onchange='toggleTopics()' style='margin-left: 0;' %MQTTTOPICS% />
+        <input type='checkbox' name='MQTTTOPICS' value='on' style='margin-left: 0;' %MQTTTOPICS% />
 
-        <div class='mqtt-topics'>
+        <div class='if-topics'>
 
-        <label>MQTT topic name: </label><input style='max-width: 250px;' type='text' name='MQTTTOPIC' value="%MQTTTOPIC%" />
-        <label>Prefix for MQTT object ID: </label><input style='max-width: 250px;' type='text' name='MQTTOBJIDPREFIX' value="%MQTTOBJIDPREFIX%" />
-        <label>HA device name: </label><input style='max-width: 250px;' type='text' name='MQTTDEVICENAME' value="%MQTTDEVICENAME%" />
-        <label>HA device ID: </label><input style='max-width: 250px;' type='text' name='HADEVICEID' value="%HADEVICEID%" />
+        <label>MQTT topic name: </label><input type='text' name='MQTTTOPIC' value="%MQTTTOPIC%" />
+        <label>Prefix for MQTT object ID: </label><input type='text' name='MQTTOBJIDPREFIX' value="%MQTTOBJIDPREFIX%" />
+        <label>HA device name: </label><input type='text' name='MQTTDEVICENAME' value="%MQTTDEVICENAME%" />
+        <label>HA device ID: </label><input type='text' name='HADEVICEID' value="%HADEVICEID%" />
 
         </div>
 


### PR DESCRIPTION
### What
Add four new settings (pack/cell max/min voltage limits), and apply them to the custom-BMS batteries only.

I rejigged the settings JS/CSS/HTML a bit:
- tidying up some weird styling
- replacing JS-controlled hide/reveal behaviour with CSS
- enabled hide/reveal for dependent battery/inverter/charger/shunt/double-battery settings

### Why
Will be necessary for COMMON_IMAGE use of custom BMSes.

Also checking that I've added these settings correctly.