### PR TITLE
Nissan LEAF: Add all temperature measurements to More Battery Info page

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -188,6 +188,10 @@ void NissanLeafBattery::
     datalayer_nissan->HeatingStart = battery_Heating_Start;
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
     datalayer_nissan->battery_HX = battery_HX;
+    datalayer_nissan->temperature1 = ((Temp_fromRAW_to_F(battery_temp_raw_1) - 320) * 5) / 9;  //Convert from F to C
+    datalayer_nissan->temperature2 = ((Temp_fromRAW_to_F(battery_temp_raw_2) - 320) * 5) / 9;  //Convert from F to C
+    datalayer_nissan->temperature3 = ((Temp_fromRAW_to_F(battery_temp_raw_3) - 320) * 5) / 9;  //Convert from F to C
+    datalayer_nissan->temperature4 = ((Temp_fromRAW_to_F(battery_temp_raw_4) - 320) * 5) / 9;  //Convert from F to C
     datalayer_nissan->CryptoChallenge = incomingChallenge;
     datalayer_nissan->SolvedChallengeMSB =
         ((solvedChallenge[7] << 24) | (solvedChallenge[6] << 16) | (solvedChallenge[5] << 8) | solvedChallenge[4]);
@@ -799,6 +803,8 @@ bool NissanLeafBattery::is_message_corrupt(CAN_frame rx_frame) {
 uint16_t Temp_fromRAW_to_F(uint16_t temperature) {  //This function feels horrible, but apparently works well
   if (temperature == 1021) {
     return 10;
+  } else if (temperature == 65535) {  //Value unavailable, sensor does not exist
+    return 718;                       //0*C final calculation
   } else if (temperature >= 589) {
     return static_cast<uint16_t>(1620 - temperature * 1.81);
   } else if (temperature >= 569) {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -198,11 +198,11 @@ class NissanLeafBattery : public CanBattery {
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
   uint16_t battery_HX = 0;              //Internal resistance
   uint16_t battery_insulation = 0;      //Insulation resistance
-  uint16_t battery_temp_raw_1 = 0;
+  uint16_t battery_temp_raw_1 = 718;
   uint8_t battery_temp_raw_2_highnibble = 0;
-  uint16_t battery_temp_raw_2 = 0;
-  uint16_t battery_temp_raw_3 = 0;
-  uint16_t battery_temp_raw_4 = 0;
+  uint16_t battery_temp_raw_2 = 718;
+  uint16_t battery_temp_raw_3 = 718;  //This measurement not available on 2013+
+  uint16_t battery_temp_raw_4 = 718;
   uint16_t battery_temp_raw_max = 0;
   uint16_t battery_temp_raw_min = 0;
   int16_t battery_temp_polled_max = 0;

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -54,6 +54,10 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Heating stopped: " + String(datalayer_extended.nissanleaf.HeatingStop) + "</h4>";
     content += "<h4>Heating started: " + String(datalayer_extended.nissanleaf.HeatingStart) + "</h4>";
     content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
+    content += "<h4>Temperature 1: " + String(datalayer_extended.nissanleaf.temperature1) + " &deg;C</h4>";
+    content += "<h4>Temperature 2: " + String(datalayer_extended.nissanleaf.temperature2) + " &deg;C</h4>";
+    content += "<h4>Temperature 3: " + String(datalayer_extended.nissanleaf.temperature3) + " &deg;C</h4>";
+    content += "<h4>Temperature 4: " + String(datalayer_extended.nissanleaf.temperature4) + " &deg;C</h4>";
     content += "<h4>CryptoChallenge: " + String(datalayer_extended.nissanleaf.CryptoChallenge) + "</h4>";
     content += "<h4>SolvedChallenge: " + String(datalayer_extended.nissanleaf.SolvedChallengeMSB) +
                String(datalayer_extended.nissanleaf.SolvedChallengeLSB) + "</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -625,6 +625,12 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** int16_t */
   /** Insulation resistance, most likely kOhm */
   uint16_t Insulation = 0;
+  /** int16_t */
+  /** Temperature sensoros 1-4 */
+  int16_t temperature1 = 0;
+  int16_t temperature2 = 0;
+  int16_t temperature3 = 0;  // This sensor not available on 2013+ packs
+  int16_t temperature4 = 0;
   /** uint8_t */
   /** battery_FAIL status */
   uint8_t RelayCutRequest = 0;


### PR DESCRIPTION
### What
This PR adds the 4 temperature measurements the LEAF has to the "More Battery Info" page

### Why
Easier troubleshooting of defective temperature sensors

NOTE: 2013+ packs do not report valid measurements on Sensor3!

### How

<img width="357" height="234" alt="image" src="https://github.com/user-attachments/assets/4bbcd634-8d84-473b-bcad-83a80061656d" />

