### PR TITLE
Improvement: Update CPU temperature setpoint

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -26,7 +26,7 @@ void update_machineryprotection() {
   /* Check if the ESP32 CPU running the Battery-Emulator is too hot. 
   We start with a warning, you can start to see Wifi issues if it becomes too hot 
   If the chip starts to approach the design limit, we perform a graceful shutdown */
-  if (datalayer.system.info.CPU_temperature > 80.0f) {
+  if (datalayer.system.info.CPU_temperature > 87.0f) {
     set_event(EVENT_CPU_OVERHEATING, 0);
   } else {
     clear_event(EVENT_CPU_OVERHEATING);

--- a/test/safety_tests.cpp
+++ b/test/safety_tests.cpp
@@ -6,7 +6,7 @@
 
 TEST(SafetyTests, ShouldSetEventWhenTemperatureTooHigh) {
   init_events();
-  datalayer.system.info.CPU_temperature = 82;
+  datalayer.system.info.CPU_temperature = 88;
   update_machineryprotection();
 
   auto event_pointer = get_event_pointer(EVENT_CPU_OVERHEATING);


### PR DESCRIPTION
### What
This PR changes the CPU overheat warning message to be less sensitive

### Why
To cut down on false positive warnings. So many people report issues, even though there are no issues

### How
Raised the CPU temperature warning from 80 to 87deg 
