### PR TITLE
Improvement: UI visualization of contactor states

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -192,7 +192,7 @@ void handle_contactors() {
       set(negPin, OFF, PWM_OFF_DUTY);
       set(posPin, OFF, PWM_OFF_DUTY);
       set_event(EVENT_ERROR_OPEN_CONTACTOR, 0);
-      datalayer.system.status.contactors_engaged = false;
+      datalayer.system.status.contactors_engaged = 2;
       return;  // A fault scenario latches the contactor control. It is not possible to recover without a powercycle (and investigation why fault occured)
     }
 
@@ -201,10 +201,9 @@ void handle_contactors() {
       set(prechargePin, OFF);
       set(negPin, OFF, PWM_OFF_DUTY);
       set(posPin, OFF, PWM_OFF_DUTY);
-      datalayer.system.status.contactors_engaged = false;
+      datalayer.system.status.contactors_engaged = 0;
 
-      if (datalayer.system.status.battery_allows_contactor_closing &&
-          datalayer.system.status.inverter_allows_contactor_closing &&
+      if (datalayer.system.status.inverter_allows_contactor_closing &&
           !datalayer.system.settings.equipment_stop_active) {
         contactorStatus = START_PRECHARGE;
       }
@@ -263,7 +262,7 @@ void handle_contactors() {
           set(posPin, ON, PWM_HOLD_DUTY);
           dbg_contactors("PRECHARGE_OFF");
           contactorStatus = COMPLETED;
-          datalayer.system.status.contactors_engaged = true;
+          datalayer.system.status.contactors_engaged = 1;
         }
         break;
       default:

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -55,7 +55,7 @@ const int OFF = 0;
 #define OFF 1
 #endif  //NC_CONTACTORS
 
-#define MAX_ALLOWED_FAULT_TICKS 1000
+#define MAX_ALLOWED_FAULT_TICKS 1000  //1000 = 10 seconds
 #define NEGATIVE_CONTACTOR_TIME_MS \
   500  // Time after negative contactor is turned on, to start precharge (not actual precharge time!)
 #define PRECHARGE_COMPLETED_TIME_MS \

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -310,8 +310,8 @@ struct DATALAYER_SYSTEM_STATUS_TYPE {
   /** True if the inverter allows for the contactors to close */
   bool inverter_allows_contactor_closing = true;
 
-  /** True if the contactor controlled by battery-emulator is closed */
-  bool contactors_engaged = false;
+  /** 0 if starting up, 1 if contactors engaged, 2 if the contactors controlled by battery-emulator is opened */
+  uint8_t contactors_engaged = 0;
   /** True if the contactor controlled by battery-emulator is closed. Determined by check_interconnect_available(); if voltage is OK */
   bool contactors_battery2_engaged = false;
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -270,8 +270,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_INTERFACE_MISSING:
       return "Configuration trying to use CAN interface not baked into the software. Recompile software!";
     case EVENT_ERROR_OPEN_CONTACTOR:
-      return "Too much time spent in error state. Opening contactors, not safe to continue charging. "
-             "Check other error code for reason!";
+      return "Too much time spent in error state. Opening contactors, not safe to continue. "
+             "Check other active ERROR code for reason. Reboot emulator after problem is solved!";
     case EVENT_MODBUS_INVERTER_MISSING:
       return "Modbus inverter has not sent any data. Inspect communication wiring!";
     case EVENT_NO_ENABLE_DETECTED:

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1222,47 +1222,6 @@ String processor(const String& var) {
         } else {  // > 0
           content += "<h4>Battery charging!</h4>";
         }
-
-        if (contactor_control_enabled) {
-          content += "<h4>Contactors controlled by emulator, state: ";
-          if (datalayer.system.status.contactors_battery2_engaged) {
-            content += "<span style='color: green;'>ON</span>";
-          } else {
-            content += "<span style='color: red;'>OFF</span>";
-          }
-          content += "</h4>";
-
-          if (contactor_control_enabled_double_battery) {
-            content += "<h4>Cont. Neg.: ";
-            if (pwm_contactor_control) {
-              if (datalayer.system.status.contactors_battery2_engaged) {
-                content += "<span style='color: green;'>Economized</span>";
-                content += " Cont. Pos.: ";
-                content += "<span style='color: green;'>Economized</span>";
-              } else {
-                content += "<span style='color: red;'>&#10005;</span>";
-                content += " Cont. Pos.: ";
-                content += "<span style='color: red;'>&#10005;</span>";
-              }
-            } else {  // No PWM_CONTACTOR_CONTROL , we can read the pin and see feedback. Helpful if channel overloaded
-#if defined(SECOND_POSITIVE_CONTACTOR_PIN) && defined(SECOND_NEGATIVE_CONTACTOR_PIN)
-              if (digitalRead(SECOND_NEGATIVE_CONTACTOR_PIN) == HIGH) {
-                content += "<span style='color: green;'>&#10003;</span>";
-              } else {
-                content += "<span style='color: red;'>&#10005;</span>";
-              }
-
-              content += " Cont. Pos.: ";
-              if (digitalRead(SECOND_POSITIVE_CONTACTOR_PIN) == HIGH) {
-                content += "<span style='color: green;'>&#10003;</span>";
-              } else {
-                content += "<span style='color: red;'>&#10005;</span>";
-              }
-#endif
-            }
-            content += "</h4>";
-          }
-        }
         content += "</div>";
         content += "</div>";
       }
@@ -1320,25 +1279,20 @@ String processor(const String& var) {
       }
       content += "</h4></div>";
       if (contactor_control_enabled_double_battery) {
+        content += "<h4>Secondary battery contactor, state: ";
         if (pwm_contactor_control) {
-          content += "<h4>Cont. Neg.: ";
           if (datalayer.system.status.contactors_battery2_engaged) {
             content += "<span style='color: green;'>Economized</span>";
-            content += " Cont. Pos.: ";
-            content += "<span style='color: green;'>Economized</span>";
           } else {
-            content += "<span style='color: red;'>&#10005;</span>";
-            content += " Cont. Pos.: ";
-            content += "<span style='color: red;'>&#10005;</span>";
+            content += "<span style='color: red;'>OFF</span>";
           }
         } else if (
             esp32hal->SECOND_BATTERY_CONTACTORS_PIN() !=
             GPIO_NUM_NC) {  // No PWM_CONTACTOR_CONTROL , we can read the pin and see feedback. Helpful if channel overloaded
-          content += "<h4>Cont. Neg.: ";
           if (digitalRead(esp32hal->SECOND_BATTERY_CONTACTORS_PIN()) == HIGH) {
-            content += "<span style='color: green;'>&#10003;</span>";
+            content += "<span style='color: green;'>ON</span>";
           } else {
-            content += "<span style='color: red;'>&#10005;</span>";
+            content += "<span style='color: red;'>OFF</span>";
           }
         }  //no PWM_CONTACTOR_CONTROL
         content += "</h4>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1277,7 +1277,7 @@ String processor(const String& var) {
       content += "<h4 style='color: red;'>Power status: " + String(get_emulator_pause_status().c_str()) + " </h4>";
     }
 
-    content += "<h4>Battery allows contactor closing: ";
+    content += "<h4>Emulator allows contactor closing: ";
     if (datalayer.battery.status.bms_status == FAULT) {
       content += "<span style='color: red;'>&#10005;</span>";
     } else {
@@ -1289,11 +1289,13 @@ String processor(const String& var) {
     } else {
       content += "<span style='color: red;'>&#10005;</span></h4>";
     }
-    content += "<h4>Secondary battery allowed to join ";
-    if (datalayer.system.status.battery2_allowed_contactor_closing == true) {
-      content += "<span>&#10003;</span>";
-    } else {
-      content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
+    if (battery2) {
+      content += "<h4>Secondary battery allowed to join ";
+      if (datalayer.system.status.battery2_allowed_contactor_closing == true) {
+        content += "<span>&#10003;</span>";
+      } else {
+        content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
+      }
     }
 
     if (!contactor_control_enabled) {
@@ -1304,13 +1306,19 @@ String processor(const String& var) {
           "powering the contactors. Battery-Emulator will have limited amount of control over the contactors!</span>";
       content += "</div>";
     } else {  //contactor_control_enabled TRUE
-      content += "<h4>Contactors controlled by emulator, state: ";
-      if (datalayer.system.status.contactors_engaged) {
+      content += "<div class=\"tooltip\"><h4>Contactors controlled by emulator, state: ";
+      if (datalayer.system.status.contactors_engaged == 0) {
+        content += "<span style='color: green;'>PRECHARGE</span>";
+      } else if (datalayer.system.status.contactors_engaged == 1) {
         content += "<span style='color: green;'>ON</span>";
-      } else {
+      } else if (datalayer.system.status.contactors_engaged == 2) {
         content += "<span style='color: red;'>OFF</span>";
+        content += "<span class=\"tooltip-icon\"> [!]</span>";
+        content +=
+            "<span class=\"tooltiptext\">Emulator spent too much time in critical FAULT event. Investigate event "
+            "causing this via Events page. Reboot required to resume operation!</span>";
       }
-      content += "</h4>";
+      content += "</h4></div>";
       if (contactor_control_enabled_double_battery) {
         if (pwm_contactor_control) {
           content += "<h4>Cont. Neg.: ";


### PR DESCRIPTION
### What
This PR improves the visualization of what contactors are doing at the moment

### Why
It was very hard to understand the original implementation. This PR fixes #929 and many many emails with questions sent to me :sweat: 

### How
We add a separate box below the battery info, with information on how we either control (or do not control) contactors.

Example 1: Kia64 battery with CAN controlled contactors
<img width="888" height="296" alt="image" src="https://github.com/user-attachments/assets/de34883e-ea61-43d1-88b0-91c03b52467a" />
