### PR TITLE
BYD Atto 3: Default SOC method changed to measured

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -4,12 +4,6 @@
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/events.h"
 
-/* Notes
-SOC% by default is now ESTIMATED.
-If you have a crash-locked pack, See the Wiki for more info on how to attempt an unlock
-After battery has been unlocked, you can remove the "USE_ESTIMATED_SOC" from the BYD-ATTO-3-BATTERY.h file
-*/
-
 #define POLL_FOR_BATTERY_VOLTAGE 0x0008
 #define POLL_FOR_BATTERY_CURRENT 0x0009
 #define POLL_FOR_LOWEST_TEMP_CELL 0x002f

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -7,8 +7,12 @@
 #include "BYD-ATTO-3-HTML.h"
 #include "CanBattery.h"
 
-#define USE_ESTIMATED_SOC  // If enabled, SOC is estimated from pack voltage. Useful for locked packs. \
-                           // Comment out this only if you know your BMS is unlocked and able to send SOC%
+/* Notes
+SOC% by default is now MEASURED by BMS.
+If you have a crash-locked pack, See the Wiki for more info on how to attempt an unlock.
+Remove the comment from "USE_ESTIMATED_SOC" below if you still decide to use a locked battery and want to use estimated SOC.
+*/
+//#define USE_ESTIMATED_SOC
 
 //Uncomment and configure this line, if you want to filter out a broken temperature sensor (1-10)
 //Make sure you understand risks associated with disabling. Values can be read via "More Battery info"


### PR DESCRIPTION
### What
This PR changes the default SOC method from estimated to measured by BMS.

### Why
The measured SOC method is more accurate and should be the default in the prebuilt common image. The voltage-based estimate is only relevant for batteries that are crash locked and short periods of SOC drift correction.
This change also encourages users with locked batteries to try unlocking them before opening the battery and bypassing the contactor control, which can be dangerous.

### How
By commenting out #define USE_ESTIMATED_SOC