### PR TITLE
Enabler: External system limits into datalayer

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -398,12 +398,12 @@ void update_calculated_values() {
   }
   /* Restrict values from user settings if needed */
   /* First apply MQTT limits if they exist */
-  if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_MQTT_set_charge_dA) {
-    datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_MQTT_set_charge_dA;
-    datalayer.battery.settings.MQTT_settings_limit_charge = true;
+  if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_external_set_charge_dA) {
+    datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_external_set_charge_dA;
+    datalayer.battery.settings.external_system_limit_charge = true;
     datalayer.battery.settings.user_settings_limit_charge = false;
   } else { /* Then apply user settings if MQTT didn't limit */
-    datalayer.battery.settings.MQTT_settings_limit_charge = false;
+    datalayer.battery.settings.external_system_limit_charge = false;
     if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
       datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
       datalayer.battery.settings.user_settings_limit_charge = true;
@@ -411,12 +411,12 @@ void update_calculated_values() {
       datalayer.battery.settings.user_settings_limit_charge = false;
     }
   }
-  if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_MQTT_set_discharge_dA) {
-    datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_MQTT_set_discharge_dA;
-    datalayer.battery.settings.MQTT_settings_limit_discharge = true;
+  if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_external_set_discharge_dA) {
+    datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_external_set_discharge_dA;
+    datalayer.battery.settings.external_system_limit_discharge = true;
     datalayer.battery.settings.user_settings_limit_discharge = false;
   } else { /* Then apply user settings if MQTT didn't limit */
-    datalayer.battery.settings.MQTT_settings_limit_discharge = false;
+    datalayer.battery.settings.external_system_limit_discharge = false;
     if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
       datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
       datalayer.battery.settings.user_settings_limit_discharge = true;

--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -396,18 +396,33 @@ void update_calculated_values() {
     datalayer.battery.status.max_discharge_current_dA =
         ((datalayer.battery.status.max_discharge_power_W * 100) / datalayer.battery.status.voltage_dV);
   }
-  /* Restrict values from user settings if needed*/
-  if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
-    datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
-    datalayer.battery.settings.user_settings_limit_charge = true;
-  } else {
+  /* Restrict values from user settings if needed */
+  /* First apply MQTT limits if they exist */
+  if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_MQTT_set_charge_dA) {
+    datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_MQTT_set_charge_dA;
+    datalayer.battery.settings.MQTT_settings_limit_charge = true;
     datalayer.battery.settings.user_settings_limit_charge = false;
+  } else { /* Then apply user settings if MQTT didn't limit */
+    datalayer.battery.settings.MQTT_settings_limit_charge = false;
+    if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
+      datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
+      datalayer.battery.settings.user_settings_limit_charge = true;
+    } else { /* Raw unmodified battery value used if neither MQTT or User setting limits */
+      datalayer.battery.settings.user_settings_limit_charge = false;
+    }
   }
-  if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
-    datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
-    datalayer.battery.settings.user_settings_limit_discharge = true;
-  } else {
+  if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_MQTT_set_discharge_dA) {
+    datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_MQTT_set_discharge_dA;
+    datalayer.battery.settings.MQTT_settings_limit_discharge = true;
     datalayer.battery.settings.user_settings_limit_discharge = false;
+  } else { /* Then apply user settings if MQTT didn't limit */
+    datalayer.battery.settings.MQTT_settings_limit_discharge = false;
+    if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
+      datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
+      datalayer.battery.settings.user_settings_limit_discharge = true;
+    } else { /* Raw unmodified battery value used if neither MQTT or User setting limits */
+      datalayer.battery.settings.user_settings_limit_discharge = false;
+    }
   }
   /* Calculate active power based on voltage and current*/
   datalayer.battery.status.active_power_W =

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -25,7 +25,6 @@ const uint8_t rx_queue_size = 10;  // Receive Queue size
 volatile bool send_ok_native = 0;
 volatile bool send_ok_2515 = 0;
 volatile bool send_ok_2518 = 0;
-static unsigned long previousMillis10 = 0;
 
 #ifdef USE_CANFD_INTERFACE_AS_CLASSIC_CAN
 const bool use_canfd_as_can_default = true;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -126,9 +126,16 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   uint16_t max_percentage = BATTERY_MAXPERCENTAGE;
 
   /** The user specified maximum allowed charge rate, in deciAmpere. 300 = 30.0 A */
+  /** This value gets stored in persistent memory when user updates it */
   uint16_t max_user_set_charge_dA = BATTERY_MAX_CHARGE_AMP;
   /** The user specified maximum allowed discharge rate, in deciAmpere. 300 = 30.0 A */
   uint16_t max_user_set_discharge_dA = BATTERY_MAX_DISCHARGE_AMP;
+
+  /** The MQTT specified maximum allowed charge rate, in deciAmpere. 3000 = 300.0 A */
+  /** This value defaults to a high limit on reboot. If user sends a low value in via MQTT, we use that value */
+  uint16_t max_MQTT_set_charge_dA = 3000;
+  /** The user specified maximum allowed discharge rate, in deciAmpere. 3000 = 300.0 A */
+  uint16_t max_MQTT_set_discharge_dA = 3000;
 
   /** User specified discharge/charge voltages in use. Set to true to use user specified values */
   /** Some inverters like to see a specific target voltage for charge/discharge. Use these values to override automatic voltage limits*/
@@ -144,6 +151,8 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   /** Parameters for keeping track of the limiting factor in the system */
   bool user_settings_limit_discharge = false;
   bool user_settings_limit_charge = false;
+  bool MQTT_settings_limit_discharge = false;
+  bool MQTT_settings_limit_charge = false;
   bool inverter_limits_discharge = false;
   bool inverter_limits_charge = false;
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -131,11 +131,11 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   /** The user specified maximum allowed discharge rate, in deciAmpere. 300 = 30.0 A */
   uint16_t max_user_set_discharge_dA = BATTERY_MAX_DISCHARGE_AMP;
 
-  /** The MQTT specified maximum allowed charge rate, in deciAmpere. 3000 = 300.0 A */
-  /** This value defaults to a high limit on reboot. If user sends a low value in via MQTT, we use that value */
-  uint16_t max_MQTT_set_charge_dA = 3000;
+  /** The externally specified maximum allowed charge rate, in deciAmpere. 3000 = 300.0 A */
+  /** This value defaults to a high limit on reboot. If we get a value via MQTT/Modbus/etc., we use that value */
+  uint16_t max_external_set_charge_dA = 3000;
   /** The user specified maximum allowed discharge rate, in deciAmpere. 3000 = 300.0 A */
-  uint16_t max_MQTT_set_discharge_dA = 3000;
+  uint16_t max_external_set_discharge_dA = 3000;
 
   /** User specified discharge/charge voltages in use. Set to true to use user specified values */
   /** Some inverters like to see a specific target voltage for charge/discharge. Use these values to override automatic voltage limits*/
@@ -151,8 +151,8 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   /** Parameters for keeping track of the limiting factor in the system */
   bool user_settings_limit_discharge = false;
   bool user_settings_limit_charge = false;
-  bool MQTT_settings_limit_discharge = false;
-  bool MQTT_settings_limit_charge = false;
+  bool external_system_limit_discharge = false;
+  bool external_system_limit_charge = false;
   bool inverter_limits_discharge = false;
   bool inverter_limits_charge = false;
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1020,13 +1020,17 @@ String processor(const String& var) {
         content += formatPowerValue("Max discharge power", datalayer.battery.status.max_discharge_power_W, "", 1);
         content += formatPowerValue("Max charge power", datalayer.battery.status.max_charge_power_W, "", 1);
         content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A";
-        if (datalayer.battery.settings.user_settings_limit_discharge) {
+        if (datalayer.battery.settings.MQTT_settings_limit_discharge) {
+          content += " (MQTT)</h4>";
+        } else if (datalayer.battery.settings.user_settings_limit_discharge) {
           content += " (Manual)</h4>";
         } else {
           content += " (BMS)</h4>";
         }
         content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A";
-        if (datalayer.battery.settings.user_settings_limit_charge) {
+        if (datalayer.battery.settings.MQTT_settings_limit_charge) {
+          content += " (MQTT)</h4>";
+        } else if (datalayer.battery.settings.user_settings_limit_charge) {
           content += " (Manual)</h4>";
         } else {
           content += " (BMS)</h4>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1020,16 +1020,16 @@ String processor(const String& var) {
         content += formatPowerValue("Max discharge power", datalayer.battery.status.max_discharge_power_W, "", 1);
         content += formatPowerValue("Max charge power", datalayer.battery.status.max_charge_power_W, "", 1);
         content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A";
-        if (datalayer.battery.settings.MQTT_settings_limit_discharge) {
-          content += " (MQTT)</h4>";
+        if (datalayer.battery.settings.external_system_limit_discharge) {
+          content += " (External limit)</h4>";
         } else if (datalayer.battery.settings.user_settings_limit_discharge) {
           content += " (Manual)</h4>";
         } else {
           content += " (BMS)</h4>";
         }
         content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A";
-        if (datalayer.battery.settings.MQTT_settings_limit_charge) {
-          content += " (MQTT)</h4>";
+        if (datalayer.battery.settings.external_system_limit_charge) {
+          content += " (External limit)</h4>";
         } else if (datalayer.battery.settings.user_settings_limit_charge) {
           content += " (Manual)</h4>";
         } else {


### PR DESCRIPTION
### What
This PR paves the way for MQTT writing of allowed charge/discharge limits. External automation system could write allowed Ampere to the Battery-Emulator, to allow for smarter use of battery

### Why
User requested feature

### How
Note, this is only ½ the implementation. MQTT side is missing, since I do not have the skills or testing setup to get this working, maybe someone else can continue on that part?
