### PR TITLE
BYD Atto 3: Send correct data in 441 message

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -543,7 +543,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     }
 
     if (counter_100ms > 3) {
-      if (BMS_voltage_available) { // Transmit battery voltage back to BMS when confirmed it's available, this closes the contactors
+      if (BMS_voltage_available) {  // Transmit battery voltage back to BMS when confirmed it's available, this closes the contactors
         ATTO_3_441.data.u8[4] = (uint8_t)(battery_voltage - 1);
         ATTO_3_441.data.u8[5] = ((battery_voltage - 1) >> 8);
         ATTO_3_441.data.u8[6] = 0xFF;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -393,6 +393,7 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
       //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
+      BMS_voltage_available = true;
       break;
     case 0x445:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -542,7 +543,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     }
 
     if (counter_100ms > 3) {
-      if (battery_voltage > 0) {
+      if (BMS_voltage_available) { // Transmit battery voltage back to BMS when confirmed it's available, this closes the contactors
         ATTO_3_441.data.u8[4] = (uint8_t)(battery_voltage - 1);
         ATTO_3_441.data.u8[5] = ((battery_voltage - 1) >> 8);
         ATTO_3_441.data.u8[6] = 0xFF;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -136,14 +136,14 @@ uint16_t estimateSOCstandard(uint16_t packVoltage) {  // Linear interpolation fu
   return 0;  // Default return for safety, should never reach here
 }
 
-uint8_t compute441Checksum(const uint8_t* u8) // Computes the 441 checksum byte
+uint8_t compute441Checksum(const uint8_t* u8)  // Computes the 441 checksum byte
 {
-    int sum = 0;
-    for (int i = 0; i < 7; ++i) {
-        sum += u8[i];
-    }
-    uint8_t lsb = static_cast<uint8_t>(sum & 0xFF);
-    return static_cast<uint8_t>(~lsb & 0xFF);
+  int sum = 0;
+  for (int i = 0; i < 7; ++i) {
+    sum += u8[i];
+  }
+  uint8_t lsb = static_cast<uint8_t>(sum & 0xFF);
+  return static_cast<uint8_t>(~lsb & 0xFF);
 }
 
 void BydAttoBattery::
@@ -542,7 +542,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     }
 
     if (counter_100ms > 3) {
-      if (battery_voltage > 0){
+      if (battery_voltage > 0) {
         ATTO_3_441.data.u8[4] = (uint8_t)(battery_voltage - 1);
         ATTO_3_441.data.u8[5] = ((battery_voltage - 1) >> 8);
         ATTO_3_441.data.u8[6] = 0xFF;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -98,6 +98,7 @@ class BydAttoBattery : public CanBattery {
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;  // will store last time a 200ms CAN Message was send
   bool SOC_method = false;
+  bool BMS_voltage_available = false;
   uint8_t counter_50ms = 0;
   uint8_t counter_100ms = 0;
   uint8_t frame6_counter = 0xB;


### PR DESCRIPTION
### What
This PR sends the correct data in 441 message towards the battery, which is probably used as a confirmation from the car to the battery that it sees the same voltage as the BMS.

### Why
To fully support 50 kWh battery and solving the issue with contactors not staying closed.
Not sending the correct voltage could potentially cause issues with the 60 kWh if real voltage deviates too much from the previous static message.

### How
By sending the battery voltage and calculated checksum.