### PR TITLE
Adding the ability to set a temporary maximum charge or discharge lim…

### DIFF
--- a/Software/Software.ino
+++ b/Software/Software.ino
@@ -292,7 +292,7 @@ void core_loop(void*) {
         battery2->update_values();
         check_interconnect_available();
       }
-      update_calculated_values();
+      update_calculated_values(currentMillis);
       update_machineryprotection();  // Check safeties
 
       // Update values heading towards inverter
@@ -377,7 +377,7 @@ void check_interconnect_available() {
   }
 }
 
-void update_calculated_values() {
+void update_calculated_values(volatile unsigned long currentMillis) {
   /* Update CPU temperature*/
   union {
     float temp;
@@ -388,6 +388,14 @@ void update_calculated_values() {
     datalayer.system.info.CPU_temperature = temp.temp;
   }
 
+  /* Check is remote set limits have timed out */
+  if(currentMillis > datalayer.battery.settings.remote_set_timestamp + datalayer.battery.settings.remote_set_timeout) {
+    datalayer.battery.settings.remote_settings_limit_charge = false;
+    datalayer.battery.settings.remote_settings_limit_discharge = false;
+    datalayer.battery.settings.max_remote_set_charge_dA = 0;
+    datalayer.battery.settings.max_remote_set_discharge_dA = 0;
+  }
+
   /* Calculate allowed charge/discharge currents*/
   if (datalayer.battery.status.voltage_dV > 10) {
     // Only update value when we have voltage available to avoid div0. TODO: This should be based on nominal voltage
@@ -396,19 +404,37 @@ void update_calculated_values() {
     datalayer.battery.status.max_discharge_current_dA =
         ((datalayer.battery.status.max_discharge_power_W * 100) / datalayer.battery.status.voltage_dV);
   }
-  /* Restrict values from user settings if needed*/
-  if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
-    datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
-    datalayer.battery.settings.user_settings_limit_charge = true;
+
+  /* Apply remote restrictions if set*/
+  if(datalayer.battery.settings.remote_settings_limit_charge){
+    if(datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_remote_set_charge_dA) {
+      datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_remote_set_charge_dA;
+    }
   } else {
-    datalayer.battery.settings.user_settings_limit_charge = false;
+    /* Restrict values from user settings if needed*/
+    if (datalayer.battery.status.max_charge_current_dA > datalayer.battery.settings.max_user_set_charge_dA) {
+      datalayer.battery.status.max_charge_current_dA = datalayer.battery.settings.max_user_set_charge_dA;
+      datalayer.battery.settings.user_settings_limit_charge = true;
+    } else {
+      datalayer.battery.settings.user_settings_limit_charge = false;
+    }
   }
-  if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
-    datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
-    datalayer.battery.settings.user_settings_limit_discharge = true;
+
+  /* Apply remote restrictions if set*/
+  if(datalayer.battery.settings.remote_settings_limit_discharge){
+    if(datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_remote_set_charge_dA) {
+      datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_remote_set_discharge_dA;
+    }
   } else {
-    datalayer.battery.settings.user_settings_limit_discharge = false;
+    /* Restrict values from user settings if needed*/
+    if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_user_set_discharge_dA) {
+      datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_user_set_discharge_dA;
+      datalayer.battery.settings.user_settings_limit_discharge = true;
+    } else {
+      datalayer.battery.settings.user_settings_limit_discharge = false;
+    }
   }
+
   /* Calculate active power based on voltage and current*/
   datalayer.battery.status.active_power_W =
       (datalayer.battery.status.current_dA * (datalayer.battery.status.voltage_dV / 100));

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -125,10 +125,19 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
    * will "see" 100% */
   uint16_t max_percentage = BATTERY_MAXPERCENTAGE;
 
-  /** The user specified maximum allowed charge rate, in deciAmpere. 300 = 30.0 A */
+  /** The user specified maximum allowed charge rate, in deciAmpere. 300 = 30.0 A, persisted to memory */
   uint16_t max_user_set_charge_dA = BATTERY_MAX_CHARGE_AMP;
-  /** The user specified maximum allowed discharge rate, in deciAmpere. 300 = 30.0 A */
+  /** The user specified maximum allowed discharge rate, in deciAmpere. 300 = 30.0 A, persisted to memory */
   uint16_t max_user_set_discharge_dA = BATTERY_MAX_DISCHARGE_AMP;
+
+  /** Last time a remote set command was received to enable timeout of settings */
+  unsigned long remote_set_timestamp = 0;
+  /** Timeout time for remote limits */
+  unsigned long remote_set_timeout = 0;
+  /** The remote specified maximum allowed charge rate, in deciAmpere. 300 = 30.0 A, NOT persisted to memory */
+  uint16_t max_remote_set_charge_dA = BATTERY_MAX_CHARGE_AMP;
+  /** The remote specified maximum allowed discharge rate, in deciAmpere. 300 = 30.0 A, NOT persisted to memory */
+  uint16_t max_remote_set_discharge_dA = BATTERY_MAX_DISCHARGE_AMP;
 
   /** User specified discharge/charge voltages in use. Set to true to use user specified values */
   /** Some inverters like to see a specific target voltage for charge/discharge. Use these values to override automatic voltage limits*/
@@ -144,6 +153,8 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   /** Parameters for keeping track of the limiting factor in the system */
   bool user_settings_limit_discharge = false;
   bool user_settings_limit_charge = false;
+  bool remote_settings_limit_discharge = false;
+  bool remote_settings_limit_charge = false;
   bool inverter_limits_discharge = false;
   bool inverter_limits_charge = false;
 

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -598,6 +598,39 @@ void mqtt_message_received(char* topic_raw, int topic_len, char* data, int data_
   if (strcmp(topic, generateButtonTopic("STOP").c_str()) == 0) {
     setBatteryPause(true, false, true);
   }
+
+  if(strcmp(topic, generateButtonTopic("SET_LIMITS").c_str()) == 0) {
+    JsonDocument doc;
+    char* data_str = strndup(data, data_len);
+    deserializeJson(doc, data_str);
+    
+    if(doc["max_charge"].is<int>()) {
+      datalayer.battery.settings.max_remote_set_charge_dA = doc["max_charge"];
+      datalayer.battery.settings.remote_settings_limit_charge = true;
+    } else {
+      datalayer.battery.settings.max_remote_set_charge_dA = 0;
+      datalayer.battery.settings.remote_settings_limit_charge = false;
+    }
+
+    if(doc["max_discharge"].is<int>()) {
+      datalayer.battery.settings.max_remote_set_discharge_dA = doc["max_discharge"];
+      datalayer.battery.settings.remote_settings_limit_discharge = true;
+    } else {
+      datalayer.battery.settings.max_remote_set_discharge_dA = 0;
+      datalayer.battery.settings.remote_settings_limit_discharge = false;
+    }
+
+    if(doc["timeout"].is<int>()) {
+      datalayer.battery.settings.remote_set_timeout = doc["timeout"];
+    } else {
+      datalayer.battery.settings.remote_set_timeout = 5000;
+    }
+
+    datalayer.battery.settings.remote_set_timestamp = millis();
+
+    free(data_str);
+  }
+
   free(topic);
 }
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1020,13 +1020,17 @@ String processor(const String& var) {
         content += formatPowerValue("Max discharge power", datalayer.battery.status.max_discharge_power_W, "", 1);
         content += formatPowerValue("Max charge power", datalayer.battery.status.max_charge_power_W, "", 1);
         content += "<h4 style='color: white;'>Max discharge current: " + String(maxCurrentDischargeFloat, 1) + " A";
-        if (datalayer.battery.settings.user_settings_limit_discharge) {
+        if(datalayer.battery.settings.remote_settings_limit_discharge){
+          content += " (Remote)</h4>";
+        } else if (datalayer.battery.settings.user_settings_limit_discharge) {
           content += " (Manual)</h4>";
         } else {
           content += " (BMS)</h4>";
         }
         content += "<h4 style='color: white;'>Max charge current: " + String(maxCurrentChargeFloat, 1) + " A";
-        if (datalayer.battery.settings.user_settings_limit_charge) {
+        if(datalayer.battery.settings.remote_settings_limit_charge){
+          content += " (Remote)</h4>";
+        } else if (datalayer.battery.settings.user_settings_limit_charge) {
           content += " (Manual)</h4>";
         } else {
           content += " (BMS)</h4>";


### PR DESCRIPTION
Enables setting a temporary maximum charge and or discharge rate via MQTT

Follows a similar mechanism to SolaX inverters for temporary limits where the value is not persisted and only lasts for a short period of time as the expectation is for automations to push new values frequently. https://homeassistant-solax-modbus.readthedocs.io/en/latest/solax-mode1-modbus-power-control/

Topic: BE/command/set_limits

Message Structure:
{
	"max_charge": 30,
	"max_discharge": 10,
	"timeout": 50000
}

Charge and discharge rates are dA as per other settings
Timeout is milliseconds