### PR TITLE
Tesla: Add SOC reset feature

### DIFF
--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -92,7 +92,7 @@ class Battery {
 
   virtual void clear_isolation() {}
   virtual void reset_BMS() {}
-  virtual void reset_SOC() {}  
+  virtual void reset_SOC() {}
   virtual void reset_crash() {}
   virtual void reset_contactor() {}
   virtual void reset_NVROL() {}

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -73,6 +73,7 @@ class Battery {
 
   virtual bool supports_clear_isolation() { return false; }
   virtual bool supports_reset_BMS() { return false; }
+  virtual bool supports_reset_SOC() { return false; }
   virtual bool supports_reset_crash() { return false; }
   virtual bool supports_reset_NVROL() { return false; }
   virtual bool supports_reset_DTC() { return false; }
@@ -91,6 +92,7 @@ class Battery {
 
   virtual void clear_isolation() {}
   virtual void reset_BMS() {}
+  virtual void reset_SOC() {}  
   virtual void reset_crash() {}
   virtual void reset_contactor() {}
   virtual void reset_NVROL() {}

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2331,41 +2331,41 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
     if (stateMachineSOCReset != 0xFF) {
       //This implementation should be rewritten to actually reply to the UDS responses sent by the BMS
       //While this may work, it is not the correct way to implement this
-      switch (stateMachineBMSReset) {
+      switch (stateMachineSOCReset) {
         case 0:
           TESLA_602.data = {0x02, 0x27, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00};
           transmit_can_frame(&TESLA_602);
-          stateMachineBMSReset = 1;
+          stateMachineSOCReset = 1;
           break;
         case 1:
           TESLA_602.data = {0x30, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00};
           transmit_can_frame(&TESLA_602);
-          stateMachineBMSReset = 2;
+          stateMachineSOCReset = 2;
           break;
         case 2:
           TESLA_602.data = {0x10, 0x12, 0x27, 0x06, 0x35, 0x34, 0x37, 0x36};
           transmit_can_frame(&TESLA_602);
-          stateMachineBMSReset = 3;
+          stateMachineSOCReset = 3;
           break;
         case 3:
           TESLA_602.data = {0x21, 0x31, 0x30, 0x33, 0x32, 0x3D, 0x3C, 0x3F};
           transmit_can_frame(&TESLA_602);
-          stateMachineBMSReset = 4;
+          stateMachineSOCReset = 4;
           break;
         case 4:
           TESLA_602.data = {0x22, 0x3E, 0x39, 0x38, 0x3B, 0x3A, 0x00, 0x00};
           transmit_can_frame(&TESLA_602);
           //Should generate a CAN UDS log message indicating ECU unlocked
-          stateMachineBMSReset = 5;
+          stateMachineSOCReset = 5;
           break;
         case 5:
           TESLA_602.data = {0x04, 0x31, 0x01, 0x04, 0x07, 0x00, 0x00, 0x00};
           transmit_can_frame(&TESLA_602);
-          stateMachineBMSReset = 0xFF;
+          stateMachineSOCReset = 0xFF;
           break;
         default:
           //Something went wrong. Reset all and cancel
-          stateMachineBMSReset = 0xFF;
+          stateMachineSOCReset = 0xFF;
           break;
       }
     }

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -33,6 +33,9 @@ class TeslaBattery : public CanBattery {
   bool supports_reset_BMS() { return true; }
   void reset_BMS() { datalayer.battery.settings.user_requests_tesla_bms_reset = true; }
 
+  bool supports_reset_SOC() { return true; }
+  void reset_SOC() { datalayer.battery.settings.user_requests_tesla_soc_reset = true; }
+
   bool supports_charged_energy() { return true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
@@ -486,6 +489,7 @@ class TeslaBattery : public CanBattery {
 
   uint8_t stateMachineClearIsolationFault = 0xFF;
   uint8_t stateMachineBMSReset = 0xFF;
+  uint8_t stateMachineSOCReset = 0xFF;
   uint8_t stateMachineBMSQuery = 0xFF;
   uint16_t sendContactorClosingMessagesStill = 300;
   uint16_t battery_cell_max_v = 3300;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -152,6 +152,7 @@ struct DATALAYER_BATTERY_SETTINGS_TYPE {
   bool user_requests_balancing = false;
   bool user_requests_tesla_isolation_clear = false;
   bool user_requests_tesla_bms_reset = false;
+  bool user_requests_tesla_soc_reset = false;
   /* Forced balancing max time & start timestamp */
   uint32_t balancing_time_ms = 3600000;  //1h default, (60min*60sec*1000ms)
   uint32_t balancing_start_time_ms = 0;  //For keeping track when balancing started

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -25,6 +25,10 @@ std::vector<BatteryCommand> battery_commands = {
      [](Battery* b) {
        b->reset_BMS();
      }},
+    {"resetSOC", "SOC reset", "reset SOC?", [](Battery* b) { return b && b->supports_reset_SOC(); },
+     [](Battery* b) {
+       b->reset_SOC();
+     }},
     {"resetCrash", "Unlock crashed BMS",
      "reset crash data? Note this will unlock your BMS and enable contactor closing and SOC calculation.",
      [](Battery* b) { return b && b->supports_reset_crash(); },


### PR DESCRIPTION
### What
Adds Tesla pack SOC reset function.

### Why
On some batteries SOC drifts over time and becomes inaccurate, particularly LFP packs - the SOC reset function resets the BMS SOC based on Open Circuit Voltage (OCV), known as SocByOcv.

### How
Implements the same UDS commands Tesla's software does to reset SOC, only if current SOC <15% or >90%. 
