### PR TITLE
Volvo SPA: Swap precharge/positive state

### DIFF
--- a/Software/src/battery/VOLVO-SPA-HTML.h
+++ b/Software/src/battery/VOLVO-SPA-HTML.h
@@ -55,7 +55,7 @@ class VolvoSpaHtmlRenderer : public BatteryHtmlRenderer {
       default:
         content += String("Closed");
     }
-    content += "<h4>Positive contactor status: ";
+    content += "<h4>Precharge contactor status: ";
     switch (datalayer_extended.VolvoPolestar.HVILstatusBits & 0x08) {
       case 0x08:
         content += String("Open");
@@ -63,7 +63,7 @@ class VolvoSpaHtmlRenderer : public BatteryHtmlRenderer {
       default:
         content += String("Closed");
     }
-    content += "<h4>Precharge Contactor status: ";
+    content += "<h4>Positive Contactor status: ";
     switch (datalayer_extended.VolvoPolestar.HVILstatusBits & 0x10) {
       case 0x10:
         content += String("Open");


### PR DESCRIPTION
### What
This PR fixes a bug in the More battery Info page for Volvo SPA

### Why
<img width="312" height="79" alt="image" src="https://github.com/user-attachments/assets/843582c5-783b-4dfd-a73c-5da2c0ab1dcb" />

Precharge was swapped with Positive Contactor

### How
These are now inverted to correct orientation!
