### PR TITLE
Tesla: Configurable GTW settings via Webserver

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -319,11 +319,11 @@ void setup_battery() {
 
 /* User-selected Tesla settings */
 bool user_selected_tesla_digital_HVIL = false;
-uint16_t user_selected_tesla_GTW_country = 0;
-bool user_selected_tesla_GTW_rightHandDrive = false;
-uint16_t user_selected_tesla_GTW_mapRegion = 0;
-uint16_t user_selected_tesla_GTW_chassisType = 0;
-uint16_t user_selected_tesla_GTW_packEnergy = 0;
+uint16_t user_selected_tesla_GTW_country = 17477;
+bool user_selected_tesla_GTW_rightHandDrive = true;
+uint16_t user_selected_tesla_GTW_mapRegion = 2;
+uint16_t user_selected_tesla_GTW_chassisType = 2;
+uint16_t user_selected_tesla_GTW_packEnergy = 1;
 
 /* User-selected voltages used for custom-BMS batteries (RJXZS etc.) */
 #if defined(MAX_CUSTOM_PACK_VOLTAGE_DV) && defined(MIN_CUSTOM_PACK_VOLTAGE_DV) && \

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -317,6 +317,14 @@ void setup_battery() {
 }
 #endif
 
+/* User-selected Tesla settings */
+bool user_selected_tesla_digital_HVIL = false;
+uint16_t user_selected_tesla_GTW_country = 0;
+bool user_selected_tesla_GTW_rightHandDrive = false;
+uint16_t user_selected_tesla_GTW_mapRegion = 0;
+uint16_t user_selected_tesla_GTW_chassisType = 0;
+uint16_t user_selected_tesla_GTW_packEnergy = 0;
+
 /* User-selected voltages used for custom-BMS batteries (RJXZS etc.) */
 #if defined(MAX_CUSTOM_PACK_VOLTAGE_DV) && defined(MIN_CUSTOM_PACK_VOLTAGE_DV) && \
     defined(MAX_CUSTOM_CELL_VOLTAGE_MV) && defined(MIN_CUSTOM_CELL_VOLTAGE_MV)

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -61,4 +61,11 @@ extern uint16_t user_selected_min_pack_voltage_dV;
 extern uint16_t user_selected_max_cell_voltage_mV;
 extern uint16_t user_selected_min_cell_voltage_mV;
 
+extern bool user_selected_tesla_digital_HVIL;
+extern uint16_t user_selected_tesla_GTW_country;
+extern bool user_selected_tesla_GTW_rightHandDrive;
+extern uint16_t user_selected_tesla_GTW_mapRegion;
+extern uint16_t user_selected_tesla_GTW_chassisType;
+extern uint16_t user_selected_tesla_GTW_packEnergy;
+
 #endif

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -676,39 +676,39 @@ void TeslaBattery::
     clear_event(EVENT_BATTERY_FUSE);
   }
 
-#ifdef TESLA_MODEL_3Y_BATTERY
-  // Autodetect algoritm for chemistry on 3/Y packs.
-  // NCM/A batteries have 96s, LFP has 102-108s
-  // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
-  if (datalayer.battery.info.number_of_cells > 101) {
-    datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
-  }
+  if (user_selected_tesla_GTW_chassisType > 1) {  //{{0, "Model S"}, {1, "Model X"}, {2, "Model 3"}, {3, "Model Y"}};
+    // Autodetect algoritm for chemistry on 3/Y packs.
+    // NCM/A batteries have 96s, LFP has 102-108s
+    // Drawback with this check is that it takes 3-5minutes before all cells have been counted!
+    if (datalayer.battery.info.number_of_cells > 101) {
+      datalayer.battery.info.chemistry = battery_chemistry_enum::LFP;
+    }
 
-  //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
-  if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
-    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
-    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
-    datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_LFP;
-    datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_LFP;
-    datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_LFP;
-  } else {  // NCM/A chemistry
-    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
-    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
-    datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
-    datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_NCA_NCM;
-    datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_NCA_NCM;
-  }
+    //Once cell chemistry is determined, set maximum and minimum total pack voltage safety limits
+    if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
+      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
+      datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_LFP;
+      datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_LFP;
+      datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_LFP;
+    } else {  // NCM/A chemistry
+      datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+      datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
+      datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
+      datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_NCA_NCM;
+      datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_NCA_NCM;
+    }
 
-  // During forced balancing request via webserver, we allow the battery to exceed normal safety parameters
-  if (datalayer.battery.settings.user_requests_balancing) {
-    datalayer.battery.status.real_soc = 9900;  //Force battery to show up as 99% when balancing
-    datalayer.battery.info.max_design_voltage_dV = datalayer.battery.settings.balancing_max_pack_voltage_dV;
-    datalayer.battery.info.max_cell_voltage_mV = datalayer.battery.settings.balancing_max_cell_voltage_mV;
-    datalayer.battery.info.max_cell_voltage_deviation_mV =
-        datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV;
-    datalayer.battery.status.max_charge_power_W = datalayer.battery.settings.balancing_float_power_W;
+    // During forced balancing request via webserver, we allow the battery to exceed normal safety parameters
+    if (datalayer.battery.settings.user_requests_balancing) {
+      datalayer.battery.status.real_soc = 9900;  //Force battery to show up as 99% when balancing
+      datalayer.battery.info.max_design_voltage_dV = datalayer.battery.settings.balancing_max_pack_voltage_dV;
+      datalayer.battery.info.max_cell_voltage_mV = datalayer.battery.settings.balancing_max_cell_voltage_mV;
+      datalayer.battery.info.max_cell_voltage_deviation_mV =
+          datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV;
+      datalayer.battery.status.max_charge_power_W = datalayer.battery.settings.balancing_float_power_W;
+    }
   }
-#endif  // TESLA_MODEL_3Y_BATTERY
 
   // Check if user requests some action
   if (datalayer.battery.settings.user_requests_tesla_isolation_clear) {
@@ -2015,7 +2015,7 @@ int index_118 = 0;
 
 void TeslaBattery::transmit_can(unsigned long currentMillis) {
 
-  if (operate_contactors) {  //Special S/X mode
+  if (user_selected_tesla_digital_HVIL) {  //Special S/X? mode for 2024+ batteries
     if ((datalayer.system.status.inverter_allows_contactor_closing) && (datalayer.battery.status.bms_status != FAULT)) {
       if (currentMillis - lastSend1CF >= 10) {
         transmit_can_frame(&can_msg_1CF[index_1CF]);
@@ -2628,12 +2628,12 @@ void TeslaModel3YBattery::setup(void) {  // Performs one time setup at startup
 
   //0x7FF GTW CAN frame values
   //Mux1
-  write_signal_value(&TESLA_7FF_Mux1, 16, 16, GTW_country, false);
-  write_signal_value(&TESLA_7FF_Mux1, 11, 1, GTW_rightHandDrive, false);
+  write_signal_value(&TESLA_7FF_Mux1, 16, 16, user_selected_tesla_GTW_country, false);
+  write_signal_value(&TESLA_7FF_Mux1, 11, 1, user_selected_tesla_GTW_country, false);
   //Mux3
-  write_signal_value(&TESLA_7FF_Mux3, 8, 4, GTW_mapRegion, false);
-  write_signal_value(&TESLA_7FF_Mux3, 18, 3, GTW_chassisType, false);
-  write_signal_value(&TESLA_7FF_Mux3, 32, 5, GTW_packEnergy, false);
+  write_signal_value(&TESLA_7FF_Mux3, 8, 4, user_selected_tesla_GTW_mapRegion, false);
+  write_signal_value(&TESLA_7FF_Mux3, 18, 3, user_selected_tesla_GTW_chassisType, false);
+  write_signal_value(&TESLA_7FF_Mux3, 32, 5, user_selected_tesla_GTW_packEnergy, false);
 
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -11,12 +11,14 @@
 #define SELECTED_BATTERY_CLASS TeslaModelSXBattery
 #endif
 
-/*NOTE! IMPORTANT INFORMATION!
-Be sure to scroll down in this file and configure all "GTW_" parameters to suit your battery. 
-Failure to configure these will result in VCFRONT and GTW MIA errors
-*/
-
-//#define EXP_TESLA_BMS_DIGITAL_HVIL    // Experimental parameter. Forces the transmission of additional CAN frames for experimental purposes, to test potential HVIL issues in 3/Y packs with newer firmware.
+// 0x7FF gateway config, "Gen3" vehicles only, not applicable to Gen2 "classic" Model S and Model X
+// These are user configurable from the Webserver UI
+extern bool user_selected_tesla_digital_HVIL;
+extern uint16_t user_selected_tesla_GTW_country;
+extern bool user_selected_tesla_GTW_rightHandDrive;
+extern uint16_t user_selected_tesla_GTW_mapRegion;
+extern uint16_t user_selected_tesla_GTW_chassisType;
+extern uint16_t user_selected_tesla_GTW_packEnergy;
 
 class TeslaBattery : public CanBattery {
  public:
@@ -52,21 +54,6 @@ class TeslaBattery : public CanBattery {
 
   // Set this to true to try to close contactors/full startup even with no inverter defined/connected
   bool batteryTestOverride = false;
-
-  // 0x7FF gateway config, "Gen3" vehicles only, not applicable to Gen2 "classic" Model S and Model X
-  //
-  // ** MANUALLY SET FOR NOW **, TODO: change based on USER_SETTINGS.h or preset
-  //
-  static const uint16_t GTW_country =
-      18242;  // "US" (USA): 21843, "CA" (Canada): 17217, "GB" (UK & N Ireland): 18242, "DK" (Denmark): 17483, "DE" (Germany): 17477, "AU" (Australia): 16725  [HVP shows errors if EU/US region mismatch for example]
-  // GTW_country is ISO 3166-1 Alpha-2 code, each letter converted to binary (8-bit chunks), those 8-bit chunks concatenated and then converted to decimal
-  static const uint8_t GTW_rightHandDrive =
-      1;  // Left: 0, Right: 1 (not sure this matters but there for consistency in emulating the car - make sure correct for GTW_country, e.g. 0 for USA)
-  static const uint8_t GTW_mapRegion =
-      1;  // "ME": 8, "NONE": 2, "CN": 3, "TW": 6, "JP": 5, "US": 0, "KR": 7, "AU": 4, "EU": 1 (not sure this matters but there for consistency)
-  static const uint8_t GTW_chassisType =
-      2;  // "MODEL_3_CHASSIS": 2, "MODEL_Y_CHASSIS": 3  ("MODEL_S_CHASSIS": 0, "MODEL_X_CHASSIS": 1)
-  static const uint8_t GTW_packEnergy = 1;  // "PACK_50_KWH": 0, "PACK_74_KWH": 1, "PACK_62_KWH": 2, "PACK_100_KWH": 3
 
   /* Do not change anything below this line! */
   static const int RAMPDOWN_SOC = 900;  // 90.0 SOC% to start ramping down from max charge power towards 0 at 100.00%
@@ -926,19 +913,14 @@ class TeslaBattery : public CanBattery {
 
 class TeslaModel3YBattery : public TeslaBattery {
  public:
-  TeslaModel3YBattery(battery_chemistry_enum chemistry) {
-    datalayer.battery.info.chemistry = chemistry;
-#ifdef EXP_TESLA_BMS_DIGITAL_HVIL
-    operate_contactors = true;
-#endif
-  }
+  TeslaModel3YBattery(battery_chemistry_enum chemistry) { datalayer.battery.info.chemistry = chemistry; }
   static constexpr const char* Name = "Tesla Model 3/Y";
   virtual void setup(void);
 };
 
 class TeslaModelSXBattery : public TeslaBattery {
  public:
-  TeslaModelSXBattery() { operate_contactors = true; }
+  TeslaModelSXBattery() {}
   static constexpr const char* Name = "Tesla Model S/X";
   virtual void setup(void);
 };

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -103,6 +103,12 @@ void init_stored_settings() {
   user_selected_inverter_ah_capacity = settings.getUInt("INVAHCAPACITY", 0);
   user_selected_inverter_battery_type = settings.getUInt("INVBTYPE", 0);
   user_selected_inverter_ignore_contactors = settings.getBool("INVICNT", false);
+  user_selected_tesla_digital_HVIL = settings.getBool("DIGITALHVIL", false);
+  user_selected_tesla_GTW_country = settings.getUInt("GTWCOUNTRY", 0);
+  user_selected_tesla_GTW_rightHandDrive = settings.getBool("GTWRHD", false);
+  user_selected_tesla_GTW_mapRegion = settings.getUInt("GTWMAPREG", 0);
+  user_selected_tesla_GTW_chassisType = settings.getUInt("GTWCHASSIS", 0);
+  user_selected_tesla_GTW_packEnergy = settings.getUInt("GTWPACK", 0);
 
   auto readIf = [](const char* settingName) {
     auto batt1If = (comm_interface)settings.getUInt(settingName, (int)comm_interface::CanNative);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -78,6 +78,33 @@ String options_for_enum(TEnum selected, Func name_for_type) {
   return options;
 }
 
+template <typename TMap>
+String options_from_map(int selected, const TMap& value_name_map) {
+  String options;
+  for (const auto& [value, name] : value_name_map) {
+    options += "<option value=\"" + String(value) + "\"";
+    if (selected == value) {
+      options += " selected";
+    }
+    options += ">";
+    options += name;
+    options += "</option>";
+  }
+  return options;
+}
+
+static const std::map<int, String> tesla_countries = {
+    {21843, "US (USA)"},     {17217, "CA (Canada)"},  {18242, "GB (UK & N Ireland)"},
+    {17483, "DK (Denmark)"}, {17477, "DE (Germany)"}, {16725, "AU (Australia)"}};
+
+static const std::map<int, String> tesla_mapregion = {
+    {8, "ME (Middle East)"}, {2, "NONE"},       {3, "CN (China)"},     {6, "TW (Taiwan)"}, {5, "JP (Japan)"},
+    {0, "US (USA)"},         {7, "KR (Korea)"}, {4, "AU (Australia)"}, {1, "EU (Europe)"}};
+
+static const std::map<int, String> tesla_chassis = {{0, "Model S"}, {1, "Model X"}, {2, "Model 3"}, {3, "Model Y"}};
+
+static const std::map<int, String> tesla_pack = {{0, "50 kWh"}, {2, "62 kWh"}, {1, "74 kWh"}, {3, "100 kWh"}};
+
 const char* name_for_button_type(STOP_BUTTON_BEHAVIOR behavior) {
   switch (behavior) {
     case STOP_BUTTON_BEHAVIOR::LATCHING_SWITCH:
@@ -505,7 +532,7 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
   }
 
   if (var == "GTWCOUNTRY") {
-    return String(settings.getUInt("GTWCOUNTRY", 0));
+    return options_from_map(settings.getUInt("GTWCOUNTRY", 0), tesla_countries);
   }
 
   if (var == "GTWRHD") {
@@ -513,15 +540,15 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
   }
 
   if (var == "GTWMAPREG") {
-    return String(settings.getUInt("GTWMAPREG", 0));
+    return options_from_map(settings.getUInt("GTWMAPREG", 0), tesla_mapregion);
   }
 
   if (var == "GTWCHASSIS") {
-    return String(settings.getUInt("GTWCHASSIS", 0));
+    return options_from_map(settings.getUInt("GTWCHASSIS", 0), tesla_chassis);
   }
 
   if (var == "GTWPACK") {
-    return String(settings.getUInt("GTWPACK", 0));
+    return options_from_map(settings.getUInt("GTWPACK", 0), tesla_pack);
   }
 
   return String();
@@ -767,16 +794,20 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <div class="if-tesla">
         <label>Digital HVIL (2024+): </label>
         <input type='checkbox' name='DIGITALHVIL' value='on' style='margin-left: 0;' %DIGITALHVIL% />
-        <label>Country code: </label>
-        <input name='GTWCOUNTRY' type='text' value="%GTWCOUNTRY%" pattern="^[0-9]{1,2}$" />
         <label>Right hand drive: </label>
         <input type='checkbox' name='GTWRHD' value='on' style='margin-left: 0;' %GTWRHD% />
-        <label>Map region: </label>
-        <input name='GTWMAPREG' type='text' value="%GTWMAPREG%" pattern="^[0-9]{1,2}$" />
-        <label>Chassis type: </label>
-        <input name='GTWCHASSIS' type='text' value="%GTWCHASSIS%" pattern="^[0-9]{1,2}$" />
-        <label>Pack type: </label>
-        <input name='GTWPACK' type='text' value="%GTWPACK%" pattern="^[0-9]{1,2}$" />
+        <label for='GTWCOUNTRY'>Country code: </label><select name='GTWCOUNTRY' id='GTWCOUNTRY'>
+        %GTWCOUNTRY%
+        </select>
+        <label for='GTWMAPREG'>Map region: </label><select name='GTWMAPREG' id='GTWMAPREG'>
+        %GTWMAPREG%
+        </select>
+        <label for='GTWCHASSIS'>Chassis type: </label><select name='GTWCHASSIS' id='GTWCHASSIS'>
+        %GTWCHASSIS%
+        </select>
+        <label for='GTWPACK'>Pack type: </label><select name='GTWPACK' id='GTWPACK'>
+        %GTWPACK%
+        </select>
         </div>
 
         <div class="if-battery">

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -500,6 +500,30 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return settings.getBool("INVICNT") ? "checked" : "";
   }
 
+  if (var == "DIGITALHVIL") {
+    return settings.getBool("DIGITALHVIL") ? "checked" : "";
+  }
+
+  if (var == "GTWCOUNTRY") {
+    return String(settings.getUInt("GTWCOUNTRY", 0));
+  }
+
+  if (var == "GTWRHD") {
+    return settings.getBool("GTWRHD") ? "checked" : "";
+  }
+
+  if (var == "GTWMAPREG") {
+    return String(settings.getUInt("GTWMAPREG", 0));
+  }
+
+  if (var == "GTWCHASSIS") {
+    return String(settings.getUInt("GTWCHASSIS", 0));
+  }
+
+  if (var == "GTWPACK") {
+    return String(settings.getUInt("GTWPACK", 0));
+  }
+
   return String();
 }
 
@@ -686,6 +710,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    form .if-tesla { display: none; }
+    form[data-battery="32"] .if-tesla, form[data-battery="33"] .if-tesla {
+      display: contents;
+    }
+
     form .if-dblbtr { display: none; }
     form[data-dblbtr="true"] .if-dblbtr {
       display: contents;
@@ -734,6 +763,21 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label for='battery'>Battery: </label><select name='battery' if='battery'>
         %BATTTYPE%
         </select>
+
+        <div class="if-tesla">
+        <label>Digital HVIL (2024+): </label>
+        <input type='checkbox' name='DIGITALHVIL' value='on' style='margin-left: 0;' %DIGITALHVIL% />
+        <label>Country code: </label>
+        <input name='GTWCOUNTRY' type='text' value="%GTWCOUNTRY%" pattern="^[0-9]{1,2}$" />
+        <label>Right hand drive: </label>
+        <input type='checkbox' name='GTWRHD' value='on' style='margin-left: 0;' %GTWRHD% />
+        <label>Map region: </label>
+        <input name='GTWMAPREG' type='text' value="%GTWMAPREG%" pattern="^[0-9]{1,2}$" />
+        <label>Chassis type: </label>
+        <input name='GTWCHASSIS' type='text' value="%GTWCHASSIS%" pattern="^[0-9]{1,2}$" />
+        <label>Pack type: </label>
+        <input name='GTWPACK' type='text' value="%GTWPACK%" pattern="^[0-9]{1,2}$" />
+        </div>
 
         <div class="if-battery">
         <label for='BATTCOMM'>Battery comm I/F: </label><select name='BATTCOMM' id='BATTCOMM'>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -413,8 +413,8 @@ void init_webserver() {
   };
 
   const char* boolSettingNames[] = {
-      "DBLBTR",     "CNTCTRL",       "CNTCTRLDBL",  "PWMCNTCTRL", "PERBMSRESET", "REMBMSRESET",
-      "CANFDASCAN", "WIFIAPENABLED", "MQTTENABLED", "HADISC",     "MQTTTOPICS",  "INVICNT",
+      "DBLBTR",        "CNTCTRL",     "CNTCTRLDBL", "PWMCNTCTRL", "PERBMSRESET", "REMBMSRESET", "CANFDASCAN",
+      "WIFIAPENABLED", "MQTTENABLED", "HADISC",     "MQTTTOPICS", "INVICNT",     "GTWRHD",      "DIGITALHVIL",
   };
 
   // Handles the form POST from UI to save settings of the common image
@@ -515,6 +515,18 @@ void init_webserver() {
       } else if (p->name() == "INVBTYPE") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("INVBTYPE", (int)type);
+      } else if (p->name() == "GTWCOUNTRY") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("GTWCOUNTRY", type);
+      } else if (p->name() == "GTWMAPREG") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("GTWMAPREG", type);
+      } else if (p->name() == "GTWCHASSIS") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("GTWCHASSIS", type);
+      } else if (p->name() == "GTWPACK") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("GTWPACK", type);
       }
 
       for (auto& boolSetting : boolSettings) {


### PR DESCRIPTION
### What
This PR implements easily configurable gateway, HVIL and generation settings for Tesla S/3/X/Y batteries

### Why
It was not possible to use the Common Image from releases directly with Tesla packs. This PR makes it possible

### How
Everything now easily editable via Webserver, and stored to flash!

<img width="555" height="238" alt="image" src="https://github.com/user-attachments/assets/182bc4c9-97cb-4e33-b534-752e2595954a" />

