### PR TITLE
Improvement: Remove old method to compile, all is now Common Image

### DIFF
--- a/Software/USER_SETTINGS.cpp
+++ b/Software/USER_SETTINGS.cpp
@@ -21,25 +21,14 @@ volatile CAN_Configuration can_config = {
     .shunt = CAN_NATIVE                   // (OPTIONAL) Which CAN is your shunt connected to?
 };
 
-#ifdef COMMON_IMAGE
 std::string ssid;
 std::string password;
 std::string passwordAP;
-#else
-std::string ssid = WIFI_SSID;          // Set in USER_SECRETS.h
-std::string password = WIFI_PASSWORD;  // Set in USER_SECRETS.h
-std::string passwordAP = AP_PASSWORD;  // Set in USER_SECRETS.h
-#endif
 
 const uint8_t wifi_channel = 0;  // Set to 0 for automatic channel selection
 
-#ifdef COMMON_IMAGE
 std::string http_username;
 std::string http_password;
-#else
-std::string http_username = HTTP_USERNAME;  // Set in USER_SECRETS.h
-std::string http_password = HTTP_PASSWORD;  // Set in USER_SECRETS.h
-#endif
 
 // Set your Static IP address. Only used incase WIFICONFIG is set in USER_SETTINGS.h
 IPAddress local_IP(192, 168, 10, 150);
@@ -47,13 +36,8 @@ IPAddress gateway(192, 168, 10, 1);
 IPAddress subnet(255, 255, 255, 0);
 
 // MQTT
-#ifdef COMMON_IMAGE
 std::string mqtt_user;
 std::string mqtt_password;
-#else
-std::string mqtt_user = MQTT_USER;          // Set in USER_SECRETS.h
-std::string mqtt_password = MQTT_PASSWORD;  // Set in USER_SECRETS.h
-#endif
 
 const char* mqtt_topic_name =
     "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"

--- a/Software/USER_SETTINGS.h
+++ b/Software/USER_SETTINGS.h
@@ -6,8 +6,6 @@
 
 /* This file is being transitioned towards COMMON_IMAGE. Use v8.16 if you are taking this software into use! */
 
-//#define COMMON_IMAGE
-
 /* Select hardware used for Battery-Emulator */
 //#define HW_LILYGO
 //#define HW_STARK

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -3,10 +3,6 @@
 #include "CanBattery.h"
 #include "RS485Battery.h"
 
-#if !defined(COMMON_IMAGE) && !defined(SELECTED_BATTERY_CLASS)
-#error No battery selected! Choose one from the USER_SETTINGS.h file or build COMMON_IMAGE.
-#endif
-
 Battery* battery = nullptr;
 Battery* battery2 = nullptr;
 
@@ -149,11 +145,6 @@ const battery_chemistry_enum battery_chemistry_default = battery_chemistry_enum:
 
 battery_chemistry_enum user_selected_battery_chemistry = battery_chemistry_default;
 
-#ifdef COMMON_IMAGE
-#ifdef SELECTED_BATTERY_CLASS
-#error "Compile time SELECTED_BATTERY_CLASS should not be defined with COMMON_IMAGE"
-#endif
-
 BatteryType user_selected_battery_type = BatteryType::NissanLeaf;
 bool user_selected_second_battery = false;
 
@@ -287,39 +278,6 @@ void setup_battery() {
     }
   }
 }
-#else  // Battery selection has been made at build-time
-
-void setup_battery() {
-  // Instantiate the battery only once just in case this function gets called multiple times.
-  if (battery == nullptr) {
-#ifdef TESLA_MODEL_3Y_BATTERY
-    battery = new SELECTED_BATTERY_CLASS(user_selected_battery_chemistry);
-#else
-    battery = new SELECTED_BATTERY_CLASS();
-#endif
-  }
-  battery->setup();
-
-#ifdef DOUBLE_BATTERY
-  if (battery2 == nullptr) {
-#if defined(BMW_I3_BATTERY)
-    battery2 =
-        new SELECTED_BATTERY_CLASS(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
-                                   can_config.battery_double, esp32hal->WUP_PIN2());
-#elif defined(KIA_HYUNDAI_64_BATTERY)
-    battery2 = new SELECTED_BATTERY_CLASS(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,
-                                          &datalayer.system.status.battery2_allowed_contactor_closing,
-                                          can_config.battery_double);
-#elif defined(SANTA_FE_PHEV_BATTERY) || defined(TEST_FAKE_BATTERY)
-    battery2 = new SELECTED_BATTERY_CLASS(&datalayer.battery2, can_config.battery_double);
-#else
-    battery2 = new SELECTED_BATTERY_CLASS(&datalayer.battery2, nullptr, can_config.battery_double);
-#endif
-  }
-  battery2->setup();
-#endif
-}
-#endif
 
 /* User-selected Tesla settings */
 bool user_selected_tesla_digital_HVIL = false;
@@ -329,7 +287,7 @@ uint16_t user_selected_tesla_GTW_mapRegion = 2;
 uint16_t user_selected_tesla_GTW_chassisType = 2;
 uint16_t user_selected_tesla_GTW_packEnergy = 1;
 
-// Use 0V for user selected cell/pack voltage defaults (COMMON_IMAGE will replace with saved values from NVM)
+// Use 0V for user selected cell/pack voltage defaults (On boot will be replaced with saved values from NVM)
 uint16_t user_selected_max_pack_voltage_dV = 0;
 uint16_t user_selected_min_pack_voltage_dV = 0;
 uint16_t user_selected_max_cell_voltage_mV = 0;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -6,10 +6,6 @@
 #include "BMW-I3-HTML.h"
 #include "CanBattery.h"
 
-#ifdef BMW_I3_BATTERY
-#define SELECTED_BATTERY_CLASS BmwI3Battery
-#endif
-
 class BmwI3Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -4,10 +4,6 @@
 #include "BMW-IX-HTML.h"
 #include "CanBattery.h"
 
-#ifdef BMW_IX_BATTERY
-#define SELECTED_BATTERY_CLASS BmwIXBattery
-#endif
-
 class BmwIXBattery : public CanBattery {
  public:
   BmwIXBattery() : renderer(*this) {}

--- a/Software/src/battery/BMW-PHEV-BATTERY.h
+++ b/Software/src/battery/BMW-PHEV-BATTERY.h
@@ -3,10 +3,6 @@
 #include "BMW-PHEV-HTML.h"
 #include "CanBattery.h"
 
-#ifdef BMW_PHEV_BATTERY
-#define SELECTED_BATTERY_CLASS BmwPhevBattery
-#endif
-
 class BmwPhevBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -3,10 +3,6 @@
 #include "BOLT-AMPERA-HTML.h"
 #include "CanBattery.h"
 
-#ifdef BOLT_AMPERA_BATTERY
-#define SELECTED_BATTERY_CLASS BoltAmperaBattery
-#endif
-
 class BoltAmperaBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -24,9 +24,6 @@ static const int RAMPDOWN_POWER_ALLOWED =
     10000;  // Power to start ramp down from, set a lower value to limit the power even further as SOC decreases
 
 /* Do not modify the rows below */
-#ifdef BYD_ATTO_3_BATTERY
-#define SELECTED_BATTERY_CLASS BydAttoBattery
-#endif
 
 class BydAttoBattery : public CanBattery {
  public:

--- a/Software/src/battery/CELLPOWER-BMS.h
+++ b/Software/src/battery/CELLPOWER-BMS.h
@@ -3,10 +3,6 @@
 #include "CELLPOWER-HTML.h"
 #include "CanBattery.h"
 
-#ifdef CELLPOWER_BMS
-#define SELECTED_BATTERY_CLASS CellPowerBms
-#endif
-
 class CellPowerBms : public CanBattery {
  public:
   CellPowerBms() : CanBattery(CAN_Speed::CAN_SPEED_250KBPS) {}

--- a/Software/src/battery/CHADEMO-BATTERY.h
+++ b/Software/src/battery/CHADEMO-BATTERY.h
@@ -7,10 +7,6 @@
 #include "CHADEMO-BATTERY-HTML.h"
 #include "CanBattery.h"
 
-#ifdef CHADEMO_BATTERY
-#define SELECTED_BATTERY_CLASS ChademoBattery
-#endif
-
 class ChademoBattery : public CanBattery {
  public:
   ChademoBattery() {

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -4,10 +4,6 @@
 #include "CMFA-EV-HTML.h"
 #include "CanBattery.h"
 
-#ifdef CMFA_EV_BATTERY
-#define SELECTED_BATTERY_CLASS CmfaEvBattery
-#endif
-
 class CmfaEvBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -3,10 +3,6 @@
 
 #include "RS485Battery.h"
 
-#ifdef DALY_BMS
-#define SELECTED_BATTERY_CLASS DalyBms
-#endif
-
 class DalyBms : public RS485Battery {
  public:
   void setup();

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -3,10 +3,6 @@
 #include "CanBattery.h"
 #include "ECMP-HTML.h"
 
-#ifdef STELLANTIS_ECMP_BATTERY
-#define SELECTED_BATTERY_CLASS EcmpBattery
-#endif
-
 class EcmpBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/FOXESS-BATTERY.h
+++ b/Software/src/battery/FOXESS-BATTERY.h
@@ -2,10 +2,6 @@
 #define FOXESS_BATTERY_H
 #include "CanBattery.h"
 
-#ifdef FOXESS_BATTERY
-#define SELECTED_BATTERY_CLASS FoxessBattery
-#endif
-
 class FoxessBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
+++ b/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
@@ -4,10 +4,6 @@
 #include "CanBattery.h"
 #include "GEELY-GEOMETRY-C-HTML.h"
 
-#ifdef GEELY_GEOMETRY_C_BATTERY
-#define SELECTED_BATTERY_CLASS GeelyGeometryCBattery
-#endif
-
 class GeelyGeometryCBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
@@ -6,10 +6,6 @@
 #include "CanBattery.h"
 #include "HYUNDAI-IONIQ-28-BATTERY-HTML.h"
 
-#ifdef HYUNDAI_IONIQ_28_BATTERY
-#define SELECTED_BATTERY_CLASS HyundaiIoniq28Battery
-#endif
-
 class HyundaiIoniq28Battery : public CanBattery {
  public:
   // Use the default constructor to create the first or single battery.

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -2,10 +2,6 @@
 #define IMIEV_CZERO_ION_BATTERY_H
 #include "CanBattery.h"
 
-#ifdef IMIEV_CZERO_ION_BATTERY
-#define SELECTED_BATTERY_CLASS ImievCZeroIonBattery
-#endif
-
 class ImievCZeroIonBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.h
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef JAGUAR_IPACE_BATTERY
-#define SELECTED_BATTERY_CLASS JaguarIpaceBattery
-#endif
-
 class JaguarIpaceBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -5,10 +5,6 @@
 
 #define ESTIMATE_SOC_FROM_CELLVOLTAGE
 
-#ifdef KIA_HYUNDAI_64_FD_BATTERY
-#define SELECTED_BATTERY_CLASS Kia64FDBattery
-#endif
-
 class Kia64FDBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -5,10 +5,6 @@
 
 #define ESTIMATE_SOC_FROM_CELLVOLTAGE
 
-#ifdef KIA_E_GMP_BATTERY
-#define SELECTED_BATTERY_CLASS KiaEGmpBattery
-#endif
-
 class KiaEGmpBattery : public CanBattery {
  public:
   KiaEGmpBattery() : renderer(*this) {}

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -5,10 +5,6 @@
 #include "CanBattery.h"
 #include "KIA-HYUNDAI-64-HTML.h"
 
-#ifdef KIA_HYUNDAI_64_BATTERY
-#define SELECTED_BATTERY_CLASS KiaHyundai64Battery
-#endif
-
 class KiaHyundai64Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -2,10 +2,6 @@
 #define KIA_HYUNDAI_HYBRID_BATTERY_H
 #include "CanBattery.h"
 
-#ifdef KIA_HYUNDAI_HYBRID_BATTERY
-#define SELECTED_BATTERY_CLASS KiaHyundaiHybridBattery
-#endif
-
 class KiaHyundaiHybridBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -3,10 +3,6 @@
 #include "CanBattery.h"
 #include "MEB-HTML.h"
 
-#ifdef MEB_BATTERY
-#define SELECTED_BATTERY_CLASS MebBattery
-#endif
-
 class MebBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -2,10 +2,6 @@
 #define MG_5_BATTERY_H
 #include "CanBattery.h"
 
-#ifdef MG_5_BATTERY
-#define SELECTED_BATTERY_CLASS Mg5Battery
-#endif
-
 class Mg5Battery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef MG_HS_PHEV_BATTERY
-#define SELECTED_BATTERY_CLASS MgHsPHEVBattery
-#endif
-
 class MgHsPHEVBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -6,10 +6,6 @@
 #include "CanBattery.h"
 #include "NISSAN-LEAF-HTML.h"
 
-#ifdef NISSAN_LEAF_BATTERY
-#define SELECTED_BATTERY_CLASS NissanLeafBattery
-#endif
-
 class NissanLeafBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/ORION-BMS.h
+++ b/Software/src/battery/ORION-BMS.h
@@ -4,10 +4,6 @@
 #include "../system_settings.h"
 #include "CanBattery.h"
 
-#ifdef ORION_BMS
-#define SELECTED_BATTERY_CLASS OrionBms
-#endif
-
 class OrionBms : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -4,10 +4,6 @@
 #include "../datalayer/datalayer.h"
 #include "CanBattery.h"
 
-#ifdef PYLON_BATTERY
-#define SELECTED_BATTERY_CLASS PylonBattery
-#endif
-
 class PylonBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef RANGE_ROVER_PHEV_BATTERY
-#define SELECTED_BATTERY_CLASS RangeRoverPhevBattery
-#endif
-
 class RangeRoverPhevBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/RELION-LV-BATTERY.h
+++ b/Software/src/battery/RELION-LV-BATTERY.h
@@ -4,10 +4,6 @@
 #include "../system_settings.h"
 #include "CanBattery.h"
 
-#ifdef RELION_BATTERY
-#define SELECTED_BATTERY_CLASS RelionBattery
-#endif
-
 class RelionBattery : public CanBattery {
  public:
   RelionBattery() : CanBattery(CAN_Speed::CAN_SPEED_250KBPS) {}

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef RENAULT_KANGOO_BATTERY
-#define SELECTED_BATTERY_CLASS RenaultKangooBattery
-#endif
-
 class RenaultKangooBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/RENAULT-TWIZY.h
+++ b/Software/src/battery/RENAULT-TWIZY.h
@@ -2,10 +2,6 @@
 #define RENAULT_TWIZY_BATTERY_H
 #include "CanBattery.h"
 
-#ifdef RENAULT_TWIZY_BATTERY
-#define SELECTED_BATTERY_CLASS RenaultTwizyBattery
-#endif
-
 class RenaultTwizyBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -4,10 +4,6 @@
 #include "CanBattery.h"
 #include "RENAULT-ZOE-GEN1-HTML.h"
 
-#ifdef RENAULT_ZOE_GEN1_BATTERY
-#define SELECTED_BATTERY_CLASS RenaultZoeGen1Battery
-#endif
-
 class RenaultZoeGen1Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -4,10 +4,6 @@
 #include "CanBattery.h"
 #include "RENAULT-ZOE-GEN2-HTML.h"
 
-#ifdef RENAULT_ZOE_GEN2_BATTERY
-#define SELECTED_BATTERY_CLASS RenaultZoeGen2Battery
-#endif
-
 class RenaultZoeGen2Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -4,10 +4,6 @@
 #include "../system_settings.h"
 #include "CanBattery.h"
 
-#ifdef RJXZS_BMS
-#define SELECTED_BATTERY_CLASS RjxzsBms
-#endif
-
 class RjxzsBms : public CanBattery {
  public:
   RjxzsBms() : CanBattery(CAN_Speed::CAN_SPEED_250KBPS) {}

--- a/Software/src/battery/SAMSUNG-SDI-LV-BATTERY.h
+++ b/Software/src/battery/SAMSUNG-SDI-LV-BATTERY.h
@@ -4,10 +4,6 @@
 #include "../datalayer/datalayer.h"
 #include "CanBattery.h"
 
-#ifdef SAMSUNG_SDI_LV_BATTERY
-#define SELECTED_BATTERY_CLASS SamsungSdiLVBattery
-#endif
-
 class SamsungSdiLVBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -3,10 +3,6 @@
 #include "../datalayer/datalayer.h"
 #include "CanBattery.h"
 
-#ifdef SANTA_FE_PHEV_BATTERY
-#define SELECTED_BATTERY_CLASS SantaFePhevBattery
-#endif
-
 class SantaFePhevBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/SIMPBMS-BATTERY.h
+++ b/Software/src/battery/SIMPBMS-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef SIMPBMS_BATTERY
-#define SELECTED_BATTERY_CLASS SimpBmsBattery
-#endif
-
 class SimpBmsBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/SONO-BATTERY.h
+++ b/Software/src/battery/SONO-BATTERY.h
@@ -3,10 +3,6 @@
 
 #include "CanBattery.h"
 
-#ifdef SONO_BATTERY
-#define SELECTED_BATTERY_CLASS SonoBattery
-#endif
-
 class SonoBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/Shunts.cpp
+++ b/Software/src/battery/Shunts.cpp
@@ -4,11 +4,6 @@
 CanShunt* shunt = nullptr;
 ShuntType user_selected_shunt_type = ShuntType::None;
 
-#ifdef COMMON_IMAGE
-#ifdef SELECTED_SHUNT_CLASS
-#error "Compile time SELECTED_SHUNT_CLASS should not be defined with COMMON_IMAGE"
-#endif
-
 void setup_can_shunt() {
   if (shunt) {
     return;
@@ -29,21 +24,6 @@ void setup_can_shunt() {
     shunt->setup();
   }
 }
-
-#else
-void setup_can_shunt() {
-  if (shunt) {
-    return;
-  }
-
-#if defined(SELECTED_SHUNT_CLASS)
-  shunt = new SELECTED_SHUNT_CLASS();
-  if (shunt) {
-    shunt->setup();
-  }
-#endif
-}
-#endif
 
 extern std::vector<ShuntType> supported_shunt_types() {
   std::vector<ShuntType> types;

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -4,13 +4,6 @@
 #include "CanBattery.h"
 #include "TESLA-HTML.h"
 
-#ifdef TESLA_MODEL_3Y_BATTERY
-#define SELECTED_BATTERY_CLASS TeslaModel3YBattery
-#endif
-#ifdef TESLA_MODEL_SX_BATTERY
-#define SELECTED_BATTERY_CLASS TeslaModelSXBattery
-#endif
-
 // 0x7FF gateway config, "Gen3" vehicles only, not applicable to Gen2 "classic" Model S and Model X
 // These are user configurable from the Webserver UI
 extern bool user_selected_tesla_digital_HVIL;

--- a/Software/src/battery/TEST-FAKE-BATTERY.h
+++ b/Software/src/battery/TEST-FAKE-BATTERY.h
@@ -3,10 +3,6 @@
 #include "../datalayer/datalayer.h"
 #include "CanBattery.h"
 
-#ifdef TEST_FAKE_BATTERY
-#define SELECTED_BATTERY_CLASS TestFakeBattery
-#endif
-
 class TestFakeBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.

--- a/Software/src/battery/VOLVO-SPA-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.h
@@ -4,10 +4,6 @@
 #include "CanBattery.h"
 #include "VOLVO-SPA-HTML.h"
 
-#ifdef VOLVO_SPA_BATTERY
-#define SELECTED_BATTERY_CLASS VolvoSpaBattery
-#endif
-
 class VolvoSpaBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.h
@@ -3,10 +3,6 @@
 #include "CanBattery.h"
 #include "VOLVO-SPA-HYBRID-HTML.h"
 
-#ifdef VOLVO_SPA_HYBRID_BATTERY
-#define SELECTED_BATTERY_CLASS VolvoSpaHybridBattery
-#endif
-
 class VolvoSpaHybridBattery : public CanBattery {
  public:
   virtual void setup(void);

--- a/Software/src/charger/CHARGERS.cpp
+++ b/Software/src/charger/CHARGERS.cpp
@@ -30,16 +30,11 @@ extern const char* name_for_charger_type(ChargerType type) {
 }
 
 void setup_charger() {
-#ifdef COMMON_IMAGE
+
   switch (user_selected_charger_type) {
     case ChargerType::ChevyVolt:
       charger = new ChevyVoltCharger();
     case ChargerType::NissanLeaf:
       charger = new NissanLeafCharger();
   }
-#else
-#ifdef SELECTED_CHARGER_CLASS
-  charger = new SELECTED_CHARGER_CLASS();
-#endif
-#endif
 }

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -87,7 +87,6 @@ void init_stored_settings() {
     datalayer.battery.settings.user_set_bms_reset_duration_ms = temp;
   }
 
-#ifdef COMMON_IMAGE
   user_selected_battery_type = (BatteryType)settings.getUInt("BATTTYPE", (int)BatteryType::None);
   user_selected_battery_chemistry =
       (battery_chemistry_enum)settings.getUInt("BATTCHEM", (int)battery_chemistry_enum::NCA);
@@ -167,8 +166,6 @@ void init_stored_settings() {
   mqtt_port = settings.getUInt("MQTTPORT", 0);
   mqtt_user = settings.getString("MQTTUSER").c_str();
   mqtt_password = settings.getString("MQTTPASSWORD").c_str();
-
-#endif
 
   settings.end();
 }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -15,29 +15,11 @@
 #include "mqtt.h"
 #include "mqtt_client.h"
 
-#ifdef MQTT
-const bool mqtt_enabled_default = true;
-#else
-const bool mqtt_enabled_default = false;
-#endif
+bool mqtt_enabled = false;
+bool ha_autodiscovery_enabled = false;
 
-bool mqtt_enabled = mqtt_enabled_default;
-
-#ifdef HA_AUTODISCOVERY
-const bool ha_autodiscovery_enabled_default = true;
-#else
-const bool ha_autodiscovery_enabled_default = false;
-#endif
-
-bool ha_autodiscovery_enabled = ha_autodiscovery_enabled_default;
-
-#ifdef COMMON_IMAGE
 const int mqtt_port_default = 0;
 const char* mqtt_server_default = "";
-#else
-const int mqtt_port_default = MQTT_PORT;
-const char* mqtt_server_default = MQTT_SERVER;
-#endif
 
 int mqtt_port = mqtt_port_default;
 std::string mqtt_server = mqtt_server_default;
@@ -626,7 +608,7 @@ bool init_mqtt(void) {
   }
 
   if (mqtt_manual_topic_object_name) {
-#ifdef COMMON_IMAGE
+
     BatteryEmulatorSettingsStore settings;
     topic_name = settings.getString("MQTTTOPIC", mqtt_topic_name);
     object_id_prefix = settings.getString("MQTTOBJIDPREFIX", mqtt_object_id_prefix);
@@ -649,13 +631,6 @@ bool init_mqtt(void) {
       device_id = ha_device_id;
     }
 
-#else
-    // Use custom topic name, object ID prefix, and device name from user settings
-    topic_name = mqtt_topic_name;
-    object_id_prefix = mqtt_object_id_prefix;
-    device_name = mqtt_device_name;
-    device_id = ha_device_id;
-#endif
   } else {
     // Use default naming based on WiFi hostname for topic, object ID prefix, and device name
     topic_name = "battery-emulator_" + String(WiFi.getHostname());

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -135,12 +135,6 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return String(ssid.c_str());
   }
 
-#ifndef COMMON_IMAGE
-  if (var == "COMMONIMAGEDIVCLASS") {
-    return "hidden";
-  }
-#endif
-
   if (var == "SAVEDCLASS") {
     if (!settingsUpdated) {
       return "hidden";
@@ -839,7 +833,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     <h4 style='color: white;'>SSID: <span id='SSID'>%SSID%</span><button onclick='editSSID()'>Edit</button></h4>
     <h4 style='color: white;'>Password: ######## <span id='Password'></span> <button onclick='editPassword()'>Edit</button></h4>
     
-    <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px;border-radius: 50px; class="%COMMONIMAGEDIVCLASS%">
+    <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>
     <div style='max-width: 500px;'>
         <form action='saveSettings' method='post' style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -23,21 +23,10 @@
 extern std::string http_username;
 extern std::string http_password;
 
-#ifdef WEBSERVER
-const bool webserver_enabled_default = true;
-#else
-const bool webserver_enabled_default = false;
-#endif
+bool webserver_enabled =
+    true;  // Global flag to enable or disable the webserver //Old method to disable was with  #ifdef WEBSERVER
 
-bool webserver_enabled = webserver_enabled_default;  // Global flag to enable or disable the webserver
-
-#ifndef COMMON_IMAGE
-const bool webserver_auth_default = WEBSERVER_AUTH_REQUIRED;
-#else
-const bool webserver_auth_default = false;
-#endif
-
-bool webserver_auth = webserver_auth_default;
+bool webserver_auth = false;
 
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
@@ -401,7 +390,6 @@ void init_webserver() {
     request->send(200, "text/html", "OK");
   });
 
-#ifdef COMMON_IMAGE
   struct BoolSetting {
     const char* name;
     bool existingValue;
@@ -557,7 +545,6 @@ void init_webserver() {
     settingsUpdated = settings.were_settings_updated();
     request->redirect("/settings");
   });
-#endif
 
   // Route for editing SSID
   def_route_with_auth("/updateSSID", server, HTTP_GET, [](AsyncWebServerRequest* request) {
@@ -908,9 +895,6 @@ String processor(const String& var) {
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
     content += "<h4>Software: " + String(version_number);
 
-#ifdef COMMON_IMAGE
-    content += " (Common image) ";
-#endif
 // Show hardware used:
 #ifdef HW_LILYGO
     content += " Hardware: LilyGo T-CAN485";

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -12,17 +12,7 @@ const bool wifi_enabled_default = false;
 
 bool wifi_enabled = wifi_enabled_default;
 
-#ifdef COMMON_IMAGE
-const bool wifiap_enabled_default = true;
-#else
-#ifdef WIFIAP
-const bool wifiap_enabled_default = true;
-#else
-const bool wifiap_enabled_default = false;
-#endif
-#endif
-
-bool wifiap_enabled = wifiap_enabled_default;
+bool wifiap_enabled = true;  //Old method was with ifdef
 
 #ifdef MDNSRESPONDER
 const bool mdns_enabled_default = true;

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -96,11 +96,6 @@ extern const char* name_for_inverter_type(InverterProtocolType type) {
   return nullptr;
 }
 
-#ifdef COMMON_IMAGE
-#ifdef SELECTED_INVERTER_CLASS
-#error "Compile time SELECTED_INVERTER_CLASS should not be defined with COMMON_IMAGE"
-#endif
-
 bool setup_inverter() {
   if (inverter) {
     return true;
@@ -205,24 +200,3 @@ bool setup_inverter() {
 
   return false;
 }
-
-#else
-bool setup_inverter() {
-  if (inverter) {
-    // The inverter is setup only once.
-    return true;
-  }
-
-#ifdef SELECTED_INVERTER_CLASS
-  inverter = new SELECTED_INVERTER_CLASS();
-
-  if (inverter) {
-    return inverter->setup();
-  }
-
-  return false;
-#else
-  return true;
-#endif
-}
-#endif

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -7,11 +7,6 @@ extern InverterProtocol* inverter;
 #include "../../USER_SETTINGS.h"
 
 #include "AFORE-CAN.h"
-
-#ifdef BYD_CAN_DEYE
-#define BYD_CAN
-#endif
-
 #include "BYD-CAN.h"
 #include "BYD-MODBUS.h"
 #include "FERROAMP-CAN.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ monitor_speed = 115200
 monitor_filters = default, time, log2file
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_LILYGO -DCOMMON_IMAGE
+build_flags = -I include -DHW_LILYGO
 lib_deps = 
 
 [env:stark_330]
@@ -38,17 +38,7 @@ monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_STARK -DCOMMON_IMAGE
-lib_deps = 
-
-[env:stark_330_debuglog]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
-board = esp32dev
-monitor_speed = 115200
-monitor_filters = default, time, log2file, esp32_exception_decoder
-board_build.partitions = min_spiffs.csv
-framework = arduino
-build_flags = -I include -DHW_STARK -DCOMMON_IMAGE -DDEBUG_VIA_USB
+build_flags = -I include -DHW_STARK
 lib_deps = 
 
 [env:lilygo_2CAN_330]
@@ -62,7 +52,6 @@ framework = arduino
 build_flags = 
     -I include
     -D HW_LILYGO2CAN
-    -D COMMON_IMAGE
     -D BOARD_HAS_PSRAM
     -D ARDUINO_USB_MODE=1
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port


### PR DESCRIPTION
### What
This PR removes the ability to compile software old method, one component at a time

### Why
Common Image replaces this. Scales way better!

### How
All COMMON_IMAGE ifdefs removed.
