### PR TITLE
Bugfix: Increase CAN TX buffer to avoid dropping messages

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -34,7 +34,7 @@
 #endif
 
 // The current software version, shown on webserver
-const char* version_number = "9.0.RC5";
+const char* version_number = "9.0.RC6experimental";
 
 // Interval timers
 volatile unsigned long currentMillis = 0;

--- a/Software/src/lib/pierremolinaro-acan-esp32/ACAN_ESP32_Settings.h
+++ b/Software/src/lib/pierremolinaro-acan-esp32/ACAN_ESP32_Settings.h
@@ -101,7 +101,7 @@ class ACAN_ESP32_Settings {
   //    Transmit buffer sizes
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    public: uint16_t mDriverTransmitBufferSize = 16 ;
+    public: uint16_t mDriverTransmitBufferSize = 32 ;
 
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //    Compute actual bit rate


### PR DESCRIPTION
### What
This PR increases the TX transmit buffer for Native CAN, to avoid messages being dropped on CAN heavy integrations like the BMW i3

### Why
Dropped messages means integrations wont work

### How
mDriverTransmitBufferSize increased from 16 -> 32, benchtest seems OK, no longer drops messages towards a Kvases Memorator
