### PR TITLE
Fixing mqtt_loop setup regression bug

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -474,6 +474,18 @@ void core_loop(void*) {
   }
 }
 
+void mqtt_loop(void*) {
+  esp_task_wdt_add(NULL);  // Register this task with WDT
+
+  while (true) {
+    START_TIME_MEASUREMENT(mqtt);
+    mqtt_client_loop();
+    END_TIME_MEASUREMENT_MAX(mqtt, datalayer.system.status.mqtt_task_10s_max_us);
+    esp_task_wdt_reset();  // Reset watchdog
+    delay(1);
+  }
+}
+
 // Initialization
 void setup() {
   init_hal();
@@ -573,15 +585,3 @@ void setup() {
 
 // Loop empty, all functionality runs in tasks
 void loop() {}
-
-void mqtt_loop(void*) {
-  esp_task_wdt_add(NULL);  // Register this task with WDT
-
-  while (true) {
-    START_TIME_MEASUREMENT(mqtt);
-    mqtt_loop();
-    END_TIME_MEASUREMENT_MAX(mqtt, datalayer.system.status.mqtt_task_10s_max_us);
-    esp_task_wdt_reset();  // Reset watchdog
-    delay(1);
-  }
-}

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -675,7 +675,7 @@ bool init_mqtt(void) {
   return true;
 }
 
-void mqtt_loop(void) {
+void mqtt_client_loop(void) {
   // Only attempt to publish/reconnect MQTT if Wi-Fi is connectedand checkTimmer is elapsed
   if (check_global_timer.elapsed() && WiFi.status() == WL_CONNECTED) {
 

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -58,7 +58,7 @@ extern const char* ha_device_id;
 extern char mqtt_msg[MQTT_MSG_BUFFER_SIZE];
 
 bool init_mqtt(void);
-void mqtt_loop(void);
+void mqtt_client_loop(void);
 bool mqtt_publish(const char* topic, const char* mqtt_msg, bool retain);
 
 #endif


### PR DESCRIPTION
### What
This PR fixes the mqtt setup crash

### Why
When mqtt is enabled it will cause the board to crash loop

### How
The mqtt_loop task was incorrectly using the mqtt_loop method in the mqtt class and not the one in Software.cpp. The correct method has been moved up the Software.cppfile and the mqtt class method has been renamed to avoid any future repeats of this issue