### PR TITLE
Remove the duplicate CanBattery constructor.

### DIFF
--- a/Software/src/battery/CanBattery.cpp
+++ b/Software/src/battery/CanBattery.cpp
@@ -6,6 +6,12 @@ CanBattery::CanBattery(CAN_Speed speed) {
   register_can_receiver(this, can_interface, speed);
 }
 
+CanBattery::CanBattery(CAN_Interface interface, CAN_Speed speed) {
+  can_interface = interface;
+  register_transmitter(this);
+  register_can_receiver(this, can_interface, speed);
+}
+
 CAN_Speed CanBattery::change_can_speed(CAN_Speed speed) {
   return ::change_can_speed(can_interface, speed);
 }

--- a/Software/src/battery/CanBattery.h
+++ b/Software/src/battery/CanBattery.h
@@ -24,12 +24,7 @@ class CanBattery : public Battery, Transmitter, CanReceiver {
   CAN_Interface can_interface;
 
   CanBattery(CAN_Speed speed = CAN_Speed::CAN_SPEED_500KBPS);
-
-  CanBattery(CAN_Interface interface, CAN_Speed speed = CAN_Speed::CAN_SPEED_500KBPS) {
-    can_interface = interface;
-    register_transmitter(this);
-    register_can_receiver(this, can_interface, speed);
-  }
+  CanBattery(CAN_Interface interface, CAN_Speed speed = CAN_Speed::CAN_SPEED_500KBPS);
 
   CAN_Speed change_can_speed(CAN_Speed speed);
 


### PR DESCRIPTION
### What
Move the two-arg CanBattery constructor to the cpp file - it is possible that the default argument was causing problems (speculative!).

### Why
Might fix the RJXZS rate issues? probably not!
