### PR TITLE
Sofar: Crashfix, remove faulty print causing crash

### DIFF
--- a/Software/src/inverter/SOFAR-CAN.cpp
+++ b/Software/src/inverter/SOFAR-CAN.cpp
@@ -292,8 +292,5 @@ bool SofarInverter::setup() {  // Performs one time setup at startup over CAN bu
   init_frame(SOFAR_783, 0x783);
   init_frame(SOFAR_784, 0x784);
 
-  snprintf(datalayer.system.info.inverter_brand, sizeof(datalayer.system.info.inverter_brand), "%s",
-           datalayer.battery.settings.sofar_user_specified_battery_id);
-
   return true;
 }


### PR DESCRIPTION
### What
This PR fixes a crash when using the Sofar CAN protocol

### Why
Regression during common image development

### How
We fix the crash by removing an unnecessary snprintf(); call 