### PR TITLE
Bugfix: Make setup() unable to return early

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -493,7 +493,7 @@ void setup() {
   init_serial();
 
   // We print this after setting up serial, so that is also printed if configured to do so
-  logging.printf("Battery emulator %s build " __DATE__ " " __TIME__ "\n", version_number);
+  DEBUG_PRINTF("Battery emulator %s build " __DATE__ " " __TIME__ "\n", version_number);
 
   init_events();
 
@@ -504,43 +504,28 @@ void setup() {
                             &connectivity_loop_task, esp32hal->WIFICORE());
   }
 
-  if (!led_init()) {
-    return;
-  }
+  led_init();
 
   if (datalayer.system.info.CAN_SD_logging_active || datalayer.system.info.SD_logging_active) {
     xTaskCreatePinnedToCore((TaskFunction_t)&logging_loop, "logging_loop", 4096, NULL, TASK_CONNECTIVITY_PRIO,
                             &logging_loop_task, esp32hal->WIFICORE());
   }
 
-  if (!init_contactors()) {
-    return;
-  }
+  init_contactors();
 
-  if (!init_precharge_control()) {
-    return;
-  }
+  init_precharge_control();
 
   setup_charger();
-
-  if (!setup_inverter()) {
-    return;
-  }
+  setup_inverter();
   setup_battery();
   setup_can_shunt();
 
   // Init CAN only after any CAN receivers have had a chance to register.
-  if (!init_CAN()) {
-    return;
-  }
+  init_CAN();
 
-  if (!init_rs485()) {
-    return;
-  }
+  init_rs485();
 
-  if (!init_equipment_stop_button()) {
-    return;
-  }
+  init_equipment_stop_button();
 
   // BOOT button at runtime is used as an input for various things
   pinMode(0, INPUT_PULLUP);
@@ -569,9 +554,7 @@ void setup() {
   // Start tasks
 
   if (mqtt_enabled) {
-    if (!init_mqtt()) {
-      return;
-    }
+    init_mqtt();
 
     xTaskCreatePinnedToCore((TaskFunction_t)&mqtt_loop, "mqtt_loop", 4096, NULL, TASK_MQTT_PRIO, &mqtt_loop_task,
                             esp32hal->WIFICORE());
@@ -580,7 +563,7 @@ void setup() {
   xTaskCreatePinnedToCore((TaskFunction_t)&core_loop, "core_loop", 4096, NULL, TASK_CORE_PRIO, &main_loop_task,
                           esp32hal->CORE_FUNCTION_CORE());
 
-  DEBUG_PRINTF("setup() complete\n");
+  DEBUG_PRINTF("Setup complete!\n");
 }
 
 // Loop empty, all functionality runs in tasks

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -74,6 +74,7 @@ bool init_contactors() {
     auto precPin = esp32hal->PRECHARGE_PIN();
 
     if (!esp32hal->alloc_pins(contactors, posPin, negPin, precPin)) {
+      DEBUG_PRINTF("GPIO controlled contactor setup failed\n");
       return false;
     }
 
@@ -97,6 +98,7 @@ bool init_contactors() {
   if (contactor_control_enabled_double_battery) {
     auto second_contactors = esp32hal->SECOND_BATTERY_CONTACTORS_PIN();
     if (!esp32hal->alloc_pins(contactors, second_contactors)) {
+      DEBUG_PRINTF("Secondary battery contactor control setup failed\n");
       return false;
     }
 
@@ -108,6 +110,7 @@ bool init_contactors() {
   if (periodic_bms_reset || remote_bms_reset || esp32hal->always_enable_bms_power()) {
     auto pin = esp32hal->BMS_POWER();
     if (!esp32hal->alloc_pins("BMS power", pin)) {
+      DEBUG_PRINTF("BMS power setup failed\n");
       return false;
     }
     pinMode(pin, OUTPUT);

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -31,13 +31,11 @@ bool init_precharge_control() {
     return true;
   }
 
-  // Setup PWM Channel Frequency and Resolution
-  logging.printf("Precharge control initialised\n");
-
   auto hia4v1_pin = esp32hal->HIA4V1_PIN();
   auto inverter_disconnect_contactor_pin = esp32hal->INVERTER_DISCONNECT_CONTACTOR_PIN();
 
   if (!esp32hal->alloc_pins("Precharge control", hia4v1_pin, inverter_disconnect_contactor_pin)) {
+    DEBUG_PRINTF("Precharge control setup failed\n");
     return false;
   }
 
@@ -46,6 +44,7 @@ bool init_precharge_control() {
   pinMode(inverter_disconnect_contactor_pin, OUTPUT);
   digitalWrite(inverter_disconnect_contactor_pin, LOW);
 
+  DEBUG_PRINTF("Precharge control setup successful\n");
   return true;
 }
 

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -11,7 +11,8 @@ bool init_rs485() {
   auto pin_5v_en = esp32hal->PIN_5V_EN();
 
   if (!esp32hal->alloc_pins_ignore_unused("RS485", en_pin, se_pin, pin_5v_en)) {
-    return false;
+    DEBUG_PRINTF("Modbus failed to allocate pins\n");
+    return true;  //Early return, we do not set the pins
   }
 
   if (en_pin != GPIO_NUM_NC) {

--- a/Software/src/communication/rs485/comm_rs485.h
+++ b/Software/src/communication/rs485/comm_rs485.h
@@ -6,7 +6,7 @@
  *
  * @param[in] void
  *
- * @return true if init was successful, false otherwise.
+ * @return Safe to call even if rs485 is not used
  */
 bool init_rs485();
 

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -20,6 +20,7 @@ static LED* led;
 
 bool led_init(void) {
   if (!esp32hal->alloc_pins("LED", esp32hal->LED_PIN())) {
+    DEBUG_PRINTF("LED setup failed\n");
     return false;
   }
 


### PR DESCRIPTION
### What
This PR makes it so that the setup() cannot return early, leaving the emulator in a strange state where core_task never starts

### Why
Fixes #1501

### How
We instead use events and debug prints if some setup component fails to start, instead of just quitting the entire program. It is better with some function (like the ability to control contactors and status LED), instead of nothing if some setup component fails (like a CAN interface)
