### PR TITLE
Change several batteries to only flag CAN aliveness on relevant msgs

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -44,7 +44,6 @@ void KiaHyundaiHybridBattery::
 }
 
 void KiaHyundaiHybridBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x5F1:
       break;
@@ -53,6 +52,8 @@ void KiaHyundaiHybridBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x588:
       break;
     case 0x5AE:
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+
       interlock_missing = (bool)(rx_frame.data.u8[1] & 0x02) >> 1;
       break;
     case 0x5AF:

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -34,7 +34,6 @@ void Mg5Battery::
 }
 
 void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x171:  //Following messages were detected on a MG5 battery BMS
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN

--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -37,7 +37,6 @@ void PylonBattery::update_values() {
 }
 
 void PylonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x7310:
     case 0x7311:
@@ -55,6 +54,7 @@ void PylonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x4210:
     case 0x4211:
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       voltage_dV = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
       current_dA = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) - 30000;
       SOC = rx_frame.data.u8[6];

--- a/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
+++ b/Software/src/battery/RANGE-ROVER-PHEV-BATTERY.cpp
@@ -77,7 +77,6 @@ void RangeRoverPhevBattery::update_values() {
 }
 
 void RangeRoverPhevBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x080:  // 15ms
       StatusCAT5BPOChg = (rx_frame.data.u8[0] & 0x01);
@@ -105,6 +104,7 @@ void RangeRoverPhevBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       DischargeContPwrLmt = ((rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7]);
       break;
     case 0x102:  // 20ms
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       PwrGpCS = rx_frame.data.u8[0];
       PwrGpCounter = (rx_frame.data.u8[1] & 0x3C) >> 2;
       VoltageExt = (((rx_frame.data.u8[1] & 0x03) << 8) | rx_frame.data.u8[2]);

--- a/Software/src/battery/RENAULT-TWIZY.cpp
+++ b/Software/src/battery/RENAULT-TWIZY.cpp
@@ -52,9 +52,10 @@ void RenaultTwizyBattery::update_values() {
 }
 
 void RenaultTwizyBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x155:
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+
       // max charge power is in steps of 300W from 0 to 7
       max_charge_power = (uint16_t)rx_frame.data.u8[0] * 300;
 

--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -40,9 +40,10 @@ void SimpBmsBattery::update_values() {
 }
 
 void SimpBmsBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x355:
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+
       SOC = (rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0];
       SOH = (rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2];
 

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -89,9 +89,10 @@ void VolvoSpaBattery::
 }
 
 void VolvoSpaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+
       if ((rx_frame.data.u8[6] & 0x80) == 0x80)
         BATT_I = (0 - ((((rx_frame.data.u8[6] & 0x7F) * 256.0 + rx_frame.data.u8[7]) * 0.1) - 1638));
       else {

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -74,9 +74,9 @@ void VolvoSpaHybridBattery::
 }
 
 void VolvoSpaHybridBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
   switch (rx_frame.ID) {
     case 0x3A:
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       if ((rx_frame.data.u8[6] & 0x80) == 0x80)
         BATT_I = (0 - ((((rx_frame.data.u8[6] & 0x7F) * 256.0 + rx_frame.data.u8[7]) * 0.1) - 1638));
       else {


### PR DESCRIPTION
### What
Several batteries were failing the CAN-still-alive tests (in future PR), by setting CAN_STILL_ALIVE on irrelevant messages. This fixes those.

Hopefully I have chosen suitable CAN message IDs - there is a risk of causing problems if the messages I've picked aren't used on some batteries...

### Why
So that CAN failures are more likely to flag up error events.