### PR TITLE
Tidy up parameterised test names

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ add_executable(tests
     safety_tests.cpp 
     battery/NissanLeafTest.cpp 
     can_log_based/canlog_safety_tests.cpp
-    can_log_based/utils.cpp
+    utils/utils.cpp
     ../Software/src/communication/can/obd.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp

--- a/test/can_log_based/canlog_safety_tests.cpp
+++ b/test/can_log_based/canlog_safety_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "utils.h"
+#include "../utils/utils.h"
 
 #include "../../Software/src/battery/BATTERIES.h"
 #include "../../Software/src/devboard/utils/events.h"
@@ -171,23 +171,27 @@ void RegisterCanLogTests() {
     };
 
     if (has_flag("base")) {
-      testing::RegisterTest("CanLogTestFixture", ("TestBaseValuesPresent_" + entry.path().filename().string()).c_str(),
-                            nullptr, entry.path().filename().string().c_str(), __FILE__, __LINE__,
+      testing::RegisterTest("CanLogSafetyTests",
+                            ("TestBaseValuesPresent" + snake_case_to_camel_case(entry.path().stem().string())).c_str(),
+                            nullptr, nullptr, __FILE__, __LINE__,
                             [=]() -> CanLogTestFixture* { return new BaseValuesPresentTest(entry.path()); });
     }
     if (has_flag("ov")) {
-      testing::RegisterTest("CanLogTestFixture", ("TestOverVoltage_" + entry.path().filename().string()).c_str(),
-                            nullptr, entry.path().filename().string().c_str(), __FILE__, __LINE__,
+      testing::RegisterTest("CanLogSafetyTests",
+                            ("TestOverVoltage" + snake_case_to_camel_case(entry.path().stem().string())).c_str(),
+                            nullptr, nullptr, __FILE__, __LINE__,
                             [=]() -> CanLogTestFixture* { return new OverVoltageTest(entry.path()); });
     }
     if (has_flag("cov")) {
-      testing::RegisterTest("CanLogTestFixture", ("TestCellOverVoltage_" + entry.path().filename().string()).c_str(),
-                            nullptr, entry.path().filename().string().c_str(), __FILE__, __LINE__,
+      testing::RegisterTest("CanLogSafetyTests",
+                            ("TestCellOverVoltage" + snake_case_to_camel_case(entry.path().stem().string())).c_str(),
+                            nullptr, nullptr, __FILE__, __LINE__,
                             [=]() -> CanLogTestFixture* { return new CellOverVoltageTest(entry.path()); });
     }
     if (has_flag("cuv")) {
-      testing::RegisterTest("CanLogTestFixture", ("TestCellUnderVoltage_" + entry.path().filename().string()).c_str(),
-                            nullptr, entry.path().filename().string().c_str(), __FILE__, __LINE__,
+      testing::RegisterTest("CanLogSafetyTests",
+                            ("TestCellUnderVoltage" + snake_case_to_camel_case(entry.path().stem().string())).c_str(),
+                            nullptr, nullptr, __FILE__, __LINE__,
                             [=]() -> CanLogTestFixture* { return new CellUnderVoltageTest(entry.path()); });
     }
   }

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -27,6 +27,27 @@ void print_frame(const CAN_frame& frame) {
   std::cout << std::dec << "\n";
 }
 
+std::string snake_case_to_camel_case(const std::string& str) {
+  std::string result;
+  bool toUpper = false;
+  for (char ch : str) {
+    if (ch == '_') {
+      toUpper = true;
+    } else if (ch < '0' || (ch > '9' && ch < 'A') || (ch > 'Z' && ch < 'a') || ch > 'z') {
+      // skip non-alphanumeric characters
+      toUpper = true;
+    } else {
+      if (toUpper) {
+        result += toupper(ch);
+        toUpper = false;
+      } else {
+        result += ch;
+      }
+    }
+  }
+  return result;
+}
+
 CAN_frame parse_can_log_line(const std::string& logLine) {
   std::stringstream ss(logLine);
   CAN_frame frame = {};

--- a/test/utils/utils.h
+++ b/test/utils/utils.h
@@ -7,5 +7,6 @@ namespace fs = std::filesystem;
 
 bool ends_with(const std::string& str, const std::string& suffix);
 std::vector<std::string> split(const std::string& text, char sep);
+std::string snake_case_to_camel_case(const std::string& str);
 
 std::vector<CAN_frame> parse_can_log_file(const fs::path& filePath);


### PR DESCRIPTION
### What
As per the GTest docs, this removes underscores from test names by CamelCasing them. And removes the unnecessary parameters.

### Why
To conform better with the GTest recommendations.