### PR TITLE
Tweak CAN still-alive tests to more reliably construct batteries

### DIFF
--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -55,6 +55,7 @@ void setup_can_shunt();
 #include "VOLVO-SPA-HYBRID-BATTERY.h"
 
 void setup_battery(void);
+Battery* create_battery(BatteryType type);
 
 extern uint16_t user_selected_max_pack_voltage_dV;
 extern uint16_t user_selected_min_pack_voltage_dV;


### PR DESCRIPTION
### What
Small update to previous PR, to more reliably construct all the batteries (so we don't miss future ones), and rename things.