### PR TITLE
Improvement: Make CAN-FD frequency configurable

### DIFF
--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -5,6 +5,7 @@
 
 extern bool use_canfd_as_can;
 extern uint8_t user_selected_can_addon_crystal_frequency_mhz;
+extern uint8_t user_selected_canfd_addon_crystal_frequency_mhz;
 
 void dump_can_frame(CAN_frame& frame, frameDirection msgDir);
 void transmit_can_frame_to_interface(const CAN_frame* tx_frame, int interface);

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -102,6 +102,7 @@ void init_stored_settings() {
   user_selected_inverter_battery_type = settings.getUInt("INVBTYPE", 0);
   user_selected_inverter_ignore_contactors = settings.getBool("INVICNT", false);
   user_selected_can_addon_crystal_frequency_mhz = settings.getUInt("CANFREQ", 8);
+  user_selected_canfd_addon_crystal_frequency_mhz = settings.getUInt("CANFDFREQ", 40);
   user_selected_LEAF_interlock_mandatory = settings.getBool("INTERLOCKREQ", false);
   user_selected_tesla_digital_HVIL = settings.getBool("DIGITALHVIL", false);
   user_selected_tesla_GTW_country = settings.getUInt("GTWCOUNTRY", 0);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -637,6 +637,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return String(settings.getUInt("CANFREQ", 8));
   }
 
+  if (var == "CANFDFREQ") {
+    return String(settings.getUInt("CANFDFREQ", 40));
+  }
+
   if (var == "PRECHGMS") {
     return String(settings.getUInt("PRECHGMS", 100));
   }
@@ -1079,8 +1083,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         </select>
         </div>
 
-        <label>Can-addon frequency Mhz: </label>
+        <label>CAN addon crystal (Mhz): </label>
         <input name='CANFREQ' type='text' value="%CANFREQ%" pattern="^[0-9]+$" />
+
+        <label>CAN-FD-addon crystal (Mhz): </label>
+        <input name='CANFDFREQ' type='text' value="%CANFDFREQ%" pattern="^[0-9]+$" />
         
         <label>Equipment stop button: </label><select name='EQSTOP'>
         %EQSTOP%  

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -554,6 +554,9 @@ void init_webserver() {
       } else if (p->name() == "CANFREQ") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("CANFREQ", type);
+      } else if (p->name() == "CANFDFREQ") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("CANFDFREQ", type);
       } else if (p->name() == "PRECHGMS") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("PRECHGMS", type);


### PR DESCRIPTION
### What
This PR implements configurable CANFD add-on crystal configuration

### Why
Users pointed out that we have both 20mhz and 40mhz board options we use!

### How

<img width="557" height="60" alt="image" src="https://github.com/user-attachments/assets/88fd99ec-7e58-454e-80e5-c1ce59adc930" />
