### PR TITLE
Bugfix: Add AP password to settings page

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -163,7 +163,7 @@ void init_stored_settings() {
 
   // WIFI AP is enabled by default unless disabled in the settings
   wifiap_enabled = settings.getBool("WIFIAPENABLED", true);
-  wifi_channel = settings.getUInt("WIFICHANNEL", 2000);
+  wifi_channel = settings.getUInt("WIFICHANNEL", 0);
   passwordAP = settings.getString("APPASSWORD", "123456789").c_str();
   mqtt_enabled = settings.getBool("MQTTENABLED", false);
   mqtt_timeout_ms = settings.getUInt("MQTTTIMEOUT", 2000);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -291,6 +291,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return settings.getBool("WIFIAPENABLED", wifiap_enabled) ? "checked" : "";
   }
 
+  if (var == "APPASSWORD") {
+    return settings.getString("APPASSWORD", "123456789");
+  }
+
   if (var == "STATICIP") {
     return settings.getBool("STATICIP") ? "checked" : "";
   }
@@ -1147,6 +1151,9 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         <label>Broadcast Wifi access point: </label>
         <input type='checkbox' name='WIFIAPENABLED' value='on' %WIFIAPENABLED% />
+
+        <label>Access point password: </label>
+        <input type='text' name='APPASSWORD' value="%APPASSWORD%" />
 
         <label>Wifi channel 0-14: </label>
         <input name='WIFICHANNEL' type='text' value="%WIFICHANNEL%" pattern="^[0-9]+$" />

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -509,6 +509,8 @@ void init_webserver() {
       } else if (p->name() == "SUBNET4") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("SUBNET4", type);
+      } else if (p->name() == "APPASSWORD") {
+        settings.saveString("APPASSWORD", p->value().c_str());
       } else if (p->name() == "HOSTNAME") {
         settings.saveString("HOSTNAME", p->value().c_str());
       } else if (p->name() == "MQTTSERVER") {


### PR DESCRIPTION
### What
This PR adds the configuration option to set AP password in the settings page

### Why
Forgotten during development of common image

### How
Added as configurable option

<img width="552" height="96" alt="image" src="https://github.com/user-attachments/assets/5cf261fb-e2e1-461a-9c15-29670a9a2d41" />

