### PR TITLE
Switch T-2CAN back to dio, and try 16mb

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: 🛠 Build factory image for Lilygo 2-CAN
       run: |
-        esptool --chip esp32s3 merge-bin -o .pio/build/lilygo_2CAN_330/factory.bin --flash-mode qio --flash-freq 80m --flash-size 4MB 0x0000 .pio/build/lilygo_2CAN_330/bootloader.bin 0x8000 .pio/build/lilygo_2CAN_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/lilygo_2CAN_330/firmware.bin
+        esptool --chip esp32s3 merge-bin -o .pio/build/lilygo_2CAN_330/factory.bin --flash-mode dio --flash-freq 40m --flash-size 16MB 0x0000 .pio/build/lilygo_2CAN_330/bootloader.bin 0x8000 .pio/build/lilygo_2CAN_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/lilygo_2CAN_330/firmware.bin
         mv .pio/build/lilygo_2CAN_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_LilygoT-2CAN.factory.bin
 
     - name: 🛠 Build ota image for Stark


### PR DESCRIPTION
### What
Try and fix the T-2CAN factory image build yet again - one user reports that it might actually work this time.

The 2CAN should support qio, but this switches back to dio for now. Need to test against real hardware. Also switch back to 40mhz (even though the chip should be good for 80mhz).

It also uses 16mb (the true flash size) rather than 4mb - my assumption that it would work with the smaller size may be wrong.

Will experiment again if I can get my hands on an actual S3 to test.