### PR TITLE
Include CAN interface number in logs (with distinct TX/RX)

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -1271,7 +1271,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
       break;
     case 0x18DAF105:
-      handle_obd_frame(rx_frame);
+      handle_obd_frame(rx_frame, can_interface);
       break;
     default:
       break;

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -7,8 +7,8 @@ extern bool use_canfd_as_can;
 extern uint8_t user_selected_can_addon_crystal_frequency_mhz;
 extern uint8_t user_selected_canfd_addon_crystal_frequency_mhz;
 
-void dump_can_frame(CAN_frame& frame, frameDirection msgDir);
-void transmit_can_frame_to_interface(const CAN_frame* tx_frame, int interface);
+void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir);
+void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface interface);
 
 //These defines are not used if user updates values via Settings page
 #define CRYSTAL_FREQUENCY_MHZ 8
@@ -94,7 +94,7 @@ void receive_frame_canfd_addon();
  *
  * @return void
  */
-void print_can_frame(CAN_frame frame, frameDirection msgDir);
+void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirection msgDir);
 
 // Stop/pause CAN communication for all interfaces
 void stop_can();

--- a/Software/src/communication/can/obd.cpp
+++ b/Software/src/communication/can/obd.cpp
@@ -23,7 +23,7 @@ void show_dtc(uint8_t byte0, uint8_t byte1) {
   logging.printf("%c%d\n", letter, ((byte0 & 0x3F) << 8) | byte1);
 }
 
-void handle_obd_frame(CAN_frame& rx_frame) {
+void handle_obd_frame(CAN_frame& rx_frame, CAN_Interface interface) {
   if (rx_frame.data.u8[1] == 0x7F) {
     const char* error_str = "?";
     switch (rx_frame.data.u8[3]) {  // See https://automotive.wiki/index.php/ISO_14229
@@ -105,10 +105,10 @@ void handle_obd_frame(CAN_frame& rx_frame) {
         logging.printf("ODBx reply frame received:\n");
     }
   }
-  dump_can_frame(rx_frame, MSG_RX);
+  dump_can_frame(rx_frame, interface, MSG_RX);
 }
 
-void transmit_obd_can_frame(unsigned int address, int interface, bool canFD) {
+void transmit_obd_can_frame(unsigned int address, CAN_Interface interface, bool canFD) {
   static CAN_frame OBD_frame;
   OBD_frame.FD = canFD;
   OBD_frame.ID = address;

--- a/Software/src/communication/can/obd.h
+++ b/Software/src/communication/can/obd.h
@@ -3,8 +3,8 @@
 
 #include "comm_can.h"
 
-void handle_obd_frame(CAN_frame& rx_frame);
+void handle_obd_frame(CAN_frame& rx_frame, CAN_Interface interface);
 
-void transmit_obd_can_frame(unsigned int address, int interface, bool canFD);
+void transmit_obd_can_frame(unsigned int address, CAN_Interface interface, bool canFD);
 
 #endif  // _OBD_H_

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -157,7 +157,7 @@ void canReplayTask(void* param) {
                           (datalayer.system.info.can_replay_interface == CANFD_ADDON_MCP2518);
         currentFrame.ext_ID = (currentFrame.ID > 0x7F0);
 
-        transmit_can_frame_to_interface(&currentFrame, datalayer.system.info.can_replay_interface);
+        transmit_can_frame_to_interface(&currentFrame, (CAN_Interface)datalayer.system.info.can_replay_interface);
       }
     } while (datalayer.system.info.loop_playback);
 

--- a/test/emul/can.cpp
+++ b/test/emul/can.cpp
@@ -1,7 +1,7 @@
 #include "../../Software/src/communication/Transmitter.h"
 #include "../../Software/src/communication/can/comm_can.h"
 
-void transmit_can_frame_to_interface(const CAN_frame* tx_frame, int interface) {}
+void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface interface) {}
 
 void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {}
 
@@ -19,4 +19,4 @@ char const* getCANInterfaceName(CAN_Interface) {
 
 void register_transmitter(Transmitter* transmitter) {}
 
-void dump_can_frame(CAN_frame& frame, frameDirection msgDir) {}
+void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir) {}


### PR DESCRIPTION
### What
Makes the RX0/TX1 entries in CAN logs reflect the actual interface. Multiples the enum as an int by two, so that the TX is always one higher than the RX.

The logs end up like this:
```
(494.182) RX0 172 [8] 45 60 8B 49 00 93 00 00
(494.183) RX0 173 [8] 00 00 C7 C8 0F 61 0F 59
(494.184) TX1 8A [8] 80 00 00 04 00 02 36 B0
(494.184) TX1 1F1 [8] 0E 00 00 00 00 00 00 00
(494.186) RX4 1871 [8] 01 00 01 00 00 00 00 00
(494.186) TX5 187E [8] A2 30 00 00 63 58 00 00
(494.186) TX5 187A [8] 01 50 00 00 00 00 00 00
(494.186) TX5 1872 [8] C4 0E E6 0A 3C 00 3C 00
(494.187) TX5 1873 [8] DB 0D F9 FF 58 00 51 04
(494.187) TX5 1874 [8] C1 00 AD 00 9A 10 59 0F
(494.188) TX5 1875 [8] B7 00 04 00 01 00 00 00
(494.188) TX5 1876 [8] C1 00 61 0F AD 00 59 0F
(494.188) TX5 1877 [8] 00 00 00 00 54 00 22 02
(494.189) TX5 1878 [8] DB 0D 00 00 A2 30 00 00
(494.189) TX5 100A001 [0] 
(494.195) RX0 293 [8] 84 00 B1 2E 11 40 00 00
```