### PR TITLE
Stop erroneous events when saving an empty SSID/pw

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -207,10 +207,12 @@ void store_settings() {
   }
 
   if (!settings.putString("SSID", String(ssid.c_str()))) {
-    set_event(EVENT_PERSISTENT_SAVE_INFO, 1);
+    if (ssid != "")
+      set_event(EVENT_PERSISTENT_SAVE_INFO, 1);
   }
   if (!settings.putString("PASSWORD", String(password.c_str()))) {
-    set_event(EVENT_PERSISTENT_SAVE_INFO, 2);
+    if (password != "")
+      set_event(EVENT_PERSISTENT_SAVE_INFO, 2);
   }
 
   if (!settings.putUInt("BATTERY_WH_MAX", datalayer.battery.info.total_capacity_Wh)) {


### PR DESCRIPTION
### What
If you set a blank SSID or password, or set an SSID before setting a password, you get an erroneous save error. It does actually save, but putString returns 0 if the string is empty, which is currently interpreted as an error.

To be thorough it should probably getString and compare, since it can't tell the difference between saving an empty string and not saving (bad Arduino library design), but that's probably unnecessary for the moment.