### PR TITLE
Fix validation so that 8 character WiFi passwords work

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -621,7 +621,7 @@ void init_webserver() {
   def_route_with_auth("/updatePassword", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     if (request->hasParam("value")) {
       String value = request->getParam("value")->value();
-      if (value.length() > 8) {  // Check if password is within the allowable length
+      if (value.length() >= 8) {  // Password must be 8 characters or longer
         password = value.c_str();
         store_settings();
         request->send(200, "text/plain", "Updated successfully");


### PR DESCRIPTION
### What
Mirek P found a bug where exactly-8-character WiFi passwords didn't work.

This fixes a off-by-one so these now save.