### PR TITLE
Tesla: Make contactor opening take 9s instead of 60s

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -78,7 +78,11 @@ class TeslaBattery : public CanBattery {
   uint8_t muxNumber_TESLA_221 = 0;
   uint8_t frameCounter_TESLA_221 = 15;  // Start at 15 for Mux 0
   uint8_t vehicleState = 1;             // "OFF": 0, "DRIVE": 1, "ACCESSORY": 2, "GOING_DOWN": 3
-  uint16_t powerDownTimer = 180;  // Car power down (i.e. contactor open) tracking timer, 3 seconds per sendingState
+  static const uint8_t CAR_OFF = 0;
+  static const uint8_t CAR_DRIVE = 1;
+  static const uint8_t ACCESSORY = 2;
+  static const uint8_t GOING_DOWN = 3;
+  uint8_t powerDownSeconds = 9;  // Car power down (i.e. contactor open) tracking timer, 3 seconds per sendingState
   //0x2E1 VCFRONT_status, 6 mux tracker
   uint8_t muxNumber_TESLA_2E1 = 0;
   //0x334 UI


### PR DESCRIPTION
### What
This PR speeds up contactor opening on Tesla.

### Why
During refactoring, we (I) accidentally moved a 50ms code block to a 1000ms evaluation period. This made contactor opening very slow (60s instead of 9s)

### How
We fix the hardcoded ticks to suit this new evaluation period. Bonus, also add some enumerations to make code easier to read