### PR TITLE
Volvo SPA: Add low 12V voltage safety

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -86,6 +86,13 @@ void VolvoSpaBattery::
       datalayer.battery.info.total_capacity_Wh = 69511;
     }
   }
+
+  //Check safeties
+  if (datalayer_extended.VolvoPolestar.BECMsupplyVoltage < 10700) {  //10.7V,
+    //If 12V voltage goes under this, latch battery OFF to prevent contactors from swinging between on/off
+    set_event(EVENT_12V_LOW, (datalayer_extended.VolvoPolestar.BECMsupplyVoltage / 100));
+    set_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, 0);
+  }
 }
 
 void VolvoSpaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -766,7 +766,7 @@ struct DATALAYER_INFO_VOLVO_POLESTAR {
   uint16_t soc_calc = 0;
   uint16_t soc_rescaled = 0;
   uint16_t soh_bms = 0;
-  uint16_t BECMsupplyVoltage = 0;
+  uint16_t BECMsupplyVoltage = 12000;
 
   uint16_t BECMBatteryVoltage = 0;
   int16_t BECMBatteryCurrent = 0;


### PR DESCRIPTION
### What
This PR implements 12V safety for Volvo SPA platform

### Why
User feedback on Discord

_Shouldn't BE cut the power and open the contactors when the BECM supply voltage goes below a certain level? Now it seems that if the chargin of 12 V  battery stops and the voltage drops the HV contactors open, then the voltage increases again due to less load on the 12 V battery and the contactors close again for a short while and open again and so on.._

### How
We now check the 12V voltage, and if it drops below 10.7V we perform a controlled shutdown
