### PR TITLE
Rename protocol to make it more clear it is SMA

### DIFF
--- a/Software/src/inverter/SMA-BYD-H-CAN.h
+++ b/Software/src/inverter/SMA-BYD-H-CAN.h
@@ -10,7 +10,7 @@ class SmaBydHInverter : public SmaInverterBase {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr const char* Name = "BYD over SMA CAN";
+  static constexpr const char* Name = "SMA compatible BYD H";
 
   virtual bool controls_contactor() { return true; }
 

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.h
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.h
@@ -10,7 +10,7 @@ class SmaBydHvsInverter : public SmaInverterBase {
   void update_values();
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
-  static constexpr const char* Name = "BYD Battery-Box HVS over SMA CAN";
+  static constexpr const char* Name = "SMA compatible BYD Battery-Box HVS";
 
   virtual bool controls_contactor() { return true; }
 


### PR DESCRIPTION
### What
This PR renames the SMA protocols

### Why
To avoid users accidentally using SMA protocols when they dont mean to

### How

"BYD Battery-Box HVS over SMA CAN" ->  SMA compatible BYD Battery-Box HVS"
"BYD over SMA CAN" -> ""SMA compatible BYD H"