### PR TITLE
Improvement: Make AP name configurable

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -165,6 +165,7 @@ void init_stored_settings() {
   // WIFI AP is enabled by default unless disabled in the settings
   wifiap_enabled = settings.getBool("WIFIAPENABLED", true);
   wifi_channel = settings.getUInt("WIFICHANNEL", 0);
+  ssidAP = settings.getString("APNAME", "BatteryEmulator").c_str();
   passwordAP = settings.getString("APPASSWORD", "123456789").c_str();
   mqtt_enabled = settings.getBool("MQTTENABLED", false);
   mqtt_timeout_ms = settings.getUInt("MQTTTIMEOUT", 2000);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -299,6 +299,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return settings.getString("APPASSWORD", "123456789");
   }
 
+  if (var == "APNAME") {
+    return settings.getString("APNAME", "BatteryEmulator");
+  }
+
   if (var == "STATICIP") {
     return settings.getBool("STATICIP") ? "checked" : "";
   }
@@ -1220,6 +1224,9 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         <label>Broadcast Wifi access point: </label>
         <input type='checkbox' name='WIFIAPENABLED' value='on' %WIFIAPENABLED% />
+
+        <label>Access point name: </label>
+        <input type='text' name='APNAME' value="%APNAME%" />
 
         <label>Access point password: </label>
         <input type='text' name='APPASSWORD' value="%APPASSWORD%" />

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -506,6 +506,8 @@ void init_webserver() {
       } else if (p->name() == "SUBNET4") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("SUBNET4", type);
+      } else if (p->name() == "APNAME") {
+        settings.saveString("APNAME", p->value().c_str());
       } else if (p->name() == "APPASSWORD") {
         settings.saveString("APPASSWORD", p->value().c_str());
       } else if (p->name() == "HOSTNAME") {

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -54,7 +54,7 @@ static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
 
 void init_WiFi() {
-  DEBUG_PRINTF("init_Wifi enabled=%d, apå=%d, ssid=%s, password=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str(),
+  DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s, password=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str(),
                password.c_str());
 
   if (!custom_hostname.empty()) {


### PR DESCRIPTION
### What
This PR implements configurable access point name

### Why
User requested feature, forgotten during development of v9.0.0. Fixes #1553

### How
How does it do it?

<img width="557" height="143" alt="image" src="https://github.com/user-attachments/assets/85baf584-6ca9-4a8b-8eea-d02a7c669e00" />
