### PR TITLE
Tesla: Fix GTW 0x7FF frame incorrect value written

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2601,7 +2601,7 @@ void TeslaModel3YBattery::setup(void) {  // Performs one time setup at startup
   //0x7FF GTW CAN frame values
   //Mux1
   write_signal_value(&TESLA_7FF_Mux1, 16, 16, user_selected_tesla_GTW_country, false);
-  write_signal_value(&TESLA_7FF_Mux1, 11, 1, user_selected_tesla_GTW_country, false);
+  write_signal_value(&TESLA_7FF_Mux1, 11, 1, user_selected_tesla_GTW_rightHandDrive, false);
   //Mux3
   write_signal_value(&TESLA_7FF_Mux3, 8, 4, user_selected_tesla_GTW_mapRegion, false);
   write_signal_value(&TESLA_7FF_Mux3, 18, 3, user_selected_tesla_GTW_chassisType, false);


### PR DESCRIPTION

### What
This PR implements a fix for the TESLA_7FF_Mux1 frame written values, where user_selected_tesla_GTW_country was written to the both start bit 16 and 11, instead of user_selected_tesla_GTW_rightHandDrive.

### Why
An incorrect or invalid user_selected_tesla_GTW_rightHandDrive value (such as the value of user_selected_tesla_GTW_country) could cause unexpected behaviour.

### How
Writes the correct user_selected_tesla_GTW_rightHandDrive value to start bit 11 instead.
