### PR TITLE
Automatically set the version number during Actions builds

### DIFF
--- a/.github/workflows/compile-common-image-lilygo-2CAN.yml
+++ b/.github/workflows/compile-common-image-lilygo-2CAN.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       name: Checkout code
+      with:
+        # Fetch a bunch of commits to pick up the most recent tag
+        fetch-depth: 200
+        # Include tags too
+        fetch-tags: true
+        # Specify the ref explicitly to avoid weird tag-related error
+        ref: ${{ github.ref }}
 
     - uses: actions/cache@v4
       with:
@@ -44,6 +51,13 @@ jobs:
     - name: Install PlatformIO Core
       run: pip install --upgrade platformio
 
+    - name: Set version number from git tag
+      run: |
+           ver=$(git describe --tags --always)
+           stripped=${ver#"v"}
+           sed -i 's/const char\* version_number = "[^"]*";/const char\* version_number = "'"$stripped"'";/' Software/Software.cpp
+           echo "Set version to $stripped"
+           
     - name: Build image for Lilygo
       run: pio run -e lilygo_2CAN_330
 

--- a/.github/workflows/compile-common-image-lilygo-TCAN.yml
+++ b/.github/workflows/compile-common-image-lilygo-TCAN.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       name: Checkout code
+      with:
+        # Fetch a bunch of commits to pick up the most recent tag
+        fetch-depth: 200
+        # Include tags too
+        fetch-tags: true
+        # Specify the ref explicitly to avoid weird tag-related error
+        ref: ${{ github.ref }}
 
     - uses: actions/cache@v4
       with:
@@ -43,6 +50,13 @@ jobs:
         python-version: '3.11'
     - name: Install PlatformIO Core
       run: pip install --upgrade platformio
+    
+    - name: Set version number from git tag
+      run: |
+           ver=$(git describe --tags --always)
+           stripped=${ver#"v"}
+           sed -i 's/const char\* version_number = "[^"]*";/const char\* version_number = "'"$stripped"'";/' Software/Software.cpp
+           echo "Set version to $stripped"
 
     - name: Build image for Lilygo
       run: pio run -e lilygo_330

--- a/.github/workflows/compile-common-image-stark.yml
+++ b/.github/workflows/compile-common-image-stark.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       name: Checkout code
+      with:
+        # Fetch a bunch of commits to pick up the most recent tag
+        fetch-depth: 200
+        # Include tags too
+        fetch-tags: true
+        # Specify the ref explicitly to avoid weird tag-related error
+        ref: ${{ github.ref }}
 
     - uses: actions/cache@v4
       with:
@@ -43,6 +50,13 @@ jobs:
         python-version: '3.11'
     - name: Install PlatformIO Core
       run: pip install --upgrade platformio
+
+    - name: Set version number from git tag
+      run: |
+           ver=$(git describe --tags --always)
+           stripped=${ver#"v"}
+           sed -i 's/const char\* version_number = "[^"]*";/const char\* version_number = "'"$stripped"'";/' Software/Software.cpp
+           echo "Set version to $stripped"
 
     - name: Build image for Stark CMR
       run: pio run -e stark_330

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -47,6 +47,13 @@ jobs:
     - name: Install PlatformIO Core
       run: pip install --upgrade platformio
 
+    - name: Set version number from git tag
+      run: |
+           ver=$(git describe --tags --always)
+           stripped=${ver#"v"}
+           sed -i 's/const char\* version_number = "[^"]*";/const char\* version_number = "'"$stripped"'";/' Software/Software.cpp      
+           echo "Set version to $stripped"
+
     - name: 🛠 Build ota image for Lilygo T-CAN
       run: |
         pio run -e lilygo_330


### PR DESCRIPTION
### What
This replaces the version_number string in Software.cpp just before compiling in the Actions builds (both the on-push and on-release ones). The version number will be based on the current tag (with the leading "v" stripped), eg for releases:
`9.1.0`
and for random commits, it'll be the most recent tag, plus the number of commits since, plus the commit hash:
`9.1.0-2-g440bf2be`

### Why
Makes the automatically-built OTA images have sensible version numbers, and also saves having to push a commit that bumps the version number when releasing.