### PR TITLE
Kia E-GMP: Update valid cellvoltage filter

### DIFF
--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -72,7 +72,7 @@ uint16_t KiaEGmpBattery::selectSOC(uint16_t SOC_low, uint16_t SOC_high) {
 
 void KiaEGmpBattery::set_cell_voltages(CAN_frame rx_frame, int start, int length, int startCell) {
   for (size_t i = 0; i < length; i++) {
-    if ((rx_frame.data.u8[start + i] * 20) > 1000) {
+    if ((rx_frame.data.u8[start + i] * 20) > 1800) {
       datalayer.battery.status.cell_voltages_mV[startCell + i] = (rx_frame.data.u8[start + i] * 20);
     }
   }


### PR DESCRIPTION
### What
This PR improves cellvoltage validation for Kia EGMP

### Why
Incorrect values getting interpreted as actual cellvoltages

<img width="600" height="358" alt="image" src="https://github.com/user-attachments/assets/e702e8ee-5426-49ff-9725-6083e3908da2" />


### How
Previous filter would filter out values below 1000mV, we now update this to below 1800 getting filtered outu
