### PR TITLE
Stark CMR: Make BMS power on by default

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -21,6 +21,9 @@ class StarkHal : public Esp32Hal {
  public:
   const char* name() { return "Stark CMR Module"; }
 
+  //Always enable BMS power on Stark CMR, it does not collide with any pin definitions
+  virtual bool always_enable_bms_power() { return true; }
+
   // Not needed, GPIO 16 has hardware pullup for PSRAM compatibility
   virtual gpio_num_t PIN_5V_EN() { return GPIO_NUM_NC; }
 


### PR DESCRIPTION
### What
This PR makes the BMS power default ON

### Why
Very useful to have, and not require BMS reset feature in order to toggle this pin ON. Fixes #1588 

### How
By default it is now set ON at startup
