### PR TITLE
Tesla: Optimize CAN handler for faster execution + WELDED fix

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1887,12 +1887,21 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&TESLA_39D);
 
     if (battery_contactor == 4) {  // Contactors closed
+      // Increment counter, but cap at 10
+      if (contactor_counter < 10) {
+        contactor_counter++;
+      }
 
-      // Frames to be sent only when contactors closed
-
-      //0x3A1 VCFRONT_vehicleStatus, critical otherwise VCFRONT_MIA triggered
-      transmit_can_frame(&TESLA_3A1[frameCounter_TESLA_3A1]);
-      frameCounter_TESLA_3A1 = (frameCounter_TESLA_3A1 + 1) % 16;
+      if (contactor_counter > 1) {
+        // Frames to be sent only when contactors closed
+        transmit_can_frame(&TESLA_3A1[frameCounter_TESLA_3A1]);
+        frameCounter_TESLA_3A1 = (frameCounter_TESLA_3A1 + 1) % 16;
+      }
+    } else {
+      // Contactors open - decrement counter, but don't go below 0
+      if (contactor_counter > 0) {
+        contactor_counter--;
+      }
     }
 
     //Generate next frame

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -936,7 +936,8 @@ void TeslaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_fcCtrsRequestStatus = (rx_frame.data.u8[3] & (0x03U));              //24|2@1+ (1,0) [0|2] ""  Receiver
       battery_fcCtrsResetRequestRequired = ((rx_frame.data.u8[3] >> 2) & (0x01U));  //26|1@1+ (1,0) [0|1] ""  Receiver
       battery_fcLinkAllowedToEnergize = ((rx_frame.data.u8[5] >> 4) & (0x03U));     //44|2@1+ (1,0) [0|2] ""  Receiver
-    case 0x212:                                                                     //530 BMS_status: 8
+      break;
+    case 0x212:  //530 BMS_status: 8
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       BMS_hvacPowerRequest = (rx_frame.data.u8[0] & (0x01U));
       BMS_notEnoughPowerForDrive = ((rx_frame.data.u8[0] >> 1) & (0x01U));
@@ -1887,21 +1888,12 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&TESLA_39D);
 
     if (battery_contactor == 4) {  // Contactors closed
-      // Increment counter, but cap at 10
-      if (contactor_counter < 10) {
-        contactor_counter++;
-      }
 
-      if (contactor_counter > 1) {
-        // Frames to be sent only when contactors closed
-        transmit_can_frame(&TESLA_3A1[frameCounter_TESLA_3A1]);
-        frameCounter_TESLA_3A1 = (frameCounter_TESLA_3A1 + 1) % 16;
-      }
-    } else {
-      // Contactors open - decrement counter, but don't go below 0
-      if (contactor_counter > 0) {
-        contactor_counter--;
-      }
+      // Frames to be sent only when contactors closed
+
+      //0x3A1 VCFRONT_vehicleStatus, critical otherwise VCFRONT_MIA triggered
+      transmit_can_frame(&TESLA_3A1[frameCounter_TESLA_3A1]);
+      frameCounter_TESLA_3A1 = (frameCounter_TESLA_3A1 + 1) % 16;
     }
 
     //Generate next frame

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1813,31 +1813,26 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
     switch (muxNumber_TESLA_2E1) {
       case 0:
         transmit_can_frame(&TESLA_2E1_VEHICLE_AND_RAILS);
-        muxNumber_TESLA_2E1++;
         break;
       case 1:
         transmit_can_frame(&TESLA_2E1_HOMELINK);
-        muxNumber_TESLA_2E1++;
         break;
       case 2:
         transmit_can_frame(&TESLA_2E1_REFRIGERANT_SYSTEM);
-        muxNumber_TESLA_2E1++;
         break;
       case 3:
         transmit_can_frame(&TESLA_2E1_LV_BATTERY_DEBUG);
-        muxNumber_TESLA_2E1++;
         break;
       case 4:
         transmit_can_frame(&TESLA_2E1_MUX_5);
-        muxNumber_TESLA_2E1++;
         break;
       case 5:
         transmit_can_frame(&TESLA_2E1_BODY_CONTROLS);
-        muxNumber_TESLA_2E1 = 0;
         break;
       default:
         break;
     }
+    muxNumber_TESLA_2E1 = (muxNumber_TESLA_2E1 + 1) % 6;  //Cycle betweeen 0-1-2-3-4-5-0...
     //Generate next frames
     generateFrameCounterChecksum(TESLA_118, 8, 4, 0, 8);
   }
@@ -1848,75 +1843,45 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
 
     //0x221 VCFRONT_LVPowerState
     if (vehicleState == CAR_DRIVE) {
-      switch (muxNumber_TESLA_221) {
-        case 0:
-          generateMuxFrameCounterChecksum(TESLA_221_DRIVE_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_DRIVE_Mux0);
-          muxNumber_TESLA_221++;
-          break;
-        case 1:
-          generateMuxFrameCounterChecksum(TESLA_221_DRIVE_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_DRIVE_Mux1);
-          muxNumber_TESLA_221 = 0;
-          break;
-        default:
-          break;
+      if (alternateMux) {
+        generateMuxFrameCounterChecksum(TESLA_221_DRIVE_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_DRIVE_Mux0);
+      } else {
+        generateMuxFrameCounterChecksum(TESLA_221_DRIVE_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_DRIVE_Mux1);
+      }
+    } else if (vehicleState == ACCESSORY) {
+      if (alternateMux) {
+        generateMuxFrameCounterChecksum(TESLA_221_ACCESSORY_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_ACCESSORY_Mux0);
+      } else {
+        generateMuxFrameCounterChecksum(TESLA_221_ACCESSORY_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_ACCESSORY_Mux1);
+      }
+    } else if (vehicleState == GOING_DOWN) {
+      if (alternateMux) {
+        generateMuxFrameCounterChecksum(TESLA_221_GOING_DOWN_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_GOING_DOWN_Mux0);
+      } else {
+        generateMuxFrameCounterChecksum(TESLA_221_GOING_DOWN_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_GOING_DOWN_Mux1);
+      }
+    } else if (vehicleState == CAR_OFF) {
+      if (alternateMux) {
+        generateMuxFrameCounterChecksum(TESLA_221_OFF_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_OFF_Mux0);
+      } else {
+        generateMuxFrameCounterChecksum(TESLA_221_OFF_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
+        transmit_can_frame(&TESLA_221_OFF_Mux1);
       }
     }
-    if (vehicleState == ACCESSORY) {
-      switch (muxNumber_TESLA_221) {
-        case 0:
-          generateMuxFrameCounterChecksum(TESLA_221_ACCESSORY_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_ACCESSORY_Mux0);
-          muxNumber_TESLA_221++;
-          break;
-        case 1:
-          generateMuxFrameCounterChecksum(TESLA_221_ACCESSORY_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_ACCESSORY_Mux1);
-          muxNumber_TESLA_221 = 0;
-          break;
-        default:
-          break;
-      }
-    }
-    if (vehicleState == GOING_DOWN) {
-      switch (muxNumber_TESLA_221) {
-        case 0:
-          generateMuxFrameCounterChecksum(TESLA_221_GOING_DOWN_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_GOING_DOWN_Mux0);
-          muxNumber_TESLA_221++;
-          break;
-        case 1:
-          generateMuxFrameCounterChecksum(TESLA_221_GOING_DOWN_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_GOING_DOWN_Mux1);
-          muxNumber_TESLA_221 = 0;
-          break;
-        default:
-          break;
-      }
-    }
-    if (vehicleState == CAR_OFF) {
-      switch (muxNumber_TESLA_221) {
-        case 0:
-          generateMuxFrameCounterChecksum(TESLA_221_OFF_Mux0, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_OFF_Mux0);
-          muxNumber_TESLA_221++;
-          break;
-        case 1:
-          generateMuxFrameCounterChecksum(TESLA_221_OFF_Mux1, frameCounter_TESLA_221, 52, 4, 56, 8);
-          transmit_can_frame(&TESLA_221_OFF_Mux1);
-          muxNumber_TESLA_221 = 0;
-          break;
-        default:
-          break;
-      }
-    }
+
+    alternateMux ^= 1;  // Flips between 0 and 1. Used to Flip between sending Mux0 and Mux1 on each pass
     //Generate next new frame
     frameCounter_TESLA_221 = (frameCounter_TESLA_221 + 1) % 16;
 
     //0x3C2 VCLEFT_switchStatus
-    transmit_can_frame(muxNumber_TESLA_3C2 == 0 ? &TESLA_3C2_Mux0 : &TESLA_3C2_Mux1);
-    muxNumber_TESLA_3C2 = !muxNumber_TESLA_3C2;  // Flip between sending Mux0 and Mux1 on each pass
+    transmit_can_frame(alternateMux == 0 ? &TESLA_3C2_Mux0 : &TESLA_3C2_Mux1);
 
     //0x39D IBST_status
     transmit_can_frame(&TESLA_39D);
@@ -1956,28 +1921,23 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
     switch (muxNumber_TESLA_7FF) {
       case 0:
         transmit_can_frame(&TESLA_7FF_Mux1);
-        muxNumber_TESLA_7FF++;
         break;
       case 1:
         transmit_can_frame(&TESLA_7FF_Mux2);
-        muxNumber_TESLA_7FF++;
         break;
       case 2:
         transmit_can_frame(&TESLA_7FF_Mux3);
-        muxNumber_TESLA_7FF++;
         break;
       case 3:
         transmit_can_frame(&TESLA_7FF_Mux4);
-        muxNumber_TESLA_7FF++;
         break;
       case 4:
         transmit_can_frame(&TESLA_7FF_Mux5);
-        muxNumber_TESLA_7FF = 0;
         break;
       default:
         break;
     }
-
+    muxNumber_TESLA_7FF = (muxNumber_TESLA_7FF + 1) % 5;  //Cycle betweeen 0-1-2-3-4-0...
     //Generate next frames
     generateTESLA_229(TESLA_229);
     generateFrameCounterChecksum(TESLA_2A8, 52, 4, 56, 8);

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -75,7 +75,7 @@ class TeslaBattery : public CanBattery {
   //UDS session tracker
   //static bool uds_SessionInProgress = false; // Future use
   //0x221 VCFRONT_LVPowerState
-  uint8_t muxNumber_TESLA_221 = 0;
+  uint8_t alternateMux = 0;
   uint8_t frameCounter_TESLA_221 = 15;  // Start at 15 for Mux 0
   uint8_t vehicleState = 1;             // "OFF": 0, "DRIVE": 1, "ACCESSORY": 2, "GOING_DOWN": 3
   static const uint8_t CAR_OFF = 0;
@@ -89,8 +89,6 @@ class TeslaBattery : public CanBattery {
   bool TESLA_334_INITIAL_SENT = false;
   //0x3A1 VCFRONT_vehicleStatus, 15 frame counter (temporary)
   uint8_t frameCounter_TESLA_3A1 = 0;
-  //0x3C2 VCLEFT_switchStatus
-  uint8_t muxNumber_TESLA_3C2 = 0;
   //0x504 TWC_status
   bool TESLA_504_INITIAL_SENT = false;
   //0x7FF GTW_carConfig, 5 mux tracker

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -461,6 +461,7 @@ class TeslaBattery : public CanBattery {
       .data = {0x02, 0x10, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};  // Define initial UDS request
   uint8_t index_1CF = 0;
   uint8_t index_118 = 0;
+  uint8_t contactor_counter = 0;
   uint8_t stateMachineClearIsolationFault = 0xFF;
   uint8_t stateMachineBMSReset = 0xFF;
   uint8_t stateMachineSOCReset = 0xFF;


### PR DESCRIPTION
### What
This PR optimizes the CAN handler inside the Tesla battery section, and attempts to fix the WELDED issue seen on 9.x

### Why
Suspected Tesla issues in 9.X , causing WELDED + found some possible optimizations while looking at code

### How
- Re-using of unified mux counter to save memory and less instructions
- Replaced Switch statement with else-if (and the most likely always being the first if check)
- Add missing break to 20A message