### PR TITLE
Improvement: Move SSID/Password to common image

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -32,18 +32,8 @@ void init_stored_settings() {
 
   esp32hal->set_default_configuration_values();
 
-  char tempSSIDstring[63];  // Allocate buffer with sufficient size
-  size_t lengthSSID = settings.getString("SSID", tempSSIDstring, sizeof(tempSSIDstring));
-  if (lengthSSID > 0) {  // Successfully read the string from memory. Set it to SSID!
-    ssid = tempSSIDstring;
-  } else {  // Reading from settings failed. Do nothing with SSID. Raise event?
-  }
-  char tempPasswordString[63];  // Allocate buffer with sufficient size
-  size_t lengthPassword = settings.getString("PASSWORD", tempPasswordString, sizeof(tempPasswordString));
-  if (lengthPassword > 7) {  // Successfully read the string from memory. Set it to password!
-    password = tempPasswordString;
-  } else {  // Reading from settings failed. Do nothing with SSID. Raise event?
-  }
+  ssid = settings.getString("SSID", "REPLACEME").c_str();
+  password = settings.getString("PASSWORD", "REPLACEME").c_str();
 
   temp = settings.getUInt("BATTERY_WH_MAX", false);
   if (temp != 0) {
@@ -206,15 +196,6 @@ void store_settings() {
   if (!settings.begin("batterySettings", false)) {
     set_event(EVENT_PERSISTENT_SAVE_INFO, 0);
     return;
-  }
-
-  if (!settings.putString("SSID", String(ssid.c_str()))) {
-    if (ssid != "")
-      set_event(EVENT_PERSISTENT_SAVE_INFO, 1);
-  }
-  if (!settings.putString("PASSWORD", String(password.c_str()))) {
-    if (password != "")
-      set_event(EVENT_PERSISTENT_SAVE_INFO, 2);
   }
 
   if (!settings.putUInt("BATTERY_WH_MAX", datalayer.battery.info.total_capacity_Wh)) {

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -132,8 +132,13 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
       return battery->interface_name();
     }
   }
+
   if (var == "SSID") {
-    return String(ssid.c_str());
+    return settings.getString("SSID", "REPLACEME");
+  }
+
+  if (var == "PASSWORD") {
+    return settings.getString("PASSWORD", "REPLACEME");
   }
 
   if (var == "SAVEDCLASS") {
@@ -750,12 +755,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
     function editError(){alert('Invalid input');}
 
-        function editSSID(){var value=prompt('Which SSID to connect to. Enter new SSID:');if(value!==null){var xhr=new 
-        XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/updateSSID?value='+encodeURIComponent(value),true);xhr.send();}}
-        
-        function editPassword(){var value=prompt('Enter new password:');if(value!==null){var xhr=new 
-        XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/updatePassword?value='+encodeURIComponent(value),true);xhr.send();}}
-
         function editWh(){var value=prompt('How much energy the battery can store. Enter new Wh value (1-400000):');
           if(value!==null){if(value>=1&&value<=400000){var xhr=new 
         XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/updateBatterySize?value='+value,true);xhr.send();}else{
@@ -983,16 +982,26 @@ const char* getCANInterfaceName(CAN_Interface interface) {
   <button onclick='goToMainPage()'>Back to main page</button>
   <button onclick="askFactoryReset()">Factory reset</button>
 
-<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>
-    <h4 style='color: white;'>SSID: <span id='SSID'>%SSID%</span><button onclick='editSSID()'>Edit</button></h4>
-    <h4 style='color: white;'>Password: ######## <span id='Password'></span> <button onclick='editPassword()'>Edit</button></h4>
-</div>
-
 <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>
         <form action='saveSettings' method='post'>
 
         <div style='grid-column: span 2; text-align: center; padding-top: 10px;' class="%SAVEDCLASS%">
           <p>Settings saved. Reboot to take the new settings into use.<p> <button type='button' onclick='askReboot()'>Reboot</button>
+        </div>
+
+        <div class="settings-card">
+        <h3>Network config</h3>
+        <div style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>
+
+        <label>SSID: </label>
+        <input type='text' name='SSID' value="%SSID%" 
+        pattern="[A-Za-z0-9!#*-]{8,63}" 
+        title="Name must be 8-63 characters long and may only contain letters, numbers and some special characters: !#*-"/>
+
+        <label>Password: </label><input type='password' name='PASSWORD' value="%PASSWORD%" 
+        pattern="[A-Za-z0-9!#*-]{8,63}" 
+        title="Password must be 8-63 characters long and may only contain letters, numbers and some special characters: !#*-" />
+        </div>
         </div>
 
         <div class="settings-card">
@@ -1253,8 +1262,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         title="Name must be 8-63 characters long and may only contain letters, numbers and some special characters: !#*-"
         required />
 
-        <label>Access point password: </label>
-        <input type='text' name='APPASSWORD' value="%APPASSWORD%" 
+        <label>Access point password: </label><input type='password' name='APPASSWORD' value="%APPASSWORD%" 
         pattern="[A-Za-z0-9!#*-]{8,63}" 
         title="Password must be 8-63 characters long and may only contain letters, numbers and some special characters: !#*-"
         required />

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -506,6 +506,10 @@ void init_webserver() {
       } else if (p->name() == "SUBNET4") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("SUBNET4", type);
+      } else if (p->name() == "SSID") {
+        settings.saveString("SSID", p->value().c_str());
+      } else if (p->name() == "PASSWORD") {
+        settings.saveString("PASSWORD", p->value().c_str());
       } else if (p->name() == "APNAME") {
         settings.saveString("APNAME", p->value().c_str());
       } else if (p->name() == "APPASSWORD") {
@@ -600,37 +604,6 @@ void init_webserver() {
 
     settingsUpdated = settings.were_settings_updated();
     request->redirect("/settings");
-  });
-
-  // Route for editing SSID
-  def_route_with_auth("/updateSSID", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (request->hasParam("value")) {
-      String value = request->getParam("value")->value();
-      if (value.length() <= 63) {  // Check if SSID is within the allowable length
-        ssid = value.c_str();
-        store_settings();
-        request->send(200, "text/plain", "Updated successfully");
-      } else {
-        request->send(400, "text/plain", "SSID must be 63 characters or less");
-      }
-    } else {
-      request->send(400, "text/plain", "Bad Request");
-    }
-  });
-  // Route for editing Password
-  def_route_with_auth("/updatePassword", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (request->hasParam("value")) {
-      String value = request->getParam("value")->value();
-      if (value.length() >= 8) {  // Password must be 8 characters or longer
-        password = value.c_str();
-        store_settings();
-        request->send(200, "text/plain", "Updated successfully");
-      } else {
-        request->send(400, "text/plain", "Password must be atleast 8 characters");
-      }
-    } else {
-      request->send(400, "text/plain", "Bad Request");
-    }
   });
 
   auto update_string = [](const char* route, std::function<void(String)> setter,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -508,8 +508,10 @@ void init_webserver() {
         settings.saveUInt("SUBNET4", type);
       } else if (p->name() == "SSID") {
         settings.saveString("SSID", p->value().c_str());
+        ssid = settings.getString("SSID", "REPLACEME").c_str();
       } else if (p->name() == "PASSWORD") {
         settings.saveString("PASSWORD", p->value().c_str());
+        password = settings.getString("PASSWORD", "REPLACEME").c_str();
       } else if (p->name() == "APNAME") {
         settings.saveString("APNAME", p->value().c_str());
       } else if (p->name() == "APPASSWORD") {


### PR DESCRIPTION
### What
This PR refactors the SSID/Password handling to be part of the common image instead of freefloating Edit elements

### Why
Stark boards have issues with OTA. Maybe this helps?

### How
Proper password field, and part of the common image
<img width="810" height="295" alt="image" src="https://github.com/user-attachments/assets/198193c9-8511-434f-a80f-b01ccccaaa49" />

