### PR TITLE
Proposed pin assignments for LilyGo T-2CAN (suggestions welcome)

### DIFF
--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -3,6 +3,33 @@
 
 #include "hal.h"
 
+/*
+The 2CAN has four GPIOs on the top (43/44 and 1/2 on each of the SH-1mm
+connectors) and 21 on the bottom (on the 2x13 header). GPIO35-37 aren't usable
+if opi PSRAM is enabled.
+
+43:RS485_RX
+44:RS485_TX
+
+1:WUP1/BMS_POWER/ESTOP
+2:WUP2/LED
+
+3.3V                   GND
+  5V                   GND
+ x35:LED                39:INT
+  38:SCK                42:SDI
+ x37:SDO                41:nCS
+ x36:ESTOP              40
+  16                     4
+  15                     5:BAT2_CTRS
+  45                    48:POS_CTR
+  47:                   21:PRECHARGE
+  14:HV_INV_DIS/[WUP2]  17:NEG_CTR
+  18:HV_PRE/[WUP1]     GND
+  46:INV_CTR_EN          3:BMS_POWER
+
+*/
+
 class LilyGo2CANHal : public Esp32Hal {
  public:
   const char* name() { return "LilyGo T_2CAN"; }
@@ -17,6 +44,14 @@ class LilyGo2CANHal : public Esp32Hal {
   virtual gpio_num_t CAN_TX_PIN() { return GPIO_NUM_7; }
   virtual gpio_num_t CAN_RX_PIN() { return GPIO_NUM_6; }
 
+  // Note: these are used by the bootloader UART, although the other way round -
+  // so there'll be a brief clash of TX outputs on startup. This shouldn't cause
+  // any problems (neither the ESP32 nor common RS485 transcievers should suffer
+  // damage from shorted outputs) and ensures that we don't send any bootloader
+  // chatter to any attached batteries/inverters.
+  virtual gpio_num_t RS485_TX_PIN() { return GPIO_NUM_44; }
+  virtual gpio_num_t RS485_RX_PIN() { return GPIO_NUM_43; }
+
   // Built In MCP2515 CAN_ADDON
   virtual gpio_num_t MCP2515_SCK() { return GPIO_NUM_12; }
   virtual gpio_num_t MCP2515_MOSI() { return GPIO_NUM_11; }
@@ -26,40 +61,40 @@ class LilyGo2CANHal : public Esp32Hal {
   virtual gpio_num_t MCP2515_RST() { return GPIO_NUM_9; }
 
   // CANFD_ADDON defines for MCP2517
-  virtual gpio_num_t MCP2517_SCK() { return GPIO_NUM_17; }
-  virtual gpio_num_t MCP2517_SDI() { return GPIO_NUM_16; }
-  virtual gpio_num_t MCP2517_SDO() { return GPIO_NUM_18; }
-  virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_15; }
-  virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_14; }
+  virtual gpio_num_t MCP2517_SCK() { return GPIO_NUM_38; }
+  virtual gpio_num_t MCP2517_SDI() { return GPIO_NUM_42; }
+  virtual gpio_num_t MCP2517_SDO() { return GPIO_NUM_37; }
+  virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_41; }
+  virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_39; }
 
   // Contactor handling
-  virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_38; }
-  virtual gpio_num_t NEGATIVE_CONTACTOR_PIN() { return GPIO_NUM_39; }
-  virtual gpio_num_t PRECHARGE_PIN() { return GPIO_NUM_40; }
-  virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_41; }
+  virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_48; }
+  virtual gpio_num_t NEGATIVE_CONTACTOR_PIN() { return GPIO_NUM_17; }
+  virtual gpio_num_t PRECHARGE_PIN() { return GPIO_NUM_21; }
+  virtual gpio_num_t BMS_POWER() { return GPIO_NUM_3; }
+  virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_5; }
 
   // Automatic precharging
-  virtual gpio_num_t HIA4V1_PIN() { return GPIO_NUM_41; }
-  virtual gpio_num_t INVERTER_DISCONNECT_CONTACTOR_PIN() { return GPIO_NUM_40; }
+  virtual gpio_num_t HIA4V1_PIN() { return GPIO_NUM_18; }
+  virtual gpio_num_t INVERTER_DISCONNECT_CONTACTOR_PIN() { return GPIO_NUM_14; }
 
-  // SMA CAN contactor pins
-  virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_PIN() { return GPIO_NUM_14; }
-
-  virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_LED_PIN() { return GPIO_NUM_5; }
+  // SMA CAN contactor pin
+  virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_PIN() { return GPIO_NUM_46; }
 
   // LED
-  virtual gpio_num_t LED_PIN() { return GPIO_NUM_4; }
+  virtual gpio_num_t LED_PIN() { return GPIO_NUM_35; }
   virtual uint8_t LED_MAX_BRIGHTNESS() { return 40; }
 
   // Equipment stop pin
-  virtual gpio_num_t EQUIPMENT_STOP_PIN() { return GPIO_NUM_5; }
+  virtual gpio_num_t EQUIPMENT_STOP_PIN() { return GPIO_NUM_36; }
 
   // Battery wake up pins
-  virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_40; }
-  virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_38; }
+  virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_1; }
+  virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_2; }
 
   std::vector<comm_interface> available_interfaces() {
-    return {comm_interface::CanNative, comm_interface::CanAddonMcp2515};
+    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
+            comm_interface::CanFdAddonMcp2518};
   }
 };
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ src_dir = ./Software
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
-monitor_filters = default, time, log2file
+monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -Wimplicit-fallthrough
@@ -25,7 +25,7 @@ lib_deps =
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
-monitor_filters = default, time, log2file
+monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.flash_mode = qio
 board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
@@ -51,9 +51,12 @@ lib_deps =
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
-monitor_filters = default, time, log2file
-board_build.arduino.partitions = default_16MB.csv 
-board_build.arduino.memory_type = qio_opi
+monitor_filters = default, time, log2file, esp32_exception_decoder
+board_build.arduino.partitions = default_16MB.csv
+; The 2CAN's PSRAM is opi, but we set it to qspi, to give us back the use of
+; GPIO35-37. Unfortunately it will fail to init (opi PSRAM doesn't work in qspi
+; mode), but we're not using it anyway.
+board_build.arduino.memory_type = qio_qspi
 framework = arduino
 build_flags = 
     -I include


### PR DESCRIPTION
### What
Note: This is in slight conflict with https://github.com/dalathegreat/Battery-Emulator/pull/1589

This assigns the pin connections on the LilyGo T-2CAN to try and make the best use of the GPIOs. It allows for:

- RS485 on the first SH-1.0mm connector, with TX/RX flipped so bootloader chatter isn't sent down the bus
- GPIO on the second SH-1.0mm, currently BMW WUP1/2 as per the other PR, but I propose this is made configurable (eg, for BMS_RESET/ESTOP/LED for people not using BMW batteries).
- SPI connections for a MCP2518, with the pins in the same order as the common AliExpress modules
- BMS_RESET/POS/NEG/PRE/BAT2 contactor connections together in a row
- LED near the power pins for easy wiring of an indicator
- HV precharge pins next to each other

ASCII-art diagram:
```
43:RS485_RX
44:RS485_TX

1:WUP1/BMS_POWER/ESTOP
2:WUP2/LED

3.3V                   GND
  5V                   GND
 x35:LED                39:INT
  38:SCK                42:SDI
 x37:SDO                41:nCS
 x36:ESTOP              40
  16                     4
  15                     5:BAT2_CTRS
  45                    48:POS_CTR
  47:                   21:PRECHARGE
  14:HV_INV_DIS/[WUP2]  17:NEG_CTR
  18:HV_PRE/[WUP1]     GND
  46:INV_CTR_EN          3:BMS_POWER
```

### Why
I think it is important that we come up with a layout that everyone is happy with now, since once this is in wide use, we won't be able to change it in the future.

I'm also concerned that we might encounter inverters that don't like bootloader chatter on the RS485 pins, hence the TX/RX swap.

This allows a header to be soldered to the PCB, and two Dupont connectors used:

- a 2x5 for a connection to a MCP2518FD board, including power lines
- a 2x8 for contactor/precharge connections, including a ground line
