### PR TITLE
Fix three select-case-fallthrough bugs (and enable compile warning flag)

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -264,6 +264,7 @@ void setup_battery() {
         battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,
                                            &datalayer.system.status.battery2_allowed_contactor_closing,
                                            can_config.battery_double);
+        break;
       case BatteryType::SantaFePhev:
         battery2 = new SantaFePhevBattery(&datalayer.battery2, can_config.battery_double);
         break;

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -209,6 +209,7 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_POLL_CUMULATIVE_ENERGY_IN_REGEN:
           cumulative_energy_in_regen = (uint64_t)((rx_frame.data.u8[4] << 24) | (rx_frame.data.u8[5] << 16) |
                                                   (rx_frame.data.u8[6] << 8) | (rx_frame.data.u8[7]));
+          break;
         case PID_POLL_CELL_1:
           cellvoltages_mv[0] = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
           break;

--- a/Software/src/charger/CHARGERS.cpp
+++ b/Software/src/charger/CHARGERS.cpp
@@ -43,7 +43,9 @@ void setup_charger() {
   switch (user_selected_charger_type) {
     case ChargerType::ChevyVolt:
       charger = new ChevyVoltCharger();
+      break;
     case ChargerType::NissanLeaf:
       charger = new NissanLeafCharger();
+      break;
   }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ monitor_speed = 115200
 monitor_filters = default, time, log2file
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include
+build_flags = -I include -Wimplicit-fallthrough
 lib_deps = 
 
 [env:lilygo_330]
@@ -31,7 +31,7 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_LILYGO
+build_flags = -I include -Wimplicit-fallthrough -DHW_LILYGO
 lib_deps = 
 
 [env:stark_330]
@@ -44,7 +44,7 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_STARK
+build_flags = -I include -Wimplicit-fallthrough -DHW_STARK
 lib_deps = 
 
 [env:lilygo_2CAN_330]
@@ -57,6 +57,7 @@ board_build.arduino.memory_type = qio_opi
 framework = arduino
 build_flags = 
     -I include
+    -Wimplicit-fallthrough
     -D HW_LILYGO2CAN
     -D BOARD_HAS_PSRAM
     -D ARDUINO_USB_MODE=1


### PR DESCRIPTION
### What
Turns out there's a compiler flag (`-Wimplicit-fallthrough`) to detect missing `break;` statements in select cases.

This enables it, and fixes three bugs that it detected:

- `setup_charger()` always chose `NissanLeafCharger` regardless of what you selected.  
- CMFA-EV-BATTERY would overwrite the first cellvoltage sometimes.  
- KiaHyundai64 wasn't usable as a second battery.

The Tesla 0x212 bug is left unfixed (as it is in a separate PR).