### PR TITLE
Rename the CAN interfaces and hide irrelevant options per-HW

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -32,22 +32,7 @@ const char* name_for_chemistry(battery_chemistry_enum chem) {
 }
 
 const char* name_for_comm_interface(comm_interface comm) {
-  switch (comm) {
-    case comm_interface::Modbus:
-      return "Modbus";
-    case comm_interface::RS485:
-      return "RS485";
-    case comm_interface::CanNative:
-      return "Native CAN";
-    case comm_interface::CanFdNative:
-      return "Native CAN FD";
-    case comm_interface::CanAddonMcp2515:
-      return "CAN MCP 2515 add-on";
-    case comm_interface::CanFdAddonMcp2518:
-      return "CAN FD MCP 2518 add-on";
-    default:
-      return nullptr;
-  }
+  return esp32hal->name_for_comm_interface(comm);
 }
 
 const char* name_for_battery_type(BatteryType type) {

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -165,6 +165,25 @@ class Esp32Hal {
   // Returns the available comm interfaces on this HW
   virtual std::vector<comm_interface> available_interfaces() = 0;
 
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::Modbus:
+        return "Modbus";
+      case comm_interface::RS485:
+        return "RS485";
+      case comm_interface::CanNative:
+        return "CAN (Native)";
+      case comm_interface::CanFdNative:
+        return "";
+      case comm_interface::CanAddonMcp2515:
+        return "CAN (MCP2515 add-on)";
+      case comm_interface::CanFdAddonMcp2518:
+        return "CAN FD (MCP2518 add-on)";
+      default:
+        return nullptr;
+    }
+  }
+
   String failed_allocator() { return allocator_name; }
   String conflicting_allocator() { return allocated_name; }
 

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -79,6 +79,20 @@ class LilyGoHal : public Esp32Hal {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
             comm_interface::CanFdAddonMcp2518};
   }
+
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::CanNative:
+        return "CAN (Native)";
+      case comm_interface::CanFdNative:
+        return "";
+      case comm_interface::CanAddonMcp2515:
+        return "CAN (MCP2515 add-on)";
+      case comm_interface::CanFdAddonMcp2518:
+        return "CAN FD (MCP2518 add-on)";
+    }
+    return Esp32Hal::name_for_comm_interface(comm);
+  }
 };
 
 #define HalClass LilyGoHal

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -61,6 +61,18 @@ class LilyGo2CANHal : public Esp32Hal {
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::CanNative, comm_interface::CanAddonMcp2515};
   }
+
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::CanNative:
+        return "CAN B (Native)";
+      case comm_interface::CanFdNative:
+        return "";
+      case comm_interface::CanAddonMcp2515:
+        return "CAN A (MCP2515)";
+    }
+    return Esp32Hal::name_for_comm_interface(comm);
+  }
 };
 
 #define HalClass LilyGo2CANHal

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -84,6 +84,20 @@ class StarkHal : public Esp32Hal {
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanFdNative};
   }
+
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::CanNative:
+        return "CAN 1 (Native)";
+      case comm_interface::CanFdNative:
+        return "CAN FD 2 (Native)";
+      case comm_interface::CanAddonMcp2515:
+        return "";
+      case comm_interface::CanFdAddonMcp2518:
+        return "";
+    }
+    return Esp32Hal::name_for_comm_interface(comm);
+  }
 };
 
 #endif  // __HW_STARK_H__

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -71,6 +71,8 @@ String options_for_enum(TEnum selected, Func name_for_type) {
   String options;
   auto values = enum_values_and_names<TEnum>(name_for_type, nullptr);
   for (const auto& [name, type] : values) {
+    if (name[0] == '\0')
+      continue;  // Don't show blank options
     options +=
         ("<option value=\"" + String(static_cast<int>(type)) + "\"" + (selected == type ? " selected" : "") + ">");
     options += name;


### PR DESCRIPTION
### What
Move the `name_for_comm_interface(...)` function to `Esp32Hal` so that each hardware type can have its own names for the communication interfaces (and also hide irrelevant ones by setting to an empty string).

Eg, 2CAN now looks like this:

<img width="261" height="156" alt="image" src="https://github.com/user-attachments/assets/818f6efd-b5be-41b8-95ac-1aa6bc88c367" />

### Why
Makes it a bit more user-friendly?