### PR TITLE
Update SUNGROW-CAN.cpp

### DIFF
--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -40,6 +40,9 @@ void SungrowInverter::
   //SUNGROW_703.data.u8[6] =
   //SUNGROW_703.data.u8[7] =
 
+    if (datalayer.battery.status.voltage_dV == 0) then {
+    datalayer.battery.status.voltage_dV = 1000; } //preset batt V too 100v, to avoid sungrow error 703
+
   //Vbat (eg 400.0V = 4000 , 16bits long)
   SUNGROW_704.data.u8[0] = (datalayer.battery.status.voltage_dV & 0x00FF);
   SUNGROW_704.data.u8[1] = (datalayer.battery.status.voltage_dV >> 8);


### PR DESCRIPTION
made initial batt voltage 100v, to avoid sungrow error 703

### What
This PR implements ...preset sungrow sbr protocol to 100v 

### Why
Why does it do it?...to avoid error 703, low battery voltage 

### How
How does it do it? upon updating values in sungrow-can.cpp if vbat = 0, then vbat = 1000 (decivolts)
