### PR TITLE
Bugfix: Make it possible to save 0 as minpercentage

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -54,7 +54,7 @@ void init_stored_settings() {
     datalayer.battery.settings.max_percentage = temp * 10;  // Multiply by 10 for backwards compatibility
   }
   temp = settings.getUInt("MINPERCENTAGE", false);
-  if (temp != 0) {
+  if (temp < 499) {
     datalayer.battery.settings.min_percentage = temp * 10;  // Multiply by 10 for backwards compatibility
   }
   temp = settings.getUInt("MAXCHARGEAMP", false);


### PR DESCRIPTION
### What
This PR makes it possible to use MINSOC as 0% when using Scaled SOC

### Why
User reported issue. Fixes #1542 

### How
We now allow values set to 0 to be used at boot
