### PR TITLE
BMW iX: Fix incorrectly applied min/max voltages

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -60,11 +60,10 @@ void BmwIXBattery::update_values() {  //This function maps all the values fetche
 
   datalayer.battery.status.soh_pptt = min_soh_state;
 
-  datalayer.battery.status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
+  datalayer.battery.status.max_discharge_power_W =
+      datalayer.battery.status.override_discharge_power_W;  //TODO: Estimated from UI
 
-  //datalayer.battery.status.max_charge_power_W = 3200; //10000; //Aux HV Port has 100A Fuse  Moved to Ramping
-
-  // Charge power is set in .h file
+  // Estimated charge power is set in Settings page. Ramp power on top
   if (datalayer.battery.status.real_soc > 9900) {
     datalayer.battery.status.max_charge_power_W = MAX_CHARGE_POWER_WHEN_TOPBALANCING_W;
   } else if (datalayer.battery.status.real_soc > RAMPDOWN_SOC) {
@@ -98,10 +97,6 @@ void BmwIXBattery::update_values() {  //This function maps all the values fetche
   if (terminal30_12v_voltage < 1100) {  //11.000V
     set_event(EVENT_12V_LOW, terminal30_12v_voltage);
   }
-
-  datalayer.battery.info.max_design_voltage_dV = max_design_voltage;
-
-  datalayer.battery.info.min_design_voltage_dV = min_design_voltage;
 
   datalayer.battery.info.number_of_cells = detected_number_of_cells;
 

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -98,14 +98,25 @@ void BmwIXBattery::update_values() {  //This function maps all the values fetche
     set_event(EVENT_12V_LOW, terminal30_12v_voltage);
   }
 
+  if ((datalayer.battery.status.cell_voltages_mV[77] > 1000) &&
+      (datalayer.battery.status.cell_voltages_mV[78] < 1000)) {
+    //If we detect cellvoltage on cell78, but nothing on 79, we can confirm we are on SE12
+    detected_number_of_cells = 78;  //We are on 78S SE12 battery from BMW IX1
+  }  //Sidenote, detection of 96S and 108S batteries happen inside the cellvoltage reading blocks
+
   datalayer.battery.info.number_of_cells = detected_number_of_cells;
 
-  if (battery_info_available) {
-    // If we have data from battery - override the defaults to suit
-    datalayer.battery.info.max_design_voltage_dV = max_design_voltage;
-    datalayer.battery.info.min_design_voltage_dV = min_design_voltage;
-    datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-    datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  if (detected_number_of_cells == 78) {
+    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_78S_DV;
+    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_78S_DV;
+  }
+  if (detected_number_of_cells == 96) {
+    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_96S_DV;
+    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_96S_DV;
+  }
+  if (detected_number_of_cells == 108) {
+    datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_108S_DV;
+    datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_108S_DV;
   }
 }
 
@@ -333,8 +344,8 @@ void BmwIXBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         if ((rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]) < 4700 &&
             (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]) > 2600) {  //Make sure values are plausible
           battery_info_available = true;
-          max_design_voltage = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);
-          min_design_voltage = (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]);
+          max_design_voltage = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);  //Not valid on all iX
+          min_design_voltage = (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]);  //Not valid on all iX
         }
       }
 
@@ -443,9 +454,9 @@ void BmwIXBattery::setup(void) {  // Performs one time setup at startup
   //Reset Battery at bootup
   //transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET);
 
-  //Before we have started up and detected which battery is in use, use 108S values
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  //Before we have started up and detected which battery is in use, use largest deviation possible to avoid errors
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_108S_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_78S_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -43,8 +43,12 @@ class BmwIXBattery : public CanBattery {
   bool userRequestContactorOpen = false;
 
   BmwIXHtmlRenderer renderer;
-  static const int MAX_PACK_VOLTAGE_DV = 4650;  //4650 = 465.0V
-  static const int MIN_PACK_VOLTAGE_DV = 3000;
+  static const int MAX_PACK_VOLTAGE_78S_DV = 3354;  //SE12 battery, BMW iX1, 66.45kWh 286.3vNom
+  static const int MIN_PACK_VOLTAGE_78S_DV = 2200;
+  static const int MAX_PACK_VOLTAGE_96S_DV = 4128;
+  static const int MIN_PACK_VOLTAGE_96S_DV = 2688;
+  static const int MAX_PACK_VOLTAGE_108S_DV = 4650;
+  static const int MIN_PACK_VOLTAGE_108S_DV = 3000;
   static const int MAX_CELL_DEVIATION_MV = 250;
   static const int MAX_CELL_VOLTAGE_MV = 4300;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2800;  //Battery is put into emergency stop if one cell goes below this value
@@ -542,8 +546,8 @@ CAN_frame BMWiX_49C = {.FD = true,
   uint16_t min_soh_state = 9900;  // Uses E5 45, also available in 78 73
   uint16_t avg_soh_state = 9900;  // Uses E5 45, also available in 78 73
   uint16_t max_soh_state = 9900;  // Uses E5 45, also available in 78 73
-  uint16_t max_design_voltage = MAX_PACK_VOLTAGE_DV;
-  uint16_t min_design_voltage = MIN_PACK_VOLTAGE_DV;
+  uint16_t max_design_voltage = 0;
+  uint16_t min_design_voltage = 0;
   uint32_t remaining_capacity = 0;
   uint32_t max_capacity = 0;
   int16_t min_battery_temperature = 0;
@@ -575,7 +579,7 @@ CAN_frame BMWiX_49C = {.FD = true,
   uint8_t pyro_status_pss4 = 0;            //Using AC 93
   uint8_t pyro_status_pss6 = 0;            //Using AC 93
   uint8_t uds_req_id_counter = 0;
-  uint8_t detected_number_of_cells = 108;
+  uint8_t detected_number_of_cells = 0;
   const unsigned long STALE_PERIOD =
       STALE_PERIOD_CONFIG;  // Time in milliseconds to check for staleness (e.g., 5000 ms = 5 seconds)
   //End iX Intermediate vars

--- a/Software/src/battery/BMW-IX-BATTERY.h
+++ b/Software/src/battery/BMW-IX-BATTERY.h
@@ -542,8 +542,8 @@ CAN_frame BMWiX_49C = {.FD = true,
   uint16_t min_soh_state = 9900;  // Uses E5 45, also available in 78 73
   uint16_t avg_soh_state = 9900;  // Uses E5 45, also available in 78 73
   uint16_t max_soh_state = 9900;  // Uses E5 45, also available in 78 73
-  uint16_t max_design_voltage = 0;
-  uint16_t min_design_voltage = 0;
+  uint16_t max_design_voltage = MAX_PACK_VOLTAGE_DV;
+  uint16_t min_design_voltage = MIN_PACK_VOLTAGE_DV;
   uint32_t remaining_capacity = 0;
   uint32_t max_capacity = 0;
   int16_t min_battery_temperature = 0;


### PR DESCRIPTION
### What
This PR makes it possible to charge/discharge 78S iX1 batteries properly

### Why
User reported bug on Discord, not possible to charge battery due to 0kW allowed even though it should allow

### How
We now define limits separately for 78S, 96S and 108S packs. This PR makes all iX integrations more robust
