### PR TITLE
Disable noisy WiFi status logging to keep log quieter

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -108,8 +108,9 @@ void wifi_monitor() {
   if ((hasConnectedBefore && (currentMillis - lastWiFiCheck > current_check_interval)) ||
       (!hasConnectedBefore && (currentMillis - lastWiFiCheck > INIT_WIFI_FULL_RECONNECT_INTERVAL))) {
 
-    DEBUG_PRINTF("Wi-Fi status: %d, %d, %d, %d, %d\n", hasConnectedBefore, currentMillis, lastWiFiCheck,
-                 current_check_interval, INIT_WIFI_FULL_RECONNECT_INTERVAL);
+    // Uncomment for testing, but otherwise this quickly fills up the log
+    //DEBUG_PRINTF("Wi-Fi status: %d, %d, %d, %d, %d\n", hasConnectedBefore, currentMillis, lastWiFiCheck,
+    //             current_check_interval, INIT_WIFI_FULL_RECONNECT_INTERVAL);
 
     lastWiFiCheck = currentMillis;
 


### PR DESCRIPTION
### What
Currently, you get a log entry every few seconds when connected to WiFi:

```
     126.713 Wi-Fi status: 1, 126713, 124712, 2000, 10000
     128.714 Wi-Fi status: 1, 128714, 126713, 2000, 10000
     130.715 Wi-Fi status: 1, 130715, 128714, 2000, 10000
     132.716 Wi-Fi status: 1, 132716, 130715, 2000, 10000
     134.717 Wi-Fi status: 1, 134717, 132716, 2000, 10000
     136.718 Wi-Fi status: 1, 136718, 134717, 2000, 10000
     138.719 Wi-Fi status: 1, 138719, 136718, 2000, 10000
     140.720 Wi-Fi status: 1, 140720, 138719, 2000, 10000
     142.721 Wi-Fi status: 1, 142721, 140720, 2000, 10000
     144.722 Wi-Fi status: 1, 144722, 142721, 2000, 10000
```

This isn't very interesting, and makes the log less useful for other things. Have commented it out so it can still be reenabled when you're debugging WiFi issues.
