### PR TITLE
Feature: Add configurable option for Pylon send (Needed for ZCS Azzurro inverter)

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -94,6 +94,7 @@ void init_stored_settings() {
   user_selected_min_pack_voltage_dV = settings.getUInt("BATTPVMIN", 0);
   user_selected_max_cell_voltage_mV = settings.getUInt("BATTCVMAX", 0);
   user_selected_min_cell_voltage_mV = settings.getUInt("BATTCVMIN", 0);
+  user_selected_pylon_send = settings.getUInt("PYLONSEND", 0);
   user_selected_inverter_cells = settings.getUInt("INVCELLS", 0);
   user_selected_inverter_modules = settings.getUInt("INVMODULES", 0);
   user_selected_inverter_cells_per_module = settings.getUInt("INVCELLSPER", 0);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -619,6 +619,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
     return String(settings.getUInt("SOFAR_ID", 0));
   }
 
+  if (var == "PYLONSEND") {
+    return String(settings.getUInt("PYLONSEND", 0));
+  }
+
   if (var == "INVCELLS") {
     return String(settings.getUInt("INVCELLS", 0));
   }
@@ -952,6 +956,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    form .if-pylon { display: none; }
+    form[data-inverter="10"] .if-pylon {
+      display: contents;
+    }
+
     form .if-pylonish { display: none; }
     form[data-inverter="4"] .if-pylonish, form[data-inverter="10"] .if-pylonish, form[data-inverter="19"] .if-pylonish {
       display: contents;
@@ -1107,6 +1116,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <div class="if-sofar">
         <label>Sofar Battery ID (0-15): </label>
         <input name='SOFAR_ID' type='text' value="%SOFAR_ID%" pattern="[0-9]{1,2}" />
+        </div>
+
+        <div class="if-pylon">
+        <label>Send group (0-1): </label>
+        <input name='PYLONSEND' type='text' value="%PYLONSEND%" pattern="[0-9]+" />
         </div>
 
         <div class="if-pylonish">

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -535,6 +535,9 @@ void init_webserver() {
       } else if (p->name() == "SOFAR_ID") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("SOFAR_ID", type);
+      } else if (p->name() == "PYLONSEND") {
+        auto type = atoi(p->value().c_str());
+        settings.saveUInt("PYLONSEND", type);
       } else if (p->name() == "INVCELLS") {
         auto type = atoi(p->value().c_str());
         settings.saveUInt("INVCELLS", type);

--- a/Software/src/inverter/INVERTERS.cpp
+++ b/Software/src/inverter/INVERTERS.cpp
@@ -7,6 +7,7 @@ InverterProtocolType user_selected_inverter_protocol = InverterProtocolType::Byd
 // Some user-configurable settings that can be used by inverters. These
 // inverters should use sensible defaults if the corresponding user_selected
 // value is zero.
+uint16_t user_selected_pylon_send = 0;
 uint16_t user_selected_inverter_cells = 0;
 uint16_t user_selected_inverter_modules = 0;
 uint16_t user_selected_inverter_cells_per_module = 0;

--- a/Software/src/inverter/INVERTERS.h
+++ b/Software/src/inverter/INVERTERS.h
@@ -29,6 +29,7 @@ extern InverterProtocol* inverter;
 // Call to initialize the build-time selected inverter. Safe to call even though inverter was not selected.
 bool setup_inverter();
 
+extern uint16_t user_selected_pylon_send;
 extern uint16_t user_selected_inverter_cells;
 extern uint16_t user_selected_inverter_modules;
 extern uint16_t user_selected_inverter_cells_per_module;

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -3,8 +3,6 @@
 #include "../datalayer/datalayer.h"
 #include "../inverter/INVERTERS.h"
 
-#define SEND_0  //If defined, the messages will have ID ending with 0 (useful for some inverters)
-//#define SEND_1 //If defined, the messages will have ID ending with 1 (useful for some inverters)
 #define INVERT_LOW_HIGH_BYTES  //If defined, certain frames will have inverted low/high bytes \
                                //useful for some inverters like Sofar that report the voltages incorrect otherwise
 //#define SET_30K_OFFSET  //If defined, current values are sent with a 30k offest (useful for ferroamp)
@@ -318,42 +316,50 @@ void PylonInverter::transmit_can(unsigned long currentMillis) {
 }
 
 void PylonInverter::send_setup_info() {  //Ensemble information
-#ifdef SEND_0
-  transmit_can_frame(&PYLON_7310);
-  transmit_can_frame(&PYLON_7320);
-#endif
-#ifdef SEND_1
-  transmit_can_frame(&PYLON_7311);
-  transmit_can_frame(&PYLON_7321);
-#endif
+  if (pylon_send_0) {
+    transmit_can_frame(&PYLON_7310);
+    transmit_can_frame(&PYLON_7320);
+  }
+  if (pylon_send_1) {
+    transmit_can_frame(&PYLON_7311);
+    transmit_can_frame(&PYLON_7321);
+  }
 }
 
 void PylonInverter::send_system_data() {  //System equipment information
-#ifdef SEND_0
-  transmit_can_frame(&PYLON_4210);
-  transmit_can_frame(&PYLON_4220);
-  transmit_can_frame(&PYLON_4230);
-  transmit_can_frame(&PYLON_4240);
-  transmit_can_frame(&PYLON_4250);
-  transmit_can_frame(&PYLON_4260);
-  transmit_can_frame(&PYLON_4270);
-  transmit_can_frame(&PYLON_4280);
-  transmit_can_frame(&PYLON_4290);
-#endif
-#ifdef SEND_1
-  transmit_can_frame(&PYLON_4211);
-  transmit_can_frame(&PYLON_4221);
-  transmit_can_frame(&PYLON_4231);
-  transmit_can_frame(&PYLON_4241);
-  transmit_can_frame(&PYLON_4251);
-  transmit_can_frame(&PYLON_4261);
-  transmit_can_frame(&PYLON_4271);
-  transmit_can_frame(&PYLON_4281);
-  transmit_can_frame(&PYLON_4291);
-#endif
+  if (pylon_send_0) {
+    transmit_can_frame(&PYLON_4210);
+    transmit_can_frame(&PYLON_4220);
+    transmit_can_frame(&PYLON_4230);
+    transmit_can_frame(&PYLON_4240);
+    transmit_can_frame(&PYLON_4250);
+    transmit_can_frame(&PYLON_4260);
+    transmit_can_frame(&PYLON_4270);
+    transmit_can_frame(&PYLON_4280);
+    transmit_can_frame(&PYLON_4290);
+  }
+  if (pylon_send_1) {
+    transmit_can_frame(&PYLON_4211);
+    transmit_can_frame(&PYLON_4221);
+    transmit_can_frame(&PYLON_4231);
+    transmit_can_frame(&PYLON_4241);
+    transmit_can_frame(&PYLON_4251);
+    transmit_can_frame(&PYLON_4261);
+    transmit_can_frame(&PYLON_4271);
+    transmit_can_frame(&PYLON_4281);
+    transmit_can_frame(&PYLON_4291);
+  }
 }
 
 bool PylonInverter::setup() {
+  if (user_selected_pylon_send == 0) {
+    pylon_send_0 = true;
+    pylon_send_1 = false;
+  }
+  if (user_selected_pylon_send == 1) {
+    pylon_send_0 = false;
+    pylon_send_1 = true;
+  }
   if (user_selected_inverter_cells > 0) {
     PYLON_7320.data.u8[0] = user_selected_inverter_cells & 0xff;
     PYLON_7320.data.u8[1] = (uint8_t)(user_selected_inverter_cells >> 8);

--- a/Software/src/inverter/PYLON-CAN.h
+++ b/Software/src/inverter/PYLON-CAN.h
@@ -16,6 +16,9 @@ class PylonInverter : public CanInverterProtocol {
   void send_system_data();
   void send_setup_info();
 
+  bool pylon_send_0 = true;
+  bool pylon_send_1 = false;
+
   /* Some inverters need to see a specific amount of cells/modules to emulate a specific Pylon battery.
      Change the following only if your inverter is generating fault codes about voltage range */
   static const int TOTAL_CELL_AMOUNT = 120;


### PR DESCRIPTION
### What
This PR implements configurable send0 / send1 for Pylon HV protocol

### Why
This was missing config option from development  of 9.X. This PR enables use of [ZCS Azzurro inverters](github.com/dalathegreat/Battery-Emulator/wiki/Inverter:-ZCS-Azzurro) 

### How
New field added to the Settings, visible when Pylon is selected. User can enter if they want to send 0 or send 1

<img width="597" height="162" alt="image" src="https://github.com/user-attachments/assets/dc822786-354c-4838-888e-f6505d847cd2" />

