### PR TITLE
Improvement: Make successful BMS reset increment event counter properly

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -292,6 +292,7 @@ void handle_BMSpower() {
 
       datalayer.system.status.BMS_startup_in_progress = false;  // Reset the BMS warmup removal flag
       set_event(EVENT_PERIODIC_BMS_RESET, 0);
+      clear_event(EVENT_PERIODIC_BMS_RESET);
     }
   }
 }


### PR DESCRIPTION
### What
This PR makes a successful BMS reset increment event counter properly

### Why
User reported feedback on the Discord

### How
We now instantly clear the BMS reset info event, so the next one increments occurrence counter