### PR TITLE
Safety: Implement interconnect contactor opening if voltage diffs :battery: :battery: 

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -127,9 +127,11 @@ void check_interconnect_available() {
   }
 
   uint16_t voltage_diff = abs(datalayer.battery.status.voltage_dV - datalayer.battery2.status.voltage_dV);
+  uint8_t secondsOutOfVoltageSync = 0;
 
   if (voltage_diff <= 30) {  // If we are within 3.0V between the batteries
     clear_event(EVENT_VOLTAGE_DIFFERENCE);
+    secondsOutOfVoltageSync = 0;
     if (datalayer.battery.status.bms_status == FAULT) {
       // If main battery is in fault state, disengage the second battery
       datalayer.system.status.battery2_allowed_contactor_closing = false;
@@ -138,6 +140,13 @@ void check_interconnect_available() {
     }
   } else {  //Voltage between the two packs is too large
     set_event(EVENT_VOLTAGE_DIFFERENCE, (uint8_t)(voltage_diff / 10));
+
+    //If we start to drift out of sync between the two packs for more than 10 seconds, open contactors
+    if (secondsOutOfVoltageSync < 10) {
+      secondsOutOfVoltageSync++;
+    } else {
+      datalayer.system.status.battery2_allowed_contactor_closing = false;
+    }
   }
 }
 


### PR DESCRIPTION
### What
This PR implements opening of the contactor for battery2, if the voltage between battery1 and battery2 appears

### Why
Good safety improvement, avoids arcing and blowing fuses in rare scenarios.

Example scenario: Someone disconnects the fuse on battery 1 High voltage.. then leaves it there for a few days, then realizes the mistake and slaps it on again, we then have equalisation at max A, blowing all the fuses.

### How
Now after closing the interconnect contactor, we keep track of if the voltage diff grows over 3.0V between battery1&2, and if it does for over 10 seconds, we open contactors for battery2.
