### PR TITLE
BWM iX: Fixed an issue causing iX selection to revert to i3 battery

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -41,7 +41,7 @@ const char* name_for_battery_type(BatteryType type) {
       return "None";
     case BatteryType::BmwI3:
       return BmwI3Battery::Name;
-    case BatteryType::BmwIx:
+    case BatteryType::BmwIX:
       return BmwIXBattery::Name;
     case BatteryType::BmwPhev:
       return BmwPhevBattery::Name;
@@ -141,8 +141,8 @@ Battery* create_battery(BatteryType type) {
       return nullptr;
     case BatteryType::BmwI3:
       return new BmwI3Battery();
-    case BatteryType::BmwIx:
-      return new BmwI3Battery();
+    case BatteryType::BmwIX:
+      return new BmwIXBattery();
     case BatteryType::BmwPhev:
       return new BmwPhevBattery();
     case BatteryType::BoltAmpera:

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -8,7 +8,7 @@
 enum class BatteryType {
   None = 0,
   BmwI3 = 2,
-  BmwIx = 3,
+  BmwIX = 3,
   BoltAmpera = 4,
   BydAtto3 = 5,
   CellPowerBms = 6,


### PR DESCRIPTION
### What
This PR fixes a bug that made it impossible to use iX battery

### Why
User reported this bug on Discord

### How
Typo in code, iX became i3
