### PR TITLE
Bugfix: Make devkit build compile properly

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -Wimplicit-fallthrough
+build_flags = -I include -Wimplicit-fallthrough -DHW_DEVKIT
 lib_deps = 
 
 [env:lilygo_330]


### PR DESCRIPTION
### What
This PR makes it possible to build ESP32_DEVKIT

### Why
User reported bug on Discord

### How
We add the missing compiler flag
