### PR TITLE
Kia64FD: Bugfix, make startup voltage value sane

### DIFF
--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -46,7 +46,7 @@ class Kia64FDBattery : public CanBattery {
   uint16_t batterySOH = 1000;
   uint16_t CellVoltMax_mV = 3700;
   uint16_t CellVoltMin_mV = 3700;
-  uint16_t batteryVoltage = 0;
+  uint16_t batteryVoltage = 3700;
   int16_t leadAcidBatteryVoltage = 120;
   int16_t batteryAmps = 0;
   int16_t temperatureMax = 0;


### PR DESCRIPTION
### What
This PR makes the startup voltage sane for Kia64FD

### Why
To avoid fake undervoltage event on startup before values have been read

### How
Instead of initializing  battery voltage to 0V, we default it to 370.0V
