### PR TITLE
Experimental: Add used-capacity nudging for RJXZS to correct SoC drift.

### DIFF
--- a/Software/src/battery/RJXZS-BMS.h
+++ b/Software/src/battery/RJXZS-BMS.h
@@ -14,6 +14,8 @@ class RjxzsBms : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "RJXZS BMS, DIY battery";
 
+  uint16_t cell_voltage_to_soc_scaled(uint16_t v);
+
  private:
   static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 500;
   static const int RAMPDOWN_SOC =
@@ -97,6 +99,9 @@ class RjxzsBms : public CanBattery {
   uint8_t timespent_without_soc = 0;
   bool charging_active = false;
   bool discharging_active = false;
+  // The SoC levels which correspond to the min/max cell voltages
+  uint16_t max_cell_equivalent_soc = 0;
+  uint16_t min_cell_equivalent_soc = 0;
 };
 
 #endif


### PR DESCRIPTION
### What
This PR adds a 60-second routine to the RXJZS battery integration that compares the reported SoC from a value derived from the cell voltage midpoint. If the discrepancy is more than 1Ah-equivalent of charge, it nudges the 'reported usage capacity' to correct for the discrepancy.

It also adds '07' messages to instruct the BMS to open contactors if BE wants to.

Note: untested on real hardware, use at your own risk and monitor carefully!

Potential issues:
- It tries to correct the entire discrepancy in one jump, it may be prefereable to have it make smaller corrections (however the minimum resolution is 1Ah).
- There is currently no smoothing/slow-start, it may issue under/overcorrections if the cell voltage values are noisy (eg, due to large charge/discharge currents).
