### PR TITLE
Feature: Add configurable cutoff filter for CAN logging

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -57,9 +57,9 @@ uint8_t user_selected_canfd_addon_crystal_frequency_mhz = 0;
 ACAN2517FD* canfd;
 ACAN2517FDSettings* settings2517;
 bool use_canfd_as_can = false;
-// Initialization functions
-
 bool native_can_initialized = false;
+//CAN logging filter settings
+uint16_t user_selected_CAN_ID_cutoff_filter = 0;  //Messages below this ID will not be logged in webserver
 
 bool init_CAN() {
 
@@ -395,7 +395,9 @@ void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirection ms
   }
 
   if (datalayer.system.info.can_logging_active) {  // If user clicked on CAN Logging page in webserver, start recording
-    dump_can_frame(frame, interface, msgDir);
+    if (frame.ID > user_selected_CAN_ID_cutoff_filter) {  //Only log the message if CAN ID is higher than user set value
+      dump_can_frame(frame, interface, msgDir);
+    }
   }
 }
 

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -6,6 +6,7 @@
 extern bool use_canfd_as_can;
 extern uint8_t user_selected_can_addon_crystal_frequency_mhz;
 extern uint8_t user_selected_canfd_addon_crystal_frequency_mhz;
+extern uint16_t user_selected_CAN_ID_cutoff_filter;
 
 void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir);
 void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface interface);

--- a/Software/src/devboard/webserver/can_logging_html.cpp
+++ b/Software/src/devboard/webserver/can_logging_html.cpp
@@ -1,5 +1,6 @@
 #include "can_logging_html.h"
 #include <Arduino.h>
+#include "../../communication/can/comm_can.h"
 #include "../../datalayer/datalayer.h"
 #include "index_html.h"
 
@@ -21,13 +22,21 @@ String can_logger_processor(void) {
   content +=
       ".can-message { background-color: #404E57; margin-bottom: 5px; padding: 10px; border-radius: 5px; font-family: "
       "monospace; }";
+  content += ".config-item { margin: 15px 0; }";
   content += "</style>";
+
+  // Configuration section
+  content += "<div style='background-color: #303E47; padding: 20px; border-radius: 15px; margin-bottom: 20px;'>";
+  content += "<h3>CAN Logger Configuration</h3>";
+  content += "<div class='config-item'><span>CAN ID Cutoff Filter: " + String(user_selected_CAN_ID_cutoff_filter) +
+             "</span> <button onclick='editCANIDCutoff()'>Edit</button></div>";
   content += "<button onclick='refreshPage()'>Refresh data</button> ";
   content += "<button onclick='exportLog()'>Export to .txt</button> ";
 #ifdef LOG_CAN_TO_SD
   content += "<button onclick='deleteLogFile()'>Delete log file</button> ";
 #endif
   content += "<button onclick='stopLoggingAndGoToMainPage()'>Stop &amp; Back to main page</button>";
+  content += "</div>";
 
   // Start a new block for the CAN messages
   content += "<div style='background-color: #303E47; padding: 20px; border-radius: 15px'>";
@@ -51,7 +60,7 @@ String can_logger_processor(void) {
 
   content += "</div>";
 
-  // Add JavaScript for navigation
+  // Add JavaScript for navigation and configuration
   content += "<script>";
   content += "function refreshPage(){ location.reload(true); }";
   content += "function exportLog() { window.location.href = '/export_can_log'; }";
@@ -60,6 +69,21 @@ String can_logger_processor(void) {
 #endif
   content += "function stopLoggingAndGoToMainPage() {";
   content += "  fetch('/stop_can_logging').then(() => window.location.href = '/');";
+  content += "}";
+  content += "function editCANIDCutoff() {";
+  content += "  var value = prompt('CAN IDs in decimal, below this value will not be logged (0-65535):', '" +
+             String(user_selected_CAN_ID_cutoff_filter) + "');";
+  content += "  if (value !== null) {";
+  content += "    if (value >= 0 && value <= 65535) {";
+  content += "      var xhr = new XMLHttpRequest();";
+  content += "      xhr.onload = function() { location.reload(true); };";
+  content += "      xhr.onerror = function() { alert('Error updating CAN ID cutoff'); };";
+  content += "      xhr.open('GET', '/set_can_id_cutoff?value=' + value, true);";
+  content += "      xhr.send();";
+  content += "    } else {";
+  content += "      alert('Invalid value. Please enter a value between 0 and 65535');";
+  content += "    }";
+  content += "  }";
   content += "}";
   content += "</script>";
   content += index_html_footer;

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -658,6 +658,9 @@ void init_webserver() {
     datalayer.battery.settings.max_percentage = static_cast<uint16_t>(value.toFloat() * 100);
   });
 
+  // Route for editing CAN ID cutoff filter
+  update_int_setting("/set_can_id_cutoff", [](int value) { user_selected_CAN_ID_cutoff_filter = value; });
+
   // Route for pause/resume Battery emulator
   update_string("/pause", [](String value) { setBatteryPause(value == "true" || value == "1", false); });
 


### PR DESCRIPTION
### What
This PR adds a configurable cutoff filter for CAN logging

### Why
Makes reverse engineering easier, especially when dealing with OBD2 commands that usually have higher IDs than anything else.

### How
Now possible to set a ID filter on the fly on the CAN logging webserver page. As seen in this example, we filter out normal CAN messages, but the diagnostic OBD2 ones with ID>2000 are logged.

<img width="1045" height="1014" alt="image" src="https://github.com/user-attachments/assets/f6c296b4-e2a5-42c4-b5f8-b81eceb728e3" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
