### PR TITLE
Annotate all floating literals with f suffix to avoid double promotion.

### DIFF
--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -70,7 +70,7 @@ static uint16_t estimateSOC(uint16_t cellVoltage) {  // Linear interpolation fun
 
   for (int i = 1; i < numEntries; ++i) {
     if (cellVoltage >= voltage_lookup[i]) {
-      double t = (cellVoltage - voltage_lookup[i]) / (voltage_lookup[i - 1] - voltage_lookup[i]);
+      float t = (cellVoltage - voltage_lookup[i]) / (voltage_lookup[i - 1] - voltage_lookup[i]);
       return SOC[i] + t * (SOC[i - 1] - SOC[i]);
     }
   }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -113,7 +113,7 @@ uint16_t estimateSOCextended(uint16_t packVoltage) {  // Linear interpolation fu
 
   for (int i = 1; i < numPoints; ++i) {
     if (packVoltage >= voltage_extended[i]) {
-      double t = (packVoltage - voltage_extended[i]) / (voltage_extended[i - 1] - voltage_extended[i]);
+      float t = (packVoltage - voltage_extended[i]) / (voltage_extended[i - 1] - voltage_extended[i]);
       return SOC[i] + t * (SOC[i - 1] - SOC[i]);
     }
   }
@@ -130,7 +130,7 @@ uint16_t estimateSOCstandard(uint16_t packVoltage) {  // Linear interpolation fu
 
   for (int i = 1; i < numPoints; ++i) {
     if (packVoltage >= voltage_standard[i]) {
-      double t = (packVoltage - voltage_standard[i]) / (voltage_standard[i - 1] - voltage_standard[i]);
+      float t = (packVoltage - voltage_standard[i]) / (voltage_standard[i - 1] - voltage_standard[i]);
       return SOC[i] + t * (SOC[i - 1] - SOC[i]);
     }
   }
@@ -176,9 +176,9 @@ void BydAttoBattery::
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
 
-  if (SOC_method == ESTIMATED && battery_estimated_SOC * 0.1 < RAMPDOWN_SOC && RAMPDOWN_SOC > 0) {
+  if (SOC_method == ESTIMATED && battery_estimated_SOC * 0.1f < RAMPDOWN_SOC && RAMPDOWN_SOC > 0) {
     // If using estimated SOC, ramp down max discharge power as SOC decreases.
-    rampdown_power = RAMPDOWN_POWER_ALLOWED * ((battery_estimated_SOC * 0.1) / RAMPDOWN_SOC);
+    rampdown_power = RAMPDOWN_POWER_ALLOWED * ((battery_estimated_SOC * 0.1f) / RAMPDOWN_SOC);
 
     if (rampdown_power < BMS_allowed_discharge_power * 100) {  // Never allow more than BMS_allowed_discharge_power
       datalayer_battery->status.max_discharge_power_W = rampdown_power;

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -12,10 +12,10 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
   String get_status_html() {
     String content;
 
-    float soc_estimated = static_cast<float>(byd_datalayer->SOC_estimated) * 0.01;
-    float soc_measured = static_cast<float>(byd_datalayer->SOC_highprec) * 0.1;
-    float BMS_maxChargePower = static_cast<float>(byd_datalayer->chargePower) * 0.1;
-    float BMS_maxDischargePower = static_cast<float>(byd_datalayer->dischargePower) * 0.1;
+    float soc_estimated = static_cast<float>(byd_datalayer->SOC_estimated) * 0.01f;
+    float soc_measured = static_cast<float>(byd_datalayer->SOC_highprec) * 0.1f;
+    float BMS_maxChargePower = static_cast<float>(byd_datalayer->chargePower) * 0.1f;
+    float BMS_maxDischargePower = static_cast<float>(byd_datalayer->dischargePower) * 0.1f;
     static const char* SOCmethod[2] = {"Estimated from voltage", "Measured by BMS"};
 
     content += "<h4>SOC method used: " + String(SOCmethod[byd_datalayer->SOC_method]) + "</h4>";

--- a/Software/src/battery/Battery.cpp
+++ b/Software/src/battery/Battery.cpp
@@ -2,5 +2,5 @@
 #include "../datalayer/datalayer.h"
 
 float Battery::get_voltage() {
-  return static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0;
+  return static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0f;
 }

--- a/Software/src/battery/CHADEMO-SHUNTS.cpp
+++ b/Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -28,27 +28,27 @@ static int framecount = 0;
 
 /* original variables/names/types from SimpleISA. These warrant refinement */
 float Amperes;  // Floating point with current in Amperes
-double AH;      //Floating point with accumulated ampere-hours
-double KW;
-double KWH;
+float AH;       //Floating point with accumulated ampere-hours
+float KW;
+float KWH;
 
-double Voltage;
-double Voltage1;
-double Voltage2;
-double Voltage3;
-double VoltageHI;
-double Voltage1HI;
-double Voltage2HI;
-double Voltage3HI;
-double VoltageLO;
-double Voltage1LO;
-double Voltage2LO;
-double Voltage3LO;
+float Voltage;
+float Voltage1;
+float Voltage2;
+float Voltage3;
+float VoltageHI;
+float Voltage1HI;
+float Voltage2HI;
+float Voltage3HI;
+float VoltageLO;
+float Voltage1LO;
+float Voltage2LO;
+float Voltage3LO;
 
-double Temperature;
+float Temperature;
 
 bool firstframe;
-double milliamps;
+float milliamps;
 long watt;
 long As;
 long lastAs;

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY-HTML.cpp
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY-HTML.cpp
@@ -3,7 +3,7 @@
 
 String HyundaiIoniq28BatteryHtmlRenderer::get_status_html() {
   String content;
-  content += "<h4>12V voltage: " + String(batt.get_lead_acid_voltage() / 10.0, 1) + "</h4>";
+  content += "<h4>12V voltage: " + String(batt.get_lead_acid_voltage() / 10.0f, 1) + "</h4>";
   content += "<h4>Temperature, power relay: " + String(batt.get_power_relay_temperature()) + "</h4>";
   content += "<h4>Batterymanagement mode: " + String(batt.get_battery_management_mode()) + "</h4>";
   content += "<h4>Isolation resistance: " + String(batt.get_isolation_resistance()) + " kOhm</h4>";

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.cpp
@@ -50,7 +50,7 @@ void ImievCZeroIonBattery::
   min_temp_cel = cell_temperatures[0];  // Initialize min with the first element of the array
   for (int i = 1; i < m; i++) {
     if (cell_temperatures[i] < min_temp_cel) {
-      if (min_temp_cel != -50.00) {           //-50.00 means this sensor not connected
+      if (min_temp_cel != -50.00f) {          //-50.00 means this sensor not connected
         min_temp_cel = cell_temperatures[i];  // Update max if we find a smaller element
       }
     }
@@ -61,11 +61,11 @@ void ImievCZeroIonBattery::
     datalayer.battery.status.cell_voltages_mV[i] = (uint16_t)(cell_voltages[i] * 1000);
   }
   datalayer.battery.info.number_of_cells = 88;
-  if (max_volt_cel > 2.2) {  // Only update cellvoltage when we have a value
+  if (max_volt_cel > 2.2f) {  // Only update cellvoltage when we have a value
     datalayer.battery.status.cell_max_voltage_mV = (uint16_t)(max_volt_cel * 1000);
   }
 
-  if (min_volt_cel > 2.2) {  // Only update cellvoltage when we have a value
+  if (min_volt_cel > 2.2f) {  // Only update cellvoltage when we have a value
     datalayer.battery.status.cell_min_voltage_mV = (uint16_t)(min_volt_cel * 1000);
   }
 
@@ -104,8 +104,8 @@ void ImievCZeroIonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x373:  //BMU message, 100ms - Pack Voltage and current
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      BMU_Current = ((((((rx_frame.data.u8[2] * 256.0) + rx_frame.data.u8[3])) - 32768)) * 0.01);
-      BMU_PackVoltage = ((rx_frame.data.u8[4] * 256.0 + rx_frame.data.u8[5]) * 0.1);
+      BMU_Current = ((((((rx_frame.data.u8[2] * 256.0f) + rx_frame.data.u8[3])) - 32768)) * 0.01f);
+      BMU_PackVoltage = ((rx_frame.data.u8[4] * 256.0f + rx_frame.data.u8[5]) * 0.1f);
       BMU_Power = (BMU_Current * BMU_PackVoltage);
       break;
     case 0x6e1:  //BMU message, 25ms - Battery temperatures and voltages
@@ -120,17 +120,17 @@ void ImievCZeroIonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       cmu_id = (rx_frame.data.u8[0] & 0x0f);
       //
       if (rx_frame.data.u8[1] != 0) {  // Only update temperatures if value is available
-        temp1 = rx_frame.data.u8[1] - 50.0;
+        temp1 = rx_frame.data.u8[1] - 50.0f;
       }
       if (rx_frame.data.u8[2] != 0) {
-        temp2 = rx_frame.data.u8[1] - 50.0;
+        temp2 = rx_frame.data.u8[1] - 50.0f;
       }
       if (rx_frame.data.u8[3] != 0) {
-        temp3 = rx_frame.data.u8[1] - 50.0;
+        temp3 = rx_frame.data.u8[1] - 50.0f;
       }
 
-      voltage1 = (((rx_frame.data.u8[4] * 256.0 + rx_frame.data.u8[5]) * 0.005) + 2.1);
-      voltage2 = (((rx_frame.data.u8[6] * 256.0 + rx_frame.data.u8[7]) * 0.005) + 2.1);
+      voltage1 = (((rx_frame.data.u8[4] * 256.0f + rx_frame.data.u8[5]) * 0.005f) + 2.1f);
+      voltage2 = (((rx_frame.data.u8[6] * 256.0f + rx_frame.data.u8[7]) * 0.005f) + 2.1f);
 
       voltage_index = ((cmu_id - 1) * 8 + (2 * pid_index));
       temp_index = ((cmu_id - 1) * 6 + (2 * pid_index));
@@ -139,10 +139,10 @@ void ImievCZeroIonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         temp_index -= 3;
       }
 
-      if (voltage1 > 2.2) {  // Only update cellvoltages incase we have a value
+      if (voltage1 > 2.2f) {  // Only update cellvoltages incase we have a value
         cell_voltages[voltage_index] = voltage1;
       }
-      if (voltage2 > 2.2) {
+      if (voltage2 > 2.2f) {
         cell_voltages[voltage_index + 1] = voltage2;
       }
 

--- a/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
+++ b/Software/src/battery/IMIEV-CZERO-ION-BATTERY.h
@@ -30,20 +30,20 @@ class ImievCZeroIonBattery : public CanBattery {
   int temp_index = 0;
   uint8_t BMU_SOC = 0;
   int temp_value = 0;
-  double temp1 = 0;
-  double temp2 = 0;
-  double temp3 = 0;
-  double voltage1 = 0;
-  double voltage2 = 0;
-  double BMU_Current = 0;
-  double BMU_PackVoltage = 0;
-  double BMU_Power = 0;
-  double cell_voltages[88];      //array with all the cellvoltages
-  double cell_temperatures[88];  //array with all the celltemperatures
-  double max_volt_cel = 3.70;
-  double min_volt_cel = 3.70;
-  double max_temp_cel = 20.00;
-  double min_temp_cel = 19.00;
+  float temp1 = 0;
+  float temp2 = 0;
+  float temp3 = 0;
+  float voltage1 = 0;
+  float voltage2 = 0;
+  float BMU_Current = 0;
+  float BMU_PackVoltage = 0;
+  float BMU_Power = 0;
+  float cell_voltages[88];      //array with all the cellvoltages
+  float cell_temperatures[88];  //array with all the celltemperatures
+  float max_volt_cel = 3.70f;
+  float min_volt_cel = 3.70f;
+  float max_temp_cel = 20.00f;
+  float min_temp_cel = 19.00f;
 };
 
 #endif

--- a/Software/src/battery/KIA-E-GMP-HTML.cpp
+++ b/Software/src/battery/KIA-E-GMP-HTML.cpp
@@ -4,7 +4,7 @@
 String KiaEGMPHtmlRenderer::get_status_html() {
   String content;
   content += "<h4>Cells: " + String(datalayer.battery.info.number_of_cells) + "S</h4>";
-  content += "<h4>12V voltage: " + String(batt.get_battery_12V() / 10.0, 1) + "</h4>";
+  content += "<h4>12V voltage: " + String(batt.get_battery_12V() / 10.0f, 1) + "</h4>";
   content += "<h4>Waterleakage: " + String(batt.get_waterleakageSensor()) + "</h4>";
   content += "<h4>Temperature, water inlet: " + String(batt.get_temperature_water_inlet()) + "</h4>";
   content += "<h4>Temperature, power relay: " + String(batt.get_powerRelayTemperature() * 2) + "</h4>";

--- a/Software/src/battery/KIA-HYUNDAI-64-HTML.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-HTML.h
@@ -23,7 +23,7 @@ class KiaHyundai64HtmlRenderer : public BatteryHtmlRenderer {
       content += "<h4>BMS serial number: " + String(readableSerialNumber) + "</h4>";
       content += "<h4>BMS software version: " + String(readableVersionNumber) + "</h4>";
       content += "<h4>Cells: " + String(data.total_cell_count) + " S</h4>";
-      content += "<h4>12V voltage: " + String(data.battery_12V / 10.0, 1) + " V</h4>";
+      content += "<h4>12V voltage: " + String(data.battery_12V / 10.0f, 1) + " V</h4>";
       content += "<h4>Waterleakage: ";
       if (data.waterleakageSensor == 0) {
         content += " LEAK DETECTED</h4>";

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -203,26 +203,26 @@ void MebBattery::
 
   datalayer_battery->status.real_soc = battery_SOC * 5;  //*0.05*100
 
-  datalayer_battery->status.voltage_dV = BMS_voltage * 2.5;  // *0.25*10
+  datalayer_battery->status.voltage_dV = BMS_voltage * 2.5f;  // *0.25*10
 
   datalayer_battery->status.current_dA = (BMS_current - 16300);  // 0.1 * 10
 
   if (nof_cells_determined) {
     datalayer_battery->info.total_capacity_Wh =
-        ((float)datalayer_battery->info.number_of_cells) * 3.67 * ((float)BMS_capacity_ah) * 0.2 * 1.02564;
+        ((float)datalayer_battery->info.number_of_cells) * 3.67f * ((float)BMS_capacity_ah) * 0.2f * 1.02564f;
     // The factor 1.02564 = 1/0.975 is to correct for bottom 2.5% which is reported by the remaining_capacity_Wh,
     // but which is not actually usable, but if we do not include it, the remaining_capacity_Wh can be larger than
     // the total_capacity_Wh.
     // 0.935 and 0.9025 are the different conversions for different battery sizes to go from design capacity to
     // total_capacity_Wh calculated above.
 
-    int Wh_max = 61832 * 0.935;  // 108 cells
+    int Wh_max = 61832 * 0.935f;  // 108 cells
     if (datalayer_battery->info.number_of_cells <= 84)
-      Wh_max = 48091 * 0.9025;
+      Wh_max = 48091 * 0.9025f;
     else if (datalayer_battery->info.number_of_cells <= 96)
-      Wh_max = 82442 * 0.9025;
+      Wh_max = 82442 * 0.9025f;
     if (BMS_capacity_ah > 0)
-      datalayer_battery->status.soh_pptt = 10000 * datalayer_battery->info.total_capacity_Wh / (Wh_max * 1.02564);
+      datalayer_battery->status.soh_pptt = 10000 * datalayer_battery->info.total_capacity_Wh / (Wh_max * 1.02564f);
   }
 
   datalayer_battery->status.remaining_capacity_Wh = usable_energy_amount_Wh * 5;

--- a/Software/src/battery/MEB-HTML.h
+++ b/Software/src/battery/MEB-HTML.h
@@ -178,7 +178,7 @@ class MebHtmlRenderer : public BatteryHtmlRenderer {
       default:
         content += "?";
     }
-    content += "</h4><h4>Interm. Voltage (" + String(datalayer_extended.meb.BMS_voltage_intermediate_dV / 10.0, 1) +
+    content += "</h4><h4>Interm. Voltage (" + String(datalayer_extended.meb.BMS_voltage_intermediate_dV / 10.0f, 1) +
                "V) status: ";
     switch (datalayer_extended.meb.BMS_status_voltage_free) {
       case 0:
@@ -225,7 +225,7 @@ class MebHtmlRenderer : public BatteryHtmlRenderer {
       default:
         content += "?";
     }
-    content += "</h4><h4>BMS voltage: " + String(datalayer_extended.meb.BMS_voltage_dV / 10.0, 1) + "</h4>";
+    content += "</h4><h4>BMS voltage: " + String(datalayer_extended.meb.BMS_voltage_dV / 10.0f, 1) + "</h4>";
     content += datalayer_extended.meb.BMS_OBD_MIL ? "<h4>OBD MIL: ON!</h4>" : "<h4>OBD MIL: Off</h4>";
     content +=
         datalayer_extended.meb.BMS_error_lamp_req ? "<h4>Red error lamp: ON!</h4>" : "<h4>Red error lamp: Off</h4>";

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -47,7 +47,7 @@ void RenaultZoeGen2Battery::update_values() {
 
   datalayer_battery->status.voltage_dV = battery_pack_voltage_periodic_dV;
 
-  datalayer_battery->status.current_dA = ((battery_current - 32640) * 0.3125);
+  datalayer_battery->status.current_dA = ((battery_current - 32640) * 0.3125f);
 
   //Calculate the remaining Wh amount from SOC% and max Wh value.
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
@@ -59,8 +59,8 @@ void RenaultZoeGen2Battery::update_values() {
 
   //Temperatures and voltages update at slow rate. Only publish new values once both have been sampled to avoid events
   if ((battery_min_temp != 920) && (battery_max_temp != 920)) {
-    datalayer_battery->status.temperature_min_dC = ((battery_min_temp - 640) * 0.625);
-    datalayer_battery->status.temperature_max_dC = ((battery_max_temp - 640) * 0.625);
+    datalayer_battery->status.temperature_min_dC = ((battery_min_temp - 640) * 0.625f);
+    datalayer_battery->status.temperature_max_dC = ((battery_max_temp - 640) * 0.625f);
   }
 
   datalayer_battery->status.cell_min_voltage_mV = battery_minimum_cell_voltage_mV;
@@ -819,14 +819,14 @@ void RenaultZoeGen2Battery::setup(void) {  // Performs one time setup at startup
 
 void RenaultZoeGen2Battery::transmit_can_frame_376(void) {
   unsigned int secondsSinceProduction = ZOE_376_time_now_s - kProductionTimestamp_s;
-  float minutesSinceProduction = (float)secondsSinceProduction / 60.0;
-  float yearUnfloored = minutesSinceProduction / 255.0 / 255.0;
+  float minutesSinceProduction = (float)secondsSinceProduction / 60.0f;
+  float yearUnfloored = minutesSinceProduction / 255.0f / 255.0f;
   int yearSeg = floor(yearUnfloored);
   float remainderYears = yearUnfloored - yearSeg;
-  float remainderHoursUnfloored = (remainderYears * 255.0);
+  float remainderHoursUnfloored = (remainderYears * 255.0f);
   int hourSeg = floor(remainderHoursUnfloored);
   float remainderHours = remainderHoursUnfloored - hourSeg;
-  int minuteSeg = floor(remainderHours * 255.0);
+  int minuteSeg = floor(remainderHours * 255.0f);
 
   ZOE_376.data.u8[0] = yearSeg;
   ZOE_376.data.u8[1] = hourSeg;

--- a/Software/src/battery/TESLA-HTML.h
+++ b/Software/src/battery/TESLA-HTML.h
@@ -12,119 +12,119 @@ class TeslaHtmlRenderer : public BatteryHtmlRenderer {
     String content;
 
     float beginning_of_life = static_cast<float>(datalayer_extended.tesla.battery_beginning_of_life);
-    float battTempPct = static_cast<float>(datalayer_extended.tesla.battery_battTempPct) * 0.4;
-    float dcdcLvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625;
-    float dcdcHvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcHvBusVolt) * 0.146484;
-    float dcdcLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1;
+    float battTempPct = static_cast<float>(datalayer_extended.tesla.battery_battTempPct) * 0.4f;
+    float dcdcLvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;
+    float dcdcHvBusVolt = static_cast<float>(datalayer_extended.tesla.battery_dcdcHvBusVolt) * 0.146484f;
+    float dcdcLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     float nominal_full_pack_energy =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy) * 0.1f;
     float nominal_full_pack_energy_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy_m0) * 0.02;
+        static_cast<float>(datalayer_extended.tesla.battery_nominal_full_pack_energy_m0) * 0.02f;
     float nominal_energy_remaining =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining) * 0.1f;
     float nominal_energy_remaining_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining_m0) * 0.02;
-    float ideal_energy_remaining = static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.battery_nominal_energy_remaining_m0) * 0.02f;
+    float ideal_energy_remaining = static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining) * 0.1f;
     float ideal_energy_remaining_m0 =
-        static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining_m0) * 0.02;
+        static_cast<float>(datalayer_extended.tesla.battery_ideal_energy_remaining_m0) * 0.02f;
     float energy_to_charge_complete =
-        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete) * 0.1f;
     float energy_to_charge_complete_m1 =
-        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete_m1) * 0.02;
-    float energy_buffer = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer) * 0.1;
-    float energy_buffer_m1 = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer_m1) * 0.01;
+        static_cast<float>(datalayer_extended.tesla.battery_energy_to_charge_complete_m1) * 0.02f;
+    float energy_buffer = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer) * 0.1f;
+    float energy_buffer_m1 = static_cast<float>(datalayer_extended.tesla.battery_energy_buffer_m1) * 0.01f;
     float expected_energy_remaining_m1 =
-        static_cast<float>(datalayer_extended.tesla.battery_expected_energy_remaining_m1) * 0.02;
-    float total_discharge = static_cast<float>(datalayer.battery.status.total_discharged_battery_Wh) * 0.001;
-    float total_charge = static_cast<float>(datalayer.battery.status.total_charged_battery_Wh) * 0.001;
+        static_cast<float>(datalayer_extended.tesla.battery_expected_energy_remaining_m1) * 0.02f;
+    float total_discharge = static_cast<float>(datalayer.battery.status.total_discharged_battery_Wh) * 0.001f;
+    float total_charge = static_cast<float>(datalayer.battery.status.total_charged_battery_Wh) * 0.001f;
     float packMass = static_cast<float>(datalayer_extended.tesla.battery_packMass);
     float platformMaxBusVoltage =
-        static_cast<float>(datalayer_extended.tesla.battery_platformMaxBusVoltage) * 0.1 + 375;
-    float bms_min_voltage = static_cast<float>(datalayer_extended.tesla.BMS_min_voltage) * 0.01 * 2;
-    float bms_max_voltage = static_cast<float>(datalayer_extended.tesla.BMS_max_voltage) * 0.01 * 2;
+        static_cast<float>(datalayer_extended.tesla.battery_platformMaxBusVoltage) * 0.1f + 375;
+    float bms_min_voltage = static_cast<float>(datalayer_extended.tesla.BMS_min_voltage) * 0.01f * 2;
+    float bms_max_voltage = static_cast<float>(datalayer_extended.tesla.BMS_max_voltage) * 0.01f * 2;
     float max_charge_current = static_cast<float>(datalayer_extended.tesla.battery_max_charge_current);
     float max_discharge_current = static_cast<float>(datalayer_extended.tesla.battery_max_discharge_current);
-    float soc_ave = static_cast<float>(datalayer_extended.tesla.battery_soc_ave) * 0.1;
-    float soc_max = static_cast<float>(datalayer_extended.tesla.battery_soc_max) * 0.1;
-    float soc_min = static_cast<float>(datalayer_extended.tesla.battery_soc_min) * 0.1;
-    float soc_ui = static_cast<float>(datalayer_extended.tesla.battery_soc_ui) * 0.1;
-    float BrickVoltageMax = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMax) * 0.002;
-    float BrickVoltageMin = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMin) * 0.002;
+    float soc_ave = static_cast<float>(datalayer_extended.tesla.battery_soc_ave) * 0.1f;
+    float soc_max = static_cast<float>(datalayer_extended.tesla.battery_soc_max) * 0.1f;
+    float soc_min = static_cast<float>(datalayer_extended.tesla.battery_soc_min) * 0.1f;
+    float soc_ui = static_cast<float>(datalayer_extended.tesla.battery_soc_ui) * 0.1f;
+    float BrickVoltageMax = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMax) * 0.002f;
+    float BrickVoltageMin = static_cast<float>(datalayer_extended.tesla.battery_BrickVoltageMin) * 0.002f;
     //float BrickModelTMax = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMax) * 0.5 - 40;
     //float BrickModelTMin = static_cast<float>(datalayer_extended.tesla.battery_BrickModelTMin) * 0.5 - 40;
     float isolationResistance = static_cast<float>(datalayer_extended.tesla.BMS_isolationResistance) * 10;
     float PCS_dcdcMaxOutputCurrentAllowed =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxOutputCurrentAllowed) * 0.1;
-    float PCS_dcdcTemp = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTemp) * 0.1 + 40;
-    float PCS_ambientTemp = static_cast<float>(datalayer_extended.tesla.PCS_ambientTemp) * 0.1 + 40;
-    float PCS_chgPhATemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhATemp) * 0.1 + 40;
-    float PCS_chgPhBTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhBTemp) * 0.1 + 40;
-    float PCS_chgPhCTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhCTemp) * 0.1 + 40;
-    float BMS_maxRegenPower = static_cast<float>(datalayer_extended.tesla.BMS_maxRegenPower) * 0.01;
-    float BMS_maxDischargePower = static_cast<float>(datalayer_extended.tesla.BMS_maxDischargePower) * 0.013;
-    //float BMS_maxStationaryHeatPower = static_cast<float>(datalayer_extended.tesla.BMS_maxStationaryHeatPower) * 0.01;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxOutputCurrentAllowed) * 0.1f;
+    float PCS_dcdcTemp = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTemp) * 0.1f + 40;
+    float PCS_ambientTemp = static_cast<float>(datalayer_extended.tesla.PCS_ambientTemp) * 0.1f + 40;
+    float PCS_chgPhATemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhATemp) * 0.1f + 40;
+    float PCS_chgPhBTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhBTemp) * 0.1f + 40;
+    float PCS_chgPhCTemp = static_cast<float>(datalayer_extended.tesla.PCS_chgPhCTemp) * 0.1f + 40;
+    float BMS_maxRegenPower = static_cast<float>(datalayer_extended.tesla.BMS_maxRegenPower) * 0.01f;
+    float BMS_maxDischargePower = static_cast<float>(datalayer_extended.tesla.BMS_maxDischargePower) * 0.013f;
+    //float BMS_maxStationaryHeatPower = static_cast<float>(datalayer_extended.tesla.BMS_maxStationaryHeatPower) * 0.01f;
     //float BMS_hvacPowerBudget = static_cast<float>(datalayer_extended.tesla.BMS_hvacPowerBudget) * 0.02;
-    float BMS_powerDissipation = static_cast<float>(datalayer_extended.tesla.BMS_powerDissipation) * 0.02;
-    float BMS_flowRequest = static_cast<float>(datalayer_extended.tesla.BMS_flowRequest) * 0.3;
+    float BMS_powerDissipation = static_cast<float>(datalayer_extended.tesla.BMS_powerDissipation) * 0.02f;
+    float BMS_flowRequest = static_cast<float>(datalayer_extended.tesla.BMS_flowRequest) * 0.3f;
     float BMS_inletActiveCoolTargetT =
-        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveCoolTargetT) * 0.25 - 25;
-    float BMS_inletPassiveTargetT = static_cast<float>(datalayer_extended.tesla.BMS_inletPassiveTargetT) * 0.25 - 25;
+        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveCoolTargetT) * 0.25f - 25;
+    float BMS_inletPassiveTargetT = static_cast<float>(datalayer_extended.tesla.BMS_inletPassiveTargetT) * 0.25f - 25;
     float BMS_inletActiveHeatTargetT =
-        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveHeatTargetT) * 0.25 - 25;
-    float BMS_packTMin = static_cast<float>(datalayer_extended.tesla.BMS_packTMin) * 0.25 - 25;
-    float BMS_packTMax = static_cast<float>(datalayer_extended.tesla.BMS_packTMax) * 0.25 - 25;
-    float PCS_dcdcMaxLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxLvOutputCurrent) * 0.1;
-    float PCS_dcdcCurrentLimit = static_cast<float>(datalayer_extended.tesla.PCS_dcdcCurrentLimit) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.BMS_inletActiveHeatTargetT) * 0.25f - 25;
+    float BMS_packTMin = static_cast<float>(datalayer_extended.tesla.BMS_packTMin) * 0.25f - 25;
+    float BMS_packTMax = static_cast<float>(datalayer_extended.tesla.BMS_packTMax) * 0.25f - 25;
+    float PCS_dcdcMaxLvOutputCurrent = static_cast<float>(datalayer_extended.tesla.PCS_dcdcMaxLvOutputCurrent) * 0.1f;
+    float PCS_dcdcCurrentLimit = static_cast<float>(datalayer_extended.tesla.PCS_dcdcCurrentLimit) * 0.1f;
     float PCS_dcdcLvOutputCurrentTempLimit =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcLvOutputCurrentTempLimit) * 0.1;
-    float PCS_dcdcUnifiedCommand = static_cast<float>(datalayer_extended.tesla.PCS_dcdcUnifiedCommand) * 0.001;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcLvOutputCurrentTempLimit) * 0.1f;
+    float PCS_dcdcUnifiedCommand = static_cast<float>(datalayer_extended.tesla.PCS_dcdcUnifiedCommand) * 0.001f;
     float PCS_dcdcCLAControllerOutput =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcCLAControllerOutput * 0.001);
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcCLAControllerOutput * 0.001f);
     float PCS_dcdcTankVoltage = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltage);
     float PCS_dcdcTankVoltageTarget = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTankVoltageTarget);
-    float PCS_dcdcClaCurrentFreq = static_cast<float>(datalayer_extended.tesla.PCS_dcdcClaCurrentFreq) * 0.0976563;
-    float PCS_dcdcTCommMeasured = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTCommMeasured) * 0.00195313;
-    float PCS_dcdcShortTimeUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcShortTimeUs) * 0.000488281;
-    float PCS_dcdcHalfPeriodUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcHalfPeriodUs) * 0.000488281;
+    float PCS_dcdcClaCurrentFreq = static_cast<float>(datalayer_extended.tesla.PCS_dcdcClaCurrentFreq) * 0.0976563f;
+    float PCS_dcdcTCommMeasured = static_cast<float>(datalayer_extended.tesla.PCS_dcdcTCommMeasured) * 0.00195313f;
+    float PCS_dcdcShortTimeUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcShortTimeUs) * 0.000488281f;
+    float PCS_dcdcHalfPeriodUs = static_cast<float>(datalayer_extended.tesla.PCS_dcdcHalfPeriodUs) * 0.000488281f;
     float PCS_dcdcIntervalMaxFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxFrequency);
     float PCS_dcdcIntervalMaxHvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxHvBusVolt) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxHvBusVolt) * 0.1f;
     float PCS_dcdcIntervalMaxLvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvBusVolt) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvBusVolt) * 0.1f;
     float PCS_dcdcIntervalMaxLvOutputCurr =
         static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMaxLvOutputCurr);
     float PCS_dcdcIntervalMinFrequency = static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinFrequency);
     float PCS_dcdcIntervalMinHvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinHvBusVolt) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinHvBusVolt) * 0.1f;
     float PCS_dcdcIntervalMinLvBusVolt =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvBusVolt) * 0.1;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvBusVolt) * 0.1f;
     float PCS_dcdcIntervalMinLvOutputCurr =
         static_cast<float>(datalayer_extended.tesla.PCS_dcdcIntervalMinLvOutputCurr);
     float PCS_dcdc12vSupportLifetimekWh =
-        static_cast<float>(datalayer_extended.tesla.PCS_dcdc12vSupportLifetimekWh) * 0.01;
-    float HVP_hvp1v5Ref = static_cast<float>(datalayer_extended.tesla.HVP_hvp1v5Ref) * 0.1;
-    float HVP_shuntCurrentDebug = static_cast<float>(datalayer_extended.tesla.HVP_shuntCurrentDebug) * 0.1;
-    float HVP_dcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkVoltage) * 0.1;
-    float HVP_packVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packVoltage) * 0.1;
-    //float HVP_fcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkVoltage) * 0.1;
-    float HVP_packContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packContVoltage) * 0.1;
-    //float HVP_packNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_packNegativeV) * 0.1;
-    //float HVP_packPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_packPositiveV) * 0.1;
-    float HVP_pyroAnalog = static_cast<float>(datalayer_extended.tesla.HVP_pyroAnalog) * 0.1;
-    //float HVP_dcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkNegativeV) * 0.1;
-    //float HVP_dcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkPositiveV) * 0.1;
-    //float HVP_fcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkNegativeV) * 0.1;
-    //float HVP_fcContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_fcContCoilCurrent) * 0.1;
-    //float HVP_fcContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcContVoltage) * 0.1;
-    float HVP_hvilInVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilInVoltage) * 0.1;
-    float HVP_hvilOutVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilOutVoltage) * 0.1;
-    //float HVP_fcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkPositiveV) * 0.1;
-    float HVP_packContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_packContCoilCurrent) * 0.1;
-    float HVP_battery12V = static_cast<float>(datalayer_extended.tesla.HVP_battery12V) * 0.1;
-    //float HVP_shuntRefVoltageDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntRefVoltageDbg) * 0.001;
-    //float HVP_shuntAuxCurrentDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAuxCurrentDbg) * 0.1;
-    //float HVP_shuntBarTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntBarTempDbg) * 0.01;
-    //float HVP_shuntAsicTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAsicTempDbg) * 0.01;
+        static_cast<float>(datalayer_extended.tesla.PCS_dcdc12vSupportLifetimekWh) * 0.01f;
+    float HVP_hvp1v5Ref = static_cast<float>(datalayer_extended.tesla.HVP_hvp1v5Ref) * 0.1f;
+    float HVP_shuntCurrentDebug = static_cast<float>(datalayer_extended.tesla.HVP_shuntCurrentDebug) * 0.1f;
+    float HVP_dcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkVoltage) * 0.1f;
+    float HVP_packVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packVoltage) * 0.1f;
+    //float HVP_fcLinkVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkVoltage) * 0.1f;
+    float HVP_packContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_packContVoltage) * 0.1f;
+    //float HVP_packNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_packNegativeV) * 0.1f;
+    //float HVP_packPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_packPositiveV) * 0.1f;
+    float HVP_pyroAnalog = static_cast<float>(datalayer_extended.tesla.HVP_pyroAnalog) * 0.1f;
+    //float HVP_dcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkNegativeV) * 0.1f;
+    //float HVP_dcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_dcLinkPositiveV) * 0.1f;
+    //float HVP_fcLinkNegativeV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkNegativeV) * 0.1f;
+    //float HVP_fcContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_fcContCoilCurrent) * 0.1f;
+    //float HVP_fcContVoltage = static_cast<float>(datalayer_extended.tesla.HVP_fcContVoltage) * 0.1f;
+    float HVP_hvilInVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilInVoltage) * 0.1f;
+    float HVP_hvilOutVoltage = static_cast<float>(datalayer_extended.tesla.HVP_hvilOutVoltage) * 0.1f;
+    //float HVP_fcLinkPositiveV = static_cast<float>(datalayer_extended.tesla.HVP_fcLinkPositiveV) * 0.1f;
+    float HVP_packContCoilCurrent = static_cast<float>(datalayer_extended.tesla.HVP_packContCoilCurrent) * 0.1f;
+    float HVP_battery12V = static_cast<float>(datalayer_extended.tesla.HVP_battery12V) * 0.1f;
+    //float HVP_shuntRefVoltageDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntRefVoltageDbg) * 0.001f;
+    //float HVP_shuntAuxCurrentDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAuxCurrentDbg) * 0.1f;
+    //float HVP_shuntBarTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntBarTempDbg) * 0.01f;
+    //float HVP_shuntAsicTempDbg = static_cast<float>(datalayer_extended.tesla.HVP_shuntAsicTempDbg) * 0.01f;
 
     static const char* contactorText[] = {"UNKNOWN(0)",  "OPEN",        "CLOSING",    "BLOCKED", "OPENING",
                                           "CLOSED",      "UNKNOWN(6)",  "WELDED",     "POS_CL",  "NEG_CL",

--- a/Software/src/charger/CHARGERS.cpp
+++ b/Software/src/charger/CHARGERS.cpp
@@ -12,8 +12,8 @@ volatile float CHARGER_SET_HV = 384;      // Reasonably appropriate 4.0v per cel
 volatile float CHARGER_MAX_HV = 420;      // Max permissible output (VDC) of charger
 volatile float CHARGER_MIN_HV = 200;      // Min permissible output (VDC) of charger
 volatile float CHARGER_MAX_POWER = 3300;  // Max power capable of charger, as a ceiling for validating config
-volatile float CHARGER_MAX_A = 11.5;      // Max current output (amps) of charger
-volatile float CHARGER_END_A = 1.0;       // Current at which charging is considered complete
+volatile float CHARGER_MAX_A = 11.5f;     // Max current output (amps) of charger
+volatile float CHARGER_END_A = 1.0f;      // Current at which charging is considered complete
 
 std::vector<ChargerType> supported_charger_types() {
   std::vector<ChargerType> types;

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.cpp
@@ -35,16 +35,16 @@ void ChevyVoltCharger::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x212:
       datalayer.charger.CAN_charger_still_alive = CAN_STILL_ALIVE;  // Let system know charger is sending CAN
       charger_stat_HVcur_temp = (uint16_t)(rx_frame.data.u8[0] << 8 | rx_frame.data.u8[1]);
-      datalayer.charger.charger_stat_HVcur = (float)(charger_stat_HVcur_temp >> 3) * 0.05;
+      datalayer.charger.charger_stat_HVcur = (float)(charger_stat_HVcur_temp >> 3) * 0.05f;
 
       charger_stat_HVvol_temp = (uint16_t)((((rx_frame.data.u8[1] << 8 | rx_frame.data.u8[2])) >> 1) & 0x3ff);
-      datalayer.charger.charger_stat_HVvol = (float)(charger_stat_HVvol_temp) * .5;
+      datalayer.charger.charger_stat_HVvol = (float)(charger_stat_HVvol_temp) * .5f;
 
       charger_stat_LVcur_temp = (uint16_t)(((rx_frame.data.u8[2] << 8 | rx_frame.data.u8[3]) >> 1) & 0x00ff);
-      datalayer.charger.charger_stat_LVcur = (float)(charger_stat_LVcur_temp) * .2;
+      datalayer.charger.charger_stat_LVcur = (float)(charger_stat_LVcur_temp) * .2f;
 
       charger_stat_LVvol_temp = (uint16_t)(((rx_frame.data.u8[3] << 8 | rx_frame.data.u8[4]) >> 1) & 0x00ff);
-      datalayer.charger.charger_stat_LVvol = (float)(charger_stat_LVvol_temp) * .1;
+      datalayer.charger.charger_stat_LVvol = (float)(charger_stat_LVvol_temp) * .1f;
 
       break;
 
@@ -52,7 +52,7 @@ void ChevyVoltCharger::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x30A:
       datalayer.charger.CAN_charger_still_alive = CAN_STILL_ALIVE;  // Let system know charger is sending CAN
       charger_stat_ACcur_temp = (uint16_t)((rx_frame.data.u8[0] << 8 | rx_frame.data.u8[1]) >> 4);
-      datalayer.charger.charger_stat_ACcur = (float)(charger_stat_ACcur_temp) * 0.2;
+      datalayer.charger.charger_stat_ACcur = (float)(charger_stat_ACcur_temp) * 0.2f;
 
       charger_stat_ACvol_temp = (uint16_t)(((rx_frame.data.u8[1] << 8 | rx_frame.data.u8[2]) >> 4) & 0x00ff);
       datalayer.charger.charger_stat_ACvol = (float)(charger_stat_ACvol_temp) * 2;
@@ -147,9 +147,9 @@ void ChevyVoltCharger::transmit_can(unsigned long currentMillis) {
   /* Serial echo every 5s of charger stats */
   if (currentMillis - previousMillis5000ms >= INTERVAL_5_S) {
     previousMillis5000ms = currentMillis;
-    logging.printf("Charger AC in IAC=%fA VAC=%fV\n", AC_input_current(), AC_input_voltage());
-    logging.printf("Charger HV out IDC=%fA VDC=%fV\n", HVDC_output_current(), HVDC_output_voltage());
-    logging.printf("Charger LV out IDC=%fA VDC=%fV\n", LVDC_output_current(), LVDC_output_voltage());
+    logging.printf("Charger AC in IAC=%fA VAC=%fV\n", (double)AC_input_current(), (double)AC_input_voltage());
+    logging.printf("Charger HV out IDC=%fA VDC=%fV\n", (double)HVDC_output_current(), (double)HVDC_output_voltage());
+    logging.printf("Charger LV out IDC=%fA VDC=%fV\n", (double)LVDC_output_current(), (double)LVDC_output_voltage());
     logging.printf("Charger mode=%s\n", (charger_mode > MODE_DISABLED) ? "Enabled" : "Disabled");
     logging.printf("Charger HVset=%uV,%uA finishCurrent=%uA\n", setpoint_HV_VDC, setpoint_HV_IDC, setpoint_HV_IDC_END);
   }

--- a/Software/src/charger/CHEVY-VOLT-CHARGER.h
+++ b/Software/src/charger/CHEVY-VOLT-CHARGER.h
@@ -32,9 +32,9 @@ class ChevyVoltCharger : public CanCharger {
  * Relative to runtime settings, expectations are:
  * hw minimum <= setting minimum <= setting maximum <= hw max
  */
-  const float CHEVYVOLT_MAX_HVDC = 420.0;
-  const float CHEVYVOLT_MIN_HVDC = 200.0;
-  const float CHEVYVOLT_MAX_AMP = 11.5;
+  const float CHEVYVOLT_MAX_HVDC = 420.0f;
+  const float CHEVYVOLT_MIN_HVDC = 200.0f;
+  const float CHEVYVOLT_MAX_AMP = 11.5f;
   const float CHEVYVOLT_MAX_POWER = 3300;
 
   /* CAN cycles and timers */

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -211,18 +211,18 @@ static String generateButtonTopic(const char* subtype) {
 
 void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& battery, const String& suffix,
                             bool supports_charged) {
-  doc["SOC" + suffix] = ((float)battery.status.reported_soc) / 100.0;
-  doc["SOC_real" + suffix] = ((float)battery.status.real_soc) / 100.0;
-  doc["state_of_health" + suffix] = ((float)battery.status.soh_pptt) / 100.0;
-  doc["temperature_min" + suffix] = ((float)((int16_t)battery.status.temperature_min_dC)) / 10.0;
-  doc["temperature_max" + suffix] = ((float)((int16_t)battery.status.temperature_max_dC)) / 10.0;
+  doc["SOC" + suffix] = ((float)battery.status.reported_soc) / 100.0f;
+  doc["SOC_real" + suffix] = ((float)battery.status.real_soc) / 100.0f;
+  doc["state_of_health" + suffix] = ((float)battery.status.soh_pptt) / 100.0f;
+  doc["temperature_min" + suffix] = ((float)((int16_t)battery.status.temperature_min_dC)) / 10.0f;
+  doc["temperature_max" + suffix] = ((float)((int16_t)battery.status.temperature_max_dC)) / 10.0f;
   doc["cpu_temp" + suffix] = datalayer.system.info.CPU_temperature;
   doc["stat_batt_power" + suffix] = ((float)((int32_t)battery.status.active_power_W));
-  doc["battery_current" + suffix] = ((float)((int16_t)battery.status.current_dA)) / 10.0;
-  doc["battery_voltage" + suffix] = ((float)battery.status.voltage_dV) / 10.0;
+  doc["battery_current" + suffix] = ((float)((int16_t)battery.status.current_dA)) / 10.0f;
+  doc["battery_voltage" + suffix] = ((float)battery.status.voltage_dV) / 10.0f;
   if (battery.info.number_of_cells != 0u && battery.status.cell_voltages_mV[battery.info.number_of_cells - 1] != 0u) {
-    doc["cell_max_voltage" + suffix] = ((float)battery.status.cell_max_voltage_mV) / 1000.0;
-    doc["cell_min_voltage" + suffix] = ((float)battery.status.cell_min_voltage_mV) / 1000.0;
+    doc["cell_max_voltage" + suffix] = ((float)battery.status.cell_max_voltage_mV) / 1000.0f;
+    doc["cell_min_voltage" + suffix] = ((float)battery.status.cell_min_voltage_mV) / 1000.0f;
     doc["cell_voltage_delta" + suffix] =
         ((float)battery.status.cell_max_voltage_mV) - ((float)battery.status.cell_min_voltage_mV);
   }
@@ -374,7 +374,7 @@ static bool publish_cell_voltages(void) {
 
     JsonArray cell_voltages = doc["cell_voltages"].to<JsonArray>();
     for (size_t i = 0; i < datalayer.battery.info.number_of_cells; ++i) {
-      cell_voltages.add(((float)datalayer.battery.status.cell_voltages_mV[i]) / 1000.0);
+      cell_voltages.add(((float)datalayer.battery.status.cell_voltages_mV[i]) / 1000.0f);
     }
 
     serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
@@ -393,7 +393,7 @@ static bool publish_cell_voltages(void) {
 
       JsonArray cell_voltages = doc["cell_voltages"].to<JsonArray>();
       for (size_t i = 0; i < datalayer.battery2.info.number_of_cells; ++i) {
-        cell_voltages.add(((float)datalayer.battery2.status.cell_voltages_mV[i]) / 1000.0);
+        cell_voltages.add(((float)datalayer.battery2.status.cell_voltages_mV[i]) / 1000.0f);
       }
 
       serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -11,10 +11,10 @@
 
 #define BPM_TO_MS(x) ((uint16_t)((60.0f / ((float)x)) * 1000))
 
-static const float heartbeat_base = 0.15;
-static const float heartbeat_peak1 = 0.80;
-static const float heartbeat_peak2 = 0.55;
-static const float heartbeat_deviation = 0.05;
+static const float heartbeat_base = 0.15f;
+static const float heartbeat_peak1 = 0.80f;
+static const float heartbeat_peak2 = 0.55f;
+static const float heartbeat_deviation = 0.05f;
 
 static LED* led;
 
@@ -70,19 +70,19 @@ void LED::exe(void) {
 
 void LED::classic_run(void) {
   // Determine how bright the LED should be
-  brightness = up_down(0.5);
+  brightness = up_down(0.5f);
 }
 
 void LED::flow_run(void) {
   // Determine how bright the LED should be
   if (datalayer.battery.status.active_power_W < -50) {
     // Discharging
-    brightness = max_brightness - up_down(0.95);
+    brightness = max_brightness - up_down(0.95f);
   } else if (datalayer.battery.status.active_power_W > 50) {
     // Charging
-    brightness = up_down(0.95);
+    brightness = up_down(0.95f);
   } else {
-    brightness = up_down(0.5);
+    brightness = up_down(0.5f);
   }
 }
 
@@ -108,18 +108,18 @@ void LED::heartbeat_run(void) {
   float period_pct = ((float)ms) / period;
   float brightness_f;
 
-  if (period_pct < 0.10) {
+  if (period_pct < 0.10f) {
     brightness_f = map_float(period_pct, 0.00f, 0.10f, heartbeat_base, heartbeat_base - heartbeat_deviation);
-  } else if (period_pct < 0.20) {
+  } else if (period_pct < 0.20f) {
     brightness_f = map_float(period_pct, 0.10f, 0.20f, heartbeat_base - heartbeat_deviation,
                              heartbeat_base - heartbeat_deviation * 2);
-  } else if (period_pct < 0.25) {
+  } else if (period_pct < 0.25f) {
     brightness_f = map_float(period_pct, 0.20f, 0.25f, heartbeat_base - heartbeat_deviation * 2, heartbeat_peak1);
-  } else if (period_pct < 0.30) {
+  } else if (period_pct < 0.30f) {
     brightness_f = map_float(period_pct, 0.25f, 0.30f, heartbeat_peak1, heartbeat_base - heartbeat_deviation);
-  } else if (period_pct < 0.40) {
+  } else if (period_pct < 0.40f) {
     brightness_f = map_float(period_pct, 0.30f, 0.40f, heartbeat_base - heartbeat_deviation, heartbeat_peak2);
-  } else if (period_pct < 0.55) {
+  } else if (period_pct < 0.55f) {
     brightness_f = map_float(period_pct, 0.40f, 0.55f, heartbeat_peak2, heartbeat_base + heartbeat_deviation * 2);
   } else {
     brightness_f = map_float(period_pct, 0.55f, 1.00f, heartbeat_base + heartbeat_deviation * 2, heartbeat_base);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -496,11 +496,11 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "BATTPVMAX") {
-    return String(static_cast<float>(settings.getUInt("BATTPVMAX", 0)) / 10.0, 1);
+    return String(static_cast<float>(settings.getUInt("BATTPVMAX", 0)) / 10.0f, 1);
   }
 
   if (var == "BATTPVMIN") {
-    return String(static_cast<float>(settings.getUInt("BATTPVMIN", 0)) / 10.0, 1);
+    return String(static_cast<float>(settings.getUInt("BATTPVMIN", 0)) / 10.0f, 1);
   }
 
   if (var == "BATTCVMAX") {
@@ -516,27 +516,27 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "MAX_CHARGE_SPEED") {
-    return String(datalayer.battery.settings.max_user_set_charge_dA / 10.0, 1);
+    return String(datalayer.battery.settings.max_user_set_charge_dA / 10.0f, 1);
   }
 
   if (var == "MAX_DISCHARGE_SPEED") {
-    return String(datalayer.battery.settings.max_user_set_discharge_dA / 10.0, 1);
+    return String(datalayer.battery.settings.max_user_set_discharge_dA / 10.0f, 1);
   }
 
   if (var == "SOC_MAX_PERCENTAGE") {
-    return String(datalayer.battery.settings.max_percentage / 100.0, 1);
+    return String(datalayer.battery.settings.max_percentage / 100.0f, 1);
   }
 
   if (var == "SOC_MIN_PERCENTAGE") {
-    return String(datalayer.battery.settings.min_percentage / 100.0, 1);
+    return String(datalayer.battery.settings.min_percentage / 100.0f, 1);
   }
 
   if (var == "CHARGE_VOLTAGE") {
-    return String(datalayer.battery.settings.max_user_set_charge_voltage_dV / 10.0, 1);
+    return String(datalayer.battery.settings.max_user_set_charge_voltage_dV / 10.0f, 1);
   }
 
   if (var == "DISCHARGE_VOLTAGE") {
-    return String(datalayer.battery.settings.max_user_set_discharge_voltage_dV / 10.0, 1);
+    return String(datalayer.battery.settings.max_user_set_discharge_voltage_dV / 10.0f, 1);
   }
 
   if (var == "SOC_SCALING_ACTIVE_CLASS") {
@@ -590,25 +590,25 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "BALANCING_MAX_TIME") {
-    return String(datalayer.battery.settings.balancing_time_ms / 60000.0, 1);
+    return String(datalayer.battery.settings.balancing_time_ms / 60000.0f, 1);
   }
 
   if (var == "BAL_POWER") {
-    return String(datalayer.battery.settings.balancing_float_power_W / 1.0, 0);
+    return String(datalayer.battery.settings.balancing_float_power_W / 1.0f, 0);
   }
 
   if (var == "BAL_MAX_PACK_VOLTAGE") {
-    return String(datalayer.battery.settings.balancing_max_pack_voltage_dV / 10.0, 0);
+    return String(datalayer.battery.settings.balancing_max_pack_voltage_dV / 10.0f, 0);
   }
   if (var == "BAL_MAX_CELL_VOLTAGE") {
-    return String(datalayer.battery.settings.balancing_max_cell_voltage_mV / 1.0, 0);
+    return String(datalayer.battery.settings.balancing_max_cell_voltage_mV / 1.0f, 0);
   }
   if (var == "BAL_MAX_DEV_CELL_VOLTAGE") {
-    return String(datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV / 1.0, 0);
+    return String(datalayer.battery.settings.balancing_max_deviation_cell_voltage_mV / 1.0f, 0);
   }
 
   if (var == "BMS_RESET_DURATION") {
-    return String(datalayer.battery.settings.user_set_bms_reset_duration_ms / 1000.0, 0);
+    return String(datalayer.battery.settings.user_set_bms_reset_duration_ms / 1000.0f, 0);
   }
 
   if (var == "CHARGER_CLASS") {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -88,8 +88,8 @@ void canReplayTask(void* param) {
     }
 
     do {
-      float firstTimestamp = -1.0;
-      float lastTimestamp = 0.0;
+      float firstTimestamp = -1.0f;
+      float lastTimestamp = 0.0f;
       bool firstMessageSent = false;  // Track first message
 
       for (size_t i = 0; i < messages.size(); i++) {
@@ -431,10 +431,10 @@ void init_webserver() {
         auto type = static_cast<comm_interface>(atoi(p->value().c_str()));
         settings.saveUInt("BATTCOMM", (int)type);
       } else if (p->name() == "BATTPVMAX") {
-        auto type = p->value().toFloat() * 10.0;
+        auto type = p->value().toFloat() * 10.0f;
         settings.saveUInt("BATTPVMAX", (int)type);
       } else if (p->name() == "BATTPVMIN") {
-        auto type = p->value().toFloat() * 10.0;
+        auto type = p->value().toFloat() * 10.0f;
         settings.saveUInt("BATTPVMIN", (int)type);
       } else if (p->name() == "BATTCVMAX") {
         auto type = atoi(p->value().c_str());
@@ -1053,22 +1053,22 @@ String processor(const String& var) {
 
       // Display battery statistics within this block
       float socRealFloat =
-          static_cast<float>(datalayer.battery.status.real_soc) / 100.0;  // Convert to float and divide by 100
+          static_cast<float>(datalayer.battery.status.real_soc) / 100.0f;  // Convert to float and divide by 100
       float socScaledFloat =
-          static_cast<float>(datalayer.battery.status.reported_soc) / 100.0;  // Convert to float and divide by 100
+          static_cast<float>(datalayer.battery.status.reported_soc) / 100.0f;  // Convert to float and divide by 100
       float sohFloat =
-          static_cast<float>(datalayer.battery.status.soh_pptt) / 100.0;  // Convert to float and divide by 100
+          static_cast<float>(datalayer.battery.status.soh_pptt) / 100.0f;  // Convert to float and divide by 100
       float voltageFloat =
-          static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
+          static_cast<float>(datalayer.battery.status.voltage_dV) / 10.0f;  // Convert to float and divide by 10
       float currentFloat =
-          static_cast<float>(datalayer.battery.status.current_dA) / 10.0;  // Convert to float and divide by 10
-      float powerFloat = static_cast<float>(datalayer.battery.status.active_power_W);               // Convert to float
-      float tempMaxFloat = static_cast<float>(datalayer.battery.status.temperature_max_dC) / 10.0;  // Convert to float
-      float tempMinFloat = static_cast<float>(datalayer.battery.status.temperature_min_dC) / 10.0;  // Convert to float
+          static_cast<float>(datalayer.battery.status.current_dA) / 10.0f;  // Convert to float and divide by 10
+      float powerFloat = static_cast<float>(datalayer.battery.status.active_power_W);                // Convert to float
+      float tempMaxFloat = static_cast<float>(datalayer.battery.status.temperature_max_dC) / 10.0f;  // Convert to float
+      float tempMinFloat = static_cast<float>(datalayer.battery.status.temperature_min_dC) / 10.0f;  // Convert to float
       float maxCurrentChargeFloat =
-          static_cast<float>(datalayer.battery.status.max_charge_current_dA) / 10.0;  // Convert to float
+          static_cast<float>(datalayer.battery.status.max_charge_current_dA) / 10.0f;  // Convert to float
       float maxCurrentDischargeFloat =
-          static_cast<float>(datalayer.battery.status.max_discharge_current_dA) / 10.0;  // Convert to float
+          static_cast<float>(datalayer.battery.status.max_discharge_current_dA) / 10.0f;  // Convert to float
       uint16_t cell_delta_mv =
           datalayer.battery.status.cell_max_voltage_mV - datalayer.battery.status.cell_min_voltage_mV;
 
@@ -1227,17 +1227,17 @@ String processor(const String& var) {
 
         // Display battery statistics within this block
         socRealFloat =
-            static_cast<float>(datalayer.battery2.status.real_soc) / 100.0;  // Convert to float and divide by 100
+            static_cast<float>(datalayer.battery2.status.real_soc) / 100.0f;  // Convert to float and divide by 100
         //socScaledFloat; // Same value used for bat2
         sohFloat =
-            static_cast<float>(datalayer.battery2.status.soh_pptt) / 100.0;  // Convert to float and divide by 100
+            static_cast<float>(datalayer.battery2.status.soh_pptt) / 100.0f;  // Convert to float and divide by 100
         voltageFloat =
-            static_cast<float>(datalayer.battery2.status.voltage_dV) / 10.0;  // Convert to float and divide by 10
+            static_cast<float>(datalayer.battery2.status.voltage_dV) / 10.0f;  // Convert to float and divide by 10
         currentFloat =
-            static_cast<float>(datalayer.battery2.status.current_dA) / 10.0;        // Convert to float and divide by 10
+            static_cast<float>(datalayer.battery2.status.current_dA) / 10.0f;       // Convert to float and divide by 10
         powerFloat = static_cast<float>(datalayer.battery2.status.active_power_W);  // Convert to float
-        tempMaxFloat = static_cast<float>(datalayer.battery2.status.temperature_max_dC) / 10.0;  // Convert to float
-        tempMinFloat = static_cast<float>(datalayer.battery2.status.temperature_min_dC) / 10.0;  // Convert to float
+        tempMaxFloat = static_cast<float>(datalayer.battery2.status.temperature_max_dC) / 10.0f;  // Convert to float
+        tempMinFloat = static_cast<float>(datalayer.battery2.status.temperature_min_dC) / 10.0f;  // Convert to float
         cell_delta_mv = datalayer.battery2.status.cell_max_voltage_mV - datalayer.battery2.status.cell_min_voltage_mV;
 
         if (datalayer.battery.settings.soc_scaling_active)
@@ -1564,8 +1564,8 @@ String formatPowerValue(T value, String unit, int precision) {
   if (std::is_same<T, float>::value || std::is_same<T, uint16_t>::value || std::is_same<T, uint32_t>::value) {
     float convertedValue = static_cast<float>(value);
 
-    if (convertedValue >= 1000.0 || convertedValue <= -1000.0) {
-      result += String(convertedValue / 1000.0, precision) + " kW";
+    if (convertedValue >= 1000.0f || convertedValue <= -1000.0f) {
+      result += String(convertedValue / 1000.0f, precision) + " kW";
     } else {
       result += String(convertedValue, 0) + " W";
     }


### PR DESCRIPTION
### What
A lot of the floating point literals in the code were, eg, `0.1` rather than `0.1f`. The lack of suffix causes them to be promoted to a double, which both uses more code space, and is considerably slower on ESP32/ESP32S3 (which both have hardware FPUs which can only do single-precision).

Have temporarily enabled the `-Wdouble-promotion` flag and fixed all the issues. Unfortunately we can't leave this on, since the arduino-esp32 libs don't compile with this set.

Also changed a few doubles to floats.

### Why
Saves code space (main branch on Lilygo):

Before:
```
Flash: [==========]  99.6% (used 1958831 bytes from 1966080 bytes)
```

After:
```
Flash: [==========]  99.4% (used 1955071 bytes from 1966080 bytes)
```

and should be faster too. The very slight precision loss shouldn't be noticable as we're saving most of these values in floats too.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
