### PR TITLE
Allow using the inverter protocol as a shunt

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -558,7 +558,7 @@ void setup() {
   setup_charger();
   setup_inverter();
   setup_battery();
-  setup_can_shunt();
+  setup_shunt();
 
   // Init CAN only after any CAN receivers have had a chance to register.
   init_CAN();

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -9,7 +9,7 @@ class Battery;
 extern Battery* battery;
 extern Battery* battery2;
 
-void setup_can_shunt();
+void setup_shunt();
 
 #include "BMW-I3-BATTERY.h"
 #include "BMW-IX-BATTERY.h"

--- a/Software/src/battery/Shunt.h
+++ b/Software/src/battery/Shunt.h
@@ -9,7 +9,7 @@
 
 #include <vector>
 
-enum class ShuntType { None = 0, BmwSbox = 1, Highest };
+enum class ShuntType { None = 0, BmwSbox = 1, Inverter = 2, Highest };
 
 class CanShunt : public Transmitter, CanReceiver {
  public:
@@ -39,8 +39,6 @@ class CanShunt : public Transmitter, CanReceiver {
 
   void transmit_can_frame(CAN_frame* frame) { transmit_can_frame_to_interface(frame, can_interface); }
 };
-
-extern CanShunt* shunt;
 
 extern std::vector<ShuntType> supported_shunt_types();
 extern const char* name_for_shunt_type(ShuntType type);

--- a/Software/src/battery/Shunts.cpp
+++ b/Software/src/battery/Shunts.cpp
@@ -1,10 +1,11 @@
+#include "../inverter/INVERTERS.h"
 #include "BMW-SBOX.h"
 #include "Shunt.h"
 
 CanShunt* shunt = nullptr;
 ShuntType user_selected_shunt_type = ShuntType::None;
 
-void setup_can_shunt() {
+void setup_shunt() {
   if (shunt) {
     return;
   }
@@ -15,22 +16,23 @@ void setup_can_shunt() {
       return;
     case ShuntType::BmwSbox:
       shunt = new BmwSbox();
+      shunt->setup();
       break;
+    case ShuntType::Inverter:
+      if (inverter && inverter->provides_shunt())
+        inverter->enable_shunt();
     default:
       return;
-  }
-
-  if (shunt) {
-    shunt->setup();
   }
 }
 
 extern std::vector<ShuntType> supported_shunt_types() {
   std::vector<ShuntType> types;
+  types.push_back(ShuntType::None);
+  types.push_back(ShuntType::BmwSbox);
 
-  for (int i = 0; i < (int)ShuntType::Highest; i++) {
-    types.push_back((ShuntType)i);
-  }
+  if (inverter && inverter->provides_shunt())
+    types.push_back(ShuntType::Inverter);
 
   return types;
 }
@@ -41,6 +43,8 @@ extern const char* name_for_shunt_type(ShuntType type) {
       return "None";
     case ShuntType::BmwSbox:
       return BmwSbox::Name;
+    case ShuntType::Inverter:
+      return "Using inverter values";
     default:
       return nullptr;
   }

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -280,7 +280,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "SHUNTCLASS") {
-    if (!shunt) {
+    if (user_selected_shunt_type == ShuntType::None) {
       return "hidden";
     }
   }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -982,7 +982,7 @@ String processor(const String& var) {
     // Close the block
     content += "</div>";
 
-    if (inverter || battery || shunt || charger) {
+    if (inverter || battery || charger || user_selected_shunt_type != ShuntType::None) {
       // Start a new block with a specific background color
       content += "<div style='background-color: #333; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
 
@@ -1007,7 +1007,7 @@ String processor(const String& var) {
         content += "</h4>";
       }
 
-      if (shunt) {
+      if (user_selected_shunt_type != ShuntType::None) {
         content += "<h4 style='color: white;'>Shunt protocol: ";
         content += datalayer.system.info.shunt_protocol;
         content += "</h4>";

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -115,6 +115,16 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       inverter_voltage = ((rx_frame.data.u8[0] << 8) | rx_frame.data.u8[1]) * 0.1;
       inverter_current = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]) * 0.1;
       inverter_temperature = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.1;
+      if (useAsShunt) {
+        datalayer.shunt.available = true;
+        datalayer.shunt.precharging = false;
+        datalayer.shunt.contactors_engaged = true;
+        datalayer.shunt.measured_voltage_dV = inverter_voltage;
+        datalayer.shunt.measured_voltage_mV = inverter_voltage * 100;
+        datalayer.shunt.measured_outvoltage_mV = inverter_voltage * 100;
+        datalayer.shunt.measured_amperage_dA = inverter_current;
+        datalayer.shunt.measured_amperage_mA = inverter_current * 100;
+      }
       break;
     case 0x0D1:
       inverterStartedUp = true;
@@ -179,4 +189,9 @@ void BydCanInverter::send_initial_data() {
   transmit_can_frame(&BYD_3D0);
   BYD_3D0.data = {0x03, 0x56, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00};  //VS
   transmit_can_frame(&BYD_3D0);
+}
+
+void BydCanInverter::enable_shunt() {
+  strncpy(datalayer.system.info.shunt_protocol, Name, 63);
+  useAsShunt = true;
 }

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -10,6 +10,8 @@ class BydCanInverter : public CanInverterProtocol {
   void transmit_can(unsigned long currentMillis);
   void map_can_frame_to_variable(CAN_frame rx_frame);
   void update_values();
+  bool provides_shunt() { return true; }
+  void enable_shunt();
   static constexpr const char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
 
  private:
@@ -17,6 +19,7 @@ class BydCanInverter : public CanInverterProtocol {
   unsigned long previousMillis2s = 0;   // will store last time a 2s CAN Message was send
   unsigned long previousMillis10s = 0;  // will store last time a 10s CAN Message was send
   unsigned long previousMillis60s = 0;  // will store last time a 60s CAN Message was send
+  bool useAsShunt = false;
 
   static const int FW_MAJOR_VERSION = 0x03;
   static const int FW_MINOR_VERSION = 0x29;

--- a/Software/src/inverter/InverterProtocol.h
+++ b/Software/src/inverter/InverterProtocol.h
@@ -53,6 +53,9 @@ class InverterProtocol {
   virtual bool allows_contactor_closing() { return false; }
 
   virtual bool supports_battery_id() { return false; }
+
+  virtual bool provides_shunt() { return false; }
+  virtual void enable_shunt() {}
 };
 
 extern InverterProtocol* inverter;

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -125,7 +125,7 @@ void KostalInverterProtocol::update_values() {
   float2frame(CYCLIC_DATA, (float)average_temperature_dC / 10, 14);
 
   //Only perform this operation when Shunt is in used and set to BMW SBOX
-  if (shunt || (user_selected_shunt_type == ShuntType::BmwSbox)) {
+  if (user_selected_shunt_type == ShuntType::BmwSbox) {
     float2frame(CYCLIC_DATA, (float)(datalayer.shunt.measured_amperage_mA / 100) / 10, 18);
     float2frame(CYCLIC_DATA, (float)(datalayer.shunt.measured_avg1S_amperage_mA / 100) / 10, 22);
 


### PR DESCRIPTION
### What
This PR implements using voltage and current values provided by inverters as shunt values

### Why
Some inverters provide voltage and current measurements. This can be used for battery protocols like chademo which require a shunt. 
This removes the requirement of buying an expensive external shunt.

### How
Added a new shunt type "inverter", added two new functions `provides_shunt` and `enable_shunt` for inverters.
Currently only implemented for BYD CAN, but could probably implemented for others as well (namely SMA BYD CAN, ...))
