### PR TITLE
Fix Release Assets workflow (esptool went missing)

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -87,7 +87,7 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         mkdir -p images/${{ steps.vars.outputs.tag }}
-        cp ../output/*.factory.bin images/${{ steps.vars.outputs.tag }}/
+        cp ../output/*.factory.bin ../output/*.ota.bin images/${{ steps.vars.outputs.tag }}/
         git add images
         git commit -m "Deploy from GitHub Actions"
         git push origin main


### PR DESCRIPTION
### What
It seems PlatformIO no longer install esptool as a normal requirements.txt dependency (instead they bundle it as a tool or something). 

So we now just manually install esptool ourselves to use it to generate the factory images.

Also, this puts the .ota.bin files in the BE-Web-Installer repo too. The web installer will ignore these, but they could be used by a future Javascript frontend to implement an easy download-and-flash-in-one mechanism.

### Why
Fixes the Release Assets workflow.