### PR TITLE
ECMP: Add reminder for diag commands

### DIFF
--- a/Software/src/battery/ECMP-HTML.h
+++ b/Software/src/battery/ECMP-HTML.h
@@ -509,6 +509,7 @@ class EcmpHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += "No</h4>";
     }
+    content += "<h4>Remember to press Open Contactors from main menu before running the dianostic commands below:</h4>";
     return content;
   }
 };


### PR DESCRIPTION
### What
This PR adds a reminder to ECMP diag commands

### Why
Easy for users to miss this step

### How
Above the buttons we write

**Remember to press Open Contactors from main menu before running the dianostic commands below:**

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
