### PR TITLE
Bugfix: Stark OTA failure (Dowgrade ESP32)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,17 +12,17 @@
 src_dir = ./Software
 
 [env:esp32dev] 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_DEVKIT -Wimplicit-fallthrough -Wextra -Wall -Werror
+build_flags = -I include -DHW_DEVKIT -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -31,11 +31,11 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_LILYGO -Wimplicit-fallthrough -Wextra -Wall -Werror
+build_flags = -I include -DHW_LILYGO -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:stark_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -44,11 +44,11 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall -Werror
+build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_2CAN_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder


### PR DESCRIPTION
### What
This PR fixes Starks unable to OTA to v9.2.0 from v9.1.4

### Why
Breaking OTA is unacceptable. Multiple issue reports from users

### How
We fix the issue by downgrading ESP32 from v3.3.2 -> 3.3.0

Unfortunately Werror has to be removed for now, since 3.3.0 contains problems causing Werror to fail build

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
