### PR TITLE
Improvement: Rewrite LED handler to avoid floating point math

### DIFF
--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -9,14 +9,19 @@
 #define COLOR_RED(x) (((uint32_t)x << 16) | ((uint32_t)0 << 8) | 0)
 #define COLOR_BLUE(x) (((uint32_t)0 << 16) | ((uint32_t)0 << 8) | x)
 
-#define BPM_TO_MS(x) ((uint16_t)((60.0f / ((float)x)) * 1000))
+#define BPM_TO_MS(x) ((60000 / (x)))  // 60 * 1000 = 60000
 
-static const float heartbeat_base = 0.15f;
-static const float heartbeat_peak1 = 0.80f;
-static const float heartbeat_peak2 = 0.55f;
-static const float heartbeat_deviation = 0.05f;
+#define HEARTBEAT_BASE 150      // 0.15 * 1000
+#define HEARTBEAT_PEAK1 800     // 0.80 * 1000
+#define HEARTBEAT_PEAK2 550     // 0.55 * 1000
+#define HEARTBEAT_DEVIATION 50  // 0.05 * 1000
+#define SCALE_FACTOR 1000
 
 static LED* led;
+
+uint16_t map_int(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) {
+  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
 
 bool led_init(void) {
   if (!esp32hal->alloc_pins("LED", esp32hal->LED_PIN())) {
@@ -34,7 +39,6 @@ void led_exe(void) {
 }
 
 void LED::exe(void) {
-
   // Update brightness
   switch (datalayer.battery.status.led_mode) {
     case led_mode_enum::FLOW:
@@ -70,19 +74,19 @@ void LED::exe(void) {
 
 void LED::classic_run(void) {
   // Determine how bright the LED should be
-  brightness = up_down(0.5f);
+  brightness = up_down(500);
 }
 
 void LED::flow_run(void) {
   // Determine how bright the LED should be
   if (datalayer.battery.status.active_power_W < -50) {
     // Discharging
-    brightness = max_brightness - up_down(0.95f);
+    brightness = max_brightness - up_down(950);
   } else if (datalayer.battery.status.active_power_W > 50) {
     // Charging
-    brightness = up_down(0.95f);
-  } else {
-    brightness = up_down(0.5f);
+    brightness = up_down(950);
+  } else {  // Idle
+    brightness = up_down(500);
   }
 }
 
@@ -90,54 +94,56 @@ void LED::heartbeat_run(void) {
   uint16_t period;
   switch (get_event_level()) {
     case EVENT_LEVEL_WARNING:
-      // phew, starting to sweat here
       period = BPM_TO_MS(70);
       break;
     case EVENT_LEVEL_ERROR:
-      // omg omg OMG OMGG
       period = BPM_TO_MS(100);
       break;
     default:
-      // Keep default chill bpm (ba-dunk... ba-dunk... ba-dunk...)
       period = BPM_TO_MS(35);
       break;
   }
 
-  uint16_t ms = (uint16_t)(millis() % period);
+  uint16_t ms = millis() % period;
 
-  float period_pct = ((float)ms) / period;
-  float brightness_f;
+  // Calculate percentage as integer (0-1000 represents 0.0-1.0)
+  uint16_t period_pct = (ms * SCALE_FACTOR) / period;
+  uint16_t brightness_scaled;
 
-  if (period_pct < 0.10f) {
-    brightness_f = map_float(period_pct, 0.00f, 0.10f, heartbeat_base, heartbeat_base - heartbeat_deviation);
-  } else if (period_pct < 0.20f) {
-    brightness_f = map_float(period_pct, 0.10f, 0.20f, heartbeat_base - heartbeat_deviation,
-                             heartbeat_base - heartbeat_deviation * 2);
-  } else if (period_pct < 0.25f) {
-    brightness_f = map_float(period_pct, 0.20f, 0.25f, heartbeat_base - heartbeat_deviation * 2, heartbeat_peak1);
-  } else if (period_pct < 0.30f) {
-    brightness_f = map_float(period_pct, 0.25f, 0.30f, heartbeat_peak1, heartbeat_base - heartbeat_deviation);
-  } else if (period_pct < 0.40f) {
-    brightness_f = map_float(period_pct, 0.30f, 0.40f, heartbeat_base - heartbeat_deviation, heartbeat_peak2);
-  } else if (period_pct < 0.55f) {
-    brightness_f = map_float(period_pct, 0.40f, 0.55f, heartbeat_peak2, heartbeat_base + heartbeat_deviation * 2);
+  if (period_pct < 100) {  // 0.10 * 1000
+    brightness_scaled = map_int(period_pct, 0, 100, HEARTBEAT_BASE, HEARTBEAT_BASE - HEARTBEAT_DEVIATION);
+  } else if (period_pct < 200) {  // 0.20 * 1000
+    brightness_scaled =
+        map_int(period_pct, 100, 200, HEARTBEAT_BASE - HEARTBEAT_DEVIATION, HEARTBEAT_BASE - HEARTBEAT_DEVIATION * 2);
+  } else if (period_pct < 250) {  // 0.25 * 1000
+    brightness_scaled = map_int(period_pct, 200, 250, HEARTBEAT_BASE - HEARTBEAT_DEVIATION * 2, HEARTBEAT_PEAK1);
+  } else if (period_pct < 300) {  // 0.30 * 1000
+    brightness_scaled = map_int(period_pct, 250, 300, HEARTBEAT_PEAK1, HEARTBEAT_BASE - HEARTBEAT_DEVIATION);
+  } else if (period_pct < 400) {  // 0.40 * 1000
+    brightness_scaled = map_int(period_pct, 300, 400, HEARTBEAT_BASE - HEARTBEAT_DEVIATION, HEARTBEAT_PEAK2);
+  } else if (period_pct < 550) {  // 0.55 * 1000
+    brightness_scaled = map_int(period_pct, 400, 550, HEARTBEAT_PEAK2, HEARTBEAT_BASE + HEARTBEAT_DEVIATION * 2);
   } else {
-    brightness_f = map_float(period_pct, 0.55f, 1.00f, heartbeat_base + heartbeat_deviation * 2, heartbeat_base);
+    brightness_scaled =
+        map_int(period_pct, 550, SCALE_FACTOR, HEARTBEAT_BASE + HEARTBEAT_DEVIATION * 2, HEARTBEAT_BASE);
   }
 
-  brightness = (uint8_t)(brightness_f * esp32hal->LED_MAX_BRIGHTNESS());
+  // Convert scaled brightness (0-1000) to actual brightness (0-255)
+  brightness = (brightness_scaled * max_brightness) / SCALE_FACTOR;
 }
 
-uint8_t LED::up_down(float middle_point_f) {
-  // Determine how bright the LED should be
-  middle_point_f = CONSTRAIN(middle_point_f, 0.0f, 1.0f);
-  uint16_t middle_point = (uint16_t)(middle_point_f * LED_PERIOD_MS);
-  uint16_t ms = (uint16_t)(millis() % LED_PERIOD_MS);
-  brightness = map_uint16(ms, 0, middle_point, 0, max_brightness);
+uint8_t LED::up_down(uint16_t middle_point_scaled) {
+  // Convert scaled middle point to actual milliseconds
+  uint16_t middle_point = (middle_point_scaled * LED_PERIOD_MS) / SCALE_FACTOR;
+  middle_point = CONSTRAIN(middle_point, 0, LED_PERIOD_MS);
+
+  uint16_t ms = millis() % LED_PERIOD_MS;
+
   if (ms < middle_point) {
     brightness = map_uint16(ms, 0, middle_point, 0, max_brightness);
   } else {
-    brightness = esp32hal->LED_MAX_BRIGHTNESS() - map_uint16(ms, middle_point, LED_PERIOD_MS, 0, max_brightness);
+    brightness = max_brightness - map_uint16(ms, middle_point, LED_PERIOD_MS, 0, max_brightness);
   }
+
   return CONSTRAIN(brightness, 0, max_brightness);
 }

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -24,8 +24,8 @@ class LED {
   void flow_run(void);
   void heartbeat_run(void);
 
-  uint8_t up_down(float middle_point_f);
-  int LED_PERIOD_MS = 3000;
+  uint8_t up_down(uint16_t middle_point_f);
+  uint16_t LED_PERIOD_MS = 3000;
 };
 
 bool led_init(void);


### PR DESCRIPTION
### What
This PR rewrites the LED handler to avoid floating point math

### Why
Performance. Avoiding floating point math is faster, and we also save flash memory by using smaller integers

### How
We save -380 bytes of flash memory

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
