### PR TITLE
Bugfix: Make interconnect check more robust

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -122,8 +122,8 @@ void logging_loop(void*) {
 }
 
 void check_interconnect_available() {
-  if (datalayer.battery.status.voltage_dV == 0 || datalayer.battery2.status.voltage_dV == 0) {
-    return;  // Both voltage values need to be available to start check
+  if (datalayer.battery.status.voltage_dV == 3700 || datalayer.battery2.status.voltage_dV == 0) {
+    return;  // Both voltage values need to be available to start check. Bat1 defaults to 370.0V, and Bat2 defaults to 0V
   }
 
   uint16_t voltage_diff = abs(datalayer.battery.status.voltage_dV - datalayer.battery2.status.voltage_dV);

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -251,7 +251,7 @@ void setup_battery() {
         break;
       case BatteryType::BmwI3:
         battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
-                                    can_config.battery_double, esp32hal->WUP_PIN2());
+                                    can_config.battery_double);
         break;
       case BatteryType::CmfaEv:
         battery2 = new CmfaEvBattery(&datalayer.battery2, nullptr, can_config.battery_double);

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -250,8 +250,7 @@ void setup_battery() {
         battery2 = new NissanLeafBattery(&datalayer.battery2, nullptr, can_config.battery_double);
         break;
       case BatteryType::BmwI3:
-        battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
-                                    can_config.battery_double);
+        battery2 = new BmwI3Battery(&datalayer.battery2, can_config.battery_double);
         break;
       case BatteryType::CmfaEv:
         battery2 = new CmfaEvBattery(&datalayer.battery2, nullptr, can_config.battery_double);

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -41,10 +41,10 @@ uint8_t BmwI3Battery::increment_alive_counter(uint8_t counter) {
   return counter;
 }
 
-void BmwI3Battery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
+void BmwI3Battery::update_values() {
   if (datalayer.system.info.equipment_stop_active == true) {
     digitalWrite(wakeup_pin, LOW);  // Turn off wakeup pin
-  } else if (millis() > INTERVAL_1_S) {
+  } else {
     digitalWrite(wakeup_pin, HIGH);  // Wake up the battery
   }
 
@@ -499,6 +499,7 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
 
 void BmwI3Battery::setup(void) {  // Performs one time setup at startup
   if (!esp32hal->alloc_pins(Name, wakeup_pin)) {
+    //Check if the wakeup pins can be allocated. If they collide with other functions, abort setup
     return;
   }
 
@@ -516,5 +517,5 @@ void BmwI3Battery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.number_of_cells = NUMBER_OF_CELLS;
 
   pinMode(wakeup_pin, OUTPUT);
-  digitalWrite(wakeup_pin, LOW);  // Set pin to low, prepare to wakeup later on!
+  digitalWrite(wakeup_pin, LOW);  // Startup pin in low state, prepare to wakeup later on!
 }

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -112,8 +112,11 @@ void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive =
           CAN_STILL_ALIVE;  //This message is only sent if 30C (Wakeup pin on battery) is energized with 12V
       battery_current = (rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]) - 8192;  //deciAmps (-819.2 to 819.0A)
-      battery_volts = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);           //500.0 V
-      datalayer_battery->status.voltage_dV = battery_volts;  // Update the datalayer as soon as possible with this info
+      tempval = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);                 //500.0 V (Unavailable 0xFFFF)
+      if (tempval < 0xFFFE) {
+        battery_volts = tempval;
+        datalayer_battery->status.voltage_dV = tempval;  // Update the datalayer as soon as possible
+      }
       battery_HVBatt_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8 | rx_frame.data.u8[4]);
       battery_request_open_contactors = (rx_frame.data.u8[5] & 0xC0) >> 6;
       battery_request_open_contactors_instantly = (rx_frame.data.u8[6] & 0x03);

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -292,27 +292,10 @@ class BmwI3Battery : public CanBattery {
 
   //The above CAN messages need to be sent towards the battery to keep it alive
 
-  uint8_t startup_counter_contactor = 0;
-  uint8_t alive_counter_20ms = 0;
-  uint8_t alive_counter_100ms = 0;
-  uint8_t alive_counter_200ms = 0;
-  uint8_t alive_counter_500ms = 0;
-  uint8_t alive_counter_1000ms = 0;
-  uint8_t alive_counter_5000ms = 0;
-  uint8_t BMW_1D0_counter = 0;
-  uint8_t BMW_13E_counter = 0;
-  uint8_t BMW_380_counter = 0;
   uint32_t BMW_328_seconds = 243785948;  // Initialized to make the battery think vehicle was made 7.7years ago
   uint16_t BMW_328_days =
       9244;  //Time since 1.1.2000. Hacky implementation to make it think current date is 23rd April 2025
   uint32_t BMS_328_seconds_to_day = 0;  //Counter to keep track of days uptime
-
-  bool battery_awake = false;
-  bool battery_info_available = false;
-  bool skipCRCCheck = false;
-  bool CRCCheckPassedPreviously = false;
-
-  uint16_t cellvoltage_temp_mV = 0;
   uint32_t battery_serial_number = 0;
   uint32_t battery_available_power_shortterm_charge = 0;
   uint32_t battery_available_power_shortterm_discharge = 0;
@@ -322,6 +305,7 @@ class BmwI3Battery : public CanBattery {
   uint32_t battery_BEV_available_power_shortterm_discharge = 0;
   uint32_t battery_BEV_available_power_longterm_charge = 0;
   uint32_t battery_BEV_available_power_longterm_discharge = 0;
+  uint16_t tempval = 0;
   uint16_t battery_energy_content_maximum_Wh = 0;
   uint16_t battery_display_SOC = 0;
   uint16_t battery_volts = 0;
@@ -342,6 +326,7 @@ class BmwI3Battery : public CanBattery {
   uint16_t battery_soc_hvmax = 0;
   uint16_t battery_soc_hvmin = 0;
   uint16_t battery_capacity_cah = 0;
+  uint16_t cellvoltage_temp_mV = 0;
   int16_t battery_temperature_HV = 0;
   int16_t battery_temperature_heat_exchanger = 0;
   int16_t battery_temperature_max = 0;
@@ -379,10 +364,23 @@ class BmwI3Battery : public CanBattery {
   uint8_t battery_status_diagnosis_powertrain_immediate_multiplexer = 0;
   uint8_t battery_ID2 = 0;
   uint8_t battery_soh = 99;
-
-  uint8_t message_data[50];
   uint8_t next_data = 0;
   uint8_t current_cell_polled = 0;
+  uint8_t startup_counter_contactor = 0;
+  uint8_t alive_counter_20ms = 0;
+  uint8_t alive_counter_100ms = 0;
+  uint8_t alive_counter_200ms = 0;
+  uint8_t alive_counter_500ms = 0;
+  uint8_t alive_counter_1000ms = 0;
+  uint8_t alive_counter_5000ms = 0;
+  uint8_t BMW_1D0_counter = 0;
+  uint8_t BMW_13E_counter = 0;
+  uint8_t BMW_380_counter = 0;
+  uint8_t message_data[50];
+  bool battery_awake = false;
+  bool battery_info_available = false;
+  bool skipCRCCheck = false;
+  bool CRCCheckPassedPreviously = false;
 };
 
 #endif

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -9,13 +9,10 @@
 class BmwI3Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.
-  BmwI3Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, bool* contactor_closing_allowed_ptr, CAN_Interface targetCan)
+  BmwI3Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan)
       : CanBattery(targetCan), renderer(*this) {
     datalayer_battery = datalayer_ptr;
-    contactor_closing_allowed = contactor_closing_allowed_ptr;
-    allows_contactor_closing = nullptr;
     wakeup_pin = esp32hal->WUP_PIN2();
-
     //Init voltage to 0 to allow interconnect contactor check to operate without default values colliding
     battery_volts = 0;
   }
@@ -23,9 +20,8 @@ class BmwI3Battery : public CanBattery {
   // Use the default constructor to create the first or single battery.
   BmwI3Battery() : renderer(*this) {
     datalayer_battery = &datalayer.battery;
-    allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
-    contactor_closing_allowed = nullptr;
     wakeup_pin = esp32hal->WUP_PIN1();
+    primary_battery = true;
   }
 
   virtual void setup(void);
@@ -84,11 +80,7 @@ class BmwI3Battery : public CanBattery {
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;
 
-  // If not null, this battery decides when the contactor can be closed and writes the value here.
-  bool* allows_contactor_closing;
-
-  // If not null, this battery listens to this boolean to determine whether contactor closing is allowed
-  bool* contactor_closing_allowed;
+  bool primary_battery = false;
 
   gpio_num_t wakeup_pin;  //Set in constructor when initializing
 

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -9,15 +9,14 @@
 class BmwI3Battery : public CanBattery {
  public:
   // Use this constructor for the second battery.
-  BmwI3Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, bool* contactor_closing_allowed_ptr, CAN_Interface targetCan,
-               gpio_num_t wakeup)
+  BmwI3Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, bool* contactor_closing_allowed_ptr, CAN_Interface targetCan)
       : CanBattery(targetCan), renderer(*this) {
     datalayer_battery = datalayer_ptr;
     contactor_closing_allowed = contactor_closing_allowed_ptr;
     allows_contactor_closing = nullptr;
-    wakeup_pin = wakeup;
+    wakeup_pin = esp32hal->WUP_PIN2();
 
-    //Init voltage to 0 to allow contactor check to operate without fear of default values colliding
+    //Init voltage to 0 to allow interconnect contactor check to operate without default values colliding
     battery_volts = 0;
   }
 
@@ -91,7 +90,7 @@ class BmwI3Battery : public CanBattery {
   // If not null, this battery listens to this boolean to determine whether contactor closing is allowed
   bool* contactor_closing_allowed;
 
-  gpio_num_t wakeup_pin;
+  gpio_num_t wakeup_pin;  //Set in constructor when initializing
 
   unsigned long previousMillis20 = 0;     // will store last time a 20ms CAN Message was send
   unsigned long previousMillis100 = 0;    // will store last time a 100ms CAN Message was send


### PR DESCRIPTION
### What
This PR makes the Double-Battery interconnect check more reliable, especially for BMW i3

### Why
Fixes #1694

### How
- We now skip the interconnect check if Battery1 is 370.0V, OR, Battery2 is 0V
- We now skip reading BMW voltage if value unavailable (can be on boot, 0xFFFF)
- BONUS: Slight flash save of 32bytes by smarter packing of BMW struct
- Experimental: We refactor how i3 contactor closing is handled to make it smoother for second battery

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
