### PR TITLE
Safety: Tighten DC-bus requirement to 1.5V

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -129,7 +129,7 @@ void check_interconnect_available() {
   uint16_t voltage_diff = abs(datalayer.battery.status.voltage_dV - datalayer.battery2.status.voltage_dV);
   uint8_t secondsOutOfVoltageSync = 0;
 
-  if (voltage_diff <= 30) {  // If we are within 3.0V between the batteries
+  if (voltage_diff <= 15) {  // If we are within 1.5V between the batteries
     clear_event(EVENT_VOLTAGE_DIFFERENCE);
     secondsOutOfVoltageSync = 0;
     if (datalayer.battery.status.bms_status == FAULT) {


### PR DESCRIPTION
### What
This PR tightens the limit for allowing secondary battery to join the DC bus

### Why
Suspected by users that a 3VDC diff can cause arcing if contactors are opened repeatedly. Fixes #1708

### How
We tighten the limit down from 3.0VDC -> 1.5VDC.

3VDC limit originally comes from an OEM that allowed parallel/series connection of two 400VDC batteries. But that system was designed for constant switching, all EV packs might not be as tolerant. Since software 9.2.0 we also OPEN contactors if the batteries start to drift out of spec, for instance from blowing a fuse (https://github.com/dalathegreat/Battery-Emulator/pull/1635)

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
