### PR TITLE
Improvement: Add flag for small flash size feature omitting

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,7 +1,9 @@
 #include "wifi.h"
-#include <ESPmDNS.h>
 #include "../utils/events.h"
 #include "../utils/logging.h"
+#ifndef SMALL_FLASH_DEVICE
+#include <ESPmDNS.h>
+#endif
 
 bool wifi_enabled = true;
 bool wifiap_enabled = true;
@@ -220,8 +222,9 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
   //normal reconnect retry start at first 2 seconds
 }
 
-// Initialise mDNS
+// Initialise mDNS (Only available on devices with )
 void init_mDNS() {
+#ifndef SMALL_FLASH_DEVICE
   // Calulate the host name using the last two chars from the MAC address so each one is likely unique on a network.
   // e.g batteryemulator8C.local where the mac address is 08:F9:E0:D1:06:8C
   String mac = WiFi.macAddress();
@@ -238,6 +241,7 @@ void init_mDNS() {
     // Advertise via bonjour the service so we can auto discover these battery emulators on the local network.
     MDNS.addService(mdnsHost, "tcp", 80);
   }
+#endif
 }
 
 void init_WiFi_AP() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_DEVKIT -Wimplicit-fallthrough -Wextra -Wall
+build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_330]
@@ -31,7 +31,7 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_LILYGO -Wimplicit-fallthrough -Wextra -Wall
+build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:stark_330]
@@ -44,7 +44,7 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
+build_flags = -I include -DHW_STARK -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_2CAN_330]


### PR DESCRIPTION
### What
This PR implements a build flag for low flash devices

### Why
To be able to feature gate certain functionality to large flash devices only

### How
We introduce a new flag in the PlatformIO file, `SMALL_FLASH_DEVICE` , that is applied on builds with 4MB of flash.

This flag is used to skip certain features, starting with mDNS service. This feature is from now on only available on larger flash boards.

Saves -1.1% of flash (-21676 bytes)

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
