### PR TITLE
Improvement: Make Kia64FD use user set charge/discharge values

### DIFF
--- a/Software/src/battery/KIA-64FD-BATTERY.cpp
+++ b/Software/src/battery/KIA-64FD-BATTERY.cpp
@@ -112,12 +112,12 @@ void Kia64FDBattery::update_values() {
     datalayer.battery.status.max_charge_power_W =
         RAMPDOWNPOWERALLOWED * (1 - (datalayer.battery.status.real_soc - RAMPDOWN_SOC) / (10000.0 - RAMPDOWN_SOC));
   } else {  // No limits, max charging power allowed
-    datalayer.battery.status.max_charge_power_W = MAXCHARGEPOWERALLOWED;
+    datalayer.battery.status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
   }
 
   //datalayer.battery.status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
-  //The allowed discharge power is not available. We hardcode this value for now
-  datalayer.battery.status.max_discharge_power_W = MAXDISCHARGEPOWERALLOWED;
+  //The allowed discharge power is not available. We use user set value for now
+  datalayer.battery.status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
 
   datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -24,8 +24,6 @@ class Kia64FDBattery : public CanBattery {
   static const int MAX_CELL_DEVIATION_MV = 150;
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2950;  //Battery is put into emergency stop if one cell goes below this value
-  static const int MAXCHARGEPOWERALLOWED = 10000;
-  static const int MAXDISCHARGEPOWERALLOWED = 10000;
   static const int RAMPDOWN_SOC = 9000;  // 90.00 SOC% to start ramping down from max charge power towards 0 at 100.00%
   static const int RAMPDOWNPOWERALLOWED = 10000;  // What power we ramp down from towards top balancing
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -148,7 +148,7 @@ void KiaEGmpBattery::update_values() {
   }
 
   //datalayer.battery.status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
-  //The allowed discharge power is not available. We hardcode this value for now
+  //The allowed discharge power is not available. We use user set value for now
   datalayer.battery.status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
 
   datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -951,6 +951,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     form[data-battery="24"] .if-estimated,
     form[data-battery="32"] .if-estimated, 
     form[data-battery="33"] .if-estimated,
+    form[data-battery="40"] .if-estimated,
     form[data-battery="44"] .if-estimated {
       display: contents;
     }


### PR DESCRIPTION
### What
This PR makes Kia64FD integration use user set charge/discharge values

### Why
User requested feature, to be able to use more than hardcoded 10kW

### How
Same way Kia EGMP platform does it.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
