### PR TITLE
Volvo SPA: Use SOC sent by battery

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -50,14 +50,6 @@ void VolvoSpaBattery::
   datalayer.battery.status.real_soc = SOC_CALC * 10;  //Add one decimal to make it pptt
   */
 
-  if (BATT_U > MAX_U)  // Protect if overcharged
-  {
-    datalayer.battery.status.real_soc = 10000;
-  } else if (BATT_U < MIN_U)  //Protect if undercharged
-  {
-    datalayer.battery.status.real_soc = 0;
-  }
-
   datalayer.battery.status.voltage_dV = BATT_U * 10;
   datalayer.battery.status.current_dA = BATT_I * 10;
 


### PR DESCRIPTION
### What
This PR changes the Volvo SPA implementation to use SOC% sent by battery

### Why
We previously used a calculated value. Fixes #1732

### How
Use value reported by battery
Bonus, remove unnecessary voltage safety check, now in Safety.cpp

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
