### PR TITLE
Volvo SPA: Use SOC sent by battery

### DIFF
--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -41,8 +41,7 @@ void VolvoSpaBattery::
 
   datalayer.battery.status.remaining_capacity_Wh = (datalayer.battery.info.total_capacity_Wh - CHARGE_ENERGY);
 
-  datalayer.battery.status.real_soc =
-      SOC_BMS;  // Use BMS reported SOC, havent figured out how to get the BMS to calibrate empty/full yet
+  datalayer.battery.status.real_soc = SOC_BMS * 10;  //Add one decimal to make it pptt
 
   // Use calculated SOC based on remaining_capacity
   /*


### PR DESCRIPTION
### What
This PR changes the Volvo SPA implementation to use SOC% sent by battery

### Why
We previously used a calculated value. Fixes #1732

### How
Use value reported by battery
Bonus, remove unnecessary voltage safety check, now in Safety.cpp

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
