### PR TITLE
SIMPBMS: Fix conversion of mA to dA

### DIFF
--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -57,7 +57,7 @@ void SimpBmsBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x356:
       //current status
-      current_dA = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2]) / 1000;
+      current_dA = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2]) / 100;
       voltage_dV = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]) / 10;
       break;
     case 0x373:


### PR DESCRIPTION
### What
This PR improves the current conversion signal on SIMPBMS integration

### Why
Fixes #1740

### How
We scale to dA instead of scaling to A

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
