### PR TITLE
Feature: Add Clear DTC button to BMW i3 integration

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -419,6 +419,11 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
       BMW_433.data.u8[1] = 0x01;  // First 433 message byte1 we send is unique, once we sent initial value send this
       BMW_3E8.data.u8[0] = 0xF1;  // First 3E8 message byte0 we send is unique, once we sent initial value send this
 
+      if (UserRequestDTCreset) {
+        cmdState = CLEAR_DTC;
+        UserRequestDTCreset = false;
+      }
+
       next_data = 0;
       switch (cmdState) {
         case SOC:
@@ -448,6 +453,14 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
           break;
         case CELL_VOLTAGE_CELLNO_LAST:
           transmit_can_frame(&BMW_6F1_SOC);
+          cmdState = SOC;
+          break;
+        case CLEAR_DTC:
+          transmit_can_frame(&BMW_6F1_CLEAR_DTC);
+          cmdState = SOC;  //jump back to normal polling
+          break;
+        default:
+          //Should never end up here
           cmdState = SOC;
           break;
       }

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -35,6 +35,9 @@ class BmwI3Battery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "BMW i3";
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
   // SOC% raw battery value. Might not always reach 100%
   uint16_t SOC_raw() { return (battery_HVBatt_SOC * 10); }
   // SOC% instrumentation cluster value. Will always reach 100%
@@ -68,6 +71,8 @@ class BmwI3Battery : public CanBattery {
   BmwI3HtmlRenderer renderer;
 
  private:
+  bool UserRequestDTCreset = false;
+
   const int MAX_CELL_VOLTAGE_60AH = 4110;   // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_60AH = 2700;   // Battery is put into emergency stop if one cell goes below this value
   const int MAX_CELL_VOLTAGE_94AH = 4140;   // Battery is put into emergency stop if one cell goes over this value
@@ -109,7 +114,7 @@ class BmwI3Battery : public CanBattery {
   enum BatterySize { BATTERY_60AH, BATTERY_94AH, BATTERY_120AH };
   BatterySize detectedBattery = BATTERY_60AH;
 
-  enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST };
+  enum CmdState { SOH, CELL_VOLTAGE_MINMAX, SOC, CELL_VOLTAGE_CELLNO, CELL_VOLTAGE_CELLNO_LAST, CLEAR_DTC };
 
   CmdState cmdState = SOC;
 
@@ -279,6 +284,11 @@ class BmwI3Battery : public CanBattery {
                                                  .DLC = 4,
                                                  .ID = 0x6F1,
                                                  .data = {0x07, 0x30, 0x00, 0x02}};
+  static constexpr CAN_frame BMW_6F1_CLEAR_DTC = {.FD = false,
+                                                  .ext_ID = false,
+                                                  .DLC = 6,
+                                                  .ID = 0x6F1,
+                                                  .data = {0xDF, 0x04, 0x14, 0xFF, 0xFF, 0xFF}};
   CAN_frame BMW_6F4_CELL_VOLTAGE_CELLNO = {.FD = false,
                                            .ext_ID = false,
                                            .DLC = 7,


### PR DESCRIPTION
### What
This PR implements clear DTC button to BMW i3 integration

### Why
User requested feature

### How
Button added under "More Battery Info"
<img width="325" height="490" alt="image" src="https://github.com/user-attachments/assets/70b1aae9-413d-4a31-b598-e39435803ddc" />

Next development should be Read DTC :sweat_smile: 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
