### PR TITLE
fix RJXZS cell count population

### DIFF
--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -134,13 +134,20 @@ void RjxzsBms::handle_incoming_can_frame(CAN_frame rx_frame) {
       } else if (mux >= 0x07 && mux <= 0x46) {
         // Cell voltages 1-192 (3 per message, 0x07=1-3, 0x08=4-6, ..., 0x46=190-192)
         int cell_index = (mux - 0x07) * 3;
+        bool has_valid_data = false;
         for (int i = 0; i < 3; i++) {
           if (cell_index + i >= MAX_AMOUNT_CELLS) {
             break;
           }
-          cellvoltages[cell_index + i] = (rx_frame.data.u8[1 + i * 2] << 8) | rx_frame.data.u8[2 + i * 2];
+          uint16_t cell_voltage = (rx_frame.data.u8[1 + i * 2] << 8) | rx_frame.data.u8[2 + i * 2];
+          cellvoltages[cell_index + i] = cell_voltage;
+          // Check if this cell has valid (non-zero) voltage data
+          if (cell_voltage != 0) {
+            has_valid_data = true;
+          }
         }
-        if (cell_index + 2 >= populated_cellvoltages) {
+        // Only update populated cell count if we received valid voltage data
+        if (has_valid_data && cell_index + 2 >= populated_cellvoltages) {
           populated_cellvoltages = cell_index + 2 + 1;
         }
       } else if (mux == 0x47) {


### PR DESCRIPTION

**Problem**
Cell voltages were not being published via MQTT for RJXZS BMS batteries despite the option being enabled. The root cause was that [datalayer.battery.info.number_of_cells](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was being set incorrectly, causing the MQTT publishing check to always fail.

**Root Cause**
The RJXZS BMS sends cell voltage data via CAN messages with mux IDs 0x07-0x46, with each message containing 3 cell voltages. The BMS continues sending messages in this range even after all actual cells have been reported, filling the remaining messages with zeros.

The original code incremented [populated_cellvoltages](https://github.com/dalathegreat/Battery-Emulator/blob/3b81d3384ef9e0a74b2573d2af6293a2272ba625/Software/src/battery/RJXZS-BMS.cpp#L134) for every message received in the 0x07-0x46 range, regardless of whether the message contained actual cell data or just zeros. This resulted in an incorrect cell count being reported.

For example, a 48-cell battery (16 modules × 3 cells) would:

- Send valid data in messages 0x07-0x16 (cells 1-48)
- Send all zeros in messages 0x17-0x46 (would-be cells 49-192)
- Incorrectly count cells beyond the actual 48 present

**Solution**
Modified the cell voltage parsing logic in [RJXZS-BMS.cpp](https://github.com/dalathegreat/Battery-Emulator/blob/3b81d3384ef9e0a74b2573d2af6293a2272ba625/Software/src/battery/RJXZS-BMS.cpp#L137 to only update populated_cellvoltages](https://github.com/mccasian/Battery-Emulator/blob/124084a7cae487de5dd9951f7fd19263e25470e2/Software/src/battery/RJXZS-BMS.cpp#L145C12-L145C14) when the CAN message contains at least one non-zero cell voltage value. This ensures number_of_cells accurately reflects the actual number of cells in the battery pack.

Changes
Added validation to check if received cell voltage data is non-zero before updating the populated cell count
Prevents counting phantom cells from zero-filled CAN messages
Ensures `datalayer.battery.info.number_of_cells` is set correctly for MQTT and other consumers
Testing
Validated against real CAN bus logs showing a 48-cell RJXZS BMS battery configuration.