### PR TITLE
Bugfix: Increase stack allocation for ACAN2515 library

### DIFF
--- a/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
+++ b/Software/src/lib/pierremolinaro-acan2515/ACAN2515.cpp
@@ -226,7 +226,7 @@ uint16_t ACAN2515::beginWithoutFilterCheck (const ACAN2515Settings & inSettings,
       #endif
     }
     #ifdef ARDUINO_ARCH_ESP32
-      xTaskCreate (myESP32Task, "ACAN2515Handler", 1200, this, TASK_ACAN2515_PRIORITY, NULL) ;
+      xTaskCreate (myESP32Task, "ACAN2515Handler", 2048, this, TASK_ACAN2515_PRIORITY, NULL) ;
     #endif
   }
 //----------------------------------- Return


### PR DESCRIPTION
### What
This PR increases the stack allocation for the ACAN2515 library

### Why
Attempts fixes #1783 , might be ESP32-S3 CPU allocation issue

### How
1200 increases to 2048

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
