### PR TITLE
Dacia Spring: Switch to constantly sent voltage value + celltap event

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -213,19 +213,28 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           break;
         case PID_POLL_DIDS_SUPPORTED_IN_RANGE_9041_9060:
           break;
-        default:                                                                //Unknown pid_reply, or a cellvoltage
-          if (pid_reply >= PID_POLL_CELL_1 && pid_reply <= PID_POLL_CELL_72) {  //Cellvoltage PID reply
-            uint8_t cellnumber = (pid_reply - PID_POLL_CELL_1);
-            if (cellnumber < MAX_AMOUNT_CELLS) {  //Prevent out of bounds array write
-              uint16_t cellvoltage_reading = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
-              if (cellvoltage_reading == 0) {
-                //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page. Also fire event
-                cellvoltage_reading = 10;
-                set_event(EVENT_BATTERY_FUSE, cellnumber);
-              }
-              datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading;
-            }
+        default:  //Unknown pid_reply, or a cellvoltage
+          uint8_t cellnumber = 0;
+          if (pid_reply >= PID_POLL_CELL_1 && pid_reply <= PID_POLL_CELL_31) {  //Cellvoltage PID reply
+            cellnumber = (pid_reply - PID_POLL_CELL_1);
+          } else if (pid_reply >= PID_POLL_CELL_32 && pid_reply <= PID_POLL_CELL_62) {
+            cellnumber = (pid_reply - PID_POLL_CELL_1) - 1;
+          } else if (pid_reply >= PID_POLL_CELL_63 && pid_reply <= PID_POLL_CELL_72) {
+            cellnumber = (pid_reply - PID_POLL_CELL_1) - 2;
+          } else {  //Unknown pid_reply
+            break;
           }
+
+          if (cellnumber < MAX_AMOUNT_CELLS) {  //Prevent out of bounds array write
+            uint16_t cellvoltage_reading = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
+            if (cellvoltage_reading == 0) {
+              //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page. Also fire event
+              cellvoltage_reading = 10;
+              set_event(EVENT_BATTERY_FUSE, cellnumber);
+            }
+            datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading;
+          }
+
           break;
       }
       break;
@@ -747,8 +756,4 @@ void CmfaEvBattery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-
-  for (size_t i = 0; i < 73; i++) {
-    datalayer_battery->status.cell_voltages_mV[i] = 10;
-  }
 }

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -77,6 +77,7 @@ void CmfaEvBattery::
     datalayer_cmfa->cumulative_energy_when_charging = cumulative_energy_when_charging;
     datalayer_cmfa->cumulative_energy_in_regen = cumulative_energy_in_regen;
     datalayer_cmfa->soh_average = soh_average;
+    datalayer_cmfa->average_voltage_of_cells = average_voltage_of_cells;
   }
 }
 

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -219,8 +219,9 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             if (cellnumber < MAX_AMOUNT_CELLS) {  //Prevent out of bounds array write
               uint16_t cellvoltage_reading = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
               if (cellvoltage_reading == 0) {
-                //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page
+                //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page. Also fire event
                 cellvoltage_reading = 10;
+                set_event(EVENT_BATTERY_FUSE, cellnumber);
               }
               datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading;
             }

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -34,7 +34,7 @@ void CmfaEvBattery::
 
   datalayer_battery->status.current_dA = current * 10;
 
-  datalayer_battery->status.voltage_dV = pack_voltage / 2;
+  datalayer_battery->status.voltage_dV = pack_voltage * 5;
 
   datalayer_battery->info.total_capacity_Wh = 27000;
 

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -742,7 +742,12 @@ void CmfaEvBattery::transmit_can(unsigned long currentMillis) {
         break;
     }
 
-    transmit_can_frame(&CMFA_POLLING_FRAME);
+    if (UserRequestDTCclear) {
+      transmit_can_frame(&CMFA_CLEAR_DTC);
+      UserRequestDTCclear = false;
+    } else {  //Normal PID polling
+      transmit_can_frame(&CMFA_POLLING_FRAME);
+    }
   }
 }
 

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -216,8 +216,12 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (pid_reply >= PID_POLL_CELL_1 && pid_reply <= PID_POLL_CELL_72) {  //Cellvoltage PID reply
             uint8_t cellnumber = (pid_reply - PID_POLL_CELL_1);
             if (cellnumber < MAX_AMOUNT_CELLS) {  //Prevent out of bounds array write
-              datalayer_battery->status.cell_voltages_mV[cellnumber] =
-                  (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
+              uint16_t cellvoltage_reading = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
+              if (cellvoltage_reading == 0) {
+                //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page
+                cellvoltage_reading = 10;
+              }
+              datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading;
             }
           }
           break;

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -34,7 +34,7 @@ void CmfaEvBattery::
 
   datalayer_battery->status.current_dA = current * 10;
 
-  datalayer_battery->status.voltage_dV = average_voltage_of_cells / 100;
+  datalayer_battery->status.voltage_dV = pack_voltage / 2;
 
   datalayer_battery->info.total_capacity_Wh = 27000;
 
@@ -86,6 +86,7 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       current = (((((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2]) * 0.25) - 500);
       SOC_raw = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
+      pack_voltage = (((rx_frame.data.u8[6] & 0x03) << 8) | rx_frame.data.u8[7]);
       break;
     case 0x3D6:  //100ms, Same structure as old Zoe 0x424 message!
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -98,7 +99,6 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x3D7:  //100ms
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      pack_voltage = ((rx_frame.data.u8[6] << 4 | (rx_frame.data.u8[5] & 0x0F)));
       break;
     case 0x3D8:  //100ms
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -747,4 +747,8 @@ void CmfaEvBattery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+
+  for (size_t i = 0; i < 73; i++) {
+    datalayer_battery->status.cell_voltages_mV[i] = 10;
+  }
 }

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -25,6 +25,9 @@ class CmfaEvBattery : public CanBattery {
     datalayer_cmfa = &datalayer_extended.CMFAEV;
   }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCclear = true; }
+
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
@@ -41,6 +44,8 @@ class CmfaEvBattery : public CanBattery {
 
   // If not null, this battery decides when the contactor can be closed and writes the value here.
   bool* allows_contactor_closing;
+
+  bool UserRequestDTCclear = false;
 
   uint16_t rescale_raw_SOC(uint32_t raw_SOC);
 
@@ -186,6 +191,11 @@ class CmfaEvBattery : public CanBattery {
                                   .DLC = 8,
                                   .ID = 0x79B,
                                   .data = {0x03, 0x22, 0x90, 0x01, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CMFA_CLEAR_DTC = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x79B,
+                              .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
   bool end_of_charge = false;
   bool interlock_flag = false;
   uint16_t soc_z = 0;

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -228,7 +228,7 @@ class CmfaEvBattery : public CanBattery {
   uint32_t SOC_raw = 0;
   uint16_t SOH = 99;
   int16_t current = 0;
-  uint16_t pack_voltage = 2700;
+  uint16_t pack_voltage = 500;
   int16_t highest_cell_temperature = 0;
   int16_t lowest_cell_temperature = 0;
   uint32_t discharge_power_w = 0;

--- a/Software/src/battery/CMFA-EV-HTML.h
+++ b/Software/src/battery/CMFA-EV-HTML.h
@@ -16,6 +16,7 @@ class CmfaEvHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>12V voltage: " + String(datalayer_extended.CMFAEV.lead_acid_voltage) + "mV</h4>";
     content += "<h4>Highest cell number: " + String(datalayer_extended.CMFAEV.highest_cell_voltage_number) + "</h4>";
     content += "<h4>Lowest cell number: " + String(datalayer_extended.CMFAEV.lowest_cell_voltage_number) + "</h4>";
+    content += "<h4>Sum of cellvoltages: " + String(datalayer_extended.CMFAEV.average_voltage_of_cells) + "</h4>";
     content += "<h4>Max regen power: " + String(datalayer_extended.CMFAEV.max_regen_power) + "</h4>";
     content += "<h4>Max discharge power: " + String(datalayer_extended.CMFAEV.max_discharge_power) + "</h4>";
     content += "<h4>Max charge power: " + String(datalayer_extended.CMFAEV.maximum_charge_power) + "</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -247,6 +247,8 @@ struct DATALAYER_INFO_CMFAEV {
   uint64_t cumulative_energy_when_charging = 0;
   uint64_t cumulative_energy_in_regen = 0;
 
+  uint32_t average_voltage_of_cells = 0;
+
   uint16_t soc_z = 0;
   uint16_t soc_u = 0;
   uint16_t soh_average = 0;


### PR DESCRIPTION
### What
This PR changes the Dacia-Spring (CMFA-EV) to use constantly sent voltage value instead of PID polled value

### Why
Some users reported corrupt values on voltages.

### How
Instead of using the slow to update (and sometimes corrupt!) PID polled value, we switch to using the constantly broadcasted value in CAN message 0x127

- We also added a CLEAR DTC button to the More Battery Info page so users can clear diagnostic trouble codes
- We also now shown blown fuse celltaps in the cellmonitor page
- Finally we also fire an event if cellvoltages are missing, hinting towards internal battery error

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
