### PR TITLE
BMW i3: Charge battery more fully

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -52,8 +52,13 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
     return;
   }
 
-  // datalayer_battery->status.real_soc = (battery_display_SOC * 50); //Always reaches 100%
-  datalayer_battery->status.real_soc = (battery_HVBatt_SOC * 10);  //Does not always reach 100% (Experiment)
+  datalayer_battery->status.real_soc = (battery_display_SOC * 50);  //Always reaches 100%
+  if (datalayer_battery->status.real_soc == 10000) {                //If fully charged
+    if (datalayer_battery->status.max_charge_power_W > 0) {         //But still allowing power into battery
+      //Set SOC to 99.9% to avoid safety.cpp blocking balance-charge
+      datalayer_battery->status.real_soc = 9990;
+    }
+  }
 
   datalayer_battery->status.voltage_dV = battery_volts;  //Unit V+1 (5000 = 500.0V)
 


### PR DESCRIPTION
### What
This PR explores the possibility to charge the BMW i3 battery more

### Why
22kWh i3 battery can only use 2/3 capacity.

### How
- Also check short term charge limits and use those if available, instead of only longterm charge limits
- If displayed SOC% goes to 100% while the battery still wants to charge, we override it to 99.9%

This results in BMW i3 60Ah battery reaching 394V instead of 390V :partying_face: 


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
