### PR TITLE
Bugfix: Spring, add scaling to cellvoltage readings

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -232,7 +232,7 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               cellvoltage_reading = 10;
               set_event(EVENT_BATTERY_FUSE, cellnumber);
             }
-            datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading;
+            datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading * 0.976563;
           }
 
           break;


### PR DESCRIPTION
### What
This PR tweaks the cellvoltage readings for the Dacia Spring CMFA platform

### Why
Sum of all cellvoltages is >6V larger than pack voltage!

### How
We multiply all cellvoltage readings with 1000/1024, same as on Renault Zoe

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
