### PR TITLE
Fix Aws's template processor to avoid parsing inserted values again (settings page was breaking due to % chars)

### DIFF
--- a/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebResponses.cpp
+++ b/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebResponses.cpp
@@ -588,6 +588,10 @@ size_t AsyncAbstractResponse::_fillBufferAndProcessTemplates(uint8_t *data, size
         const size_t roomTaken = pTemplateStart + numBytesCopied - pTemplateEnd - 1;
         len = std::min(len + roomTaken, originalLen);
       }
+      // Battery Emulator Fix: update pTemplateStart to point after inserted
+      // parameter value, so that % characters in the inserted value aren't
+      // parsed again
+      pTemplateStart += numBytesCopied;
     }
   }  // while(pTemplateStart)
   return len;


### PR DESCRIPTION
### What
There is a bizarre issue where entering % characters in any setting will break the page when it reloads. This seems to be because % characters are used by AsyncWebServer's template processor to delimit substitution variable names, and AsyncWebServer incorrectly parses the substituted value again.

A straightforward fix is to add on the length of the substitution output onto the pointer into the working data, which skips past the inserted data and fixes the issue.

**However**, this is not a complete fix, as there is a streaming mode where the template is processed in chunks, and the substituted value may be too long to fit in the current chunk and so gets stored for the next iteration. In this case the next invocation of the processor would need to skip past the initial content that was the result of a substitution the previous time, but the code is difficult to read and so it is not immediately clear how to do this.

This isn't a problem for BE since it doesn't use the streaming mode to render templates, hence this proposed fix.