### PR TITLE
Fronius: Safety :warning:  Force SOC% to never go below 1% to avoid overdischarge

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -83,7 +83,11 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   }
   mbPV[300] = datalayer.battery.status.bms_status;
   mbPV[302] = 128 + bms_char_dis_status;
-  mbPV[303] = datalayer.battery.status.reported_soc;
+  if (datalayer.battery.status.reported_soc < 100) {
+    mbPV[303] = 100;  //Force SOC to never go below 1% to avoid overdischarge
+  } else {
+    mbPV[303] = datalayer.battery.status.reported_soc;
+  }
   if (battery2) {
     mbPV[304] = std::min(datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh,
                          static_cast<uint32_t>(60000u));  //Cap to 60kWh


### PR DESCRIPTION
### What
This PR makes it so that SOC% can never be 0% for BYD Modbus

### Why
Fronius has changed something recently when it comes to SOC% and charging. Previously it allowed forced charging between 0-5% to avoid overdischarged batteries. But now this only seems to work between 1-5%, and if the battery reports 0% it stops the attempt to force charge

### How
We fix this by never reporting below 1% SOC for Fronius Modbus protocol

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
