### PR TITLE
BMW i3: Bugfix, update SOC init to 50%

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -333,7 +333,7 @@ class BmwI3Battery : public CanBattery {
   uint32_t battery_BEV_available_power_longterm_charge = 0;
   uint32_t battery_BEV_available_power_longterm_discharge = 0;
   uint16_t battery_energy_content_maximum_Wh = 0;
-  uint16_t battery_display_SOC = 0;
+  uint16_t battery_display_SOC = 100;
   uint16_t battery_volts = 0;
   uint16_t battery_HVBatt_SOC = 0;
   uint16_t battery_DC_link_voltage = 0;


### PR DESCRIPTION
### What
This PR inits i3 SOC to 50% instead of 0%

### Why
Secondary battery not joined will cause SOC% to get stuck at 0%
<img width="665" height="487" alt="image" src="https://github.com/user-attachments/assets/7d2a555f-8342-4fc9-826c-15d5b2a52e33" />

### How
We fix this by initing soc to 50%

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
