### PR TITLE
Zoe2: Fix integer division oopsie

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -50,7 +50,7 @@ void RenaultZoeGen2Battery::update_values() {
   datalayer_battery->status.current_dA = ((battery_current - 32640) * 0.3125f);
 
   //Calculate the total Wh amount from SOH%
-  datalayer_battery->info.total_capacity_Wh = 52000 * (datalayer_battery->status.soh_pptt / 10000);
+  datalayer_battery->info.total_capacity_Wh = 52000 * (datalayer_battery->status.soh_pptt / 10000.0);
 
   //Calculate the remaining Wh amount from SOC% and max Wh value.
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(


### PR DESCRIPTION
### What
This PR fixes the Zoe2 capacity calculation that was incorrectly broken to 0Wh in firmware 9.3.0

### Why
Capacity was locked to 0Wh

### How
We fix integer division oopsie

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
