### PR TITLE
Remove CSS rules that previously didn't work, but now do and mess up the styling

### DIFF
--- a/Software/src/devboard/webserver/cellmonitor_html.cpp
+++ b/Software/src/devboard/webserver/cellmonitor_html.cpp
@@ -14,7 +14,7 @@ String cellmonitor_processor(const String& var) {
         "cursor: pointer; border-radius: 10px; }";
     content += "button:hover { background-color: #3A4A52; }";
     content += ".container { display: flex; flex-wrap: wrap; justify-content: space-around; }";
-    content += ".cell { width: 48%; margin: 1%; padding: 10px; border: 1px solid white; text-align: center; }";
+    content += ".cell { padding: 10px; border: 1px solid white; text-align: center; }";
     content += ".low-voltage { color: red; }";              // Style for low voltage text
     content += ".voltage-values { margin-bottom: 10px; }";  // Style for voltage values section
 

--- a/Software/src/devboard/webserver/events_html.cpp
+++ b/Software/src/devboard/webserver/events_html.cpp
@@ -5,7 +5,7 @@
 #include "../../devboard/utils/millis64.h"
 
 const char EVENTS_HTML_START[] = R"=====(
-<style>body{background-color:#000;color:#fff}.event-log{display:flex;flex-direction:column}.event{display:flex;flex-wrap:wrap;border:1px solid #fff;padding:10px}.event>div{flex:1;min-width:100px;max-width:90%;word-break:break-word}</style><div style="background-color:#303e47;padding:10px;margin-bottom:10px;border-radius:25px"><div class="event-log"><div class="event" style="background-color:#1e2c33;font-weight:700"><div>Event Type</div><div>Severity</div><div>Last Event</div><div>Count</div><div>Data</div><div>Message</div></div>
+<style>body{background-color:#000;color:#fff}.event-log{display:flex;flex-direction:column}.event{display:flex;flex-wrap:wrap;border:1px solid #fff;padding:10px}.event>div{flex:1;min-width:100px;word-break:break-word}</style><div style="background-color:#303e47;padding:10px;margin-bottom:10px;border-radius:25px"><div class="event-log"><div class="event" style="background-color:#1e2c33;font-weight:700"><div>Event Type</div><div>Severity</div><div>Last Event</div><div>Count</div><div>Data</div><div>Message</div></div>
 )=====";
 const char EVENTS_HTML_END[] = R"=====(
 </div></div>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -923,8 +923,6 @@ String processor(const String& var) {
     content += "  padding: 8px;";
     content += "  position: absolute;";
     content += "  z-index: 1;";
-    content += "  bottom: 125%;";
-    content += "  left: 50%;";
     content += "  margin-left: -100px;";
     content += "  opacity: 0;";
     content += "  transition: opacity 0.3s;";


### PR DESCRIPTION
### What
As of the recent Aws escaping fix, some of the styling in the HTML has messed up:

- The cellmonitor cells are now full-width rather than tiling
- The contactor status tooltip has gone missing

The cause is that percent signs were previously being stripped out, but now they're not, so these CSS rules previously weren't doing anything, but now they work, and mess up the pages.

Have removed these erroneous styles to keep things looking how they used to.