### PR TITLE
BMW iX-4-7: Fix negative temperature readings :cold_face: 

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -704,9 +704,9 @@ void BmwIXBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
       if ((rx_frame.DLC == 16) && (rx_frame.data.u8[4] == 0xDD) &&
           (rx_frame.data.u8[5] == 0xC0)) {  //Battery Temperature
-        min_battery_temperature = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]) / 10;
-        avg_battery_temperature = (rx_frame.data.u8[10] << 8 | rx_frame.data.u8[11]) / 10;
-        max_battery_temperature = (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]) / 10;
+        min_battery_temperature = (int16_t)(rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]) / 10;
+        avg_battery_temperature = (int16_t)(rx_frame.data.u8[10] << 8 | rx_frame.data.u8[11]) / 10;
+        max_battery_temperature = (int16_t)(rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]) / 10;
       }
       if ((rx_frame.DLC == 7) &&
           (rx_frame.data.u8[4] == 0xA3)) {  //Main Contactor Temperature CHECK FINGERPRINT 2 LEVEL


### PR DESCRIPTION
### What
This PR fixes the glitched temperature values that occurred on BMW iX /i4-i7 platform batteries

### Why
Negative temperature readings were ballooned to 600+degrees

### How
We interpret int16_t value correctly before shifting decimal

Before fix: Min temp 654.6°C, Max temp 0.3°C
After fix: Min temp -0.6°C, Max temp +0.4°C

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
