### PR TITLE
Double/Triple battery: Change SOC checks to see if extra batteries are used

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -362,27 +362,15 @@ void update_calculated_values(unsigned long currentMillis) {
     }
   }
 
-  if (battery2) {
-    // Perform extra SOC sanity checks on double battery setups
-    if (datalayer.battery.status.real_soc < 100) {  //If this battery is under 1.00%, use this as SOC instead of average
-      datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    }
-    if (datalayer.battery2.status.real_soc <
-        100) {  //If this battery is under 1.00%, use this as SOC instead of average
+  //Check each extra battery, and if they are at the extremes, report the SOC from these batteries instead
+  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing) {  //Battery2 is in the mix
+    if ((datalayer.battery2.status.real_soc < 100) || (datalayer.battery2.status.real_soc > 9900)) {
       datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
     }
-
-    if (datalayer.battery.status.real_soc >
-        9900) {  //If this battery is over 99.00%, use this as SOC instead of average
-      datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    }
-    if (datalayer.battery2.status.real_soc >
-        9900) {  //If this battery is over 99.00%, use this as SOC instead of average
-      datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
+  }
+  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing) {  //Battery3 is in the mix
+    if ((datalayer.battery3.status.real_soc < 100) || (datalayer.battery3.status.real_soc > 9900)) {
+      datalayer.battery.status.reported_soc = datalayer.battery3.status.real_soc;
     }
   }
 }


### PR DESCRIPTION
### What
This PR remakes the sanity SOC check on double/triple battery setups

### Why
User reported bug on Discord. This scenario led to inverter getting 99% SOC all the time, even though battery2 was disconnected

<img width="914" height="850" alt="image" src="https://github.com/user-attachments/assets/5a0462be-ac90-4110-ab0b-07f5f9abac80" />

### How
The check was hastily made back when double-battery support was introduced. We now refactor this to also check if the battery is actively in use before thinking if we want to use the SOC from it or not. We only now use the SOC as main reported value towards inverter, if it is in use, and is <1% or >99%. This is to prevent overcharging with Deye inverters mainly. 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
