### PR TITLE
Add configurable MQTT publish interval setting

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -172,6 +172,7 @@ void init_stored_settings() {
   passwordAP = settings.getString("APPASSWORD", "123456789").c_str();
   mqtt_enabled = settings.getBool("MQTTENABLED", false);
   mqtt_timeout_ms = settings.getUInt("MQTTTIMEOUT", 2000);
+  mqtt_publish_interval_ms = settings.getUInt("MQTTPUBLISHMS", 5000);
   ha_autodiscovery_enabled = settings.getBool("HADISC", false);
   mqtt_transmit_all_cellvoltages = settings.getBool("MQTTCELLV", false);
   custom_hostname = settings.getString("HOSTNAME").c_str();

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -45,6 +45,7 @@ extern const char* version_number;  // The current software version, used for mq
 extern bool mqtt_enabled;
 extern bool mqtt_transmit_all_cellvoltages;
 extern uint16_t mqtt_timeout_ms;
+extern uint16_t mqtt_publish_interval_ms;
 extern bool ha_autodiscovery_enabled;
 extern std::string mqtt_server;
 extern std::string mqtt_user;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -504,6 +504,10 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return String(settings.getUInt("MQTTTIMEOUT", 2000));
   }
 
+  if (var == "MQTTPUBLISHMS") {
+    return String(settings.getUInt("MQTTPUBLISHMS", 5000) / 1000);
+  }
+
   if (var == "MQTTOBJIDPREFIX") {
     return settings.getString("MQTTOBJIDPREFIX");
   }
@@ -1481,6 +1485,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input name='MQTTTIMEOUT' type='number' value="%MQTTTIMEOUT%" 
         min="1" max="60000" step="1"
         title="Timeout in milliseconds (1-60000)" />
+        <label>MQTT publish interval (seconds): </label>
+        <input name='MQTTPUBLISHMS' type='number' value="%MQTTPUBLISHMS%" 
+        min="1" max="300" step="1"
+        title="How often to publish MQTT messages in seconds (1-300, step 1). Default: 5" />
         <label>Send all cellvoltages via MQTT: </label><input type='checkbox' name='MQTTCELLV' value='on' %MQTTCELLV% />
         <label>Remote BMS reset via MQTT allowed: </label>
         <input type='checkbox' name='REMBMSRESET' value='on' %REMBMSRESET% />

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -537,6 +537,9 @@ void init_webserver() {
       } else if (p->name() == "MQTTTIMEOUT") {
         auto port = atoi(p->value().c_str());
         settings.saveUInt("MQTTTIMEOUT", port);
+      } else if (p->name() == "MQTTPUBLISHMS") {
+        auto interval = atoi(p->value().c_str()) * 1000;  // Convert seconds to milliseconds
+        settings.saveUInt("MQTTPUBLISHMS", interval);
       } else if (p->name() == "MQTTOBJIDPREFIX") {
         settings.saveString("MQTTOBJIDPREFIX", p->value().c_str());
       } else if (p->name() == "MQTTDEVICENAME") {


### PR DESCRIPTION
### What
This PR implements a configurable MQTT publish interval setting that can be adjusted through the web interface.

### Why
The MQTT publish interval was previously hardcoded to 5 seconds. Users with different monitoring needs or network constraints may want to adjust how frequently the Battery Emulator publishes data to MQTT. Some users may want more frequent updates (e.g., 1-2 seconds) for real-time monitoring, while others may prefer less frequent updates (e.g., 10-30 seconds) to reduce network traffic or MQTT broker load.

### How

- Added a new MQTTPUBLISHMS setting that is stored in NVM (default: 5000ms/5 seconds)
- Added a user-friendly input field in the Settings → MQTT section that accepts values in seconds (1-60 seconds)
- The web interface converts between seconds (user-facing) and milliseconds (internal storage)
- Modified [mqtt.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to configure the publish timer dynamically on first use instead of using a hardcoded value
- The setting persists across reboots and takes effect after saving and restarting

