### PR TITLE
Add support for MG5

### DIFF
--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -78,34 +78,32 @@ void Mg5Battery::update_soc(uint16_t soc_times_ten) {
     datalayer.battery.status.remaining_capacity_Wh = 0;
   }
 
-
-//#if MG5_USE_FULL_CAPACITY
+  //#if MG5_USE_FULL_CAPACITY
 
   // Calculate the maximum charge power. Taper the charge power between 90% and 100% SoC, as 100% SoC is approached
-    if (RealSoC < StartChargeTaper ) {
-      datalayer.battery.status.max_charge_power_W = MaxChargePower;
-    } else if (RealSoC >= 100) {
-      datalayer.battery.status.max_charge_power_W = TricklePower;
-    } else {
-      //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
-      datalayer.battery.status.max_charge_power_W =
-          (MaxChargePower * pow(((100 - RealSoC) / (100 - StartChargeTaper)), ChargeTaperExponent)) + TricklePower;
-    }
+  if (RealSoC < StartChargeTaper) {
+    datalayer.battery.status.max_charge_power_W = MaxChargePower;
+  } else if (RealSoC >= 100) {
+    datalayer.battery.status.max_charge_power_W = TricklePower;
+  } else {
+    //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
+    datalayer.battery.status.max_charge_power_W =
+        (MaxChargePower * pow(((100 - RealSoC) / (100 - StartChargeTaper)), ChargeTaperExponent)) + TricklePower;
+  }
 
-    // Calculate the maximum discharge power. Taper the discharge power between 10% and Min% SoC, as Min% SoC is approached
-    if (RealSoC > StartDischargeTaper) {
-      datalayer.battery.status.max_discharge_power_W = MaxDischargePower;
-    } else if (RealSoC < MinSoC) {
-      datalayer.battery.status.max_discharge_power_W = TricklePower;
-    } else {
-      //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
-      datalayer.battery.status.max_discharge_power_W =
-          (MaxDischargePower * pow(((RealSoC - MinSoC) / (StartDischargeTaper - MinSoC)), DischargeTaperExponent)) +
-          TricklePower;
-    }
+  // Calculate the maximum discharge power. Taper the discharge power between 10% and Min% SoC, as Min% SoC is approached
+  if (RealSoC > StartDischargeTaper) {
+    datalayer.battery.status.max_discharge_power_W = MaxDischargePower;
+  } else if (RealSoC < MinSoC) {
+    datalayer.battery.status.max_discharge_power_W = TricklePower;
+  } else {
+    //Taper the charge to the Trickle value. The shape and start point of the taper is set by the constants
+    datalayer.battery.status.max_discharge_power_W =
+        (MaxDischargePower * pow(((RealSoC - MinSoC) / (StartDischargeTaper - MinSoC)), DischargeTaperExponent)) +
+        TricklePower;
+  }
 
-//#endif
-
+  //#endif
 }
 
 void Mg5Battery::print_formatted_dtc(uint32_t dtc24, uint8_t status) {
@@ -239,9 +237,8 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
 
       if (rx_frame.data.u8[1] == 0x03 && previousState != 0x03) {
-        datalayer.system.status.battery_allows_contactor_closing = true; //signal to the UI that contactors are closed
-      }
-      else{
+        datalayer.system.status.battery_allows_contactor_closing = true;  //signal to the UI that contactors are closed
+      } else {
         datalayer.system.status.battery_allows_contactor_closing = false;
       }
 

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -58,9 +58,8 @@ class Mg5Battery : public CanBattery {
   uint8_t transmitIndex = 0;  //For polling switchcase
   uint8_t previousState = 0;
 
-  const int MaxChargePower =
-      11000;  // Maximum allowable charge power for the battery cells, excluding the taper, 
-  const int StartChargeTaper = 90;  // Battery percentage above which the charge power will taper to zero
+  const int MaxChargePower = 11000;  // Maximum allowable charge power for the battery cells, excluding the taper,
+  const int StartChargeTaper = 90;   // Battery percentage above which the charge power will taper to zero
   const float ChargeTaperExponent =
       1;  // Shape of charge power taper to zero. 1 is linear. >1 reduces quickly and is small at nearly full.
   const int TricklePower = 20;  // Minimimum trickle charge or discharge power (W)


### PR DESCRIPTION
### What
This PR implements support for MG5. It is tested for MG5 52.5kWh battery using stark.

### Why
To use the MG5 battery

### How
Based on MG HS PHEV.
main changes:
1) The hybridCAN does not seem to contain SOC info in the 3AC can messages, so I only use the SOC info from the PTCAN.
2) Sending the 8A can message with byte 5=0x00 does close the contactors, but it also generate  a DTC error 0293:"Lost Communication with Vehicle Control
Unit(VCU)". This prevents the contactors from closing again when when sending 8A with byte  5=0x02. I can close the contactors however by clearing the DTC's after sending byte 5=0x02.
3) changed to amount of cells, max power, limits,...
4) Added support for reading and resetting the DTC's and opening/closing the contactors

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
