### PR TITLE
Shunt: Fix current decoding on BYD CAN

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -113,7 +113,7 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       inverterStartedUp = true;
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       inverter_voltage = ((rx_frame.data.u8[0] << 8) | rx_frame.data.u8[1]) * 0.1;
-      inverter_current = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]) * 0.1;
+      inverter_current = (int16_t)((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
       inverter_temperature = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.1;
       if (useAsShunt) {
         datalayer.shunt.available = true;
@@ -122,8 +122,8 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
         datalayer.shunt.measured_voltage_dV = inverter_voltage;
         datalayer.shunt.measured_voltage_mV = inverter_voltage * 100;
         datalayer.shunt.measured_outvoltage_mV = inverter_voltage * 100;
-        datalayer.shunt.measured_amperage_dA = inverter_current;
-        datalayer.shunt.measured_amperage_mA = inverter_current * 100;
+        datalayer.shunt.measured_amperage_dA = inverter_current / 10;
+        datalayer.shunt.measured_amperage_mA = inverter_current * 10;
       }
       break;
     case 0x0D1:


### PR DESCRIPTION
### What
This PR Fixes the current decoding on BYD CAN, for when using values as a shunt

### Why
Fixes #1853

### How
Proper handling of bits

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
