### PR TITLE
Improvement: Hide access point password field entry

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1414,7 +1414,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         required />
 
         <label>Access point password: </label>
-        <input type='text' name='APPASSWORD' value="%APPASSWORD%" 
+        <input type='password' name='APPASSWORD' value="%APPASSWORD%" 
         pattern="[ -~]{8,63}" 
         title="Password must be 8-63 characters long, printable ASCII only"
         required />


### PR DESCRIPTION
### What
This PR hides the entered AP password

### Why
Better security when taking a screenshot of the settings page

### How
The data entered  in the password field is now *********

<img width="497" height="102" alt="image" src="https://github.com/user-attachments/assets/248f6fad-72b0-4a80-83eb-2ff8e831b3cc" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
