### PR TITLE
Improvement: Hide shunt interface if set to None

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -974,7 +974,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     form[data-battery="0"] .if-battery { display: none; }
     form[data-inverter="0"] .if-inverter { display: none; }    
     form[data-charger="0"] .if-charger { display: none; }
-    form[data-shunt="0"] .if-shunt { display: none; }
+    form[data-SHUNTTYPE="0"] .if-shunt { display: none; }
 
     form .if-cbms { display: none; }
     form[data-battery="6"] .if-cbms, form[data-battery="11"] .if-cbms, form[data-battery="22"] .if-cbms, form[data-battery="23"] .if-cbms, form[data-battery="24"] .if-cbms, form[data-battery="31"] .if-cbms, form[data-battery="41"] .if-cbms {


### PR DESCRIPTION
### What
This PR hides shunt interface if set to None

### Why
Less confusing for users

### How

<img width="971" height="146" alt="image" src="https://github.com/user-attachments/assets/51dc72b6-b84c-42ae-b4ae-2d3a2609208c" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
