### PR TITLE
BYD Dolphin: Fix voltage reading

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -151,7 +151,9 @@ void BydAttoBattery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   if (BMS_voltage > 0) {
-    datalayer_battery->status.voltage_dV = BMS_voltage * 10;
+    datalayer_battery->status.voltage_dV = BMS_voltage * 10;  //Polled value
+  } else if (battery_voltage > 0) {
+    datalayer_battery->status.voltage_dV = battery_voltage * 10;  //Value from periodic CAN data
   }
 
   if (battery_type == EXTENDED_RANGE) {


### PR DESCRIPTION
### What
This PR fixes the BYD Dolphin voltage reading

### Why
It was stuck at never read on some packs

### How
We now switch between using polled/periodic value depending on which is available

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
