### PR TITLE
MQTT: Increase buffer, move to stack, de-static various things

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -38,7 +38,7 @@
 #include <string>
 #include <vector>
 
-#define MQTT_MSG_BUFFER_SIZE (1024)
+#define MQTT_MSG_BUFFER_SIZE (4096)
 
 extern const char* version_number;  // The current software version, used for mqtt
 
@@ -55,8 +55,6 @@ extern const char* mqtt_topic_name;
 extern const char* mqtt_object_id_prefix;
 extern const char* mqtt_device_name;
 extern const char* ha_device_id;
-
-extern char mqtt_msg[MQTT_MSG_BUFFER_SIZE];
 
 bool init_mqtt(void);
 void mqtt_client_loop(void);


### PR DESCRIPTION
### What
Several tweaks to the MQTT library:
- Increase the buffer size from 1024 to 4096 bytes
- Dynamically allocate it at the start of the mqtt routine and free at the end.
- Fail gracefully if allocation fails.
- Remove the `static`s on the various JsonDocuments (not sure why this is necessary, they all got cleared anyway)

### Why
Should increase the space for MQTT messages (which is causing issues currently), and reduce overall RAM usage.

The mqtt_loop task has a 4096 byte stack is probably unnecessarily large (can look at tuning that later).

Needs testing by someone with a complex MQTT setup!

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
