### PR TITLE
Fix missing includes

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -1,5 +1,7 @@
 #include "BATTERIES.h"
 #include "../datalayer/datalayer_extended.h"
+#include "../devboard/hal/hal.h"
+#include "../devboard/utils/logging.h"
 #include "CanBattery.h"
 #include "RS485Battery.h"
 
@@ -143,7 +145,7 @@ const battery_chemistry_enum battery_chemistry_default = battery_chemistry_enum:
 
 battery_chemistry_enum user_selected_battery_chemistry = battery_chemistry_default;
 
-BatteryType user_selected_battery_type = BatteryType::NissanLeaf;
+BatteryType user_selected_battery_type = BatteryType::None;
 bool user_selected_second_battery = false;
 bool user_selected_triple_battery = false;
 

--- a/Software/src/charger/CHARGERS.h
+++ b/Software/src/charger/CHARGERS.h
@@ -1,6 +1,8 @@
 #ifndef CHARGERS_H
 #define CHARGERS_H
 
+#include "CanCharger.h"
+
 #include "CHEVY-VOLT-CHARGER.h"
 #include "NISSAN-LEAF-CHARGER.h"
 

--- a/Software/src/charger/CanCharger.h
+++ b/Software/src/charger/CanCharger.h
@@ -71,4 +71,6 @@ class CanCharger : public Charger, Transmitter, CanReceiver {
   void transmit_can_frame(CAN_frame* frame) { transmit_can_frame_to_interface(frame, can_interface); }
 };
 
+extern CanCharger* charger;
+
 #endif

--- a/Software/src/devboard/display/display.cpp
+++ b/Software/src/devboard/display/display.cpp
@@ -12,6 +12,7 @@ void update_display() {}
 
 #include "../../battery/BATTERIES.h"
 #include "../../datalayer/datalayer.h"
+#include "../hal/hal.h"
 #include "../utils/events.h"
 #include "../utils/logging.h"
 #include "fonts.h"

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -7,6 +7,8 @@
 #include "../../battery/BATTERIES.h"
 #include "../../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../../datalayer/datalayer.h"
+#include "../../devboard/hal/hal.h"
+#include "../../devboard/safety/safety.h"
 #include "../../lib/bblanchon-ArduinoJson/ArduinoJson.h"
 #include "../utils/events.h"
 #include "../utils/timer.h"

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
+#include "../../battery/Shunt.h"
 #include "../../charger/CHARGERS.h"
 #include "../../communication/can/comm_can.h"
 #include "../../communication/contactorcontrol/comm_contactorcontrol.h"
@@ -11,6 +12,7 @@
 #include "../../communication/nvm/comm_nvm.h"
 #include "../../datalayer/datalayer.h"
 #include "../../datalayer/datalayer_extended.h"
+#include "../../devboard/safety/safety.h"
 #include "../../inverter/INVERTERS.h"
 #include "../../lib/bblanchon-ArduinoJson/ArduinoJson.h"
 #include "../sdcard/sdcard.h"


### PR DESCRIPTION
### What
Adding missing includes

### Why
During a strip-down operation in the Battery Emulator code I have found
some missing includes that were preventing the correctly compile the
project. Most likely in the full project (all inverter and batteries compiled)
the build system is not complaining because the missing objects and functions
are indirectly included.

### How
Adding missing includes

Signed-off-by: madymax <darkmadymax@yahoo.com>

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
