### PR TITLE
Library :books: : Update ESP32 to v3.3.5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = ./Software
 
 [env:esp32dev] 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -22,7 +22,7 @@ build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:lilygo_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -35,7 +35,7 @@ build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:stark_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -48,7 +48,7 @@ build_flags = -I include -DHW_STARK -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough 
 lib_deps = 
 
 [env:lilygo_2CAN_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.35/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder


### PR DESCRIPTION
### What
This PR updates the ESP32 backbone to v3.3.5

### Why
Smaller flash usage which we desperately need, and fixes #1884

Before:
RAM:   [===       ]  25.2% (used 82432 bytes from 327680 bytes)
Flash: [==========]  99.6% (used 1957519 bytes from 1966080 bytes)
After:
RAM:   [===       ]  25.4% (used 83100 bytes from 327680 bytes)
Flash: [==========]  99.4% (used 1954255 bytes from 1966080 bytes)

### How
We update from v3.3.0 -> v3.3.5

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
