### PR TITLE
MQTT: Replace watchdog timer with 60s check from connectivity loop

### DIFF
--- a/Software/src/devboard/utils/watchdog.cpp
+++ b/Software/src/devboard/utils/watchdog.cpp
@@ -1,0 +1,17 @@
+#include "watchdog.h"
+#include "logging.h"
+
+#include <Arduino.h>
+
+void Watchdog::update() {
+  last_update_time_ms = millis();
+}
+
+void Watchdog::panic_if_exceeded_ms(uint32_t timeout_ms, const char* message) {
+  unsigned long current_time_ms = millis();
+  unsigned long last_time_ms = last_update_time_ms.load();
+  if (last_time_ms > 0 && (current_time_ms - last_time_ms) > timeout_ms) {
+    logging.println(message);
+    esp_system_abort(message);
+  }
+}

--- a/Software/src/devboard/utils/watchdog.h
+++ b/Software/src/devboard/utils/watchdog.h
@@ -1,0 +1,14 @@
+#include <atomic>
+
+class Watchdog {
+ public:
+  // Call this periodically to reset the watchdog timer. The timer is inactive
+  // until the first call.
+  void update();
+  // Panic if the time since the last update exceeds timeout_ms. If update has
+  // never been called, this does nothing.
+  void panic_if_exceeded_ms(uint32_t timeout_ms, const char* message);
+
+ private:
+  std::atomic<unsigned long> last_update_time_ms = 0;
+};


### PR DESCRIPTION
### What
This removes the ESP32 watchdog timer setup/reset from the MQTT loop, and instead adds an atomic last-looped-time variable, which is set during the loop, and checked from the connectivity loop.

This allows the timeout to be increased to 60s, avoiding nuisance resets due to wdt timeouts under heavy load (since the mqtt_loop runs with a low priority, it can easily be blocked for 5s.

The code is a bit messy, there's probably a neater way of doing it...

(Also increases the mqtt_loop delay from 1ms to 100ms, given that it publishes at most every 800ms anyway).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
