### PR TITLE
BYD Atto3: Add SOH% candidate

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -173,6 +173,8 @@ void BydAttoBattery::
     datalayer_battery->status.real_soc = battery_estimated_SOC;
   }
 
+  datalayer_battery->status.soh_pptt = BMS_SOH * 100;
+
   datalayer_battery->status.current_dA = -BMS_current;
 
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
@@ -395,6 +397,7 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x444:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
+      BMS_SOH = rx_frame.data.u8[4];
       //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
       BMS_voltage_available = true;
       break;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -128,6 +128,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t counter_100ms = 0;
   uint8_t frame6_counter = 0xB;
   uint8_t frame7_counter = 0x5;
+  uint8_t BMS_SOH = 99;
   uint8_t BMS_unknown10 = 0;
   uint8_t BMS_unknown11 = 0;
   uint8_t BMS_unknown12 = 0;


### PR DESCRIPTION
### What
This PR implements SOH% readout for BYD batteries

### Why
Previously we have not set any SOH% value on BYD batteries, and value has just been locked to default 99%.

### How
Thanks to the CAN deverse engineering done by demon1300 over on the Discord server, we now have a suitable candidate for SOH% :raised_hands: 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
