### PR TITLE
BYD Atto 3: Experimental cell balancing

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,7 +594,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {                      // initially enabled
       if (uptime_ticks > 50) {                    // bms running for 10s min, ensure contactors closed etc
-        if (BMS_lowest_cell_voltage_mV > 3599) {  // if minimum cell voltage >=3.6v
+        if (BMS_highest_cell_voltage_mV > 3650) {  // if max cell voltage >=3.6v
           uds_reset = false;                      // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -102,7 +102,8 @@ const uint16_t voltage_extended[numPoints] = {4300, 4250, 4230, 4205, 4180, 4175
 const uint16_t voltage_standard[numPoints] = {3570, 3552, 3485, 3464, 3443, 3439, 3435, 3434, 3433, 3429,
                                               3425, 3412, 3400, 3396, 3392, 3391, 3390, 3382, 3375, 3362,
                                               3350, 3332, 3315, 3282, 3250, 3195, 3170, 3140};
-
+bool uds_reset = true;
+unsigned long uptime_ticks = 0;
 uint16_t estimateSOCextended(uint16_t packVoltage) {  // Linear interpolation function
   if (packVoltage >= voltage_extended[0]) {
     return SOC[0];
@@ -588,6 +589,23 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
     previousMillis200 = currentMillis;
+    
+  uptime_ticks++;
+ 
+    if (uds_reset == true){    // initially enabled
+      if (uptime_ticks > 50){  // bms running for 10s min, ensure contactors closed etc
+        if (BMS_lowest_cell_voltage_mV > 3599){ // if minimum cell voltage >=3.6v
+      uds_reset = false;       // reset to false, wait 12hrs       
+     transmit_can_frame(&ATTO_3_RESET);
+        }
+      }
+    }
+   
+ 
+    if (uptime_ticks > 0x34bc0){  // 12hrs * 60min * 60s * 5 * 200millis = 216000u
+       uptime_ticks = 0;
+      uds_reset = true;  //enable uds_reset after 12hrs
+    }
 
     switch (poll_state) {
       case POLL_FOR_BATTERY_SOC:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,10 +594,12 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {    // initially enabled
       if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660) || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) > 160) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
+        if (BMS_highest_cell_voltage_mV >= 3660)
+          || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) >
+              160) {            // if max cell voltage >=3.66v, 3.65 isnt enough..
             uds_reset = false;  // reset to false, wait 12hrs
             transmit_can_frame(&ATTO_3_RESET);
-        }
+          }
       }
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,7 +594,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {                        // initially enabled
       if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
+        if (BMS_highest_cell_voltage_mV >= 3660) || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) > 160 {  // if max cell voltage >=3.66v, 3.65 isnt enough..
           uds_reset = false;                        // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -593,13 +593,14 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     uptime_ticks++;
 
-    if (uds_reset == true) {                        // initially enabled
-      if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
+    if (uds_reset == true) {    // initially enabled
+      if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
         celldeltaMv = BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV;
-         if (BMS_highest_cell_voltage_mV > 3600) || (celldeltaMv > 100) { // if max cell voltage >3.6v or pack cell delta > 100mV  
-          uds_reset = false;                        // reset to false, wait 12hrs
-          transmit_can_frame(&ATTO_3_RESET);
-        }
+        if (BMS_highest_cell_voltage_mV > 3600)
+          || (celldeltaMv > 100) {  // if max cell voltage >3.6v or pack cell delta > 100mV
+            uds_reset = false;      // reset to false, wait 12hrs
+            transmit_can_frame(&ATTO_3_RESET);
+          }
       }
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,7 +594,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {                       // initially enabled
       if (uptime_ticks > 50) {                     // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV > 3650) {  // if max cell voltage >=3.6v
+        if (BMS_highest_cell_voltage_mV >= 3660) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
           uds_reset = false;                       // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -592,12 +592,12 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     uptime_ticks++;
 
-    if (uds_reset == true) {    // initially enabled
-      if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660) {            // if max cell voltage >=3.66v, 3.65 isnt enough..
-            uds_reset = false;  // reset to false, wait 12hrs
-            transmit_can_frame(&ATTO_3_RESET);
-          }
+    if (uds_reset == true) {                        // initially enabled
+      if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
+        if (BMS_highest_cell_voltage_mV >= 3660) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
+          uds_reset = false;                        // reset to false, wait 12hrs
+          transmit_can_frame(&ATTO_3_RESET);
+        }
       }
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,7 +594,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {    // initially enabled
       if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660) || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) > 160 {  // if max cell voltage >=3.66v, 3.65 isnt enough..
+        if (BMS_highest_cell_voltage_mV >= 3660) || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) > 160) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
             uds_reset = false;  // reset to false, wait 12hrs
             transmit_can_frame(&ATTO_3_RESET);
         }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -104,6 +104,7 @@ const uint16_t voltage_standard[numPoints] = {3570, 3552, 3485, 3464, 3443, 3439
                                               3350, 3332, 3315, 3282, 3250, 3195, 3170, 3140};
 bool uds_reset = true;
 unsigned long uptime_ticks = 0;
+uint16_t celldeltaMv = 0;
 uint16_t estimateSOCextended(uint16_t packVoltage) {  // Linear interpolation function
   if (packVoltage >= voltage_extended[0]) {
     return SOC[0];
@@ -594,7 +595,8 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {                        // initially enabled
       if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
+        celldeltaMv = BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV;
+         if (BMS_highest_cell_voltage_mV > 3600) || (celldeltaMv > 100) { // if max cell voltage >3.6v or pack cell delta > 100mV  
           uds_reset = false;                        // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -594,9 +594,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if (uds_reset == true) {    // initially enabled
       if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
-        if (BMS_highest_cell_voltage_mV >= 3660)
-          || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) >
-              160) {            // if max cell voltage >=3.66v, 3.65 isnt enough..
+        if (BMS_highest_cell_voltage_mV >= 3660) {            // if max cell voltage >=3.66v, 3.65 isnt enough..
             uds_reset = false;  // reset to false, wait 12hrs
             transmit_can_frame(&ATTO_3_RESET);
           }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -596,11 +596,11 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     if (uds_reset == true) {    // initially enabled
       if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
         celldeltaMv = BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV;
-       // if (BMS_highest_cell_voltage_mV > 3600)
-          if (celldeltaMv > 100) {  // if max cell voltage >3.6v or pack cell delta > 100mV
-            uds_reset = false;      // reset to false, wait 12hrs
-            transmit_can_frame(&ATTO_3_RESET);
-          }
+        // if (BMS_highest_cell_voltage_mV > 3600)
+        if (celldeltaMv > 100) {  // if max cell voltage >3.6v or pack cell delta > 100mV
+          uds_reset = false;      // reset to false, wait 12hrs
+          transmit_can_frame(&ATTO_3_RESET);
+        }
       }
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -589,21 +589,20 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
     previousMillis200 = currentMillis;
-    
-  uptime_ticks++;
- 
-    if (uds_reset == true){    // initially enabled
-      if (uptime_ticks > 50){  // bms running for 10s min, ensure contactors closed etc
-        if (BMS_lowest_cell_voltage_mV > 3599){ // if minimum cell voltage >=3.6v
-      uds_reset = false;       // reset to false, wait 12hrs       
-     transmit_can_frame(&ATTO_3_RESET);
+
+    uptime_ticks++;
+
+    if (uds_reset == true) {                      // initially enabled
+      if (uptime_ticks > 50) {                    // bms running for 10s min, ensure contactors closed etc
+        if (BMS_lowest_cell_voltage_mV > 3599) {  // if minimum cell voltage >=3.6v
+          uds_reset = false;                      // reset to false, wait 12hrs
+          transmit_can_frame(&ATTO_3_RESET);
         }
       }
     }
-   
- 
-    if (uptime_ticks > 0x34bc0){  // 12hrs * 60min * 60s * 5 * 200millis = 216000u
-       uptime_ticks = 0;
+
+    if (uptime_ticks > 0x34bc0) {  // 12hrs * 60min * 60s * 5 * 200millis = 216000u
+      uptime_ticks = 0;
       uds_reset = true;  //enable uds_reset after 12hrs
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -596,8 +596,8 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     if (uds_reset == true) {    // initially enabled
       if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
         celldeltaMv = BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV;
-        if (BMS_highest_cell_voltage_mV > 3600)
-          || (celldeltaMv > 100) {  // if max cell voltage >3.6v or pack cell delta > 100mV
+       // if (BMS_highest_cell_voltage_mV > 3600)
+          if (celldeltaMv > 100) {  // if max cell voltage >3.6v or pack cell delta > 100mV
             uds_reset = false;      // reset to false, wait 12hrs
             transmit_can_frame(&ATTO_3_RESET);
           }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -592,11 +592,11 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     uptime_ticks++;
 
-    if (uds_reset == true) {                        // initially enabled
-      if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
+    if (uds_reset == true) {    // initially enabled
+      if (uptime_ticks > 50) {  // bms running for 10s min, ensure contactors closed etc
         if (BMS_highest_cell_voltage_mV >= 3660) || ((BMS_highest_cell_voltage_mV - BMS_lowest_cell_voltage_mV) > 160 {  // if max cell voltage >=3.66v, 3.65 isnt enough..
-          uds_reset = false;                        // reset to false, wait 12hrs
-          transmit_can_frame(&ATTO_3_RESET);
+            uds_reset = false;  // reset to false, wait 12hrs
+            transmit_can_frame(&ATTO_3_RESET);
         }
       }
     }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -592,10 +592,10 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     uptime_ticks++;
 
-    if (uds_reset == true) {                       // initially enabled
-      if (uptime_ticks > 50) {                     // bms running for 10s min, ensure contactors closed etc
+    if (uds_reset == true) {                        // initially enabled
+      if (uptime_ticks > 50) {                      // bms running for 10s min, ensure contactors closed etc
         if (BMS_highest_cell_voltage_mV >= 3660) {  // if max cell voltage >=3.66v, 3.65 isnt enough..
-          uds_reset = false;                       // reset to false, wait 12hrs
+          uds_reset = false;                        // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }
       }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -592,10 +592,10 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     uptime_ticks++;
 
-    if (uds_reset == true) {                      // initially enabled
-      if (uptime_ticks > 50) {                    // bms running for 10s min, ensure contactors closed etc
+    if (uds_reset == true) {                       // initially enabled
+      if (uptime_ticks > 50) {                     // bms running for 10s min, ensure contactors closed etc
         if (BMS_highest_cell_voltage_mV > 3650) {  // if max cell voltage >=3.6v
-          uds_reset = false;                      // reset to false, wait 12hrs
+          uds_reset = false;                       // reset to false, wait 12hrs
           transmit_can_frame(&ATTO_3_RESET);
         }
       }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -82,7 +82,7 @@ class BydAttoBattery : public CanBattery {
   static const uint16_t MIN_PACK_VOLTAGE_EXTENDED_DV = 3800;  //Extended range
   static const uint16_t MAX_PACK_VOLTAGE_STANDARD_DV = 3796;  //Standard range
   static const uint16_t MIN_PACK_VOLTAGE_STANDARD_DV = 3136;  //Standard range
-  static const uint16_t MAX_CELL_DEVIATION_MV = 230;
+  static const uint16_t MAX_CELL_DEVIATION_MV = 400;
   static const uint16_t MAX_CELL_VOLTAGE_MV = 3690;  //Charging stops if one cell exceeds this value
   static const uint16_t MIN_CELL_VOLTAGE_MV = 2800;  //Discharging stops if one cell goes below this value
   static const uint16_t POLL_FOR_BATTERY_SOC = 0x0005;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -141,11 +141,11 @@ class BydAttoBattery : public CanBattery {
   int16_t battery_daughterboard_temperatures[10];
   uint16_t battery_cellvoltages[CELLCOUNT_EXTENDED] = {0};
 
- CAN_frame ATTO_3_RESET = {.FD = false,
-                          .ext_ID = false,
-                          .DLC = 8,
-                          .ID = 0x7E7,
-                          .data = {0x02, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ATTO_3_RESET = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x7E7,
+                            .data = {0x02, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame ATTO_3_12D = {.FD = false,
                           .ext_ID = false,
                           .DLC = 8,

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -141,6 +141,11 @@ class BydAttoBattery : public CanBattery {
   int16_t battery_daughterboard_temperatures[10];
   uint16_t battery_cellvoltages[CELLCOUNT_EXTENDED] = {0};
 
+ CAN_frame ATTO_3_RESET = {.FD = false,
+                          .ext_ID = false,
+                          .DLC = 8,
+                          .ID = 0x7E7,
+                          .data = {0x02, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame ATTO_3_12D = {.FD = false,
                           .ext_ID = false,
                           .DLC = 8,

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -141,11 +141,13 @@ class BydAttoBattery : public CanBattery {
   int16_t battery_daughterboard_temperatures[10];
   uint16_t battery_cellvoltages[CELLCOUNT_EXTENDED] = {0};
 
-  CAN_frame ATTO_3_RESET = {.FD = false,
-                            .ext_ID = false,
-                            .DLC = 8,
-                            .ID = 0x7E7,
-                            .data = {0x02, 0x11, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}}; //02 11 03 uds soft reset is rejected, 03 7f 11 12 sub function not supported
+  CAN_frame ATTO_3_RESET = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x7E7,
+      .data = {0x02, 0x11, 0x02, 0x00, 0x00, 0x00, 0x00,
+               0x00}};  //02 11 03 uds soft reset is rejected, 03 7f 11 12 sub function not supported
   CAN_frame ATTO_3_12D = {.FD = false,
                           .ext_ID = false,
                           .DLC = 8,

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -83,7 +83,7 @@ class BydAttoBattery : public CanBattery {
   static const uint16_t MAX_PACK_VOLTAGE_STANDARD_DV = 3796;  //Standard range
   static const uint16_t MIN_PACK_VOLTAGE_STANDARD_DV = 3136;  //Standard range
   static const uint16_t MAX_CELL_DEVIATION_MV = 230;
-  static const uint16_t MAX_CELL_VOLTAGE_MV = 3650;  //Charging stops if one cell exceeds this value
+  static const uint16_t MAX_CELL_VOLTAGE_MV = 3690;  //Charging stops if one cell exceeds this value
   static const uint16_t MIN_CELL_VOLTAGE_MV = 2800;  //Discharging stops if one cell goes below this value
   static const uint16_t POLL_FOR_BATTERY_SOC = 0x0005;
   uint16_t rampdown_power = 0;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -145,7 +145,7 @@ class BydAttoBattery : public CanBattery {
                             .ext_ID = false,
                             .DLC = 8,
                             .ID = 0x7E7,
-                            .data = {0x02, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                            .data = {0x02, 0x11, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}}; //02 11 03 uds soft reset is rejected, 03 7f 11 12 sub function not supported
   CAN_frame ATTO_3_12D = {.FD = false,
                           .ext_ID = false,
                           .DLC = 8,


### PR DESCRIPTION
### What
This PR implements ... experimental cell balancing -  requests a software reset of the bms, if the conditions to trigger balancing are present, only once every 12hours (assumes one complete charge from solar, per day. nigh-time energy arbitragers can alter the frequency)

### Why
Why does it do it? byd has an unusual mechanism where, the logic to trigger cell balancing is as such : if cell voltage >=3.66v then flag for balancing on the next power on event, normally this would be the ign on event after the bms wakes up, after a charge cycle, which does not happen in the BE, a subtle blocking condition.

### How How does it do it? add uds command to reset bms - 0x11 0x03, should testing fail, ill change this to 0x11 0x02 (keyoff)

after many many hours of observation, the exact voltage at which balancing is flagged is 3.66v - Best regards, Billy
