### PR TITLE
MG_HS_PHEV: Add UDS based BMS reset

### DIFF
--- a/Software/src/battery/MG-HS-PHEV-BATTERY.h
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.h
@@ -54,6 +54,9 @@ class MgHsPHEVBattery : public CanBattery {
   uint8_t cell_id = 0;
   uint8_t transmitIndex = 0;  //For polling switchcase
   uint8_t previousState = 0;
+  enum MG_HS_RESET_STATE { IDLE, SENDING_DIAG, SENDING_RESET, WAITING_RESET_COMPLETE };
+  MG_HS_RESET_STATE resetProgress = IDLE;
+  uint8_t resetTimeout = 0;
   static const uint8_t CELL_VOLTAGE_TIMEOUT = 10;  // in seconds
 
   const uint16_t MaxChargePower = 3000;  // Maximum allowable charge power, excluding the taper
@@ -83,6 +86,20 @@ class MgHsPHEVBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x7E5,
                               .data = {0x03, 0x22, 0xB0, 0x42, 0x00, 0x00, 0x00, 0x00}};
+
+  // Enter UDS extended-diagnostics mode
+  static constexpr CAN_frame MG_HS_7E5_DIAG = {.FD = false,
+                                               .ext_ID = false,
+                                               .DLC = 8,
+                                               .ID = 0x7E5,
+                                               .data = {0x02, 0x10, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+  // BMS hard reset
+  static constexpr CAN_frame MG_HS_7E5_RESET = {.FD = false,
+                                                .ext_ID = false,
+                                                .DLC = 8,
+                                                .ID = 0x7E5,
+                                                .data = {0x02, 0x11, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00}};
 };
 
 #endif


### PR DESCRIPTION
### What
Currently the MG HS PHEV needs an external contactor and BMS-reset to be able to recover from certain situations (including isolation failure detection).

Instead, it is possible to use a UDS hard reset command to reset the BMS, which does so in <500ms if a stuck state is detected. An external contactor is no longer required for reliable operation.

Also tidies up some things (removing some unnecessary PID-set values, changing CAN_still_alive trigger).

### Why
Makes the MG HS PHEV integration more user friendly, avoids extra hardware.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
