### PR TITLE
Nissan LEAF: Improve plausible SOC check

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -36,9 +36,9 @@ class NissanLeafBattery : public CanBattery {
   void reset_SOH() { datalayer_extended.nissanleaf.UserRequestSOHreset = true; }
 
   bool soc_plausible() {
-    // When pack voltage is close to max, and SOC% is still low, SOC is not plausible
+    // When pack voltage is close to max, and SOC% is still low (<65.0%), SOC is not plausible
     return !((datalayer.battery.status.voltage_dV > (datalayer.battery.info.max_design_voltage_dV - 100)) &&
-             (datalayer.battery.status.real_soc < 6500));
+             (battery_SOC < 650));
   }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }


### PR DESCRIPTION
### What
This PR improves plausible SOC check for Nissan LEAF

### Why
Avoid incorrect trigger of event

### How
We use the direct SOC reported by battery, instead of the value which can be re-scaled

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
