### PR TITLE
Foxess: Add cellvoltages to protocol

### DIFF
--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -29,6 +29,17 @@ void FoxessCanInverter::
   //Calculate the required values
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
+  //Foxess only supports LFP batteries. We need to fake an LFP cell voltage range if the battery used is not LFP
+  if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
+    //Already LFP, pass thru value
+    cell_tweaked_max_voltage_mV = datalayer.battery.status.cell_max_voltage_mV;
+    cell_tweaked_min_voltage_mV = datalayer.battery.status.cell_min_voltage_mV;
+  } else {  //linear interpolation to remap the value from the range [2500-4200] to [2500-3400]
+    cell_tweaked_max_voltage_mV =
+        (2500 + ((datalayer.battery.status.cell_max_voltage_mV - 2500) * (3400 - 2500)) / (4200 - 2500));
+    cell_tweaked_min_voltage_mV =
+        (2500 + ((datalayer.battery.status.cell_min_voltage_mV - 2500) * (3400 - 2500)) / (4200 - 2500));
+  }
 
   //Put the values into the CAN messages
   //BMS_Limits
@@ -57,11 +68,10 @@ void FoxessCanInverter::
   FOXESS_1874.data.u8[1] = (datalayer.battery.status.temperature_max_dC >> 8);
   FOXESS_1874.data.u8[2] = (int8_t)datalayer.battery.status.temperature_min_dC;
   FOXESS_1874.data.u8[3] = (datalayer.battery.status.temperature_min_dC >> 8);
-  FOXESS_1874.data.u8[4] =
-      (uint8_t)(datalayer.battery.status.cell_max_voltage_mV);  //TODO: Should we rescale other chemistries as LFP?
-  FOXESS_1874.data.u8[5] = (datalayer.battery.status.cell_max_voltage_mV >> 8);
-  FOXESS_1874.data.u8[6] = (uint8_t)(datalayer.battery.status.cell_min_voltage_mV);
-  FOXESS_1874.data.u8[7] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
+  FOXESS_1874.data.u8[4] = (uint8_t)(cell_tweaked_max_voltage_mV);
+  FOXESS_1874.data.u8[5] = (cell_tweaked_max_voltage_mV >> 8);
+  FOXESS_1874.data.u8[6] = (uint8_t)(cell_tweaked_min_voltage_mV);
+  FOXESS_1874.data.u8[7] = (cell_tweaked_min_voltage_mV >> 8);
 
   //BMS_Status
   FOXESS_1875.data.u8[0] = (uint8_t)temperature_average;

--- a/Software/src/inverter/FOXESS-CAN.h
+++ b/Software/src/inverter/FOXESS-CAN.h
@@ -14,6 +14,8 @@ class FoxessCanInverter : public CanInverterProtocol {
  private:
   int16_t temperature_average = 0;
   uint16_t voltage_per_pack = 0;
+  uint16_t cell_tweaked_max_voltage_mV = 3300;
+  uint16_t cell_tweaked_min_voltage_mV = 3300;
   int16_t current_per_pack = 0;
   uint8_t temperature_max_per_pack = 0;
   uint8_t temperature_min_per_pack = 0;


### PR DESCRIPTION
### What
This PR adds cell voltage sending to protocol

### Why
We were sending static 3300mV values on both low and high cellvoltage reporting towards Foxess

<img width="754" height="190" alt="image" src="https://github.com/user-attachments/assets/69b4df97-26f6-4786-85d9-d6f650b5b8e5" />

### How
We now send actual cellvoltage.

TODO for future, should we rescale NCM/NCA chemistries to appear as LFP range? 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
