### PR TITLE
Optimization: Feature gate MG5 for large flash devices

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -92,8 +92,10 @@ const char* name_for_battery_type(BatteryType type) {
       return MaxusEV80Battery::Name;
     case BatteryType::Meb:
       return MebBattery::Name;
+#ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return Mg5Battery::Name;
+#endif
     case BatteryType::MgHsPhev:
       return MgHsPHEVBattery::Name;
     case BatteryType::NissanLeaf:
@@ -201,8 +203,10 @@ Battery* create_battery(BatteryType type) {
       return new MaxusEV80Battery();
     case BatteryType::Meb:
       return new MebBattery();
+#ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return new Mg5Battery();
+#endif
     case BatteryType::MgHsPhev:
       return new MgHsPHEVBattery();
     case BatteryType::NissanLeaf:

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -1,10 +1,13 @@
 #include "MG-5-BATTERY.h"
+#include <Arduino.h>
 #include <cmath>    //For unit test
 #include <cstring>  //For unit test
 #include "../communication/can/comm_can.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/events.h"
 #include "../devboard/utils/logging.h"
+
+#ifndef SMALL_FLASH_DEVICE
 
 /* TODO: 
 - Get contactor closing working
@@ -731,3 +734,5 @@ void Mg5Battery::setup(void) {  // Performs one time setup at startup
   uds_req_started_ms = millis();            // prevent immediate timeout
   uds_timeout_ms = UDS_TIMEOUT_AFTER_BOOT;  // initial delay to restart UDS after boot-up
 }
+
+#endif

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -1,11 +1,9 @@
 #ifndef MG_5_BATTERY_H
 #define MG_5_BATTERY_H
-#include <Arduino.h>
+
 #include "CanBattery.h"
 
-#ifdef MG_5_BATTERY
-#define SELECTED_BATTERY_CLASS Mg5Battery
-#endif
+#ifndef SMALL_FLASH_DEVICE
 
 class Mg5Battery : public CanBattery {
  public:
@@ -296,5 +294,7 @@ class Mg5Battery : public CanBattery {
     return crc;
   }
 };
+
+#endif
 
 #endif


### PR DESCRIPTION
### What
This PR feature gates the MG5 integration too large flash devices

### Why
The implementation takes up 0.4% of all flash memory, which is pushing it slightly over the edge

### How
Until we can optimize it, we wrap the MG5 code in #ifndef SMALL_FLASH_DEVICE

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
