### PR TITLE
Pylon Battery: Bugfix, Init cellvoltage readings to sane values for LFP

### DIFF
--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -66,8 +66,8 @@ class PylonBattery : public CanBattery {
   int16_t celltemperature_min_dC = 0;
   int16_t current_dA = 0;
   uint16_t voltage_dV = 0;
-  uint16_t cellvoltage_max_mV = 3700;
-  uint16_t cellvoltage_min_mV = 3700;
+  uint16_t cellvoltage_max_mV = 3300;
+  uint16_t cellvoltage_min_mV = 3300;
   uint16_t charge_cutoff_voltage = 0;
   uint16_t discharge_cutoff_voltage = 0;
   int16_t max_charge_current = 0;


### PR DESCRIPTION
### What
This PR inits cellvoltage readings to sane values for LFP on the Pylon Battery protocol

### Why
Fixes #1925 , no more incorrect event about cell overvoltage on startup

### How
Instead of initing values to 3700mV (which is overvoltage for LFP chemistry), we init to 3300mV which is an OK value for any type of Li-Ion battery

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
