### PR TITLE
Feature: Add support for triple ReLion batteries :battery: :battery: :battery: 

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -313,6 +313,9 @@ void setup_battery() {
       case BatteryType::NissanLeaf:
         battery3 = new NissanLeafBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
         break;
+      case BatteryType::RelionBattery:
+        battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple);
+        break;
       default:
         DEBUG_PRINTF("User tried enabling triple battery on non-supported integration!\n");
         break;


### PR DESCRIPTION
### What
This PR implements support for triple ReLion batteries

### Why
User requested feature on the Discord

### How
<img width="856" height="627" alt="image" src="https://github.com/user-attachments/assets/b3adbfd3-0179-4048-bbc3-b8e27ad9712e" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
