### PR TITLE
Settings: bugfix to allow checkboxes to be unticked

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -490,15 +490,14 @@ void init_webserver() {
                     }
                   }
                 }
+              }
 
-                for (auto& boolSetting : boolSettingNames) {
-                  if (p->name() == boolSetting) {
-                    const bool default_value = (boolSetting == std::string("WIFIAPENABLED"));
-                    const bool value = (p->value() == "on");
-                    if (settings.getBool(boolSetting, default_value) != value) {
-                      settings.saveBool(boolSetting, value);
-                    }
-                  }
+              for (auto& boolSetting : boolSettingNames) {
+                auto p = request->getParam(boolSetting, true);
+                const bool default_value = (std::string(boolSetting) == std::string("WIFIAPENABLED"));
+                const bool value = p != nullptr && p->value() == "on";
+                if (settings.getBool(boolSetting, default_value) != value) {
+                  settings.saveBool(boolSetting, value);
                 }
               }
 


### PR DESCRIPTION
### What
My last PR that updated the settings code has unfortunately introduced a silly bug, you can't uncheck checkboxes anymore! This fixes (oops).

Has lost some of the previous gains (+176 bytes) but not all of them.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
