### PR TITLE
Fix SD Init bug when SD missing or is corrupted

### DIFF
--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -173,6 +173,17 @@ void init_logging_buffers() {
   }
 }
 
+void deinit_logging_buffers() {
+  if ((!datalayer.system.info.CAN_SD_logging_active) && (!datalayer.system.info.CAN_SD_logging_active)) {
+    if (can_bufferHandle != NULL) {
+      vRingbufferDelete(can_bufferHandle);
+    }
+    if (log_bufferHandle != NULL) {
+      vRingbufferDelete(log_bufferHandle);
+    }
+  }
+}
+
 bool init_sdcard() {
   auto miso_pin = esp32hal->SD_MISO_PIN();
   auto mosi_pin = esp32hal->SD_MOSI_PIN();

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -10,6 +10,7 @@
 #define LOG_FILE "/log.txt"
 
 void init_logging_buffers();
+void deinit_logging_buffers();
 
 bool init_sdcard();
 void log_sdcard_details();


### PR DESCRIPTION
### What
This fix is checking if the SD card was correctly initialized , otherwise it will delete the logging buffers, disable the SD logging and delete the logging task to save some memory

### Why
There are cases when SD logging is enabled without a phisical SD card present or the SD card is corrupted. In these cases a crash could happen because the SD init routine is not checking the result of init_sdcard() function and this could lead into different crashes depending on the case.

### How
Checks the init_sdcard() function return code.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
