### PR TITLE
Add runtime battery model configuration for Sungrow SBRXXX inverter

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -112,6 +112,11 @@ static const std::map<int, String> tesla_chassis = {{0, "Model S"}, {1, "Model X
 
 static const std::map<int, String> tesla_pack = {{0, "50 kWh"}, {2, "62 kWh"}, {1, "74 kWh"}, {3, "100 kWh"}};
 
+static const std::map<int, String> sungrow_models = {
+    {0, "SBR064 (6.4 kWh, 2 modules)"},  {1, "SBR096 (9.6 kWh, 3 modules)"},  {2, "SBR128 (12.8 kWh, 4 modules)"},
+    {3, "SBR160 (16.0 kWh, 5 modules)"}, {4, "SBR192 (19.2 kWh, 6 modules)"}, {5, "SBR224 (22.4 kWh, 7 modules)"},
+    {6, "SBR256 (25.6 kWh, 8 modules)"}};
+
 const char* name_for_button_type(STOP_BUTTON_BEHAVIOR behavior) {
   switch (behavior) {
     case STOP_BUTTON_BEHAVIOR::LATCHING_SWITCH:
@@ -244,6 +249,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
 
   if (var == "LEDMODE") {
     return options_from_map(settings.getUInt("LEDMODE", 0), led_modes);
+  }
+
+  if (var == "SUNGROW_MODEL") {
+    return options_from_map(settings.getUInt("INVBTYPE", 1), sungrow_models);  // Default: SBR096
   }
 #ifdef HW_LILYGO2CAN
   if (var == "GPIOOPT1") {
@@ -771,34 +780,6 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
 
   if (var == "INVBTYPE") {
     return String(settings.getUInt("INVBTYPE", 0));
-  }
-
-  if (var == "INVBTYPE_SBR064") {
-    return settings.getUInt("INVBTYPE", 3) == 2 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR096") {
-    return settings.getUInt("INVBTYPE", 3) == 3 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR128") {
-    return settings.getUInt("INVBTYPE", 3) == 4 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR160") {
-    return settings.getUInt("INVBTYPE", 3) == 5 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR192") {
-    return settings.getUInt("INVBTYPE", 3) == 6 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR224") {
-    return settings.getUInt("INVBTYPE", 3) == 7 ? "selected" : "";
-  }
-
-  if (var == "INVBTYPE_SBR256") {
-    return settings.getUInt("INVBTYPE", 3) == 8 ? "selected" : "";
   }
 
   if (var == "INVICNT") {
@@ -1381,15 +1362,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         <div class="if-sungrow">
         <label>Battery model: </label>
-        <select name='INVBTYPE'>
-        <option value="2" %INVBTYPE_SBR064%>SBR064 (6.4 kWh, 2 modules)</option>
-        <option value="3" %INVBTYPE_SBR096%>SBR096 (9.6 kWh, 3 modules)</option>
-        <option value="4" %INVBTYPE_SBR128%>SBR128 (12.8 kWh, 4 modules)</option>
-        <option value="5" %INVBTYPE_SBR160%>SBR160 (16.0 kWh, 5 modules)</option>
-        <option value="6" %INVBTYPE_SBR192%>SBR192 (19.2 kWh, 6 modules)</option>
-        <option value="7" %INVBTYPE_SBR224%>SBR224 (22.4 kWh, 7 modules)</option>
-        <option value="8" %INVBTYPE_SBR256%>SBR256 (25.6 kWh, 8 modules)</option>
-        </select>
+        <select name='INVBTYPE'>%SUNGROW_MODEL%</select>
         </div>
 
         <div class="if-kostal if-solax">

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -69,9 +69,8 @@ uint16_t modbus_crc(const uint8_t* data, uint8_t length) {
 }  // namespace
 
 bool SungrowInverter::setup() {
-  if (user_selected_inverter_battery_type > 0) {
-    battery_config = get_config_for_modules(user_selected_inverter_battery_type);
-  }
+  // Stored value is model (0-6), get_config_for_model handles default
+  battery_config = get_config_for_model(user_selected_inverter_battery_type);
 
   // Cell type for each active module
   // 0x42 = IEC

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -39,26 +39,26 @@ class SungrowInverter : public CanInverterProtocol {
   uint32_t capacity_wh = 0;
   uint8_t batch_send_index = 0;
 
-  // Battery configuration (set via user_selected_inverter_battery_type = module count)
+  // Battery configuration (set via user_selected_inverter_battery_type = model 0-6)
   SungrowBatteryConfig battery_config = {9600, 3};  // Default: SBR096
 
-  // Returns config based on module count (2=SBR064 through 8=SBR256)
-  // Each module adds 3200Wh of capacity
-  static constexpr SungrowBatteryConfig get_config_for_modules(uint16_t modules) {
-    switch (modules) {
-      case 2:
+  // Returns config based on battery model (0=SBR064 through 6=SBR256)
+  // Model + 2 = module count, each module adds 3200Wh of capacity
+  static constexpr SungrowBatteryConfig get_config_for_model(uint16_t model) {
+    switch (model) {
+      case 0:
         return {6400, 2};  // SBR064
-      case 4:
+      case 2:
         return {12800, 4};  // SBR128
-      case 5:
-        return {16000, 5};  // SBR160
-      case 6:
-        return {19200, 6};  // SBR192
-      case 7:
-        return {22400, 7};  // SBR224
-      case 8:
-        return {25600, 8};  // SBR256
       case 3:
+        return {16000, 5};  // SBR160
+      case 4:
+        return {19200, 6};  // SBR192
+      case 5:
+        return {22400, 7};  // SBR224
+      case 6:
+        return {25600, 8};  // SBR256
+      case 1:
       default:
         return {9600, 3};  // SBR096
     }


### PR DESCRIPTION
- Add SungrowBatteryConfig struct with nameplate capacity and module count
- Support battery models SBR064 through SBR256 (2-8 modules)
- Dynamically set battery model ID in 0x705 based on module count
- Initialize module-dependent CAN frames in setup():
  - 0x71A: cell type per module
  - 0x71B-E: production dates
  - 0x71F: serial numbers
  - 0x715-718: module voltage overview
- Add web UI dropdown for battery model selection (Sungrow inverter only)
- Conditionally transmit 0x71F frames based on configured module count

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
