### PR TITLE
Volkswagen MEB: Fix negative reading of celltemps

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -444,7 +444,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       switch (mux) {
         case 0:  // Temperatures 1-56. Value is 0xFD if sensor not present
           for (uint8_t i = 0; i < 56; i++) {
-            datalayer_extended.meb.celltemperature_dC[i] = (rx_frame.data.u8[i + 1] * 5) - 400;
+            datalayer_extended.meb.celltemperature_dC[i] = ((int16_t)rx_frame.data.u8[i + 1] * 5) - 400;
           }
           break;
         /*

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -800,7 +800,7 @@ struct DATALAYER_INFO_MEB {
   bool battery_heating = 0;     /** Battery heating status */
 
   float temp_points[18] = {0};
-  uint16_t celltemperature_dC[56] = {0};
+  int16_t celltemperature_dC[56] = {0};
 };
 
 struct DATALAYER_INFO_VOLVO_POLESTAR {


### PR DESCRIPTION
### What
This PR fixes a bug where celltemperatures would show up as 6551.1 *C when colder that 0 C

### Why
Fixes #1935

### How
We read value as int16_t instead of uint16_t

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
