### PR TITLE
Bugfix: Think startup voltage initialization

### DIFF
--- a/Software/src/battery/THINK-BATTERY.h
+++ b/Software/src/battery/THINK-BATTERY.h
@@ -30,10 +30,10 @@ class ThinkBattery : public CanBattery {
 
   uint16_t sys_voltage = 3600;
   uint16_t sys_dod = 0;
-  uint16_t sys_voltageMinDischarge = 0;
+  uint16_t sys_voltageMinDischarge = MIN_PACK_VOLTAGE_DV;
   uint16_t sys_currentMaxDischarge = 0;
   uint16_t sys_currentMaxCharge = 0;
-  uint16_t sys_voltageMaxCharge = 0;
+  uint16_t sys_voltageMaxCharge = MAX_PACK_VOLTAGE_DV;
   uint16_t BatterySOC = 500;
   int16_t sys_tempMean = 0;
   int16_t sys_current = 0;


### PR DESCRIPTION
### What
This PR fixes the Think startup voltage initialization

### Why
Value is initialized to 0, which means we might trigger Battery-Undervoltage event incase CAN data is not read the first second after poweron. Reported in #1959

### How
We init the value to 360.0V instead of 0.0V

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
