### PR TITLE
Bugfix: CANFD; Begin correct interface

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -499,7 +499,7 @@ void restart_can() {
 
   if (canfd) {
     SPI2517.begin();
-    canfd->begin(*settings2517, [] { can2515->isr(); });
+    canfd->begin(*settings2517, [] { canfd->isr(); });
   }
 }
 


### PR DESCRIPTION
### What
This PR makes restart_can call correctly for CAN-FD

### Why
Issues noticed for some integrations using MCP2518FD chips

### How
restart_can() function for CAN-FD now calls the correct CAN object (canfd instead of can2515)

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
