### PR TITLE
Testing the maximum capacity and voltage readings with the Fronius Primo and BYD Atto3

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -54,7 +54,7 @@ void BydModbusInverter::handle_update_data_modbusp201_byd() {
   }
   mbPV[205] =
       std::min(datalayer.battery.info.max_design_voltage_dV,
-               static_cast<uint16_t>(4549u));  // Max Voltage, if higher Gen24 forces discharge, cap to 454.9V for Primo
+               static_cast<uint16_t>(4500u));  // Max Voltage, if higher Gen24 forces discharge, cap to 450.0V for Primo
   mbPV[206] = (datalayer.battery.info.min_design_voltage_dV);  // Min Voltage, if lower Gen24 disables battery
 }
 


### PR DESCRIPTION
The update prevents BE from reporting a maximum or remaining capacity above 44.16 kWh to the inverter, which matches the total of two 22.08 kWh BYD HVM batteries.

What
This PR updates the implementation to report a reduced capacity value.

Why
The maximum allowed configuration by design for Fronius Gen24 inverters is 2x22.08 BYD HVM batteries.

How
Updating the previous 60kWh limit to 44.16kWh.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
