### PR TITLE
Experimental Feature: Double batteries in Series

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -148,6 +148,7 @@ battery_chemistry_enum user_selected_battery_chemistry = battery_chemistry_defau
 BatteryType user_selected_battery_type = BatteryType::None;
 bool user_selected_second_battery = false;
 bool user_selected_triple_battery = false;
+bool user_selected_series_connected_batteries = false;
 
 Battery* create_battery(BatteryType type) {
   switch (type) {

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -63,6 +63,7 @@ extern const char* name_for_comm_interface(comm_interface comm);
 extern BatteryType user_selected_battery_type;
 extern bool user_selected_second_battery;
 extern bool user_selected_triple_battery;
+extern bool user_selected_series_connected_batteries;
 
 extern battery_chemistry_enum user_selected_battery_chemistry;
 

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -136,6 +136,7 @@ void init_stored_settings() {
   equipment_stop_behavior = (STOP_BUTTON_BEHAVIOR)settings.getUInt("EQSTOP", (int)STOP_BUTTON_BEHAVIOR::NOT_CONNECTED);
   user_selected_second_battery = settings.getBool("DBLBTR", false);
   user_selected_triple_battery = settings.getBool("TRIBTR", false);
+  user_selected_series_connected_batteries = settings.getBool("SERIES", false);
   contactor_control_enabled = settings.getBool("CNTCTRL", false);
   contactor_control_inverted_logic = settings.getBool("NCCONTACTOR", false);
   precharge_time_ms = settings.getUInt("PRECHGMS", 100);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -364,6 +364,10 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("TRIBTR") ? "checked" : "";
   }
 
+  if (var == "SERIES") {
+    return settings.getBool("SERIES") ? "checked" : "";
+  }
+
   if (var == "SOCESTIMATED") {
     return settings.getBool("SOCESTIMATED") ? "checked" : "";
   }
@@ -1283,6 +1287,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
             <select name='BATT2COMM'>
                 %BATT2COMM%
             </select>
+
+        <label>Series operation, EXPERIMENTAL: </label>
+        <input type='checkbox' name='SERIES' value='on' %SERIES% 
+        title="Enable this option if you intend to run the batteries in series" />
 
         <label>Triple battery: </label>
         <input type='checkbox' name='TRIBTR' value='on' %TRIBTR% 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -398,7 +398,7 @@ void init_webserver() {
       "REMBMSRESET",   "EXTPRECHARGE", "USBENABLED",  "CANLOGUSB",    "WEBENABLED",   "CANFDASCAN",   "CANLOGSD",
       "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",   "HADISC",       "MQTTTOPICS",   "MQTTCELLV",    "INVICNT",
       "GTWRHD",        "DIGITALHVIL",  "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED", "PYLONOFFSET",  "PYLONORDER",
-      "DEYEBYD",       "NCCONTACTOR",  "TRIBTR",      "CNTCTRLTRI",
+      "DEYEBYD",       "NCCONTACTOR",  "TRIBTR",      "CNTCTRLTRI",   "SERIES",
   };
 
   const char* uintSettingNames[] = {

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -52,8 +52,14 @@ void BydModbusInverter::handle_update_data_modbusp201_byd() {
   } else {
     mbPV[202] = std::min(datalayer.battery.info.total_capacity_Wh, static_cast<uint32_t>(60000u));  //Cap to 60kWh
   }
-  mbPV[205] = (datalayer.battery.info.max_design_voltage_dV);  // Max Voltage, if higher Gen24 forces discharge
-  mbPV[206] = (datalayer.battery.info.min_design_voltage_dV);  // Min Voltage, if lower Gen24 disables battery
+
+  if (user_selected_series_connected_batteries) {
+    mbPV[205] = (datalayer.battery.info.max_design_voltage_dV) * 2;  // Max Voltage, if higher Gen24 forces discharge
+    mbPV[206] = (datalayer.battery.info.min_design_voltage_dV) * 2;  // Min Voltage, if lower Gen24 disables battery
+  } else {
+    mbPV[205] = (datalayer.battery.info.max_design_voltage_dV);  // Max Voltage, if higher Gen24 forces discharge
+    mbPV[206] = (datalayer.battery.info.min_design_voltage_dV);  // Min Voltage, if lower Gen24 disables battery
+  }
 }
 
 void BydModbusInverter::handle_update_data_modbusp301_byd() {
@@ -77,7 +83,11 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   max_charge_W = std::min(datalayer.battery.status.max_charge_power_W, user_configured_max_charge_W);
 
   if (datalayer.battery.status.bms_status == ACTIVE) {
-    mbPV[308] = datalayer.battery.status.voltage_dV;
+    if (user_selected_series_connected_batteries) {
+      mbPV[308] = (datalayer.battery.status.voltage_dV + datalayer.battery2.status.voltage_dV);
+    } else {
+      mbPV[308] = datalayer.battery.status.voltage_dV;
+    }
   } else {
     mbPV[308] = 0;
   }
@@ -104,7 +114,11 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   }
   mbPV[306] = std::min(max_discharge_W, static_cast<uint32_t>(30000u));  //Cap to 30000 if exceeding
   mbPV[307] = std::min(max_charge_W, static_cast<uint32_t>(30000u));     //Cap to 30000 if exceeding
-  mbPV[310] = datalayer.battery.status.voltage_dV;
+  if (user_selected_series_connected_batteries) {
+    mbPV[310] = (datalayer.battery.status.voltage_dV + datalayer.battery2.status.voltage_dV);
+  } else {
+    mbPV[310] = datalayer.battery.status.voltage_dV;
+  }
   mbPV[312] = datalayer.battery.status.temperature_min_dC;
   mbPV[313] = datalayer.battery.status.temperature_max_dC;
   mbPV[323] = datalayer.battery.status.soh_pptt;


### PR DESCRIPTION
### What
This PR adds support for running double battery in series connection instead of the normal parallel mode

### Why
User requested feature. Charge faster on current limited inverters

### How
To use the feature, connect batteries in Series Operation mode

<img width="1444" height="630" alt="image" src="https://github.com/user-attachments/assets/b8a70213-6153-493a-bd3e-7b303af6a5a8" />

Then, enable the "Series operation, EXPERIMENTAL" under the Double-Battery config

For now, only Fronius Gen24 is supported during testing phase


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
