### PR TITLE
Prevent voltage bouncing due to repeadetly charge/discharge with Pylon LV

### DIFF
--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -31,6 +31,17 @@ void DalyBms::update_values() {
   datalayer.battery.status.max_discharge_power_W =
       (datalayer.battery.settings.max_user_set_discharge_dA * voltage_dV) / 100;
 
+  // limit power when reaching discharge voltage limit
+  uint32_t voltage_power_limit = 999999;
+  uint16_t min_voltage = datalayer.battery.info.min_design_voltage_dV;
+  if (datalayer.battery.settings.user_set_voltage_limits_active &&
+      datalayer.battery.settings.max_user_set_discharge_voltage_dV > min_voltage)
+    min_voltage = datalayer.battery.settings.max_user_set_discharge_voltage_dV;
+  if (voltage_dV - min_voltage < 20)
+    voltage_power_limit = (uint32_t)(voltage_dV - min_voltage) * POWER_PER_DV;
+  if (voltage_power_limit < datalayer.battery.status.max_discharge_power_W)
+    datalayer.battery.status.max_discharge_power_W = voltage_power_limit;
+
   // limit power when SoC is low or high
   uint32_t adaptive_power_limit = 999999;
   if (SOC < 2000)

--- a/Software/src/battery/DALY-BMS.h
+++ b/Software/src/battery/DALY-BMS.h
@@ -12,9 +12,10 @@ class DalyBms : public RS485Battery {
   static constexpr const char* Name = "DALY RS485";
 
  private:
-  /* Tweak these according to your battery build */
+  /* You may tweak these according to your battery build. Values below are for Twizy Packs (14S2P NMC) */
   static const int POWER_PER_PERCENT =
       50;  // below 20% and above 80% limit power to 50W * SOC (i.e. 150W at 3%, 500W at 10%, ...)
+  static const int POWER_PER_DV = 50;          // max power per dV when approaching discharge voltage limit
   static const int POWER_PER_DEGREE_C = 60;    // max power added/removed per degree above/below 0°C
   static const int POWER_AT_0_DEGREE_C = 800;  // power at 0°C
 

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -85,10 +85,10 @@ void PylonLvInverter::update_values() {
     PYLON_35C.data.u8[0] = 0x00;  // disable all
   else if (datalayer.battery.status.voltage_dV < datalayer.battery.info.min_design_voltage_dV)
     PYLON_35C.data.u8[0] = 0xA0;  // enable charing, set charge immediately
-  else if (datalayer.battery.status.voltage_dV > datalayer.battery.info.max_design_voltage_dV)
+  else if (datalayer.battery.status.voltage_dV >= datalayer.battery.info.max_design_voltage_dV)
     PYLON_35C.data.u8[0] = 0x40;  // only allow discharging
   else if (datalayer.battery.settings.user_set_voltage_limits_active &&
-           datalayer.battery.status.voltage_dV > datalayer.battery.settings.max_user_set_charge_voltage_dV)
+           datalayer.battery.status.voltage_dV >= datalayer.battery.settings.max_user_set_charge_voltage_dV)
     PYLON_35C.data.u8[0] = 0x40;  // only allow discharging
   else if (datalayer.battery.settings.user_set_voltage_limits_active &&
            datalayer.battery.status.voltage_dV < datalayer.battery.settings.max_user_set_discharge_voltage_dV)


### PR DESCRIPTION
### What
This PR implements less harsh charging/discharging rules. The goal is to just stop discharging when reaching minimum voltage or soc rather than immediately running into a force charge request.

### Why
With the current code, when the battery gets discharged below the user min voltage BE immediately requests a "force charge" resulting in it being charged slightly over the min voltage and the cycle continues.
<img width="1905" height="755" alt="image" src="https://github.com/user-attachments/assets/3ce4f376-e387-43e2-a70f-6c8c18f8f575" />


### How
Only request force charge when battery below design voltage. Do not request when voltage below user limit. This way the two voltages act as a kind of hysteresis.

draft for now until I am able to test this with the real setup.
