### PR TITLE
Fix offset for bootloader for Stark CMR image

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: 🛠 Build factory image for Stark
       run: |
-        esptool --chip esp32 merge-bin -o .pio/build/stark_330/factory.bin --flash-mode qio --flash-freq 80m --flash-size 8MB 0x1000 .pio/build/stark_330/bootloader.bin 0x8000 .pio/build/stark_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/stark_330/firmware.bin
+        esptool --chip esp32 merge-bin -o .pio/build/stark_330/factory.bin --flash-mode qio --flash-freq 80m --flash-size 8MB 0x0000 .pio/build/stark_330/bootloader.bin 0x8000 .pio/build/stark_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/stark_330/firmware.bin
         mv .pio/build/stark_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_StarkCMR.factory.bin
 
     - name: 🌐 Deploy to Web Installer repo


### PR DESCRIPTION
### What
This PR implements ...

### Why
Stark bin was human readable, garbage file

<img width="797" height="808" alt="image" src="https://github.com/user-attachments/assets/ff615632-104e-433b-a710-4937da51df96" />

ESPtool trace

Warning: Image file at 0x1000 is protected with a hash checksum, so not changing the flash mode setting. Use the --flash_mode=keep option instead of --flash_mode=qio in order to remove this warning, or use the --dont-append-digest option for the elf2image command in order to generate an image file without a hash checksum
Warning: Image file at 0x1000 is protected with a hash checksum, so not changing the flash size setting. Use the --flash_size=keep option instead of --flash_size=8MB in order to remove this warning, or use the --dont-append-digest option for the elf2image command in order to generate an image file without a hash checksum

### How
We change from 0x1000 to 0x0000

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
