### PR TITLE
Bugfix: Pylon, make double-battery support work

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -283,6 +283,9 @@ void setup_battery() {
                                            &datalayer.system.status.battery2_allowed_contactor_closing,
                                            can_config.battery_double);
         break;
+      case BatteryType::Pylon:
+        battery2 = new PylonBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+        break;
       case BatteryType::SantaFePhev:
         battery2 = new SantaFePhevBattery(&datalayer.battery2, can_config.battery_double);
         break;


### PR DESCRIPTION
### What
This PR fixes a bug causing Pylon batteries not to start when configured to double battery mode

### Why
Fixes #1999

### How
Seems like a line of code was missing

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
