### PR TITLE
Bugfix: Think City CAN values

### DIFF
--- a/Software/src/battery/THINK-BATTERY.cpp
+++ b/Software/src/battery/THINK-BATTERY.cpp
@@ -25,13 +25,13 @@ void ThinkBattery::update_values() {
 
   datalayer.battery.status.temperature_max_dC = (int16_t)(max_pack_temperature * 10);
 
-  datalayer.battery.info.min_design_voltage_dV = sys_voltageMinDischarge;
+  if (max_cellvoltage > 2800) {  //Value is low when unavailable
+    datalayer.battery.status.cell_max_voltage_mV = max_cellvoltage;
+  }
 
-  datalayer.battery.info.max_design_voltage_dV = sys_voltageMaxCharge;
-
-  datalayer.battery.status.cell_max_voltage_mV = max_cellvoltage;
-
-  datalayer.battery.status.cell_min_voltage_mV = min_cellvoltage;
+  if (min_cellvoltage > 2800) {  //Value is low when unavailable
+    datalayer.battery.status.cell_min_voltage_mV = min_cellvoltage;
+  }
 }
 
 void ThinkBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -143,8 +143,8 @@ void ThinkBattery::transmit_can(unsigned long currentMillis) {
 void ThinkBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;  //Later read via CAN (sys_voltageMinCharge)
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;  //Later read via CAN (sys_voltageMinDischarge)
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.system.status.battery_allows_contactor_closing = true;

--- a/Software/src/battery/THINK-BATTERY.h
+++ b/Software/src/battery/THINK-BATTERY.h
@@ -13,11 +13,11 @@ class ThinkBattery : public CanBattery {
   static constexpr const char* Name = "Think City";
 
  private:
-  static const int MAX_PACK_VOLTAGE_DV = 3920;  //Later read via CAN (sys_voltageMinCharge)
-  static const int MIN_PACK_VOLTAGE_DV = 2400;  //Later read via CAN (sys_voltageMinDischarge)
+  static const int MAX_PACK_VOLTAGE_DV = 3940;
+  static const int MIN_PACK_VOLTAGE_DV = 2880;
   static const int MAX_CELL_DEVIATION_MV = 150;
-  static const int MAX_CELL_VOLTAGE_MV = 4200;
-  static const int MIN_CELL_VOLTAGE_MV = 3300;
+  static const int MAX_CELL_VOLTAGE_MV = 4100;
+  static const int MIN_CELL_VOLTAGE_MV = 3000;
 
   unsigned long previousMillis200 = 0;  // will store last time a 100ms CAN Message was sent
 


### PR DESCRIPTION
### What
This PR improves several CAN mappings for the Think City

### Why
Better support for Think City batteries. Fixes #2003

### How
- Change SOC to be based on DOD
- Swap charge/discharge, these were accidentally wrong way
- Fix cell temperatures to use proper min/max instead of mean temp
- Add min/max cellvoltages

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
