### PR TITLE
Bugfix: ECMP; Tighten low-voltage chargestop limits 

### DIFF
--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -31,10 +31,10 @@ class EcmpBattery : public CanBattery {
  private:
   EcmpHtmlRenderer renderer;
   static const int MAX_PACK_VOLTAGE_DV = 4546;
-  static const int MIN_PACK_VOLTAGE_DV = 3210;
+  static const int MIN_PACK_VOLTAGE_DV = 3580;
   static const int MAX_CELL_DEVIATION_MV = 100;
   static const int MAX_CELL_VOLTAGE_MV = 4250;
-  static const int MIN_CELL_VOLTAGE_MV = 2700;
+  static const int MIN_CELL_VOLTAGE_MV = 3280;
 
   unsigned long previousMillis10 = 0;    //- will store last time a 10ms CAN Message was sent
   unsigned long previousMillis20 = 0;    // will store last time a 20ms CAN Message was sent


### PR DESCRIPTION
### What
This PR tightens the low-voltage chargestop limits for Stellantis eCMP integration

### Why
One user reported an overdischarged battery in https://github.com/dalathegreat/Battery-Emulator/discussions/2005#discussion-9427494 , where contactors locked open and are not possible to close

### How
We change the limits to become more reasonable for an empty 108S battery

> [!NOTE]
> Probably a good idea still to use a 5% minimum scaled SOC for eCMP integration to avoid any overdischarge

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
