### PR TITLE
Fix for [BUG] Growatt HV CAN comparison is always true #2010 

### DIFF
--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -29,7 +29,7 @@ void GrowattHvInverter::
   // Use that when it is sane. Keep the hard-coded values as a fallback for integrations that do not populate
   // number_of_cells (e.g. some Pylon paths set it to a placeholder value).
   uint16_t total_cells = TOTAL_NUMBER_OF_CELLS;
-  if (datalayer.battery.info.number_of_cells >= 10 {
+  if (datalayer.battery.info.number_of_cells >= 10) {
     total_cells = (uint16_t)datalayer.battery.info.number_of_cells;
   }
   // If we are using a dynamic cell count, a safe default for "modules in series" is 1 unless your integration


### PR DESCRIPTION
Fix for [BUG] Growatt HV CAN comparison is always true #2010 
Removed the redundant && datalayer.battery.info.number_of_cells <= 512)

Fixes #2010

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
