### PR TITLE
Feature: Rivian Add more battery info page for Rivian (+ crash detection)

### DIFF
--- a/Software/src/battery/RIVIAN-BATTERY.h
+++ b/Software/src/battery/RIVIAN-BATTERY.h
@@ -28,7 +28,9 @@ class RivianBattery : public CanBattery {
   uint16_t main_contactor_voltage = 0;
   uint16_t voltage_reference = 0;
   uint16_t DCFC_contactor_voltage = 0;
-  uint16_t battery_SOC = 5000;
+  uint16_t battery_SOC_average = 5000;
+  uint16_t battery_SOC_max = 0;
+  uint16_t battery_SOC_min = 0;
   int32_t battery_current = 32000;
   uint16_t kWh_available_total = 135;
   uint16_t kWh_available_max = 135;
@@ -52,6 +54,9 @@ class RivianBattery : public CanBattery {
   bool liquid_fault = false;
   bool contactor_DCFC_welded = false;
   bool NACS_charger_detected = false;
+  bool slewrate_potential_violation = false;
+  bool minimum_power_potential_violation = false;
+  bool operation_limit_violation_warning = false;
   static const uint8_t SLEEP = 0;
   static const uint8_t STANDBY = 1;
   static const uint8_t READY = 2;

--- a/Software/src/battery/RIVIAN-HTML.h
+++ b/Software/src/battery/RIVIAN-HTML.h
@@ -16,6 +16,9 @@ class RivianHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Voltage, reference: " + String(datalayer_extended.rivian.voltage_reference) + " dV</h4>";
     content += "<h4>Voltage, DCFC contactors: " + String(datalayer_extended.rivian.DCFC_contactor_voltage) + " dV</h4>";
 
+    content += "<h4>SOC, max: " + String(datalayer_extended.rivian.battery_SOC_max) + " pptt</h4>";
+    content += "<h4>SOC, min: " + String(datalayer_extended.rivian.battery_SOC_min) + " pptt</h4>";
+
     if (datalayer_extended.rivian.NACS_charger_detected) {
       content += "<h4>NACS charger detected!</h4>";
     }
@@ -159,6 +162,16 @@ class RivianHtmlRenderer : public BatteryHtmlRenderer {
     }
     if (datalayer_extended.rivian.contactor_DCFC_welded) {
       content += "<h4>DCFC contactor welded</h4>";
+    }
+
+    if (datalayer_extended.rivian.slewrate_potential_violation) {
+      content += "<h4>Slewrate potential violation</h4>";
+    }
+    if (datalayer_extended.rivian.minimum_power_potential_violation) {
+      content += "<h4>Min power potential violation</h4>";
+    }
+    if (datalayer_extended.rivian.operation_limit_violation_warning) {
+      content += "<h4>Operation limit violation warning</h4>";
     }
 
     return content;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -459,6 +459,8 @@ struct DATALAYER_INFO_RIVIAN {
   uint16_t main_contactor_voltage = 0;
   uint16_t voltage_reference = 0;
   uint16_t DCFC_contactor_voltage = 0;
+  uint16_t battery_SOC_max = 0;
+  uint16_t battery_SOC_min = 0;
   uint8_t BMS_state = 0;
   uint8_t HVIL = 0;
   uint8_t error_flags_from_BMS = 0;
@@ -473,6 +475,9 @@ struct DATALAYER_INFO_RIVIAN {
   bool liquid_fault = false;
   bool contactor_DCFC_welded = false;
   bool NACS_charger_detected = false;
+  bool slewrate_potential_violation = false;
+  bool minimum_power_potential_violation = false;
+  bool operation_limit_violation_warning = false;
 };
 
 struct DATALAYER_INFO_TESLA {


### PR DESCRIPTION
### What
This PR implements a more battery info page for Rivian

### Why
To make troubleshooting easier

### How
This PR adds the following additional info reading for Rivian batteries
- Isolation measurement ongoing
- Isolation status
- Interlock status
- BMS state
- Contactor state
- Active errors and faults (Iso, crash, weld, limited, puncture, liquid)

<img width="338" height="244" alt="image" src="https://github.com/user-attachments/assets/b06c9ffa-d7f5-4853-8b8a-ffe175c66e5f" />

This PR also adds CRC check on some incoming CAN messages

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
