### PR TITLE
Renault Zoe2: Calibrate 12V reading

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -239,7 +239,7 @@ void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
           }
           break;
         case POLL_12V:
-          battery_12v = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          battery_12v = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) + 350;  //350, calibration from testing
           break;
         case POLL_AVG_TEMP:
           battery_avg_temp = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];


### PR DESCRIPTION
### What
This PR calibrates the 12V measurement

### Why
We were under-reporting the 12V

<img width="277" height="190" alt="image" src="https://github.com/user-attachments/assets/c5463b41-5f1e-4eba-b086-6f0a332762ee" />

<img width="186" height="66" alt="image" src="https://github.com/user-attachments/assets/57748d17-0b41-442e-b0da-4290c9038524" />

This is important to get right, since we use the 12V measurement for getting safeties correct

### How
Applied a 350mV offset on the measurement, to get it closer to real life

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
