### PR TITLE
Ensure the battery chemistry is set to the user selected value

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -242,7 +242,7 @@ Battery* create_battery(BatteryType type) {
     case BatteryType::SimpBms:
       return new SimpBmsBattery();
     case BatteryType::TeslaModel3Y:
-      return new TeslaModel3YBattery(user_selected_battery_chemistry);
+      return new TeslaModel3YBattery();
     case BatteryType::TeslaModelSX:
       return new TeslaModelSXBattery();
     case BatteryType::TeslaLegacy:
@@ -267,6 +267,11 @@ void setup_battery() {
     // Let's not create the battery again.
     return;
   }
+
+  // Set the chemistry to the user selected value, the battery can override.
+  datalayer.battery.info.chemistry = user_selected_battery_chemistry;
+  datalayer.battery2.info.chemistry = user_selected_battery_chemistry;
+  datalayer.battery3.info.chemistry = user_selected_battery_chemistry;
 
   battery = create_battery(user_selected_battery_type);
 

--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -572,6 +572,7 @@ void FoxessBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 0;  //Startup with no cells, populates later when we know packsize
+  datalayer.battery.info.chemistry = LFP;
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -892,14 +892,12 @@ class TeslaBattery : public CanBattery {
 
 class TeslaModel3YBattery : public TeslaBattery {
  public:
-  TeslaModel3YBattery(battery_chemistry_enum chemistry) { datalayer.battery.info.chemistry = chemistry; }
   static constexpr const char* Name = "Tesla Model 3/Y";
   virtual void setup(void);
 };
 
 class TeslaModelSXBattery : public TeslaBattery {
  public:
-  TeslaModelSXBattery() {}
   static constexpr const char* Name = "Tesla Model S/X";
   virtual void setup(void);
 };


### PR DESCRIPTION
### What
The `user_selected_battery_chemistry` value was only being used in Tesla, yet other batteries might check `datalayer.battery.info.chemistry` it in their constructor which would be NMC and not the actually user selected value.

Now all three battery datalayer entries are set to the chemistry, but the battery can change it.

All LFP-only batteries override to LFP (so it won't use NMC voltages even if someone selects NMC).

The Tesla constructor was changed, but it definitely still uses the selected limits (I have tested).

### Why
Overcharging LFP batteries is bad.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
