### PR TITLE
Feature: Add support for double-battery Stellantis CMP Smart Car

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -294,6 +294,9 @@ void setup_battery() {
       case BatteryType::CmfaEv:
         battery2 = new CmfaEvBattery(&datalayer.battery2, nullptr, can_config.battery_double);
         break;
+      case BatteryType::CmpSmartCar:
+        battery2 = new CmpSmartCarBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+        break;
       case BatteryType::KiaHyundai64:
         battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,
                                            &datalayer.system.status.battery2_allowed_contactor_closing,

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.h
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.h
@@ -1,11 +1,25 @@
 #ifndef CMP_SMART_CAR_BATTERY_H
 #define CMP_SMART_CAR_BATTERY_H
+#include "../datalayer/datalayer_extended.h"
 #include "../devboard/hal/hal.h"
 #include "CMP-SMART-CAR-BATTERY-HTML.h"
 #include "CanBattery.h"
 
 class CmpSmartCarBattery : public CanBattery {
  public:
+  // Use this constructor for the second battery.
+  CmpSmartCarBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_CMPSMART* extended, CAN_Interface targetCan)
+      : CanBattery(targetCan) {
+    datalayer_battery = datalayer_ptr;
+    datalayer_cmpsmart = extended;
+  }
+
+  // Use the default constructor to create the first or single battery.
+  CmpSmartCarBattery() {
+    datalayer_battery = &datalayer.battery;
+    datalayer_cmpsmart = &datalayer_extended.stellantisCMPsmart;
+  }
+
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
@@ -21,6 +35,9 @@ class CmpSmartCarBattery : public CanBattery {
 
  private:
   CmpSmartCarHtmlRenderer renderer;
+  DATALAYER_BATTERY_TYPE* datalayer_battery;
+  DATALAYER_INFO_CMPSMART* datalayer_cmpsmart;
+
   static const int MAX_PACK_VOLTAGE_100S_DV = 3700;
   static const int MIN_PACK_VOLTAGE_100S_DV = 2900;
   static const int MAX_CELL_DEVIATION_MV = 100;


### PR DESCRIPTION
### What
This PR implements support for running double Stellantis CMP Smart Car batteries

### Why
User requested feature. Fixes #2049

### How
Note, same WUP pin used for both batteries!

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
