### PR TITLE
Optimize for size and debug

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,8 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall -Werror
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+;   -fno-rtti ; was avoided as we receive some warnings from gcc because the flags seems to be common for gcc and g++ in platformio (unfortunately)
 lib_deps = 
 
 [env:esp32devkit_330] 
@@ -35,6 +37,7 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
+    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 
 
 [env:lilygo_330]
@@ -48,6 +51,7 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
+    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections 
 lib_deps = 
 
 [env:stark_330]
@@ -61,6 +65,7 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = default_8MB.csv
 framework = arduino
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
+    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 
 
 [env:lilygo_2CAN_330]
@@ -85,6 +90,7 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
+    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 
 
 [env:BECom_330]
@@ -106,4 +112,5 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
+    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 


### PR DESCRIPTION

### What
This commit is dealing with the compiler flag optimization for space and also improving the code for clean and predictive debug.

### Why
As there is intense need for flash space on smaller flash devices optimizations are needed on the code and also on the way the compiler works.

### How
The most important flag that actually reduced the flash size of the binary is "-fno-exceptions". C++ exceptions (throw/try/catch) are not used in Battery Emulator or libraries.
The C++ exception support
 - increases binary size significantly
 - requires extra runtime support
 - complicates stack unwinding on a small MCU

  Let's get rid of it and save ~10% of flash space ;)


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
