### PR TITLE
Precharge: Add autostart of precharge when running without battery

### DIFF
--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -65,6 +65,7 @@ void handle_precharge_control(unsigned long currentMillis) {
   // If we are running in test mode (No battery configured, enable precharge sequence so user can test HW)
   if (battery == NULL) {
     datalayer.system.info.start_precharging = true;
+    datalayer.battery.status.real_bms_status = BMS_STANDBY;
   }
 
   int32_t target_voltage = datalayer.battery.status.voltage_dV;


### PR DESCRIPTION
### What
This PR implements a test mode for H1A4V1 precharge circuit

### Why
User requested feature

### How
If user starts precharge feature "External precharge via H1A4V1" , without any Battery protocol selected, a test state will be entered, so you can check if your circuit can generate 370VDC

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
