### PR TITLE
Compile the display on all boards

### DIFF
--- a/Software/src/devboard/display/display.cpp
+++ b/Software/src/devboard/display/display.cpp
@@ -1,12 +1,3 @@
-#ifdef SMALL_FLASH_DEVICE
-
-// Don't build the display code on small flash devices to save space
-
-void init_display() {}
-void update_display() {}
-
-#else
-
 // A realtime display of battery status and events, using a I2C-connected 128x64
 // OLED display based on the SSD1306 driver.
 
@@ -479,5 +470,3 @@ void update_display() {
   }
   lastUpdateMillis = currentMillis;
 }
-
-#endif


### PR DESCRIPTION
### What
This is adding the display on all the boards (each board should add it's pinout)

### Why
Having a display to print some parameters it's a good feature that all the setups should benefit 

### How
Remove SMALL_FLASH_DEVICE from display.cpp so it can get compiled on all the boards.
 
> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
