### PR TITLE
BYD Battery: BYD Song Plus & BYD E2/E3

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -486,8 +486,10 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (battery_frame_index < (CELLCOUNT_EXTENDED / 3)) {
         uint8_t base_index = battery_frame_index * 3;
         for (uint8_t i = 0; i < 3; i++) {
-          battery_cellvoltages[base_index + i] =
-              (((rx_frame.data.u8[2 * (i + 1)] & 0x0F) << 8) | rx_frame.data.u8[2 * i + 1]);
+          uint16_t cell_voltage = (((rx_frame.data.u8[2 * (i + 1)] & 0x0F) << 8) | rx_frame.data.u8[2 * i + 1]);
+          if (cell_voltage != 0xFFF) {  //Some packs have unpopulated modules at the end
+            battery_cellvoltages[base_index + i] = cell_voltage;
+          }
         }
       }
       break;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -156,10 +156,10 @@ void BydAttoBattery::
     datalayer_battery->status.voltage_dV = battery_voltage * 10;  //Value from periodic CAN data
   }
 
-  if (battery_type == EXTENDED_RANGE) {
+  if (battery_type == BYD_ATTO3_EXTENDED_RANGE) {
     battery_estimated_SOC = estimateSOCextended(datalayer_battery->status.voltage_dV);
   }
-  if (battery_type == STANDARD_RANGE) {
+  if (battery_type == BYD_ATTO3_STANDARD_RANGE) {
     battery_estimated_SOC = estimateSOCstandard(datalayer_battery->status.voltage_dV);
   }
 
@@ -304,31 +304,42 @@ void BydAttoBattery::
 
   // Check if we are on Standard range or Extended range battery.
   // We use a variety of checks to ensure we catch a potential Standard range battery
-  if ((battery_cellvoltages[125] > 0) && (battery_type == NOT_DETERMINED_YET)) {
-    battery_type = EXTENDED_RANGE;
-  }
-  if ((battery_cellvoltages[104] == 4095) && (battery_type == NOT_DETERMINED_YET)) {
-    battery_type = STANDARD_RANGE;  //This cell reading is always 4095 on Standard range
-  }
-  if ((battery_daughterboard_temperatures[9] == 215) && (battery_type == NOT_DETERMINED_YET)) {
-    battery_type = STANDARD_RANGE;  //Sensor 10 is missing on Standard range
-  }
-  if ((battery_daughterboard_temperatures[8] == 215) && (battery_type == NOT_DETERMINED_YET)) {
-    battery_type = STANDARD_RANGE;  //Sensor 9 is missing on Standard range
+  if ((battery_cellvoltages[159] > 0)) {
+    battery_type = BYD_SONG_PLUS_RANGE;  //BYD Song Plus is 160S
+  } else if (battery_cellvoltages[125] > 0) {
+    battery_type = BYD_ATTO3_EXTENDED_RANGE;  //126S
+  } else if (battery_cellvoltages[103] > 0) {
+    battery_type = BYD_ATTO3_STANDARD_RANGE;  //104S
+  } else if (battery_cellvoltages[99] > 0) {
+    battery_type = BYD_E3;  //100S
+  } else {
+    battery_type = NOT_DETERMINED_YET;
   }
 
   switch (battery_type) {
-    case STANDARD_RANGE:
+    case BYD_SONG_PLUS_RANGE:  //BYD Song Plus, 160S LFP
+      datalayer_battery->info.total_capacity_Wh = 87000;
+      datalayer_battery->info.number_of_cells = CELLCOUNT_PLUS;
+      datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_PLUS_DV;
+      datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_PLUS_DV;
+      break;
+    case BYD_ATTO3_STANDARD_RANGE:  //Standard Range Atto 3, 104S LFP
       datalayer_battery->info.total_capacity_Wh = 50000;
       datalayer_battery->info.number_of_cells = CELLCOUNT_STANDARD;
       datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_STANDARD_DV;
       datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_STANDARD_DV;
       break;
-    case EXTENDED_RANGE:
+    case BYD_ATTO3_EXTENDED_RANGE:  //Extended Range Atto 3, 126S LFP
       datalayer_battery->info.total_capacity_Wh = 60000;
       datalayer_battery->info.number_of_cells = CELLCOUNT_EXTENDED;
       datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_EXTENDED_DV;
       datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_EXTENDED_DV;
+      break;
+    case BYD_E3:  //Unsure if this is standard or long range. Guess long range?
+      datalayer_battery->info.total_capacity_Wh = 47300;
+      datalayer_battery->info.number_of_cells = CELLCOUNT_E3;
+      datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_E3_DV;
+      datalayer_battery->info.min_design_voltage_dV = MAX_PACK_VOLTAGE_E3_DV;
       break;
     case NOT_DETERMINED_YET:
     default:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -75,13 +75,18 @@ class BydAttoBattery : public CanBattery {
 
   uint32_t BMS_unknown0 = 0;
   uint32_t BMS_unknown1 = 0;
-
+  static const uint16_t CELLCOUNT_PLUS = 160;
   static const uint16_t CELLCOUNT_EXTENDED = 126;
   static const uint16_t CELLCOUNT_STANDARD = 104;
-  static const uint16_t MAX_PACK_VOLTAGE_EXTENDED_DV = 4599;  //Extended range
-  static const uint16_t MIN_PACK_VOLTAGE_EXTENDED_DV = 3800;  //Extended range
+  static const uint16_t CELLCOUNT_E3 = 100;
+  static const uint16_t MAX_PACK_VOLTAGE_PLUS_DV = 5600;      //BYD Song Plus
+  static const uint16_t MIN_PACK_VOLTAGE_PLUS_DV = 4825;      //BYD Song Plus
+  static const uint16_t MAX_PACK_VOLTAGE_EXTENDED_DV = 4599;  //Atto3 Extended range
+  static const uint16_t MIN_PACK_VOLTAGE_EXTENDED_DV = 3800;  //Atto3 Extended range
   static const uint16_t MAX_PACK_VOLTAGE_STANDARD_DV = 3796;  //Standard range
   static const uint16_t MIN_PACK_VOLTAGE_STANDARD_DV = 3136;  //Standard range
+  static const uint16_t MAX_PACK_VOLTAGE_E3_DV = 3650;        //BYD E3
+  static const uint16_t MIN_PACK_VOLTAGE_E3_DV = 3056;        //BYD E3
   static const uint16_t MAX_CELL_DEVIATION_MV = 230;
   static const uint16_t MAX_CELL_VOLTAGE_MV = 3650;  //Charging stops if one cell exceeds this value
   static const uint16_t MIN_CELL_VOLTAGE_MV = 2800;  //Discharging stops if one cell goes below this value
@@ -116,8 +121,10 @@ class BydAttoBattery : public CanBattery {
   int16_t BMS_average_cell_temperature = 0;
 
   static const uint8_t NOT_DETERMINED_YET = 0;
-  static const uint8_t STANDARD_RANGE = 1;
-  static const uint8_t EXTENDED_RANGE = 2;
+  static const uint8_t BYD_ATTO3_STANDARD_RANGE = 1;
+  static const uint8_t BYD_ATTO3_EXTENDED_RANGE = 2;
+  static const uint8_t BYD_SONG_PLUS_RANGE = 3;
+  static const uint8_t BYD_E3 = 4;
   static const uint8_t NOT_RUNNING = 0xFF;
   static const uint8_t STARTED = 0;
   static const uint8_t RUNNING_STEP_1 = 1;
@@ -139,7 +146,7 @@ class BydAttoBattery : public CanBattery {
   bool BMS_voltage_available = false;
 
   int16_t battery_daughterboard_temperatures[10];
-  uint16_t battery_cellvoltages[CELLCOUNT_EXTENDED] = {0};
+  uint16_t battery_cellvoltages[MAX_AMOUNT_CELLS] = {0};
 
   CAN_frame ATTO_3_12D = {.FD = false,
                           .ext_ID = false,

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -47,7 +47,7 @@ class BydAttoBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
 
-  static constexpr const char* Name = "BYD Atto 3";
+  static constexpr const char* Name = "BYD Atto 3 / Song Plus / E3";
 
   bool supports_charged_energy() { return true; }
   bool supports_reset_crash() { return true; }


### PR DESCRIPTION
### What
This PR implements proper support for reading cellvoltages on BYD Song Plus and BYD E2 (also called E3 in some regions)

### Why
User requested feature, for 160S and 100S battery

### How
We re-use the BYD Atto3 integration, now being renamed to properly reflect this.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
