### PR TITLE
Add second MCP2518 interface and BECom config

### DIFF
--- a/.github/workflows/compile-common-image-BECom.yml
+++ b/.github/workflows/compile-common-image-BECom.yml
@@ -1,0 +1,54 @@
+name: 🔋 Compile Common Image for BECom
+
+on:
+  # The workflow is run when a commit is pushed or for a
+  # Pull Request.
+  - push
+  - pull_request
+
+# This is the list of jobs that will be run concurrently.
+jobs:
+  # This pre-job is run to skip workflows in case a workflow is already run, i.e. because the workflow is triggered by both push and pull_request
+  skip-duplicate-actions:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
+  build-common-image:
+    # This is the platform GitHub will use to run our workflow.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      name: Checkout code
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.platformio/.cache
+        key: ${{ runner.os }}-pio
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+    - name: Install PlatformIO Core
+      run: pip install --upgrade platformio
+
+    - name: Build image for BECom
+      run: pio run -e BECom_330
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v5
+      with:
+        name: battery-emulator-becom.bin
+        path: .pio/build/BECom_330/firmware.bin

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -203,8 +203,10 @@ bool init_CAN() {
 
     logging.println("CAN FD add-on (ESP32+MCP2517) selected");
     auto bitRate = (int)speed * 1000UL;
-    settings2517 = new ACAN2517FDSettings(quartz_fd_frequency, bitRate, DataBitRateFactor::x4);
     // Arbitration bit rate: 250/500 kbit/s, data bit rate: 1/2 Mbit/s
+    settings2517 = new ACAN2517FDSettings(quartz_fd_frequency, bitRate, DataBitRateFactor::x4);
+    // Set up clock output divider (some hardware uses this for the second CAN FD add-on)
+    settings2517->mCLKOPin = static_cast<ACAN2517FDSettings::CLKOpin>(esp32hal->MCP2517_CLKODIV());
 
     // ListenOnly / Normal20B / NormalFDs
     settings2517->mRequestedMode = use_canfd_as_can ? ACAN2517FDSettings::Normal20B : ACAN2517FDSettings::NormalFD;

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -65,6 +65,8 @@ SPIClass SPI2517(SPI2517_BUS);
 uint8_t user_selected_canfd_addon_crystal_frequency_mhz = 0;
 ACAN2517FD* canfd;
 ACAN2517FDSettings* settings2517;
+ACAN2517FD* canfd_2;
+ACAN2517FDSettings* settings2517_2;
 bool use_canfd_as_can = false;
 bool native_can_initialized = false;
 //CAN logging filter settings
@@ -171,6 +173,20 @@ bool init_CAN() {
 
   auto fdNativeIt = can_receivers.find(CANFD_NATIVE);
   auto fdAddonIt = can_receivers.find(CANFD_ADDON_MCP2518);
+  auto fdAddonIt_2 = can_receivers.find(CANFD_ADDON_MCP2518_2);
+
+  if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end() || fdAddonIt_2 != can_receivers.end()) {
+    // Initialise SPI bus first
+    auto sck_pin = esp32hal->MCP2517_SCK();
+    auto sdo_pin = esp32hal->MCP2517_SDO();
+    auto sdi_pin = esp32hal->MCP2517_SDI();
+
+    if (!esp32hal->alloc_pins("CANFD", sck_pin, sdo_pin, sdi_pin)) {
+      return false;
+    }
+
+    SPI2517.begin(sck_pin, sdo_pin, sdi_pin);
+  }
 
   if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end()) {
 
@@ -178,18 +194,14 @@ bool init_CAN() {
 
     auto cs_pin = esp32hal->MCP2517_CS();
     auto int_pin = esp32hal->MCP2517_INT();
-    auto sck_pin = esp32hal->MCP2517_SCK();
-    auto sdo_pin = esp32hal->MCP2517_SDO();
-    auto sdi_pin = esp32hal->MCP2517_SDI();
 
-    if (!esp32hal->alloc_pins("CAN", cs_pin, int_pin, sck_pin, sdo_pin, sdi_pin)) {
+    if (!esp32hal->alloc_pins("CANFD", cs_pin, int_pin)) {
       return false;
     }
 
     canfd = new ACAN2517FD(cs_pin, SPI2517, int_pin);
 
-    logging.println("CAN FD add-on (ESP32+MCP2518) selected");
-    SPI2517.begin(sck_pin, sdo_pin, sdi_pin);
+    logging.println("CAN FD add-on (ESP32+MCP2517) selected");
     auto bitRate = (int)speed * 1000UL;
     settings2517 = new ACAN2517FDSettings(quartz_fd_frequency, bitRate, DataBitRateFactor::x4);
     // Arbitration bit rate: 250/500 kbit/s, data bit rate: 1/2 Mbit/s
@@ -220,6 +232,35 @@ bool init_CAN() {
       logging.print("CAN-FD Configuration error 0x");
       logging.println(errorCode2517, HEX);
       set_event(EVENT_CANMCP2518FD_INIT_FAILURE, (uint8_t)errorCode2517);
+      return false;
+    }
+  }
+
+  if (fdAddonIt_2 != can_receivers.end()) {
+
+    auto cs_pin = esp32hal->MCP2517_CS2();
+    auto int_pin = esp32hal->MCP2517_INT2();
+
+    if (!esp32hal->alloc_pins("CANFD2", cs_pin, int_pin)) {
+      return false;
+    }
+
+    canfd_2 = new ACAN2517FD(cs_pin, SPI2517, int_pin);
+
+    logging.println("CAN FD add-on 2 (ESP32+MCP2517) selected");
+    auto speed = fdAddonIt_2->second.speed;
+    auto bitRate = (int)speed * 1000UL;
+    settings2517_2 = new ACAN2517FDSettings(quartz_fd_frequency, bitRate, DataBitRateFactor::x4);
+    // Arbitration bit rate: 250/500 kbit/s, data bit rate: 1/2 Mbit/s
+
+    settings2517_2->mRequestedMode = use_canfd_as_can ? ACAN2517FDSettings::Normal20B : ACAN2517FDSettings::NormalFD;
+
+    const uint32_t errorCode2517_2 = canfd_2->begin(*settings2517_2, [] { canfd_2->isr(); });
+    canfd_2->poll();
+    if (errorCode2517_2 != 0) {
+      logging.print("CAN-FD 2 Configuration error 0x");
+      logging.println(errorCode2517_2, HEX);
+      set_event(EVENT_CANMCP2518FD_INIT_FAILURE, (uint8_t)errorCode2517_2);
       return false;
     }
   }
@@ -280,6 +321,24 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
         datalayer.system.info.can_2518_send_fail = true;
       }
     } break;
+    case CANFD_ADDON_MCP2518_2: {
+      CANFDMessage MCP2518Frame;
+      if (tx_frame->FD) {
+        MCP2518Frame.type = CANFDMessage::CANFD_WITH_BIT_RATE_SWITCH;
+      } else {  //Classic CAN message
+        MCP2518Frame.type = CANFDMessage::CAN_DATA;
+      }
+      MCP2518Frame.id = tx_frame->ID;
+      MCP2518Frame.ext = tx_frame->ext_ID;
+      MCP2518Frame.len = tx_frame->DLC;
+      for (uint8_t i = 0; i < MCP2518Frame.len; i++) {
+        MCP2518Frame.data[i] = tx_frame->data.u8[i];
+      }
+      send_ok_2518 = canfd_2->tryToSend(MCP2518Frame);
+      if (!send_ok_2518) {
+        datalayer.system.info.can_2518_send_fail = true;
+      }
+    } break;
     default:
       // Invalid interface sent with function call. TODO: Raise event that coders messed up
       break;
@@ -298,6 +357,10 @@ void receive_can() {
 
   if (canfd) {
     receive_frame_canfd_addon();  // Receive CAN-FD messages.
+  }
+
+  if (canfd_2) {
+    receive_frame_canfd_addon_2();  // Receive CAN-FD messages on 2nd CAN-FD add-on.
   }
 }
 
@@ -346,6 +409,22 @@ void receive_frame_canfd_addon() {  // This section checks if we have a complete
     //message incoming, pass it on to the handler
     map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518);
     map_can_frame_to_variable(&rx_frame, CANFD_NATIVE);
+  }
+}
+
+void receive_frame_canfd_addon_2() {  // This section checks if we have a complete CAN-FD message incoming on 2nd CAN-FD add-on
+  CANFDMessage MCP2518frame;
+  int count = 0;
+  while (canfd_2->available() && count++ < 16) {
+    canfd_2->receive(MCP2518frame);
+
+    CAN_frame rx_frame;
+    rx_frame.ID = MCP2518frame.id;
+    rx_frame.ext_ID = MCP2518frame.ext;
+    rx_frame.DLC = MCP2518frame.len;
+    memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)64));
+    //message incoming, pass it on to the handler
+    map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518_2);
   }
 }
 

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -39,10 +39,6 @@ struct CanReceiverRegistration {
 
 static std::multimap<CAN_Interface, CanReceiverRegistration> can_receivers;
 
-volatile bool send_ok_native = 0;
-volatile bool send_ok_2515 = 0;
-volatile bool send_ok_2518 = 0;
-
 void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interface);
 
 void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {
@@ -52,43 +48,37 @@ void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_S
 
 uint32_t init_native_can(CAN_Speed speed, gpio_num_t tx_pin, gpio_num_t rx_pin);
 
-ACAN_ESP32_Settings* settingsespcan = nullptr;
+static ACAN_ESP32_Settings* settingsespcan = nullptr;
 
-static uint32_t QUARTZ_FREQUENCY;
+static uint32_t quartz_frequency;
 uint8_t user_selected_can_addon_crystal_frequency_mhz = 0;
 
 static MCP2515_Lite* can2515;
 static SPIClass SPI2515(SPI2515_BUS);
 
 static ACAN2517FDSettings::Oscillator quartz_fd_frequency;
-SPIClass SPI2517(SPI2517_BUS);
+static SPIClass SPI2517(SPI2517_BUS);
 uint8_t user_selected_canfd_addon_crystal_frequency_mhz = 0;
-ACAN2517FD* canfd;
-ACAN2517FDSettings* settings2517;
-ACAN2517FD* canfd_2;
-ACAN2517FDSettings* settings2517_2;
+static ACAN2517FD* canfd;
+static ACAN2517FDSettings* settings2517;
+static ACAN2517FD* canfd_2;
+static ACAN2517FDSettings* settings2517_2;
 bool use_canfd_as_can = false;
-bool native_can_initialized = false;
+static bool native_can_initialized = false;
 //CAN logging filter settings
 uint16_t user_selected_CAN_ID_cutoff_filter = 0;  //Messages below this ID will not be logged in webserver
 
 bool init_CAN() {
-
-  if (user_selected_can_addon_crystal_frequency_mhz > 0) {
-    QUARTZ_FREQUENCY = user_selected_can_addon_crystal_frequency_mhz * 1000000UL;
-  } else {
-    QUARTZ_FREQUENCY = CRYSTAL_FREQUENCY_MHZ * 1000000UL;
-  }
-
-  if (user_selected_canfd_addon_crystal_frequency_mhz == 20) {
-    quartz_fd_frequency = ACAN2517FDSettings::OSC_20MHz;
-  } else if (user_selected_canfd_addon_crystal_frequency_mhz == 40) {
-    quartz_fd_frequency = ACAN2517FDSettings::OSC_40MHz;
-  } else {  // Default to 40MHz incase value invalid/not set
-    quartz_fd_frequency = ACAN2517FDSettings::OSC_40MHz;
-  }
+  // Native CAN (onboard the ESP32)
 
   auto nativeIt = can_receivers.find(CAN_NATIVE);
+
+  if (user_selected_can_addon_crystal_frequency_mhz > 0) {
+    quartz_frequency = user_selected_can_addon_crystal_frequency_mhz * 1000000UL;
+  } else {
+    quartz_frequency = CRYSTAL_FREQUENCY_MHZ * 1000000UL;
+  }
+
   if (nativeIt != can_receivers.end()) {
     auto se_pin = esp32hal->CAN_SE_PIN();
     auto tx_pin = esp32hal->CAN_TX_PIN();
@@ -135,6 +125,8 @@ bool init_CAN() {
     }
   }
 
+  // Add-on CAN interface (via MCP2515)
+
   auto addonIt = can_receivers.find(CAN_ADDON_MCP2515);
   if (addonIt != can_receivers.end()) {
     auto cs_pin = esp32hal->MCP2515_CS();
@@ -162,7 +154,7 @@ bool init_CAN() {
 
     SPI2515.begin(sck_pin, miso_pin, mosi_pin);
     can2515 = new MCP2515_Lite(SPI2515, cs_pin, int_pin);
-    if (can2515->begin({(int)addonIt->second.speed * 1000UL, QUARTZ_FREQUENCY})) {
+    if (can2515->begin({(int)addonIt->second.speed * 1000UL, quartz_frequency})) {
       logging.println("MCP2515 CAN ok");
     } else {
       logging.println("MCP2515 CAN init failed");
@@ -171,9 +163,19 @@ bool init_CAN() {
     }
   }
 
+  // FD interface(s) (via MCP2518FD)
+
   auto fdNativeIt = can_receivers.find(CANFD_NATIVE);
   auto fdAddonIt = can_receivers.find(CANFD_ADDON_MCP2518);
   auto fdAddonIt_2 = can_receivers.find(CANFD_ADDON_MCP2518_2);
+
+  if (user_selected_canfd_addon_crystal_frequency_mhz == 20) {
+    quartz_fd_frequency = ACAN2517FDSettings::OSC_20MHz;
+  } else if (user_selected_canfd_addon_crystal_frequency_mhz == 40) {
+    quartz_fd_frequency = ACAN2517FDSettings::OSC_40MHz;
+  } else {  // Default to 40MHz incase value invalid/not set
+    quartz_fd_frequency = ACAN2517FDSettings::OSC_40MHz;
+  }
 
   if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end() || fdAddonIt_2 != can_receivers.end()) {
     // Initialise SPI bus first
@@ -282,7 +284,6 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
 
   switch (interface) {
     case CAN_NATIVE: {
-
       CANMessage frame;
       frame.id = tx_frame->ID;
       frame.ext = tx_frame->ext_ID;
@@ -290,17 +291,16 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
       for (uint8_t i = 0; i < frame.len; i++) {
         frame.data[i] = tx_frame->data.u8[i];
       }
-      send_ok_native = ACAN_ESP32::can.tryToSend(frame);
 
-      if (!send_ok_native) {
+      if (!ACAN_ESP32::can.tryToSend(frame)) {
         datalayer.system.info.can_native_send_fail = true;
       }
     } break;
     case CAN_ADDON_MCP2515: {
       MCP2515_Lite_Frame mcp2515_frame;
       copy_can_frame_to_mcp2515_lite_frame(*tx_frame, mcp2515_frame);
-      send_ok_2515 = can2515->sendFrame(mcp2515_frame);
-      if (!send_ok_2515) {
+
+      if (!can2515->sendFrame(mcp2515_frame)) {
         datalayer.system.info.can_2515_send_fail = true;
       }
     } break;
@@ -315,11 +315,9 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
       MCP2518Frame.id = tx_frame->ID;
       MCP2518Frame.ext = tx_frame->ext_ID;
       MCP2518Frame.len = tx_frame->DLC;
-      for (uint8_t i = 0; i < MCP2518Frame.len; i++) {
-        MCP2518Frame.data[i] = tx_frame->data.u8[i];
-      }
-      send_ok_2518 = canfd->tryToSend(MCP2518Frame);
-      if (!send_ok_2518) {
+      memcpy(MCP2518Frame.data, tx_frame->data.u8, std::min(tx_frame->DLC, (uint8_t)sizeof(MCP2518Frame.data)));
+
+      if (!canfd->tryToSend(MCP2518Frame)) {
         datalayer.system.info.can_2518_send_fail = true;
       }
     } break;
@@ -333,11 +331,9 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
       MCP2518Frame.id = tx_frame->ID;
       MCP2518Frame.ext = tx_frame->ext_ID;
       MCP2518Frame.len = tx_frame->DLC;
-      for (uint8_t i = 0; i < MCP2518Frame.len; i++) {
-        MCP2518Frame.data[i] = tx_frame->data.u8[i];
-      }
-      send_ok_2518 = canfd_2->tryToSend(MCP2518Frame);
-      if (!send_ok_2518) {
+      memcpy(MCP2518Frame.data, tx_frame->data.u8, std::min(tx_frame->DLC, (uint8_t)sizeof(MCP2518Frame.data)));
+
+      if (!canfd_2->tryToSend(MCP2518Frame)) {
         datalayer.system.info.can_2518_send_fail = true;
       }
     } break;
@@ -407,7 +403,7 @@ void receive_frame_canfd_addon() {  // This section checks if we have a complete
     rx_frame.ID = MCP2518frame.id;
     rx_frame.ext_ID = MCP2518frame.ext;
     rx_frame.DLC = MCP2518frame.len;
-    memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)64));
+    memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)sizeof(rx_frame.data.u8)));
     //message incoming, pass it on to the handler
     map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518);
     map_can_frame_to_variable(&rx_frame, CANFD_NATIVE);
@@ -424,7 +420,7 @@ void receive_frame_canfd_addon_2() {  // This section checks if we have a comple
     rx_frame.ID = MCP2518frame.id;
     rx_frame.ext_ID = MCP2518frame.ext;
     rx_frame.DLC = MCP2518frame.len;
-    memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)64));
+    memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)sizeof(rx_frame.data.u8)));
     //message incoming, pass it on to the handler
     map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518_2);
   }
@@ -588,7 +584,7 @@ bool change_can_speed(CAN_Interface interface, CAN_Speed speed) {
     }
     return true;
   } else if (interface == CAN_Interface::CAN_ADDON_MCP2515 && can2515) {
-    can2515->changeSpeed({(int)speed * 1000UL, QUARTZ_FREQUENCY});
+    can2515->changeSpeed({(int)speed * 1000UL, quartz_frequency});
     return true;
   }
 

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -90,6 +90,15 @@ void receive_frame_can_addon();
 void receive_frame_canfd_addon();
 
 /**
+ * @brief Receive CAN messages from 2nd CANFD addon chip
+ *
+ * @param[in] void
+ *
+ * @return void
+ */
+void receive_frame_canfd_addon_2();
+
+/**
  * @brief print CAN frames via USB
  *
  * @param[in] void

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -130,6 +130,8 @@ void init_stored_settings() {
         return CAN_Interface::CAN_ADDON_MCP2515;
       case comm_interface::CanFdAddonMcp2518:
         return CAN_Interface::CANFD_ADDON_MCP2518;
+      case comm_interface::CanFdAddonMcp2518_2:
+        return CAN_Interface::CANFD_ADDON_MCP2518_2;
       case comm_interface::RS485:
       case comm_interface::Modbus:
       case comm_interface::Highest:

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -127,6 +127,10 @@ class Esp32Hal {
   virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_NC; }
 
+  // 2nd CANFD Interface: MCP2517/8
+  virtual gpio_num_t MCP2517_CS2() { return GPIO_NUM_NC; }
+  virtual gpio_num_t MCP2517_INT2() { return GPIO_NUM_NC; }
+
   // CHAdeMO support pin dependencies
   virtual gpio_num_t CHADEMO_PIN_2() { return GPIO_NUM_NC; }
   virtual gpio_num_t CHADEMO_PIN_10() { return GPIO_NUM_NC; }
@@ -190,6 +194,8 @@ class Esp32Hal {
         return "CAN (MCP2515 add-on)";
       case comm_interface::CanFdAddonMcp2518:
         return "CAN FD (MCP2518 add-on)";
+      case comm_interface::CanFdAddonMcp2518_2:
+        return "";
       default:
         return nullptr;
     }

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -131,6 +131,9 @@ class Esp32Hal {
   virtual gpio_num_t MCP2517_CS2() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_INT2() { return GPIO_NUM_NC; }
 
+  // Value for first MCP2517 CLKODIV register (default, divide by 10)
+  virtual int MCP2517_CLKODIV() { return 0b11; }
+
   // CHAdeMO support pin dependencies
   virtual gpio_num_t CHADEMO_PIN_2() { return GPIO_NUM_NC; }
   virtual gpio_num_t CHADEMO_PIN_10() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_becom.h
+++ b/Software/src/devboard/hal/hw_becom.h
@@ -66,7 +66,8 @@ class BEComHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_41; }
 
   std::vector<comm_interface> available_interfaces() {
-    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanFdNative};
+    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanFdAddonMcp2518,
+            comm_interface::CanFdAddonMcp2518_2};
   }
 
   virtual const char* name_for_comm_interface(comm_interface comm) {
@@ -74,11 +75,13 @@ class BEComHal : public Esp32Hal {
       case comm_interface::CanNative:
         return "Inverter CAN (Native)";
       case comm_interface::CanFdNative:
-        return "Battery CANFD (Native)";
+        return "";
       case comm_interface::CanAddonMcp2515:
         return "";
       case comm_interface::CanFdAddonMcp2518:
-        return "CAN FD (MCP2518 add-on)";
+        return "CAN FD Battery 1 (MCP2518)";
+      case comm_interface::CanFdAddonMcp2518_2:
+        return "CAN FD Battery 2 (MCP2518)";
       case comm_interface::Modbus:
         return "Modbus";
       case comm_interface::RS485:

--- a/Software/src/devboard/hal/hw_becom.h
+++ b/Software/src/devboard/hal/hw_becom.h
@@ -91,8 +91,9 @@ class BEComHal : public Esp32Hal {
         return "RS485";
       case comm_interface::Highest:
         return "";
+      default:
+        return Esp32Hal::name_for_comm_interface(comm);
     }
-    return Esp32Hal::name_for_comm_interface(comm);
   }
 };
 

--- a/Software/src/devboard/hal/hw_becom.h
+++ b/Software/src/devboard/hal/hw_becom.h
@@ -34,6 +34,9 @@ class BEComHal : public Esp32Hal {
   virtual gpio_num_t MCP2517_CS2() { return GPIO_NUM_21; }
   virtual gpio_num_t MCP2517_INT2() { return GPIO_NUM_9; }
 
+  // Value for first MCP2517 CLKODIV register (divide by 1)
+  virtual int MCP2517_CLKODIV() { return 0b00; }
+
   // Contactor handling
   virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_47; }
   virtual gpio_num_t NEGATIVE_CONTACTOR_PIN() { return GPIO_NUM_48; }

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -144,8 +144,9 @@ class LilyGoHal : public Esp32Hal {
         return "RS485";
       case comm_interface::Highest:
         return "";
+      default:
+        return Esp32Hal::name_for_comm_interface(comm);
     }
-    return Esp32Hal::name_for_comm_interface(comm);
   }
 };
 

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -159,8 +159,9 @@ class LilyGo2CANHal : public Esp32Hal {
         return "RS485 (Add-on)";
       case comm_interface::Highest:
         return "";
+      default:
+        return Esp32Hal::name_for_comm_interface(comm);
     }
-    return Esp32Hal::name_for_comm_interface(comm);
   }
 };
 

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -125,9 +125,9 @@ class StarkHal : public Esp32Hal {
         return "RS485";
       case comm_interface::Highest:
         return "";
-        break;
+      default:
+        return Esp32Hal::name_for_comm_interface(comm);
     }
-    return Esp32Hal::name_for_comm_interface(comm);
   }
 };
 

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -24,6 +24,7 @@ enum class comm_interface {
   CanFdNative = 4,
   CanAddonMcp2515 = 5,
   CanFdAddonMcp2518 = 6,
+  CanFdAddonMcp2518_2 = 7,
   Highest
 };
 
@@ -88,8 +89,11 @@ enum CAN_Interface {
   // Add-on CAN-FD MCP2518 connected to GPIO pins
   CANFD_ADDON_MCP2518 = 3,
 
+  // 2nd add-on CAN-FD MCP2518 sharing bus with above
+  CANFD_ADDON_MCP2518_2 = 4,
+
   // No CAN interface
-  NO_CAN_INTERFACE = 4
+  NO_CAN_INTERFACE = 5
 };
 
 extern const char* getCANInterfaceName(CAN_Interface interface);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -981,6 +981,12 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       } else {
         return "Add-on CAN-FD via GPIO MCP2518";
       }
+    case CANFD_ADDON_MCP2518_2:
+      if (use_canfd_as_can) {
+        return "Add-on CAN-FD #2 via GPIO MCP2518 (Classic CAN)";
+      } else {
+        return "Add-on CAN-FD #2 via GPIO MCP2518";
+      }
     default:
       return "UNKNOWN";
   }


### PR DESCRIPTION
### What
This adds support for a second MCP2518 on the same SPI bus as the first.

It also adds the Github Actions file to build the BECom firmware.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
