### PR TITLE
Stellantis ECMP: Add DTC clear button

### DIFF
--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -1214,6 +1214,9 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
         DisableIsoMonitoringStatemachine = COMPLETED_STATE;
         timeSpentDisableIsoMonitoring = COMPLETED_STATE;
       }
+    } else if (datalayer_extended.stellantisECMP.UserRequestDTCreset) {
+      transmit_can_frame(&ECMP_CLEAR_DTC);
+      datalayer_extended.stellantisECMP.UserRequestDTCreset = false;
     } else if (datalayer_extended.stellantisECMP.UserRequestContactorReset) {
       if (ContactorResetStatemachine == 0) {
         transmit_can_frame(&ECMP_DIAG_START);

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -26,6 +26,9 @@ class EcmpBattery : public CanBattery {
   bool supports_contactor_reset() { return true; }
   void reset_contactor() { datalayer_extended.stellantisECMP.UserRequestContactorReset = true; }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { datalayer_extended.stellantisECMP.UserRequestDTCreset = true; }
+
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
  private:
@@ -198,6 +201,11 @@ class EcmpBattery : public CanBattery {
                                                  .DLC = 3,
                                                  .ID = 0x6B4,
                                                  .data = {0x02, 0x3E, 0x00}};
+  static constexpr CAN_frame ECMP_CLEAR_DTC = {.FD = false,
+                                               .ext_ID = false,
+                                               .DLC = 5,
+                                               .ID = 0x6B4,
+                                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF}};
 
 #ifdef SIMULATE_ENTIRE_VEHICLE_ECMP
   static constexpr CAN_frame ECMP_0AE = {.FD = false,

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -371,6 +371,7 @@ struct DATALAYER_INFO_ECMP {
   bool MysteryVan = false;      //mysteryvan parameters
   bool CrashMemorized = false;  //mysteryvan parameters
   bool InterlockOpen = false;
+  bool UserRequestDTCreset = false;
   bool UserRequestContactorReset = false;
   bool UserRequestCollisionReset = false;
   bool UserRequestIsolationReset = false;


### PR DESCRIPTION
### What
This PR implements DTC clearing for the Stellantis ECMP platform

### Why
Useful for clearing faults

### How
Button located under the "More Battery Info" page

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
