### PR TITLE
Improvement: Rename Deye specific fix

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1388,7 +1388,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         </div>
 
         <div class="if-byd">
-        <label>Deye offgrid specific fixes: </label>
+        <label>Deye avoid over/undercharge fix: </label>
         <input type='checkbox' name='DEYEBYD' value='on' %DEYEBYD% />
         </div>
 


### PR DESCRIPTION
### What
This PR renames the BYD specific fixes in Webserver settings page

<img width="580" height="157" alt="image" src="https://github.com/user-attachments/assets/c8c035f0-65d8-48a5-96b2-015aa73672db" />

### Why
Make it easier to understand for Deye users that they should use this fix. Less risk of over/undercharged battteries.

Example, overcharged Atto3 battery, Deye did not respect the charge limit being set to 0A, and happily continued to charge the battery over max cellvoltage.

<img width="536" height="269" alt="image" src="https://github.com/user-attachments/assets/50f12927-7ec3-4fd8-8cc1-0c888aac0ccb" />

### How
The setting is renamed from "Deye offgrid specific fixes: " -> "Deye avoid over/undercharge fix:" 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
