### PR TITLE
BYD CAN: Filter out invalid chars for inverter name

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -104,7 +104,9 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
         send_initial_data();
       } else {  // We can identify what inverter type we are connected to
         for (uint8_t i = 0; i < 7; i++) {
-          datalayer.system.info.inverter_brand[i] = rx_frame.data.u8[i + 1];
+          if ((rx_frame.data.u8[i] > 0x40) && (rx_frame.data.u8[i] > 0x7B)) {  //Filter out invalid chars
+            datalayer.system.info.inverter_brand[i] = rx_frame.data.u8[i + 1];
+          }
         }
         datalayer.system.info.inverter_brand[7] = '\0';
       }


### PR DESCRIPTION
### What
This PR implements input validation for inverter protocol name

### Why
Some inverters, such as Afore, violates the BYD standard and push garbage onto the bus. This can be seen when looking at the inverter name, and you see "!"=?!=#" . Worry is that this can crash the board even.

<img width="483" height="91" alt="image" src="https://github.com/user-attachments/assets/7f71b6ed-13c5-4b52-8210-bd0410e276a0" />

### How
We fix this by skipping reading ASCII data that does not fall within the ABC..abc...xyz range 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
