### PR TITLE
Afore: Add LFP cellvoltage spoofing

### DIFF
--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -91,11 +91,23 @@ void AforeCanInverter::
   AFORE_353.data.u8[3] = Fault L table >> 8);
   */
 
-  /*0x354 - Single cell voltage parameters*/
-  AFORE_354.data.u8[0] = (datalayer.battery.status.cell_max_voltage_mV & 0x00FF);
-  AFORE_354.data.u8[1] = (datalayer.battery.status.cell_max_voltage_mV >> 8);
-  AFORE_354.data.u8[2] = (datalayer.battery.status.cell_min_voltage_mV & 0x00FF);
-  AFORE_354.data.u8[3] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
+  //Afore only supports LFP batteries. We need to fake an LFP voltage range if the battery used is not LFP
+  if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
+    //Already LFP, pass thru value
+    cell_tweaked_max_voltage_mV = datalayer.battery.status.cell_max_voltage_mV;
+    cell_tweaked_min_voltage_mV = datalayer.battery.status.cell_min_voltage_mV;
+  } else {  //linear interpolation to remap the value from the range [2500-4200] to [2500-3400]
+    cell_tweaked_max_voltage_mV =
+        (2500 + ((datalayer.battery.status.cell_max_voltage_mV - 2500) * (3400 - 2500)) / (4200 - 2500));
+    cell_tweaked_min_voltage_mV =
+        (2500 + ((datalayer.battery.status.cell_min_voltage_mV - 2500) * (3400 - 2500)) / (4200 - 2500));
+  }
+
+  /*0x354 - Single cell voltage parameters, We fake LFP cellvoltage range if needed*/
+  AFORE_354.data.u8[0] = (cell_tweaked_max_voltage_mV & 0x00FF);
+  AFORE_354.data.u8[1] = (cell_tweaked_max_voltage_mV >> 8);
+  AFORE_354.data.u8[2] = (cell_tweaked_min_voltage_mV & 0x00FF);
+  AFORE_354.data.u8[3] = (cell_tweaked_min_voltage_mV >> 8);
   AFORE_354.data.u8[4] = (1 & 0x00FF);  //Maximum single cell voltage number, not used on emulator
   AFORE_354.data.u8[5] = (1 >> 8);
   AFORE_354.data.u8[6] = (2 & 0x00FF);  //Minimum single cell voltage number, not used on emulator

--- a/Software/src/inverter/AFORE-CAN.h
+++ b/Software/src/inverter/AFORE-CAN.h
@@ -12,6 +12,8 @@ class AforeCanInverter : public CanInverterProtocol {
   static constexpr const char* Name = "Afore battery over CAN";
 
  private:
+  uint16_t cell_tweaked_max_voltage_mV = 3300;
+  uint16_t cell_tweaked_min_voltage_mV = 3300;
   /* The code is following the Afore 2.3 CAN standard, little-endian, 500kbps, from 2023.08.07 */
   uint8_t inverter_status =
       0;  //0 = init, 1 = standby, 2 = starting, 3 = grid connected, 4 off-grid, 5 diesel generator, 6 grid connected, but disconnected, 7off grid and disconnected, 8 = power failure processing, 9 = power off, 10 = Failure


### PR DESCRIPTION
### What
This PR implements cellvoltage spoofing for Afore CAN protocl

### Why
When using Afore CAN, we notice odd charge limits. This might be due to LFP chemistry always being assumed, and if NCM is used we will overvoltage and get limited. Working theory.

### How
We switch to using the same LFP spoofing mechanism as Ferroamp is using!

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
