### PR TITLE
Solax: Fix remaining capacity being larger than 65kWh

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -22,19 +22,6 @@ void SolaxInverter::
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
 
-  // Batteries might be larger than uint16_t value can take
-  if (datalayer.battery.info.reported_total_capacity_Wh > 65000) {
-    capped_capacity_Wh = 65000;
-  } else {
-    capped_capacity_Wh = datalayer.battery.info.reported_total_capacity_Wh;
-  }
-  // Batteries might be larger than uint16_t value can take
-  if (datalayer.battery.status.reported_remaining_capacity_Wh > 65000) {
-    capped_remaining_capacity_Wh = 65000;
-  } else {
-    capped_remaining_capacity_Wh = datalayer.battery.status.reported_remaining_capacity_Wh;
-  }
-
   //Put the values into the CAN messages
   //BMS_Limits
   SOLAX_1872.data.u8[0] = (uint8_t)datalayer.battery.info.max_design_voltage_dV;
@@ -54,8 +41,8 @@ void SolaxInverter::
   SOLAX_1873.data.u8[3] = (datalayer.battery.status.reported_current_dA >> 8);
   SOLAX_1873.data.u8[4] = (uint8_t)(datalayer.battery.status.reported_soc / 100);  //SOC (100.00%)
   //SOLAX_1873.data.u8[5] = //Seems like this is not required? Or shall we put SOC decimals here?
-  SOLAX_1873.data.u8[6] = (uint8_t)(capped_remaining_capacity_Wh / 10);
-  SOLAX_1873.data.u8[7] = ((capped_remaining_capacity_Wh / 10) >> 8);
+  SOLAX_1873.data.u8[6] = (uint8_t)(datalayer.battery.status.reported_remaining_capacity_Wh / 10);
+  SOLAX_1873.data.u8[7] = ((datalayer.battery.status.reported_remaining_capacity_Wh / 10) >> 8);
 
   //BMS_CellData
   SOLAX_1874.data.u8[0] = (int8_t)datalayer.battery.status.temperature_max_dC;

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -26,8 +26,6 @@ class SolaxInverter : public CanInverterProtocol {
   uint8_t STATE = BATTERY_ANNOUNCE;
   unsigned long LastFrameTime = 0;
   uint8_t number_of_batteries = 1;
-  uint16_t capped_capacity_Wh;
-  uint16_t capped_remaining_capacity_Wh;
 
   uint16_t configured_number_of_modules = 0;
   uint16_t configured_battery_type = 0;


### PR DESCRIPTION
### What
This PR fixes that remaining capacity could not be larger than 65kWh

### Why
Fixes #2106

### How
We use the uint32_t value directly, and just smash it in

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
