### PR TITLE
fix unit conversion and add page refresh

### DIFF
--- a/Software/src/battery/CHADEMO-BATTERY-HTML.h
+++ b/Software/src/battery/CHADEMO-BATTERY-HTML.h
@@ -65,6 +65,11 @@ class ChademoBatteryHtmlRenderer : public BatteryHtmlRenderer {
     }
     content += "<h4>Protocol: " + String(datalayer_extended.chademo.ControlProtocolNumberEV) + "</h4>";
 
+    //Script for refreshing page
+    content += "<script>";
+    content += "setTimeout(function(){ location.reload(true); }, 5000);";
+    content += "</script>";
+
     return content;
   }
 };

--- a/Software/src/battery/CHADEMO-CT.cpp
+++ b/Software/src/battery/CHADEMO-CT.cpp
@@ -73,7 +73,7 @@ float get_measured_current_ct() {
   for (int i = 0; i < 10; i++) {
     pin_V += (float)analogReadMilliVolts(ct_pin);
   }
-  pin_V = (pin_V / 10.0f) * 1000.0f;
+  pin_V = (pin_V / 10.0f) / 1000.0f;
   Amperes = (pin_V - CT_V_offset) * (CT_A_nominal / CT_V_nominal);
   if (ct_invert_current) {
     Amperes = -Amperes;


### PR DESCRIPTION
### What
Fix for incorrect conversion from mV to V in CT clamp code and adds a 5s refresh on chademo page to see data updates

### Why
Why does it do it?

### How
How does it do it?

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
