### PR TITLE
Fix BYD Atto 3 charge taper low SOC behaviour

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -192,7 +192,7 @@ void BydAttoBattery::
   static uint16_t cap_slewed_dA = 0;
   static uint32_t last_ms = 0;
   static bool taper_initialized = false;  // explicit flag avoids cap_slewed_dA starting at 0
- 
+
   const uint32_t now_ms = (uint32_t)millis64();
   if (!taper_initialized) {
     last_ms = now_ms;


### PR DESCRIPTION
### What
Modifies the BYD Atto 3 charge taper to only activate at high states of charge & fixes a slew rate bug

### Why
Currently the taper will activate if any criteria are met, meaning if cell deviation etc get large at low SOC, the taper will activate restricting charge current.

### How
Introduce a initialisation fix of the slew rate limiter so that it is guaranteed to start at full current before any power cap is applied.

Only allow charge taper to apply if the cell max is already above the start of taper value, stopping it applying at low SOC.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
