### PR TITLE
Feature: Add color to Event backgrounds

### DIFF
--- a/Software/src/devboard/webserver/events_html.cpp
+++ b/Software/src/devboard/webserver/events_html.cpp
@@ -46,9 +46,33 @@ String events_processor(const String& var) {
       EVENTS_ENUM_TYPE event_handle = event.event_handle;
       event_pointer = event.event_pointer;
 
-      content.concat("<div class='event'>");
+      // Get the event level string and determine background color
+      String event_level = String(get_event_level_string(event_handle));
+      String bg_color;
+      String text_color = "#000000";
+
+      // Set colors based on event level
+      if (event_level == "INFO") {
+        bg_color = "#04b34f";
+      } else if (event_level == "WARNING") {
+        bg_color = "#ff9900";
+      } else if (event_level == "ERROR") {
+        bg_color = "#a6192e";
+        text_color = "#ffffff";
+      } else {
+        bg_color = "";
+      }
+
+      // Start event div with inline style for background color
+      content.concat("<div class='event'");
+      if (bg_color.length() > 0) {
+        content.concat(" style='background-color: " + bg_color + "; color: " + text_color + ";'>");
+      } else {
+        content.concat(">");
+      }
+
       content.concat("<div>" + String(get_event_enum_string(event_handle)) + "</div>");
-      content.concat("<div>" + String(get_event_level_string(event_handle)) + "</div>");
+      content.concat("<div>" + event_level + "</div>");
       // Frontend expects to see time difference (in ms) from now to event
       content.concat("<div class='sec-ago'>" + String(current_timestamp - event_pointer->timestamp) + "</div>");
       content.concat("<div>" + String(event_pointer->occurences) + "</div>");


### PR DESCRIPTION
### What
This PR adds color to Event backgrounds

### Why
It is easy to become overwhelmed by events, and focus on troubleshooting trivial INFO severity events. This change clearly marks the events with specific colors, to signal to user which ones need attention. This semantic colour palette was used: https://summit.calgary.ca/visual-identity/colour/semantic-colour-palette.html 

### How
Before on the left, after on the right:

<img width="1705" height="521" alt="image" src="https://github.com/user-attachments/assets/c531bbc3-fea1-45c5-a5e3-fb6954c45aab" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
