### PR TITLE
Thunderstruck: Update CAN handler for Thunderstruck

### DIFF
--- a/Software/src/battery/THUNDERSTRUCK-BMS.cpp
+++ b/Software/src/battery/THUNDERSTRUCK-BMS.cpp
@@ -79,12 +79,12 @@ void ThunderstruckBMS::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x14ff26d0:  //OCV
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
-    case 0x14ff25d0:  //DCL / CCL
+    case 0x14ff25d0:  //DCL / CCL / Discharge/Charge Current Limits
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      DCLMin = ((rx_frame.data.u8[0] << 8) | rx_frame.data.u8[1]);
-      CCLMin = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
-      DCLMax = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
-      CCLMax = ((rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7]);
+      DCLMin = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
+      CCLMin = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
+      DCLMax = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]);
+      CCLMax = ((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]);
       break;
     case 0x14ff24d0:  //SOC
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -97,13 +97,13 @@ void ThunderstruckBMS::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x14ff22d0:  //Minmax cellvoltages
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      lowest_cell_voltage = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
-      highest_cell_voltage = ((rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7]);
+      lowest_cell_voltage = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
+      highest_cell_voltage = ((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]);
       break;
     case 0x14ff21d0:  //Packvoltage
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      packvoltage_dV = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
-      pack_curent_dA = (int16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
+      packvoltage_dV = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
+      pack_curent_dA = (int16_t)((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]);
       break;
     case 0x14ff20d0:  //Active faults
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -161,7 +161,7 @@ void ThunderstruckBMS::transmit_can(unsigned long currentMillis) {
     THUND_14ebd0d8.data.u8[1] = 0xFF;           //(Still PGN field, should this be 0x00 or 0xFF?))
     THUND_14ebd0d8.data.u8[2] = 0x0a;  //Request rate (0x0a = 10, and each tick is 50ms, so 500ms between messages)
     THUND_14ebd0d8.data.u8[3] =
-        0x08;  //Request Repeat Count, requests the message be sent 8 times (0x08) before needing to be requested again.
+        0x01;  //Request Repeat Count, requests the message be sent X times (0x0X) before needing to be requested again.
     THUND_14ebd0d8.data.u8[7] = 0x00;     //Profile number //TODO: !
     transmit_can_frame(&THUND_14ebd0d8);  //J1939_MCU_ReadRequest
 

--- a/Software/src/battery/THUNDERSTRUCK-BMS.cpp
+++ b/Software/src/battery/THUNDERSTRUCK-BMS.cpp
@@ -156,9 +156,16 @@ void ThunderstruckBMS::transmit_can(unsigned long currentMillis) {
   // Send 500ms CAN Message
   if (currentMillis - previousMillis500 >= INTERVAL_500_MS) {
     previousMillis500 = currentMillis;
+    PGNindex = (PGNindex + 1) % 13;             // PGN repeats after 13 messages. 0-1..12-0
+    THUND_14ebd0d8.data.u8[0] = PGN[PGNindex];  //PGN is in byte 1 of the data
+    THUND_14ebd0d8.data.u8[1] = 0x00;           //(Still PGN field, should this be 0x00 or 0xFF?)) //TODO: !
+    THUND_14ebd0d8.data.u8[2] = 0x0a;  //Request rate (0x0a = 10, and each tick is 50ms, so 500ms between messages)
+    THUND_14ebd0d8.data.u8[3] =
+        0x08;  //Request Repeat Count, requests the message be sent 8 times (0x08) before needing to be requested again.
+    THUND_14ebd0d8.data.u8[7] = 0x00;     //Profile number //TODO: !
+    transmit_can_frame(&THUND_14ebd0d8);  //J1939_MCU_ReadRequest
 
-    transmit_can_frame(&THUND_14efd0d8);
-    //TODO, should 14ebd0d8 be sent also?
+    //transmit_can_frame(&THUND_14efd0d8); //J1939_MCU_WRITE
   }
 }
 

--- a/Software/src/battery/THUNDERSTRUCK-BMS.cpp
+++ b/Software/src/battery/THUNDERSTRUCK-BMS.cpp
@@ -158,7 +158,7 @@ void ThunderstruckBMS::transmit_can(unsigned long currentMillis) {
     previousMillis500 = currentMillis;
     PGNindex = (PGNindex + 1) % 13;             // PGN repeats after 13 messages. 0-1..12-0
     THUND_14ebd0d8.data.u8[0] = PGN[PGNindex];  //PGN is in byte 1 of the data
-    THUND_14ebd0d8.data.u8[1] = 0x00;           //(Still PGN field, should this be 0x00 or 0xFF?)) //TODO: !
+    THUND_14ebd0d8.data.u8[1] = 0xFF;           //(Still PGN field, should this be 0x00 or 0xFF?))
     THUND_14ebd0d8.data.u8[2] = 0x0a;  //Request rate (0x0a = 10, and each tick is 50ms, so 500ms between messages)
     THUND_14ebd0d8.data.u8[3] =
         0x08;  //Request Repeat Count, requests the message be sent 8 times (0x08) before needing to be requested again.

--- a/Software/src/battery/THUNDERSTRUCK-BMS.h
+++ b/Software/src/battery/THUNDERSTRUCK-BMS.h
@@ -41,7 +41,7 @@ class ThunderstruckBMS : public CanBattery {
                               .ext_ID = true,
                               .DLC = 8,
                               .ID = 0x14ebd0d8,
-                              .data = {0x20, 0x00, 0x0a, 0x08, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x20, 0xFF, 0x0a, 0x08, 0x00, 0x00, 0x00, 0x00}};
 };
 
 #endif

--- a/Software/src/battery/THUNDERSTRUCK-BMS.h
+++ b/Software/src/battery/THUNDERSTRUCK-BMS.h
@@ -31,15 +31,17 @@ class ThunderstruckBMS : public CanBattery {
   int16_t pack_curent_dA = 0;
 
   uint8_t SOC = 50;
+  uint8_t PGNindex = 0;
+  uint8_t PGN[13] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x11, 0x12, 0x18, 0x19, 0x20, 0x1A};
 
   int8_t highest_cell_temperature = 0;
   int8_t lowest_cell_temperature = 0;
 
-  CAN_frame THUND_14efd0d8 = {.FD = false,
+  CAN_frame THUND_14ebd0d8 = {.FD = false,
                               .ext_ID = true,
                               .DLC = 8,
                               .ID = 0x14ebd0d8,
-                              .data = {0x20, 0xff, 0x0a, 0x08, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x20, 0x00, 0x0a, 0x08, 0x00, 0x00, 0x00, 0x00}};
 };
 
 #endif


### PR DESCRIPTION
### What
This PR improves the J1939_MCU_ReadRequest handling

### Why
User feedback, initial implementation did not work

### How
We follow the newer v1.3.4 protocol

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
