### PR TITLE
Solax: min/max cell voltage fix/rescale for IE102 error

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -49,10 +49,33 @@ void SolaxInverter::
   SOLAX_1874.data.u8[1] = (datalayer.battery.status.temperature_max_dC >> 8);
   SOLAX_1874.data.u8[2] = (int8_t)datalayer.battery.status.temperature_min_dC;
   SOLAX_1874.data.u8[3] = (datalayer.battery.status.temperature_min_dC >> 8);
-  SOLAX_1874.data.u8[4] = (uint8_t)(datalayer.battery.info.max_cell_voltage_mV);
-  SOLAX_1874.data.u8[5] = (datalayer.battery.info.max_cell_voltage_mV >> 8);
-  SOLAX_1874.data.u8[6] = (uint8_t)(datalayer.battery.status.cell_min_voltage_mV);
-  SOLAX_1874.data.u8[7] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
+
+  int32_t cell_max_voltage_mV = datalayer.battery.status.cell_max_voltage_mV;
+  int32_t cell_min_voltage_mV = datalayer.battery.status.cell_min_voltage_mV;
+
+  // Fake values during startup?
+  if (cell_max_voltage_mV == 0) {
+    cell_max_voltage_mV = 3300;
+  }
+  if (cell_min_voltage_mV == 0) {
+    cell_min_voltage_mV = 3300;
+  }
+
+  // Rescale to the range 3.0->3.5V
+  cell_max_voltage_mV =
+      3000 + ((cell_max_voltage_mV - datalayer.battery.info.min_cell_voltage_mV) * (3500 - 3000)) /
+                 (datalayer.battery.info.max_cell_voltage_mV - datalayer.battery.info.min_cell_voltage_mV);
+  cell_min_voltage_mV =
+      3000 + ((cell_min_voltage_mV - datalayer.battery.info.min_cell_voltage_mV) * (3500 - 3000)) /
+                 (datalayer.battery.info.max_cell_voltage_mV - datalayer.battery.info.min_cell_voltage_mV);
+
+  uint16_t cell_max_voltage_dV = cell_max_voltage_mV / 100;
+  uint16_t cell_min_voltage_dV = cell_min_voltage_mV / 100;
+
+  SOLAX_1874.data.u8[4] = (uint8_t)(cell_max_voltage_dV);
+  SOLAX_1874.data.u8[5] = (cell_max_voltage_dV >> 8);
+  SOLAX_1874.data.u8[6] = (uint8_t)(cell_min_voltage_dV);
+  SOLAX_1874.data.u8[7] = (cell_min_voltage_dV >> 8);
 
   //BMS_Status
   SOLAX_1875.data.u8[0] = (uint8_t)temperature_average;

--- a/Software/src/inverter/SOLAX-CAN.h
+++ b/Software/src/inverter/SOLAX-CAN.h
@@ -14,7 +14,7 @@ class SolaxInverter : public CanInverterProtocol {
 
  private:
   static const uint8_t DEFAULT_NUMBER_OF_MODULES = 0;
-  static const uint8_t DEFAULT_BATTERY_TYPE = 0x50;
+  static const uint8_t DEFAULT_BATTERY_TYPE = 0x51;
   //SOLAX BMS States Definition
   static const int BATTERY_ANNOUNCE = 0;
   static const int WAITING_FOR_CONTACTOR = 1;


### PR DESCRIPTION
### What
The latest Solax firmware is causing Bat Mismatch IE102 errors.

From a bit of Ghidra-ing, this seems to be due to the CAN-reported cell voltages in 1874 not meeting its requirements. They are actually expected in dV, not mV, and also to fit the LFP range (2.9 to 3.6V).

This fix the reporting of these voltages and scales if necessary.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
