### PR TITLE
Remove 0 validation check from writing uint settings

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -484,9 +484,7 @@ void init_webserver() {
                 for (auto& uintSetting : uintSettingNames) {
                   if (p->name() == uintSetting) {
                     auto value = atoi(p->value().c_str());
-                    if (settings.getUInt(uintSetting, 0) != value) {
-                      settings.saveUInt(uintSetting, value);
-                    }
+                    settings.saveUInt(uintSetting, value);
                   }
                 }
 


### PR DESCRIPTION
### What
This PR removes a sanity check from the save unsigned integers function

### Why
It was preventing being able to save 0 as a value, which prevented IP addresses to get written. Fixes #2139

### How
We remove the check

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
