### PR TITLE
Stellantis eCMP: Filter out invalid 215C temperature readings

### DIFF
--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -844,13 +844,23 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               pid_coldest_module = (rx_frame.data.u8[4]);
               break;
             case PID_LOWEST_TEMPERATURE:
-              pid_lowest_temperature = (rx_frame.data.u8[4] - 40);
+              if (rx_frame.data.u8[4] == 0xFF) {
+                pid_lowest_temperature = 0;  //FF means value unavailable, set to 0 to avoid confusion
+                set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
+              } else {
+                pid_lowest_temperature = (rx_frame.data.u8[4] - 40);
+              }
               break;
             case PID_AVERAGE_TEMPERATURE:
               pid_average_temperature = (rx_frame.data.u8[4] - 40);
               break;
             case PID_HIGHEST_TEMPERATURE:
-              pid_highest_temperature = (rx_frame.data.u8[4] - 40);
+              if (rx_frame.data.u8[4] == 0xFF) {
+                pid_highest_temperature = 0;  //FF means value unavailable, set to 0 to avoid confusion
+                set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0);
+              } else {
+                pid_highest_temperature = (rx_frame.data.u8[4] - 40);
+              }
               break;
             case PID_HOTTEST_MODULE:
               pid_hottest_module = (rx_frame.data.u8[4]);


### PR DESCRIPTION
### What
This PR implements invalid temperature measurement filtering for the eCMP

### Why
Fixes #2168

Some eCMP packs have been encountered that dont respond to this poll well, or they have internal issues. This PR aids further troubleshooting

### How
Incase battery sends a 0xff unavailable temp measurement
- We fire off an EVENT_BATTERY_VALUE_UNAVAILABLE warning event
- We set temperature to 0 (previously it was set to 215*C)

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
