### PR TITLE
Update MQTT implementation to stop using deprecated option "object_id"

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -38,7 +38,7 @@ bool mqtt_manual_topic_object_name =
 // may break compatibility with previous versions of MQTT naming
 const char* mqtt_topic_name =
     "BE";  // Custom MQTT topic name. Previously, the name was automatically set to "battery-emulator_esp32-XXXXXX"
-const char* mqtt_object_id_prefix =
+const char* mqtt_default_entity_id_prefix =
     "be_";  // Custom prefix for MQTT object ID. Previously, the prefix was automatically set to "esp32-XXXXXX_"
 const char* mqtt_device_name =
     "Battery Emulator";  // Custom device name in Home Assistant. Previously, the name was automatically set to "BatteryEmulator_esp32-XXXXXX"
@@ -56,7 +56,7 @@ bool client_started = false;
 static String lwt_topic = "";
 
 static String topic_name = "";
-static String object_id_prefix = "";
+static String default_entity_id_prefix = "";
 static String device_name = "";
 static String device_id = "";
 
@@ -98,7 +98,7 @@ static bool ha_cell_voltages_published = false;
 static bool ha_events_published = false;
 static bool ha_buttons_published = false;
 struct SensorConfig {
-  const char* object_id;
+  const char* default_entity_id;
   const char* name;
   const char* value_template;
   const char* unit;
@@ -148,14 +148,14 @@ static std::list<SensorConfig> sensorConfigs;
 
 void create_battery_sensor_configs() {
   for (auto& config : batterySensorConfigTemplate) {
-    config.value_template = strdup(("{{ value_json." + std::string(config.object_id) + " }}").c_str());
+    config.value_template = strdup(("{{ value_json." + std::string(config.default_entity_id) + " }}").c_str());
 
     sensorConfigs.push_back(config);
 
     if (battery2) {
-      config.value_template = strdup(("{{ value_json." + std::string(config.object_id) + "_2 }}").c_str());
+      config.value_template = strdup(("{{ value_json." + std::string(config.default_entity_id) + "_2 }}").c_str());
       config.name = strdup(String(config.name + String(" 2")).c_str());
-      config.object_id = strdup(String(config.object_id + String("_2")).c_str());
+      config.default_entity_id = strdup(String(config.default_entity_id + String("_2")).c_str());
 
       sensorConfigs.push_back(config);
     }
@@ -164,7 +164,7 @@ void create_battery_sensor_configs() {
 
 void create_global_sensor_configs() {
   for (auto& config : globalSensorConfigTemplate) {
-    config.value_template = strdup(("{{ value_json." + std::string(config.object_id) + " }}").c_str());
+    config.value_template = strdup(("{{ value_json." + std::string(config.default_entity_id) + " }}").c_str());
     sensorConfigs.push_back(config);
   }
 }
@@ -175,16 +175,16 @@ SensorConfig buttonConfigs[] = {{"BMSRESET", "Reset BMS", nullptr, nullptr, null
                                 {"RESTART", "Restart Battery Emulator", nullptr, nullptr, nullptr, nullptr},
                                 {"STOP", "Open Contactors", nullptr, nullptr, nullptr, nullptr}};
 
-static String generateCommonInfoAutoConfigTopic(const char* object_id) {
-  return "homeassistant/sensor/" + topic_name + "/" + String(object_id) + "/config";
+static String generateCommonInfoAutoConfigTopic(const char* default_entity_id) {
+  return "homeassistant/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
 }
 
 static String generateCellVoltageAutoConfigTopic(int cell_number, String battery_suffix) {
   return "homeassistant/sensor/" + topic_name + "/cell_voltage" + battery_suffix + String(cell_number) + "/config";
 }
 
-static String generateEventsAutoConfigTopic(const char* object_id) {
-  return "homeassistant/sensor/" + topic_name + "/" + String(object_id) + "/config";
+static String generateEventsAutoConfigTopic(const char* default_entity_id) {
+  return "homeassistant/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
 }
 
 static String generateButtonAutoConfigTopic(const char* subtype) {
@@ -203,10 +203,10 @@ void set_common_discovery_attributes(JsonDocument& doc) {
 }
 
 void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, const String& state_topic,
-                                    const String& object_id_prefix, const String& battery_name_suffix) {
+                                    const String& default_entity_id_prefix, const String& battery_name_suffix) {
   doc["name"] = "Battery" + battery_name_suffix + " Cell Voltage " + String(cellNumber);
-  doc["object_id"] = object_id_prefix + "battery_voltage_cell" + String(cellNumber);
-  doc["unique_id"] = topic_name + object_id_prefix + "_battery_voltage_cell" + String(cellNumber);
+  doc["default_entity_id"] = default_entity_id_prefix + "battery_voltage_cell" + String(cellNumber);
+  doc["unique_id"] = topic_name + default_entity_id_prefix + "_battery_voltage_cell" + String(cellNumber);
   doc["device_class"] = "voltage";
   doc["state_class"] = "measurement";
   doc["state_topic"] = state_topic;
@@ -292,8 +292,8 @@ static bool publish_common_info(void) {
 
       doc["name"] = config.name;
       doc["state_topic"] = state_topic;
-      doc["unique_id"] = topic_name + "_" + String(config.object_id);
-      doc["object_id"] = object_id_prefix + String(config.object_id);
+      doc["unique_id"] = topic_name + "_" + String(config.default_entity_id);
+      doc["default_entity_id"] = default_entity_id_prefix + String(config.default_entity_id);
       doc["value_template"] = config.value_template;
       if (config.unit != nullptr && strlen(config.unit) > 0) {
         doc["unit_of_measurement"] = config.unit;
@@ -304,7 +304,7 @@ static bool publish_common_info(void) {
       }
       set_common_discovery_attributes(doc);
       serializeJson(doc, mqtt_msg);
-      if (mqtt_publish(generateCommonInfoAutoConfigTopic(config.object_id).c_str(), mqtt_msg, true)) {
+      if (mqtt_publish(generateCommonInfoAutoConfigTopic(config.default_entity_id).c_str(), mqtt_msg, true)) {
         ha_common_info_published = true;
       } else {
         return false;
@@ -357,7 +357,7 @@ static bool publish_cell_voltages(void) {
 
         for (int i = 0; i < datalayer.battery.info.number_of_cells; i++) {
           int cellNumber = i + 1;
-          set_battery_voltage_attributes(doc, i, cellNumber, state_topic, object_id_prefix, "");
+          set_battery_voltage_attributes(doc, i, cellNumber, state_topic, default_entity_id_prefix, "");
           set_common_discovery_attributes(doc);
 
           serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
@@ -377,7 +377,7 @@ static bool publish_cell_voltages(void) {
 
           for (int i = 0; i < datalayer.battery2.info.number_of_cells; i++) {
             int cellNumber = i + 1;
-            set_battery_voltage_attributes(doc, i, cellNumber, state_topic_2, object_id_prefix + "2_", " 2");
+            set_battery_voltage_attributes(doc, i, cellNumber, state_topic_2, default_entity_id_prefix + "2_", " 2");
             set_common_discovery_attributes(doc);
 
             serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
@@ -486,7 +486,7 @@ bool publish_events() {
     doc["name"] = "Event";
     doc["state_topic"] = state_topic;
     doc["unique_id"] = topic_name + "_event";
-    doc["object_id"] = object_id_prefix + "event";
+    doc["default_entity_id"] = default_entity_id_prefix + "event";
     doc["value_template"] =
         "{{ value_json.event_type ~ ' (c:' ~ value_json.count ~ ',m:' ~  value_json.millis ~ ') ' ~ value_json.message "
         "}}";
@@ -552,11 +552,11 @@ static bool publish_buttons_discovery(void) {
       for (int i = 0; i < sizeof(buttonConfigs) / sizeof(buttonConfigs[0]); i++) {
         SensorConfig& config = buttonConfigs[i];
         doc["name"] = config.name;
-        doc["unique_id"] = object_id_prefix + config.object_id;
-        doc["command_topic"] = generateButtonTopic(config.object_id);
+        doc["unique_id"] = default_entity_id_prefix + config.default_entity_id;
+        doc["command_topic"] = generateButtonTopic(config.default_entity_id);
         set_common_discovery_attributes(doc);
         serializeJson(doc, mqtt_msg);
-        if (mqtt_publish(generateButtonAutoConfigTopic(config.object_id).c_str(), mqtt_msg, true)) {
+        if (mqtt_publish(generateButtonAutoConfigTopic(config.default_entity_id).c_str(), mqtt_msg, true)) {
           ha_buttons_published = true;
         } else {
           return false;
@@ -692,7 +692,7 @@ bool init_mqtt(void) {
 
     BatteryEmulatorSettingsStore settings;
     topic_name = settings.getString("MQTTTOPIC", mqtt_topic_name);
-    object_id_prefix = settings.getString("MQTTOBJIDPREFIX", mqtt_object_id_prefix);
+    default_entity_id_prefix = settings.getString("MQTTOBJIDPREFIX", mqtt_default_entity_id_prefix);
     device_name = settings.getString("MQTTDEVICENAME", mqtt_device_name);
     device_id = settings.getString("HADEVICEID", ha_device_id);
 
@@ -700,8 +700,8 @@ bool init_mqtt(void) {
       topic_name = mqtt_topic_name;
     }
 
-    if (object_id_prefix.length() == 0) {
-      object_id_prefix = mqtt_object_id_prefix;
+    if (default_entity_id_prefix.length() == 0) {
+      default_entity_id_prefix = mqtt_default_entity_id_prefix;
     }
 
     if (device_name.length() == 0) {
@@ -715,7 +715,7 @@ bool init_mqtt(void) {
   } else {
     // Use default naming based on WiFi hostname for topic, object ID prefix, and device name
     topic_name = "battery-emulator_" + String(WiFi.getHostname());
-    object_id_prefix = String(WiFi.getHostname()) + String("_");
+    default_entity_id_prefix = String(WiFi.getHostname()) + String("_");
     device_name = "BatteryEmulator_" + String(WiFi.getHostname());
     device_id = "battery-emulator";
   }


### PR DESCRIPTION
Updated 35 object_id to default_entity_id. Addresses #1899 

What
This PR implements a fix for a Home Assistatant bug

Why
The configuration for entity sensor.be_bms_status & others use the deprecated option object_id to set the default entity id.

How
Replace the "object_id": "be_bms_status" option with "default_entity_id": "sensor.be_bms_status" in your published discovery configuration

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
