### PR TITLE
Fronius: Use actual battery voltage for calculating limits

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -68,13 +68,13 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   }
   // Convert max discharge Amp value to max Watt
   user_configured_max_discharge_W =
-      ((datalayer.battery.settings.max_user_set_discharge_dA * datalayer.battery.info.max_design_voltage_dV) / 100);
+      ((datalayer.battery.settings.max_user_set_discharge_dA * datalayer.battery.status.voltage_dV) / 100);
   // Use the smaller value, battery reported value OR user configured value
   max_discharge_W = std::min(datalayer.battery.status.max_discharge_power_W, user_configured_max_discharge_W);
 
   // Convert max charge Amp value to max Watt
   user_configured_max_charge_W =
-      ((datalayer.battery.settings.max_user_set_charge_dA * datalayer.battery.info.max_design_voltage_dV) / 100);
+      ((datalayer.battery.settings.max_user_set_charge_dA * datalayer.battery.status.voltage_dV) / 100);
   // Use the smaller value, battery reported value OR user configured value
   max_charge_W = std::min(datalayer.battery.status.max_charge_power_W, user_configured_max_charge_W);
 


### PR DESCRIPTION
### What
This PR makes the Fronius use battery voltage instead of theoretical max voltage to calculate charge/discharge limits

### Why
Old implementation could lead to confusing state, where selecting 20A would still allow inverter to charge with 22A. First when going down to 19A a change was registered on the inverter side.

### How
We switch to using actual battery voltage for charge limit calculation instead of theoretical max pack voltage limit

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
