### PR TITLE
Spring K-ZE: Add offset to min/max cellvoltage readings

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -149,13 +149,13 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               (uint32_t)((rx_frame.data.u8[5] << 16) | (rx_frame.data.u8[6] << 8) | (rx_frame.data.u8[7]));
           break;
         case PID_POLL_HIGHEST_CELL_VOLTAGE:
-          highest_cell_voltage_mv = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) - 85;
+          highest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563);
           break;
         case PID_POLL_CELL_NUMBER_HIGHEST_VOLTAGE:
           highest_cell_voltage_number = rx_frame.data.u8[4];
           break;
         case PID_POLL_LOWEST_CELL_VOLTAGE:
-          lowest_cell_voltage_mv = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) - 85;
+          lowest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563);
           break;
         case PID_POLL_CELL_NUMBER_LOWEST_VOLTAGE:
           lowest_cell_voltage_number = rx_frame.data.u8[4];


### PR DESCRIPTION
### What
This PR fixes the min/max voltages shown on the main page for CMFA platform (Spring/K-ZE)

### Why
There was a discrepancy between the reported min/max on the main page and the cellmonitor page.

### How
We take * 0.976563 from the polled values used on the main page. This makes the readings match reality. Same implementation as Zoe


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
