### PR TITLE
Feature: Double BOLT-AMPERA battery support 🔋🔋

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -38,7 +38,7 @@
 #endif
 
 // The current software version, shown on webserver
-const char* version_number = "10.4.0_BDB_v1";
+const char* version_number = "10.4.0";
 
 // Interval timers
 volatile unsigned long currentMillis = 0;
@@ -318,13 +318,13 @@ void update_calculated_values(unsigned long currentMillis) {
   if (datalayer.battery.settings.soc_scaling_active) {
     /** SOC Scaling
    * A static version of a stochastic oscillator. The scaled SoC is calculated as:
-   * 
+   *
    *     10000 * (real_soc - min_percentage)
    * ---------------------------------------
    *     (max_percentage - min_percentage)
-   * 
+   *
    * And scaled capacity is:
-   * 
+   *
    *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
    *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
    */

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -38,7 +38,7 @@
 #endif
 
 // The current software version, shown on webserver
-const char* version_number = "10.4.0";
+const char* version_number = "10.4.0_BDB_v1";
 
 // Interval timers
 volatile unsigned long currentMillis = 0;

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -289,6 +289,10 @@ void setup_battery() {
 
   if (user_selected_second_battery && !battery2) {
     switch (user_selected_battery_type) {
+      case BatteryType::BoltAmpera:
+        battery2 = new BoltAmperaBattery(&datalayer.battery2, &datalayer_extended.boltampera_2,
+                                         can_config.battery_double);
+        break;
       case BatteryType::BydAtto3:
         battery2 = new BydAttoBattery(&datalayer.battery2, nullptr, can_config.battery_double);
         break;

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -290,8 +290,8 @@ void setup_battery() {
   if (user_selected_second_battery && !battery2) {
     switch (user_selected_battery_type) {
       case BatteryType::BoltAmpera:
-        battery2 = new BoltAmperaBattery(&datalayer.battery2, &datalayer_extended.boltampera_2,
-                                         can_config.battery_double);
+        battery2 =
+            new BoltAmperaBattery(&datalayer.battery2, &datalayer_extended.boltampera_2, can_config.battery_double);
         break;
       case BatteryType::BydAtto3:
         battery2 = new BydAttoBattery(&datalayer.battery2, nullptr, can_config.battery_double);

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -79,75 +79,77 @@ static uint16_t estimateSOC(uint16_t cellVoltage) {  // Linear interpolation fun
 
 void BoltAmperaBattery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
 
-  datalayer.battery.status.real_soc = estimateSOC(battery_cell_voltage_max_mV);  //TODO, this is bad and barely works
+  datalayer_battery->status.real_soc = estimateSOC(battery_cell_voltage_max_mV);  //TODO, this is bad and barely works
 
-  datalayer.battery.status.voltage_dV = battery_voltage_periodic_dV;
+  datalayer_battery->status.voltage_dV = battery_voltage_periodic_dV;
 
-  datalayer.battery.status.current_dA = (sensed_current_sensor_1 * 0.2);  //TODO: Is sensor 1 OK?
+  datalayer_battery->status.current_dA = (sensed_current_sensor_1 * 0.2);  //TODO: Is sensor 1 OK?
 
-  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+  datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
 
-  datalayer.battery.status.soh_pptt = 9900;
+  datalayer_battery->status.soh_pptt = 9900;
 
   // Charge power is set in .h file (TODO: Remove this estimation when real value has been found)
-  if (datalayer.battery.status.real_soc > 9900) {
-    datalayer.battery.status.max_charge_power_W = MAX_CHARGE_POWER_WHEN_TOPBALANCING_W;
-  } else if (datalayer.battery.status.real_soc > RAMPDOWN_SOC) {
+  if (datalayer_battery->status.real_soc > 9900) {
+    datalayer_battery->status.max_charge_power_W = MAX_CHARGE_POWER_WHEN_TOPBALANCING_W;
+  } else if (datalayer_battery->status.real_soc > RAMPDOWN_SOC) {
     // When real SOC is between RAMPDOWN_SOC-99%, ramp the value between Max<->0
-    datalayer.battery.status.max_charge_power_W =
-        datalayer.battery.status.override_charge_power_W *
-        (1 - (datalayer.battery.status.real_soc - RAMPDOWN_SOC) / (10000.0 - RAMPDOWN_SOC));
+    datalayer_battery->status.max_charge_power_W =
+        datalayer_battery->status.override_charge_power_W *
+        (1 - (datalayer_battery->status.real_soc - RAMPDOWN_SOC) / (10000.0 - RAMPDOWN_SOC));
   } else {  // No limits, max charging power allowed
-    datalayer.battery.status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
+    datalayer_battery->status.max_charge_power_W = datalayer_battery->status.override_charge_power_W;
   }
 
   // Discharge power is also set in .h file (TODO: Remove this estimation when real value has been found)
-  datalayer.battery.status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
+  datalayer_battery->status.max_discharge_power_W = datalayer_battery->status.override_discharge_power_W;
 
-  datalayer.battery.status.temperature_min_dC = temperature_lowest_C * 10;
+  datalayer_battery->status.temperature_min_dC = temperature_lowest_C * 10;
 
-  datalayer.battery.status.temperature_max_dC = temperature_highest_C * 10;
+  datalayer_battery->status.temperature_max_dC = temperature_highest_C * 10;
 
   //Map all cell voltages to the global array
-  memcpy(datalayer.battery.status.cell_voltages_mV, cellblock_voltage, 96 * sizeof(uint16_t));
+  memcpy(datalayer_battery->status.cell_voltages_mV, cellblock_voltage, 96 * sizeof(uint16_t));
 
-  datalayer.battery.status.cell_max_voltage_mV = battery_cell_voltage_max_mV;
+  datalayer_battery->status.cell_max_voltage_mV = battery_cell_voltage_max_mV;
 
-  datalayer.battery.status.cell_min_voltage_mV = battery_cell_voltage_min_mV;
+  datalayer_battery->status.cell_min_voltage_mV = battery_cell_voltage_min_mV;
 
   // Update webserver datalayer
-  datalayer_extended.boltampera.battery_5V_ref = battery_5V_ref;
-  datalayer_extended.boltampera.battery_module_temp_1 = battery_module_temp_1;
-  datalayer_extended.boltampera.battery_module_temp_2 = battery_module_temp_2;
-  datalayer_extended.boltampera.battery_module_temp_3 = battery_module_temp_3;
-  datalayer_extended.boltampera.battery_module_temp_4 = battery_module_temp_4;
-  datalayer_extended.boltampera.battery_module_temp_5 = battery_module_temp_5;
-  datalayer_extended.boltampera.battery_module_temp_6 = battery_module_temp_6;
-  datalayer_extended.boltampera.battery_cell_average_voltage = battery_cell_average_voltage;
-  datalayer_extended.boltampera.battery_cell_average_voltage_2 = battery_cell_average_voltage_2;
-  datalayer_extended.boltampera.battery_terminal_voltage = battery_terminal_voltage;
-  datalayer_extended.boltampera.battery_ignition_power_mode = battery_ignition_power_mode;
-  datalayer_extended.boltampera.battery_current_7E7 = battery_current_7E7;
-  datalayer_extended.boltampera.battery_capacity_my17_18 = battery_capacity_my17_18;
-  datalayer_extended.boltampera.battery_capacity_my19plus = battery_capacity_my19plus;
-  datalayer_extended.boltampera.battery_SOC_display = battery_SOC_display;
-  datalayer_extended.boltampera.battery_SOC_raw_highprec = battery_SOC_raw_highprec;
-  datalayer_extended.boltampera.battery_max_temperature = battery_max_temperature;
-  datalayer_extended.boltampera.battery_min_temperature = battery_min_temperature;
-  datalayer_extended.boltampera.battery_min_cell_voltage = battery_min_cell_voltage;
-  datalayer_extended.boltampera.battery_max_cell_voltage = battery_max_cell_voltage;
-  datalayer_extended.boltampera.battery_lowest_cell = battery_lowest_cell;
-  datalayer_extended.boltampera.battery_highest_cell = battery_highest_cell;
-  datalayer_extended.boltampera.battery_internal_resistance = battery_internal_resistance;
-  datalayer_extended.boltampera.battery_voltage_polled = battery_voltage_polled;
-  datalayer_extended.boltampera.battery_vehicle_isolation = battery_vehicle_isolation;
-  datalayer_extended.boltampera.battery_isolation_kohm = battery_isolation_kohm;
-  datalayer_extended.boltampera.battery_HV_locked = battery_HV_locked;
-  datalayer_extended.boltampera.battery_crash_event = battery_crash_event;
-  datalayer_extended.boltampera.battery_HVIL = battery_HVIL;
-  datalayer_extended.boltampera.battery_HVIL_status = battery_HVIL_status;
-  datalayer_extended.boltampera.battery_current_7E4 = battery_current_7E4;
+  if (datalayer_boltampera) {
+    datalayer_boltampera->battery_5V_ref = battery_5V_ref;
+    datalayer_boltampera->battery_module_temp_1 = battery_module_temp_1;
+    datalayer_boltampera->battery_module_temp_2 = battery_module_temp_2;
+    datalayer_boltampera->battery_module_temp_3 = battery_module_temp_3;
+    datalayer_boltampera->battery_module_temp_4 = battery_module_temp_4;
+    datalayer_boltampera->battery_module_temp_5 = battery_module_temp_5;
+    datalayer_boltampera->battery_module_temp_6 = battery_module_temp_6;
+    datalayer_boltampera->battery_cell_average_voltage = battery_cell_average_voltage;
+    datalayer_boltampera->battery_cell_average_voltage_2 = battery_cell_average_voltage_2;
+    datalayer_boltampera->battery_terminal_voltage = battery_terminal_voltage;
+    datalayer_boltampera->battery_ignition_power_mode = battery_ignition_power_mode;
+    datalayer_boltampera->battery_current_7E7 = battery_current_7E7;
+    datalayer_boltampera->battery_capacity_my17_18 = battery_capacity_my17_18;
+    datalayer_boltampera->battery_capacity_my19plus = battery_capacity_my19plus;
+    datalayer_boltampera->battery_SOC_display = battery_SOC_display;
+    datalayer_boltampera->battery_SOC_raw_highprec = battery_SOC_raw_highprec;
+    datalayer_boltampera->battery_max_temperature = battery_max_temperature;
+    datalayer_boltampera->battery_min_temperature = battery_min_temperature;
+    datalayer_boltampera->battery_min_cell_voltage = battery_min_cell_voltage;
+    datalayer_boltampera->battery_max_cell_voltage = battery_max_cell_voltage;
+    datalayer_boltampera->battery_lowest_cell = battery_lowest_cell;
+    datalayer_boltampera->battery_highest_cell = battery_highest_cell;
+    datalayer_boltampera->battery_internal_resistance = battery_internal_resistance;
+    datalayer_boltampera->battery_voltage_polled = battery_voltage_polled;
+    datalayer_boltampera->battery_vehicle_isolation = battery_vehicle_isolation;
+    datalayer_boltampera->battery_isolation_kohm = battery_isolation_kohm;
+    datalayer_boltampera->battery_HV_locked = battery_HV_locked;
+    datalayer_boltampera->battery_crash_event = battery_crash_event;
+    datalayer_boltampera->battery_HVIL = battery_HVIL;
+    datalayer_boltampera->battery_HVIL_status = battery_HVIL_status;
+    datalayer_boltampera->battery_current_7E4 = battery_current_7E4;
+  }
 }
 
 void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -155,7 +157,7 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   uint8_t cellblock_index = 0;
   switch (rx_frame.ID) {
     case 0x200:  //High voltage Battery Cell Voltage Matrix 1
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       cellbank_mux = ((rx_frame.data.u8[6] & 0xE0) >> 5);  //Goes from 0-7
       cellblock_index = cellbank_mux * 3;
       cellblock_voltage[cellblock_index] =
@@ -166,7 +168,7 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           (((rx_frame.data.u8[4]) << 4) | ((rx_frame.data.u8[5] & 0xF0) >> 4)) * 1.25f;
       break;
     case 0x202:  //High voltage Battery Cell Voltage Matrix 2
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       cellbank_mux = ((rx_frame.data.u8[6] & 0xE0) >> 5);  //goes from 0-7
       cellblock_index = 24 + (cellbank_mux * 3);
       cellblock_voltage[cellblock_index] =
@@ -177,7 +179,7 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           (((rx_frame.data.u8[4]) << 4) | ((rx_frame.data.u8[5] & 0xF0) >> 4)) * 1.25f;
       break;
     case 0x204:  //High voltage Battery Cell Voltage Matrix 3
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       cellbank_mux = ((rx_frame.data.u8[6] & 0xE0) >> 5);  //goes from 0-7
       cellblock_index = 48 + (cellbank_mux * 3);
       cellblock_voltage[cellblock_index] =
@@ -188,7 +190,7 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           (((rx_frame.data.u8[4]) << 4) | ((rx_frame.data.u8[5] & 0xF0) >> 4)) * 1.25f;
       break;
     case 0x206:  //High voltage Battery Cell Voltage Matrix 4
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       cellbank_mux = ((rx_frame.data.u8[6] & 0xE0) >> 5);  //goes from 0-7
       cellblock_index = 72 + (cellbank_mux * 3);
       cellblock_voltage[cellblock_index] =
@@ -199,48 +201,48 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           (((rx_frame.data.u8[4]) << 4) | ((rx_frame.data.u8[5] & 0xF0) >> 4)) * 1.25f;
       break;
     case 0x208:  //High voltage Battery Cell Voltage Matrix 5 (Empty on most packs)
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       cellbank_mux = ((rx_frame.data.u8[6] & 0xE0) >> 5);  //goes from 0-7
       break;
     case 0x20A:  //VICM Status HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x20C:  //VITM Status HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_isolation_kohm = (rx_frame.data.u8[1] * 25);
       battery_cell_voltage_max_mV = (rx_frame.data.u8[4] * 20);
       battery_cell_voltage_min_mV = (rx_frame.data.u8[5] * 20);
       break;
     case 0x216:  // High voltage battery sensed Output HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       sensed_battery_voltage_mV = (((rx_frame.data.u8[1] & 0x0F) << 4) | rx_frame.data.u8[2]) * 125;  //mV
       sensed_current_sensor_1 = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4]);
       sensed_current_sensor_2 = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
       break;
     case 0x2C7:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage_periodic_dV = ((rx_frame.data.u8[3] << 4) | (rx_frame.data.u8[4] >> 4)) * 1.25;
       /*355V 2C7 [6] 03 20 00 AF A0 00
       360V 2C7 [6] 03 20 00 AD D0 00
       396V 2C7 [6] 03 20 53 C7 30 00*/
       break;
     case 0x260:  //VITM Diagnostic Status 1 HV (Contains which DTCs are active)
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x262:  //Battery block voltage diagnostic status
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x270:  //Battery VoltageSensor BalancingSwitches diagnostic status
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x272:  //Battery Cell Voltage Diagnostic Status HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x274:  //Battery Temperature Sensor diagnostic status HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x302:  // High Voltage Battery Temperature Matrix
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       temperature_1 = ((rx_frame.data.u8[1] / 2) - 40);  //Module 1 Temperature
       temperature_2 = ((rx_frame.data.u8[2] / 2) - 40);  //Module 2 Temperature
       temperature_3 = ((rx_frame.data.u8[3] / 2) - 40);  //Module 3 Temperature
@@ -251,26 +253,26 @@ void BoltAmperaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       //since we only care about min and max temps (from message 3E3)
       break;
     case 0x308:  //24 92 49 24 90
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x3E3:  //Min and maximum values
       //Frame0 is cellvoltage min * 20
       //Frame1 is cellvoltage max * 20
       //Frame7 is cellvoltage avg * 20
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       temperature_lowest_C = ((rx_frame.data.u8[2] / 2) - 40);
       temperature_highest_C = ((rx_frame.data.u8[4] / 2) - 40);
       break;
     case 0x460:  //Energy Storage System Temp HV
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       inlet_coolant_temperature = ((((rx_frame.data.u8[0] & 0x03) << 8) | rx_frame.data.u8[1]) / 2) - 40;
       outlet_coolant_temperature = ((((rx_frame.data.u8[2] & 0x03) << 8) | rx_frame.data.u8[3]) / 2) - 40;
       break;
     case 0x5EF:  //OBD7E7 Unsolicited tester responce (UUDT)
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x5EC:  //OBD7E4 Unsolicited tester responce (ECU to tester)
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x7EC:  //When polling 7E4 BMS replies with 7EC (This is not working for some reason)
 
@@ -449,12 +451,14 @@ void BoltAmperaBattery::transmit_can(unsigned long currentMillis) {
 void BoltAmperaBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.total_capacity_Wh = 64000;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
-  datalayer.system.status.battery_allows_contactor_closing = true;
+  datalayer_battery->info.number_of_cells = 96;
+  datalayer_battery->info.total_capacity_Wh = 64000;
+  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  if (allows_contactor_closing) {
+    *allows_contactor_closing = true;
+  }
 }

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -1,9 +1,9 @@
 #ifndef BOLT_AMPERA_BATTERY_H
 #define BOLT_AMPERA_BATTERY_H
-#include "BOLT-AMPERA-HTML.h"
-#include "CanBattery.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"
+#include "BOLT-AMPERA-HTML.h"
+#include "CanBattery.h"
 
 class BoltAmperaBattery : public CanBattery {
  public:
@@ -15,8 +15,7 @@ class BoltAmperaBattery : public CanBattery {
   }
 
   // Second battery constructor
-  BoltAmperaBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_BOLTAMPERA* extended,
-                    CAN_Interface targetCan)
+  BoltAmperaBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_BOLTAMPERA* extended, CAN_Interface targetCan)
       : CanBattery(targetCan), renderer(extended) {
     datalayer_battery = datalayer_ptr;
     allows_contactor_closing = nullptr;

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -2,9 +2,27 @@
 #define BOLT_AMPERA_BATTERY_H
 #include "BOLT-AMPERA-HTML.h"
 #include "CanBattery.h"
+#include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
 
 class BoltAmperaBattery : public CanBattery {
  public:
+  // Default constructor - first or single battery
+  BoltAmperaBattery() : renderer(&datalayer_extended.boltampera) {
+    datalayer_battery = &datalayer.battery;
+    allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
+    datalayer_boltampera = &datalayer_extended.boltampera;
+  }
+
+  // Second battery constructor
+  BoltAmperaBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_BOLTAMPERA* extended,
+                    CAN_Interface targetCan)
+      : CanBattery(targetCan), renderer(extended) {
+    datalayer_battery = datalayer_ptr;
+    allows_contactor_closing = nullptr;
+    datalayer_boltampera = extended;
+  }
+
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
@@ -16,6 +34,9 @@ class BoltAmperaBattery : public CanBattery {
 
  private:
   BoltAmperaHtmlRenderer renderer;
+  DATALAYER_BATTERY_TYPE* datalayer_battery;
+  DATALAYER_INFO_BOLTAMPERA* datalayer_boltampera;
+  bool* allows_contactor_closing;
   static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 500;
   static const int RAMPDOWN_SOC =
       9000;  // (90.00) SOC% to start ramping down from max charge power towards 0 at 100.00%

--- a/Software/src/battery/BOLT-AMPERA-HTML.h
+++ b/Software/src/battery/BOLT-AMPERA-HTML.h
@@ -6,47 +6,56 @@
 
 class BoltAmperaHtmlRenderer : public BatteryHtmlRenderer {
  public:
+  BoltAmperaHtmlRenderer(DATALAYER_INFO_BOLTAMPERA* dl) : boltampera_dl(dl) {}
+
   String get_status_html() {
     String content;
 
-    content += "<h4>5V Reference: " + String(datalayer_extended.boltampera.battery_5V_ref) + "</h4>";
-    content += "<h4>Module 1 temp: " + String(datalayer_extended.boltampera.battery_module_temp_1) + "</h4>";
-    content += "<h4>Module 2 temp: " + String(datalayer_extended.boltampera.battery_module_temp_2) + "</h4>";
-    content += "<h4>Module 3 temp: " + String(datalayer_extended.boltampera.battery_module_temp_3) + "</h4>";
-    content += "<h4>Module 4 temp: " + String(datalayer_extended.boltampera.battery_module_temp_4) + "</h4>";
-    content += "<h4>Module 5 temp: " + String(datalayer_extended.boltampera.battery_module_temp_5) + "</h4>";
-    content += "<h4>Module 6 temp: " + String(datalayer_extended.boltampera.battery_module_temp_6) + "</h4>";
+    if (!boltampera_dl) {
+      return content;
+    }
+
+    content += "<h4>5V Reference: " + String(boltampera_dl->battery_5V_ref) + "</h4>";
+    content += "<h4>Module 1 temp: " + String(boltampera_dl->battery_module_temp_1) + "</h4>";
+    content += "<h4>Module 2 temp: " + String(boltampera_dl->battery_module_temp_2) + "</h4>";
+    content += "<h4>Module 3 temp: " + String(boltampera_dl->battery_module_temp_3) + "</h4>";
+    content += "<h4>Module 4 temp: " + String(boltampera_dl->battery_module_temp_4) + "</h4>";
+    content += "<h4>Module 5 temp: " + String(boltampera_dl->battery_module_temp_5) + "</h4>";
+    content += "<h4>Module 6 temp: " + String(boltampera_dl->battery_module_temp_6) + "</h4>";
     content +=
-        "<h4>Cell average voltage: " + String(datalayer_extended.boltampera.battery_cell_average_voltage) + "</h4>";
+        "<h4>Cell average voltage: " + String(boltampera_dl->battery_cell_average_voltage) + "</h4>";
     content +=
-        "<h4>Cell average voltage 2: " + String(datalayer_extended.boltampera.battery_cell_average_voltage_2) + "</h4>";
-    content += "<h4>Terminal voltage: " + String(datalayer_extended.boltampera.battery_terminal_voltage) + "</h4>";
+        "<h4>Cell average voltage 2: " + String(boltampera_dl->battery_cell_average_voltage_2) + "</h4>";
+    content += "<h4>Terminal voltage: " + String(boltampera_dl->battery_terminal_voltage) + "</h4>";
     content +=
-        "<h4>Ignition power mode: " + String(datalayer_extended.boltampera.battery_ignition_power_mode) + "</h4>";
-    content += "<h4>Battery current (7E7): " + String(datalayer_extended.boltampera.battery_current_7E7) + "</h4>";
-    content += "<h4>Capacity MY17-18: " + String(datalayer_extended.boltampera.battery_capacity_my17_18) + "</h4>";
-    content += "<h4>Capacity MY19+: " + String(datalayer_extended.boltampera.battery_capacity_my19plus) + "</h4>";
-    content += "<h4>SOC Display: " + String(datalayer_extended.boltampera.battery_SOC_display) + "</h4>";
-    content += "<h4>SOC Raw highprec: " + String(datalayer_extended.boltampera.battery_SOC_raw_highprec) + "</h4>";
-    content += "<h4>Max temp: " + String(datalayer_extended.boltampera.battery_max_temperature) + "</h4>";
-    content += "<h4>Min temp: " + String(datalayer_extended.boltampera.battery_min_temperature) + "</h4>";
-    content += "<h4>Cell max mV: " + String(datalayer_extended.boltampera.battery_max_cell_voltage) + "</h4>";
-    content += "<h4>Cell min mV: " + String(datalayer_extended.boltampera.battery_min_cell_voltage) + "</h4>";
-    content += "<h4>Lowest cell: " + String(datalayer_extended.boltampera.battery_lowest_cell) + "</h4>";
-    content += "<h4>Highest cell: " + String(datalayer_extended.boltampera.battery_highest_cell) + "</h4>";
+        "<h4>Ignition power mode: " + String(boltampera_dl->battery_ignition_power_mode) + "</h4>";
+    content += "<h4>Battery current (7E7): " + String(boltampera_dl->battery_current_7E7) + "</h4>";
+    content += "<h4>Capacity MY17-18: " + String(boltampera_dl->battery_capacity_my17_18) + "</h4>";
+    content += "<h4>Capacity MY19+: " + String(boltampera_dl->battery_capacity_my19plus) + "</h4>";
+    content += "<h4>SOC Display: " + String(boltampera_dl->battery_SOC_display) + "</h4>";
+    content += "<h4>SOC Raw highprec: " + String(boltampera_dl->battery_SOC_raw_highprec) + "</h4>";
+    content += "<h4>Max temp: " + String(boltampera_dl->battery_max_temperature) + "</h4>";
+    content += "<h4>Min temp: " + String(boltampera_dl->battery_min_temperature) + "</h4>";
+    content += "<h4>Cell max mV: " + String(boltampera_dl->battery_max_cell_voltage) + "</h4>";
+    content += "<h4>Cell min mV: " + String(boltampera_dl->battery_min_cell_voltage) + "</h4>";
+    content += "<h4>Lowest cell: " + String(boltampera_dl->battery_lowest_cell) + "</h4>";
+    content += "<h4>Highest cell: " + String(boltampera_dl->battery_highest_cell) + "</h4>";
     content +=
-        "<h4>Internal resistance: " + String(datalayer_extended.boltampera.battery_internal_resistance) + "</h4>";
-    content += "<h4>Voltage: " + String(datalayer_extended.boltampera.battery_voltage_polled) + "</h4>";
-    content += "<h4>Isolation Ohm: " + String(datalayer_extended.boltampera.battery_vehicle_isolation) + "</h4>";
-    content += "<h4>Isolation kOhm: " + String(datalayer_extended.boltampera.battery_isolation_kohm) + "</h4>";
-    content += "<h4>HV locked: " + String(datalayer_extended.boltampera.battery_HV_locked) + "</h4>";
-    content += "<h4>Crash event: " + String(datalayer_extended.boltampera.battery_crash_event) + "</h4>";
-    content += "<h4>HVIL: " + String(datalayer_extended.boltampera.battery_HVIL) + "</h4>";
-    content += "<h4>HVIL status: " + String(datalayer_extended.boltampera.battery_HVIL_status) + "</h4>";
-    content += "<h4>Current (7E4): " + String(datalayer_extended.boltampera.battery_current_7E4) + "</h4>";
+        "<h4>Internal resistance: " + String(boltampera_dl->battery_internal_resistance) + "</h4>";
+    content += "<h4>Voltage: " + String(boltampera_dl->battery_voltage_polled) + "</h4>";
+    content += "<h4>Isolation Ohm: " + String(boltampera_dl->battery_vehicle_isolation) + "</h4>";
+    content += "<h4>Isolation kOhm: " + String(boltampera_dl->battery_isolation_kohm) + "</h4>";
+    content += "<h4>HV locked: " + String(boltampera_dl->battery_HV_locked) + "</h4>";
+    content += "<h4>Crash event: " + String(boltampera_dl->battery_crash_event) + "</h4>";
+    content += "<h4>HVIL: " + String(boltampera_dl->battery_HVIL) + "</h4>";
+    content += "<h4>HVIL status: " + String(boltampera_dl->battery_HVIL_status) + "</h4>";
+    content += "<h4>Current (7E4): " + String(boltampera_dl->battery_current_7E4) + "</h4>";
 
     return content;
   }
+
+ private:
+  DATALAYER_INFO_BOLTAMPERA* boltampera_dl;
 };
 
 #endif

--- a/Software/src/battery/BOLT-AMPERA-HTML.h
+++ b/Software/src/battery/BOLT-AMPERA-HTML.h
@@ -22,13 +22,10 @@ class BoltAmperaHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Module 4 temp: " + String(boltampera_dl->battery_module_temp_4) + "</h4>";
     content += "<h4>Module 5 temp: " + String(boltampera_dl->battery_module_temp_5) + "</h4>";
     content += "<h4>Module 6 temp: " + String(boltampera_dl->battery_module_temp_6) + "</h4>";
-    content +=
-        "<h4>Cell average voltage: " + String(boltampera_dl->battery_cell_average_voltage) + "</h4>";
-    content +=
-        "<h4>Cell average voltage 2: " + String(boltampera_dl->battery_cell_average_voltage_2) + "</h4>";
+    content += "<h4>Cell average voltage: " + String(boltampera_dl->battery_cell_average_voltage) + "</h4>";
+    content += "<h4>Cell average voltage 2: " + String(boltampera_dl->battery_cell_average_voltage_2) + "</h4>";
     content += "<h4>Terminal voltage: " + String(boltampera_dl->battery_terminal_voltage) + "</h4>";
-    content +=
-        "<h4>Ignition power mode: " + String(boltampera_dl->battery_ignition_power_mode) + "</h4>";
+    content += "<h4>Ignition power mode: " + String(boltampera_dl->battery_ignition_power_mode) + "</h4>";
     content += "<h4>Battery current (7E7): " + String(boltampera_dl->battery_current_7E7) + "</h4>";
     content += "<h4>Capacity MY17-18: " + String(boltampera_dl->battery_capacity_my17_18) + "</h4>";
     content += "<h4>Capacity MY19+: " + String(boltampera_dl->battery_capacity_my19plus) + "</h4>";
@@ -40,8 +37,7 @@ class BoltAmperaHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Cell min mV: " + String(boltampera_dl->battery_min_cell_voltage) + "</h4>";
     content += "<h4>Lowest cell: " + String(boltampera_dl->battery_lowest_cell) + "</h4>";
     content += "<h4>Highest cell: " + String(boltampera_dl->battery_highest_cell) + "</h4>";
-    content +=
-        "<h4>Internal resistance: " + String(boltampera_dl->battery_internal_resistance) + "</h4>";
+    content += "<h4>Internal resistance: " + String(boltampera_dl->battery_internal_resistance) + "</h4>";
     content += "<h4>Voltage: " + String(boltampera_dl->battery_voltage_polled) + "</h4>";
     content += "<h4>Isolation Ohm: " + String(boltampera_dl->battery_vehicle_isolation) + "</h4>";
     content += "<h4>Isolation kOhm: " + String(boltampera_dl->battery_isolation_kohm) + "</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -969,6 +969,7 @@ struct DATALAYER_INFO_ZOE_PH2 {
 class DataLayerExtended {
  public:
   DATALAYER_INFO_BOLTAMPERA boltampera;
+  DATALAYER_INFO_BOLTAMPERA boltampera_2;
   DATALAYER_INFO_BMWPHEV bmwphev;
   DATALAYER_INFO_BMWIX bmwix;
   DATALAYER_INFO_BYDATTO3 bydAtto3;


### PR DESCRIPTION
### What
This PR implements support for double Bolt/Ampera batteries.

### Why
To allow using two Bolt/Ampera battery packs in a single Battery-Emulator setup. Personal need — running two Bolt/Ampera packs in my setup.

### How
Same approach as double-ECMP/double-Kia64. Refactored BoltAmperaBattery to use instance pointers (datalayer_battery, datalayer_boltampera, allows_contactor_closing) instead of directly accessing globals.
Added a second constructor that accepts datalayer_battery2 and datalayer_extended.boltampera_2 for the second battery instance. Registered the BoltAmpera case in BATTERIES.cpp for battery2 creation.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
