### PR TITLE
BYD - Atto 3 - Fix - force the charge taper to honour the BMS allowed charge power

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -76,8 +76,18 @@ void BydAttoBattery::
   const uint16_t cell_min_mV = datalayer_battery->status.cell_min_voltage_mV;
   const uint16_t delta_mV = (cell_max_mV > cell_min_mV) ? (cell_max_mV - cell_min_mV) : 0;
 
-  // Start from the user manual limit (deci-amps), but don't allow taper to go below tail current.
+  // Start from the lower of: user manual limit, or what the BMS says it will accept.
+  // This ensures the taper always honours the BMS allowed charge power, even if it
+  // drops to zero (e.g. cell delta cutoff, overvoltage protection).
   uint16_t user_cap_dA = datalayer_battery->settings.max_user_set_charge_dA;
+  if (BMS_allowed_charge_power > 0 && datalayer_battery->status.voltage_dV > 0) {
+    uint16_t bms_cap_dA = (uint16_t)((uint32_t)BMS_allowed_charge_power * 10 /
+                                     datalayer_battery->status.voltage_dV);
+    if (bms_cap_dA < user_cap_dA)
+      user_cap_dA = bms_cap_dA;
+  } else if (BMS_allowed_charge_power == 0) {
+    user_cap_dA = 0;
+  }
   if (user_cap_dA < TAIL_CURRENT_dA)
     user_cap_dA = TAIL_CURRENT_dA;
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -81,8 +81,7 @@ void BydAttoBattery::
   // drops to zero (e.g. cell delta cutoff, overvoltage protection).
   uint16_t user_cap_dA = datalayer_battery->settings.max_user_set_charge_dA;
   if (BMS_allowed_charge_power > 0 && datalayer_battery->status.voltage_dV > 0) {
-    uint16_t bms_cap_dA = (uint16_t)((uint32_t)BMS_allowed_charge_power * 10 /
-                                     datalayer_battery->status.voltage_dV);
+    uint16_t bms_cap_dA = (uint16_t)((uint32_t)BMS_allowed_charge_power * 10 / datalayer_battery->status.voltage_dV);
     if (bms_cap_dA < user_cap_dA)
       user_cap_dA = bms_cap_dA;
   } else if (BMS_allowed_charge_power == 0) {


### PR DESCRIPTION
### What
Updates the BYD Atto 3 charge taper to honour BMS allowed charge power value.

### Why
Currently the charge taper only uses the user-set current limit as its ceiling, ignoring what the BMS itself reports as its maximum acceptable charge power (BMS_allowed_charge_power). This means that when the BMS reduces or zeros its allowed charge power (e.g. due to cell delta cutoff or overvoltage protection), the taper continues to allow current above what the BMS has requested.

### How
This change derives a current cap from BMS_allowed_charge_power and uses whichever is lower — the user setting or the BMS limit — as the taper ceiling. If the BMS reports zero allowed charge power, the taper immediately respects this and commands zero current.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
