### PR TITLE
Kia EGMP: Add DTC reset

### DIFF
--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -453,7 +453,10 @@ void KiaEGmpBattery::transmit_can(unsigned long currentMillis) {
 
       EGMP_7E4.data.u8[3] = KIA_7E4_COUNTER;
 
-      if (ok_start_polling_battery) {
+      if (UserRequestDTCreset) {
+        transmit_can_frame(&EGMP_DTCreset);
+        UserRequestDTCreset = false;
+      } else if (ok_start_polling_battery) {
         transmit_can_frame(&EGMP_7E4);
       }
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -23,7 +23,11 @@ class KiaEGmpBattery : public CanBattery {
   int get_BMS_ign() const;
   int get_batRelay() const;
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
+  bool UserRequestDTCreset = false;
   KiaEGMPHtmlRenderer renderer;
   uint16_t estimateSOC(uint16_t packVoltage, uint16_t cellCount, int16_t currentAmps);
   uint16_t selectSOC(uint16_t SOC_low, uint16_t SOC_high);
@@ -567,6 +571,12 @@ class KiaEGmpBattery : public CanBattery {
       .DLC = 8,
       .ID = 0x7E4,
       .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
+  static constexpr CAN_frame EGMP_DTCreset = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x7DF,
+      .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};  //DTC reset frame
 };
 
 #endif


### PR DESCRIPTION
### What
This PR implements DTC clearing for the Kia EGMP platform. 

### Why
Helpful to be able to reset DTCs

### How
Discovered by Kukumagi on the Discord by connecting an ; Obd scanner - mcp2515 - esp32 - mcp2518fd - battery

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
