### PR TITLE
Revert "Solax: Double battery fix; make solax ignore_contactors option wait for the first close request and then stay closed"

### DIFF
--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -79,12 +79,12 @@ class TeslaBattery : public CanBattery {
   //0x221 VCFRONT_LVPowerState
   uint8_t alternateMux = 0;
   uint8_t frameCounter_TESLA_221 = 15;  // Start at 15 for Mux 0
-  uint8_t vehicleState = 0;             // "OFF": 0, "DRIVE": 1, "ACCESSORY": 2, "GOING_DOWN": 3
+  uint8_t vehicleState = 1;             // "OFF": 0, "DRIVE": 1, "ACCESSORY": 2, "GOING_DOWN": 3
   static const uint8_t CAR_OFF = 0;
   static const uint8_t CAR_DRIVE = 1;
   static const uint8_t ACCESSORY = 2;
   static const uint8_t GOING_DOWN = 3;
-  uint8_t powerDownSeconds = 3;  // Car power down (i.e. contactor open) tracking timer, 3 seconds per sendingState
+  uint8_t powerDownSeconds = 9;  // Car power down (i.e. contactor open) tracking timer, 3 seconds per sendingState
   //0x2E1 VCFRONT_status, 6 mux tracker
   uint8_t muxNumber_TESLA_2E1 = 0;
   //0x334 UI

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -14,10 +14,8 @@
 void SolaxInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
   // If not receiveing any communication from the inverter, open contactors and return to battery announce state
-  if (millis() - LastFrameTime >= INTERVAL_2_S) {
-    if (!configured_ignore_contactors) {
-      datalayer.system.status.inverter_allows_contactor_closing = false;
-    }
+  if (millis() - LastFrameTime >= INTERVAL_2_S && !configured_ignore_contactors) {
+    datalayer.system.status.inverter_allows_contactor_closing = false;
     STATE = BATTERY_ANNOUNCE;
   }
   //Calculate the required values
@@ -137,12 +135,29 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
     if ((rx_frame.data.u8[0] == (0x01)) || (rx_frame.data.u8[0] == (0x02))) {
       LastFrameTime = millis();
 
+      if (configured_ignore_contactors) {
+        // Skip the state machine since we're not going to open/close contactors,
+        // and the Solax would otherwise wait forever for us to do so.
+
+        datalayer.system.status.inverter_allows_contactor_closing = true;
+        SOLAX_1875.data.u8[4] = (0x01);  // Inform Inverter: Contactor 0=off, 1=on.
+        transmit_can_frame(&SOLAX_187E);
+        transmit_can_frame(&SOLAX_187A);
+        transmit_can_frame(&SOLAX_1872);
+        transmit_can_frame(&SOLAX_1873);
+        transmit_can_frame(&SOLAX_1874);
+        transmit_can_frame(&SOLAX_1875);
+        transmit_can_frame(&SOLAX_1876);
+        transmit_can_frame(&SOLAX_1877);
+        transmit_can_frame(&SOLAX_1878);
+        transmit_can_frame(&SOLAX_100A001);
+        return;
+      }
+
       switch (STATE) {
         case (BATTERY_ANNOUNCE):
           logging.println("Solax Battery State: Announce");
-          if (!configured_ignore_contactors) {
-            datalayer.system.status.inverter_allows_contactor_closing = false;
-          }
+          datalayer.system.status.inverter_allows_contactor_closing = false;
           SOLAX_1875.data.u8[4] = (0x00);  // Inform Inverter: Contactor 0=off, 1=on.
           for (uint8_t i = 0; i < number_of_batteries; i++) {
             transmit_can_frame(&SOLAX_187E);
@@ -226,7 +241,11 @@ bool SolaxInverter::setup(void) {  // Performs one time setup at startup
   }
 
   configured_ignore_contactors = user_selected_inverter_ignore_contactors;
-  datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
+
+  if (!configured_ignore_contactors) {
+    // Only prevent closing if we're not ignoring contactors
+    datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
+  }
 
   return true;
 }


### PR DESCRIPTION
Reverts dalathegreat/Battery-Emulator#1679

Work still ongoing in PR #2192 , reverting this PR to be able to release 10.5.0