### PR TITLE
Rivian: Add estimated SOC for locked packs

### DIFF
--- a/Software/src/battery/RIVIAN-BATTERY.cpp
+++ b/Software/src/battery/RIVIAN-BATTERY.cpp
@@ -24,7 +24,7 @@ uint8_t RivianBattery::calculateCRC(CAN_frame rx_frame, uint8_t length, uint8_t 
   return crc;
 }
 
-uint16_t estimate_SOC_from_voltage(uint16_t voltage) {
+uint16_t estimate_SOC_based_on_voltage(uint16_t voltage) {
   uint16_t result = 0;
   //Voltage ranges between 4500dV when full, and 3500dV when empty
   result = (voltage - 3500);  //Make the range
@@ -35,7 +35,7 @@ uint16_t estimate_SOC_from_voltage(uint16_t voltage) {
 void RivianBattery::update_values() {
 
   if (user_selected_use_estimated_SOC) {  //Crash locked packs with bypassed contactors
-    datalayer.battery.status.real_soc = estimate_SOC_from_voltage(datalayer.battery.status.voltage_dV);
+    datalayer.battery.status.real_soc = estimate_SOC_based_on_voltage(datalayer.battery.status.voltage_dV);
   } else {
     datalayer.battery.status.real_soc = battery_SOC_average;
   }

--- a/Software/src/battery/RIVIAN-BATTERY.cpp
+++ b/Software/src/battery/RIVIAN-BATTERY.cpp
@@ -24,9 +24,21 @@ uint8_t RivianBattery::calculateCRC(CAN_frame rx_frame, uint8_t length, uint8_t 
   return crc;
 }
 
+uint16_t estimate_SOC_from_voltage(uint16_t voltage) {
+  uint16_t result = 0;
+  //Voltage ranges between 4500dV when full, and 3500dV when empty
+  result = (voltage - 3500);  //Make the range
+  result = result * 10;       //Add decimal
+  return result;
+}
+
 void RivianBattery::update_values() {
 
-  datalayer.battery.status.real_soc = battery_SOC_average;
+  if (user_selected_use_estimated_SOC) {  //Crash locked packs with bypassed contactors
+    datalayer.battery.status.real_soc = estimate_SOC_from_voltage(datalayer.battery.status.voltage_dV);
+  } else {
+    datalayer.battery.status.real_soc = battery_SOC_average;
+  }
 
   //datalayer.battery.status.soh_pptt; //TODO: Find usable SOH
 

--- a/Software/src/battery/RIVIAN-BATTERY.cpp
+++ b/Software/src/battery/RIVIAN-BATTERY.cpp
@@ -48,8 +48,13 @@ void RivianBattery::update_values() {
   datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
 
-  datalayer.battery.status.max_charge_power_W = ((pre_contactor_voltage / 10) * battery_charge_limit_amp);
-  datalayer.battery.status.max_discharge_power_W = ((pre_contactor_voltage / 10) * battery_discharge_limit_amp);
+  if (user_selected_use_estimated_SOC) {
+    datalayer.battery.status.max_charge_power_W = 50000;
+    datalayer.battery.status.max_discharge_power_W = 50000;
+  } else {
+    datalayer.battery.status.max_charge_power_W = ((pre_contactor_voltage / 10) * battery_charge_limit_amp);
+    datalayer.battery.status.max_discharge_power_W = ((pre_contactor_voltage / 10) * battery_discharge_limit_amp);
+  }
 
   if (cell_min_voltage_mV > 0) {
     datalayer.battery.status.cell_min_voltage_mV = cell_min_voltage_mV;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1179,7 +1179,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     form .if-socestimated { display: none; } /* Integrations where you can turn on SOC estimation */
     form[data-battery="16"] .if-socestimated,
     form[data-battery="26"] .if-socestimated,
-    form[data-battery="41"] .if-socestimated {
+    form[data-battery="41"] .if-socestimated,
+    form[data-battery="42"] .if-socestimated {
       display: contents;
     }
 


### PR DESCRIPTION
### What
This PR implements estimated SOC for Rivian packs as an option

### Why
Emergency solution for using these batteries with contactors bypassed

### How

  //Voltage ranges between 4500dV when full, and 3500dV when empty
  result = (voltage - 3500);  //Make the range

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
