### PR TITLE
Kia/Hyundai 40-64kWh: Make charge limits safer

### DIFF
--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -93,8 +93,8 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x594:
       startedUp = true;
-      allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
-      allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
+      allowedChargePower = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]) / 2;
+      allowedDischargePower = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) / 2;
       SOC_BMS = rx_frame.data.u8[5] * 5;  //100% = 200 ( 200 * 5 = 1000 )
       break;
     case 0x595:


### PR DESCRIPTION
### What
This PR implements safer charge/discharge limits for Kia64 integration

### Why
Current implementation does not match what we typically see the 64kWh packs charge at. Allowing 50kW at high SOC is unrealistic, it should be 25kW

### How
We assume a /2 was missing on the scaling. By adding this we get closer to the charge curves online

<img width="1342" height="655" alt="image" src="https://github.com/user-attachments/assets/853ae7ef-f8b5-4dee-b85d-5e99fc5816d1" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
