### PR TITLE
Stellantis ECMP: Do not read invalid temperature values

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -373,6 +373,9 @@ uint16_t user_selected_tesla_GTW_packEnergy = 1;
 /* User-selected EGMP+others settings */
 bool user_selected_use_estimated_SOC = false;
 uint16_t user_selected_pylon_baudrate = 500;
+/* User-selected ECMP+MysteryVan settings */
+bool user_selected_ECMP_mode = false;
+bool user_selected_MysteryVan_mode = false;
 
 // Use 0V for user selected cell/pack voltage defaults (On boot will be replaced with saved values from NVM)
 uint16_t user_selected_max_pack_voltage_dV = 0;

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -81,5 +81,7 @@ extern uint16_t user_selected_tesla_GTW_mapRegion;
 extern uint16_t user_selected_tesla_GTW_chassisType;
 extern uint16_t user_selected_tesla_GTW_packEnergy;
 extern uint16_t user_selected_pylon_baudrate;
+extern bool user_selected_ECMP_mode;
+extern bool user_selected_MysteryVan_mode;
 
 #endif

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -844,13 +844,21 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               pid_coldest_module = (rx_frame.data.u8[4]);
               break;
             case PID_LOWEST_TEMPERATURE:
-              pid_lowest_temperature = (rx_frame.data.u8[4] - 40);
+              if (rx_frame.data.u8[4] > 200) {
+                set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 1);
+              } else {
+                pid_lowest_temperature = (rx_frame.data.u8[4] - 40);
+              }
               break;
             case PID_AVERAGE_TEMPERATURE:
               pid_average_temperature = (rx_frame.data.u8[4] - 40);
               break;
             case PID_HIGHEST_TEMPERATURE:
-              pid_highest_temperature = (rx_frame.data.u8[4] - 40);
+              if (rx_frame.data.u8[4] > 200) {
+                set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 2);
+              } else {
+                pid_highest_temperature = (rx_frame.data.u8[4] - 40);
+              }
               break;
             case PID_HOTTEST_MODULE:
               pid_hottest_module = (rx_frame.data.u8[4]);

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -3,6 +3,7 @@
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For More Battery Info page
 #include "../devboard/utils/events.h"
+#include "BATTERIES.h"
 
 /* TODO:
 This integration is still ongoing. The same integration can be used on multiple variants of the Stellantis platforms
@@ -234,7 +235,10 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x2D4:  //MysteryVan 50/75kWh platform (TBMU 100ms periodic)
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      MysteryVan = true;
+      if (!user_selected_MysteryVan_mode && !user_selected_ECMP_mode) {
+        //If user did not explicitly select a mode, try to detect if we are on a MysteryVan battery
+        MysteryVan = true;
+      }
       SOE_MAX_CURRENT_TEMP = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];                       // (Wh, 0-200000)
       FRONT_MACHINE_POWER_LIMIT = (rx_frame.data.u8[4] << 6) | ((rx_frame.data.u8[5] & 0xFC) >> 2);  // (W 0-1000000)
       REAR_MACHINE_POWER_LIMIT = ((rx_frame.data.u8[5] & 0x03) << 12) | (rx_frame.data.u8[6] << 4) |
@@ -1908,6 +1912,14 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
 }
 
 void EcmpBattery::setup(void) {  // Performs one time setup at startup
+
+  if (user_selected_ECMP_mode) {
+    MysteryVan = false;
+  }
+  if (user_selected_MysteryVan_mode) {
+    MysteryVan = true;
+  }
+
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.battery.info.number_of_cells = 108;

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -475,8 +475,16 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x358:  //Common
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery_highestTemperature = rx_frame.data.u8[6] - 40;
-      battery_lowestTemperature = rx_frame.data.u8[7] - 40;
+      if (rx_frame.data.u8[6] > 200) {
+        set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 3);
+      } else {
+        battery_highestTemperature = rx_frame.data.u8[6] - 40;
+      }
+      if (rx_frame.data.u8[7] > 200) {
+        set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 4);
+      } else {
+        battery_lowestTemperature = rx_frame.data.u8[7] - 40;
+      }
       break;
     case 0x359:
       break;

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -109,6 +109,8 @@ void init_stored_settings() {
   user_selected_tesla_GTW_chassisType = settings.getUInt("GTWCHASSIS", 0);
   user_selected_tesla_GTW_packEnergy = settings.getUInt("GTWPACK", 0);
   user_selected_primo_gen24 = settings.getBool("PRIMOGEN24", false);
+  user_selected_ECMP_mode = settings.getBool("ECMPMODE", false);
+  user_selected_MysteryVan_mode = settings.getBool("ECMPMODE2", false);
 
   auto readIf = [](const char* settingName) {
     auto batt1If = (comm_interface)settings.getUInt(settingName, (int)comm_interface::CanNative);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -859,6 +859,14 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("INTERLOCKREQ") ? "checked" : "";
   }
 
+  if (var == "ECMPMODE") {
+    return settings.getBool("ECMPMODE") ? "checked" : "";
+  }
+
+  if (var == "ECMPMODE2") {
+    return settings.getBool("ECMPMODE2") ? "checked" : "";
+  }
+
   if (var == "DIGITALHVIL") {
     return settings.getBool("DIGITALHVIL") ? "checked" : "";
   }
@@ -1160,6 +1168,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    form .if-ecmp { display: none; }
+    form[data-battery="13"] .if-ecmp {
+      display: contents;
+    }
+
     form .if-estimated { display: none; } /* Integrations with manually set charge/discharge power */
     form[data-battery="3"] .if-estimated, 
     form[data-battery="4"] .if-estimated, 
@@ -1318,6 +1331,14 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <div class="if-nissan">
             <label for='interlock'>Interlock required: </label>
             <input type='checkbox' name='INTERLOCKREQ' id='interlock' value='on' %INTERLOCKREQ% />
+        </div>
+
+        <div class="if-ecmp">
+            <label for='ecmpmode'>Force ECMP mode: </label>
+            <input type='checkbox' name='ECMPMODE' id='ecmpmode' value='on' %ECMPMODE% />
+
+            <label for='ecmpmode2'>Force MysteryVan mode: </label>
+            <input type='checkbox' name='ECMPMODE2' id='ecmpmode2' value='on' %ECMPMODE2% />
         </div>
 
         <div class="if-tesla">

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -400,6 +400,7 @@ void init_webserver() {
       "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",   "HADISC",       "MQTTTOPICS",    "MQTTCELLV",    "INVICNT",
       "GTWRHD",        "DIGITALHVIL",  "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET",  "PYLONORDER",
       "DEYEBYD",       "NCCONTACTOR",  "TRIBTR",      "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",   "CTINVERT",
+      "ECMPMODE",      "ECMPMODE2",
   };
 
   const char* uintSettingNames[] = {


### PR DESCRIPTION
### What
This PR filters out invalid temperature readings that block operation

### Why
Stellantis ECMP packs can get stuck and show 0xFF (255) as temp, and once this happens we incorrectly log overheat event

### How
We treat the symptom, not the cause. Investigation still needed why this happens

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
