### PR TITLE
SimpBMS: Correct scaling of current value

### DIFF
--- a/Software/src/battery/SIMPBMS-BATTERY.cpp
+++ b/Software/src/battery/SIMPBMS-BATTERY.cpp
@@ -9,9 +9,9 @@ void SimpBmsBattery::update_values() {
 
   datalayer.battery.status.soh_pptt = (SOH * 100);  //Increase decimals from 100% -> 100.00%
 
-  datalayer.battery.status.voltage_dV = voltage_dV;  //value is *10 (3700 = 370.0)
+  datalayer.battery.status.voltage_dV = voltage_dV;
 
-  datalayer.battery.status.current_dA = current_dA;  //value is *10 (150 = 15.0) , invert the sign
+  datalayer.battery.status.current_dA = current_mA / 100;
 
   datalayer.battery.status.max_charge_power_W = (max_charge_current * (voltage_dV / 10));
 
@@ -55,7 +55,7 @@ void SimpBmsBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x356:
       //current status
-      current_dA = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2]) / 100;
+      current_mA = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[2]);
       voltage_dV = ((rx_frame.data.u8[1] << 8) + rx_frame.data.u8[0]) / 10;
       break;
     case 0x373:

--- a/Software/src/battery/SIMPBMS-BATTERY.h
+++ b/Software/src/battery/SIMPBMS-BATTERY.h
@@ -20,7 +20,7 @@ class SimpBmsBattery : public CanBattery {
 
   int16_t celltemperature_max_dC = 0;
   int16_t celltemperature_min_dC = 0;
-  int16_t current_dA = 0;
+  int16_t current_mA = 0;
   uint16_t voltage_dV = 0;
   uint16_t cellvoltage_max_mV = 3700;
   uint16_t cellvoltage_min_mV = 3700;


### PR DESCRIPTION
### What
This PR corrects the scaling of the current value in SimpBMS integration

### Why
Fixes #2214

### How
We read the value as int16_t properly, and scale it down elsewhere

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
