### PR TITLE
BYD Atto 3 - Fix crash reset to include security access handshake before ClearDTC

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -517,7 +517,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     transmit_can_frame(&ATTO_3_441);
 
-   switch (stateMachineClearCrash) {
+    switch (stateMachineClearCrash) {
       case STARTED:
         // DiagnosticSessionControl: enter extendedDiagnosticSession
         solvedKey = 0;
@@ -536,8 +536,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
         // SecurityAccess: sendKey
         if (solvedKey > 0) {
           ATTO_3_7E7_CLEAR_CRASH.data = {
-              0x04, 0x27, 0x02, (uint8_t)((solvedKey & 0xFF00) >> 8),
-              (uint8_t)(solvedKey & 0x00FF), 0x00, 0x00, 0x00};
+              0x04, 0x27, 0x02, (uint8_t)((solvedKey & 0xFF00) >> 8), (uint8_t)(solvedKey & 0x00FF), 0x00, 0x00, 0x00};
           transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
           stateMachineClearCrash = RUNNING_STEP_3;
         } else {

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -517,20 +517,40 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     transmit_can_frame(&ATTO_3_441);
 
-    switch (stateMachineClearCrash) {
+   switch (stateMachineClearCrash) {
       case STARTED:
-        // DiagnosticSesssionControl enter extendedDiagnosticSession
-        ATTO_3_7E7_CLEAR_CRASH.data = {0x02, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
+        // DiagnosticSessionControl: enter extendedDiagnosticSession
+        solvedKey = 0;
+        increaseTimeoutSOC = 0;
+        ATTO_3_7E7_CLEAR_CRASH.data = {0x02, 0x10, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00};
         transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
         stateMachineClearCrash = RUNNING_STEP_1;
         break;
       case RUNNING_STEP_1:
-        ATTO_3_7E7_CLEAR_CRASH.data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00};
+        // SecurityAccess: requestSeed
+        ATTO_3_7E7_CLEAR_CRASH.data = {0x02, 0x27, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
         transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
         stateMachineClearCrash = RUNNING_STEP_2;
         break;
       case RUNNING_STEP_2:
-        ATTO_3_7E7_CLEAR_CRASH.data = {0x03, 0x19, 0x02, 0x09, 0x00, 0x00, 0x00, 0x00};
+        // SecurityAccess: sendKey
+        if (solvedKey > 0) {
+          ATTO_3_7E7_CLEAR_CRASH.data = {
+              0x04, 0x27, 0x02, (uint8_t)((solvedKey & 0xFF00) >> 8),
+              (uint8_t)(solvedKey & 0x00FF), 0x00, 0x00, 0x00};
+          transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
+          stateMachineClearCrash = RUNNING_STEP_3;
+        } else {
+          increaseTimeoutSOC++;
+          if (increaseTimeoutSOC > 250) {
+            increaseTimeoutSOC = 0;
+            stateMachineClearCrash = NOT_RUNNING;
+          }
+        }
+        break;
+      case RUNNING_STEP_3:
+        // ClearDiagnosticInformation: clear all DTCs
+        ATTO_3_7E7_CLEAR_CRASH.data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00};
         transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
         stateMachineClearCrash = NOT_RUNNING;
         break;


### PR DESCRIPTION
### What
This PR fixes the BYD Atto 3 crash reset function.

### Why
The crash reset was sending ClearDTC without first authenticating with the BMS, causing it to silently fail every time.

### How
Adds the same security access handshake already used by the SOC calibration feature to the crash reset state machine, so the BMS accepts the ClearDTC request.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)