### PR TITLE
Pylon RS485: Make integration always send current set charge/discharge limits

### DIFF
--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -40,9 +40,9 @@ void PylonLV485InverterProtocol::update_values() {
 
   min_discharge_v_mv = datalayer.battery.info.min_design_voltage_dV * 100;
 
-  // Optional: Current limits for 0x63
-  max_charge_i_da = datalayer.battery.status.max_charge_current_dA * 10;
-  max_discharge_i_da = datalayer.battery.status.max_discharge_current_dA * 10;
+  max_charge_i_da = datalayer.battery.status.max_charge_current_dA;
+
+  max_discharge_i_da = datalayer.battery.status.max_discharge_current_dA;
 
   if (incoming_message_counter > 0) {
     incoming_message_counter--;
@@ -182,21 +182,7 @@ void PylonLV485InverterProtocol::handle_command_63() {
   // Command 0x63: Charge/Discharge Management (9 bytes)
   // Format: Max_Charge_Voltage(2) | Min_Discharge_Voltage(2) | Max_Charge_Current(2) | Max_Discharge_Current(2) | Status(1)
 
-  uint16_t max_charge_v_mv = 58000;     // 58V default
-  uint16_t min_discharge_v_mv = 48000;  // 48V default
-  uint16_t max_charge_i_da = 500;       // 5A default
-  uint16_t max_discharge_i_da = 500;    // 5A default
-  uint8_t status_byte = 0xC0;           // Bit 7 & 6: Charge & Discharge enabled
-
-  // Override with datalayer limits if available
-  if (datalayer.battery.info.max_design_voltage_dV > 0)
-    max_charge_v_mv = datalayer.battery.info.max_design_voltage_dV * 100;
-  if (datalayer.battery.info.min_design_voltage_dV > 0)
-    min_discharge_v_mv = datalayer.battery.info.min_design_voltage_dV * 100;
-  if (datalayer.battery.status.max_charge_current_dA > 0)
-    max_charge_i_da = datalayer.battery.status.max_charge_current_dA * 10;
-  if (datalayer.battery.status.max_discharge_current_dA > 0)
-    max_discharge_i_da = datalayer.battery.status.max_discharge_current_dA * 10;
+  uint8_t status_byte = 0xC0;  // Bit 7 & 6: Charge & Discharge enabled
 
   char info_payload[19];
   snprintf(info_payload, sizeof(info_payload), "%04X%04X%04X%04X%02X", max_charge_v_mv, min_discharge_v_mv,

--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -40,9 +40,28 @@ void PylonLV485InverterProtocol::update_values() {
 
   min_discharge_v_mv = datalayer.battery.info.min_design_voltage_dV * 100;
 
-  max_charge_i_da = datalayer.battery.status.max_charge_current_dA;
+  max_charge_i_dA = datalayer.battery.status.max_charge_current_dA;
 
-  max_discharge_i_da = datalayer.battery.status.max_discharge_current_dA;
+  max_discharge_i_dA = datalayer.battery.status.max_discharge_current_dA;
+
+  if (datalayer.battery.status.bms_status == FAULT) {
+    //If we are in FAULT mode, do not allow charging or discharging
+    charge_allowed = false;
+    discharge_allowed = false;
+  } else {  //Else, write based on current allowed, if it reaches 0, stop
+    if (max_charge_i_dA == 0) {
+      charge_allowed = false;
+    } else {
+      charge_allowed = true;
+    }
+    if (max_discharge_i_dA == 0) {
+      discharge_allowed = false;
+    } else {
+      discharge_allowed = true;
+    }
+  }
+
+  status_byte_63 = (uint8_t)((charge_allowed << 7) | (discharge_allowed << 6));
 
   if (incoming_message_counter > 0) {
     incoming_message_counter--;
@@ -182,11 +201,9 @@ void PylonLV485InverterProtocol::handle_command_63() {
   // Command 0x63: Charge/Discharge Management (9 bytes)
   // Format: Max_Charge_Voltage(2) | Min_Discharge_Voltage(2) | Max_Charge_Current(2) | Max_Discharge_Current(2) | Status(1)
 
-  uint8_t status_byte = 0xC0;  // Bit 7 & 6: Charge & Discharge enabled
-
   char info_payload[19];
   snprintf(info_payload, sizeof(info_payload), "%04X%04X%04X%04X%02X", max_charge_v_mv, min_discharge_v_mv,
-           max_charge_i_da, max_discharge_i_da, status_byte);
+           max_charge_i_dA, max_discharge_i_dA, status_byte_63);
 
   std::string info_str(info_payload);
   std::string length_field = calculate_length_field(info_str.length());

--- a/Software/src/inverter/PYLON-LV-RS485.h
+++ b/Software/src/inverter/PYLON-LV-RS485.h
@@ -48,8 +48,8 @@ class PylonLV485InverterProtocol : public Rs485InverterProtocol {
   uint16_t min_cell_v = 3350;           // 3.35V default
   uint16_t max_charge_v_mv = 52000;     // 52V default
   uint16_t min_discharge_v_mv = 48000;  // 48V default
-  uint16_t max_charge_i_da = 500;       // 5A default
-  uint16_t max_discharge_i_da = 500;    // 5A default
+  uint16_t max_charge_i_da = 0;         // 0A default
+  uint16_t max_discharge_i_da = 0;      // 0A default
 };
 
 #endif

--- a/Software/src/inverter/PYLON-LV-RS485.h
+++ b/Software/src/inverter/PYLON-LV-RS485.h
@@ -48,8 +48,11 @@ class PylonLV485InverterProtocol : public Rs485InverterProtocol {
   uint16_t min_cell_v = 3350;           // 3.35V default
   uint16_t max_charge_v_mv = 52000;     // 52V default
   uint16_t min_discharge_v_mv = 48000;  // 48V default
-  uint16_t max_charge_i_da = 0;         // 0A default
-  uint16_t max_discharge_i_da = 0;      // 0A default
+  uint16_t max_charge_i_dA = 0;         // 0A default
+  uint16_t max_discharge_i_dA = 0;      // 0A default
+  uint8_t status_byte_63 = 0x00;        // Bit 7 & 6: Charge & Discharge enabled
+  bool charge_allowed = true;
+  bool discharge_allowed = true;
 };
 
 #endif


### PR DESCRIPTION
### What
This PR makes Pylon RS485 integration always send current set charge/discharge limits

### Why
Current value was scaled too large, and not updated when value was 0A allowed

### How
We remove the incorrect code that allowed charging when current was 0A allowed.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
