### PR TITLE
Library :books: Update ESP32 to v3.3.8

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:esp32devkit_330] 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -41,7 +41,7 @@ build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:lilygo_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -55,7 +55,7 @@ build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:stark_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -69,7 +69,7 @@ build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_2CAN_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -94,7 +94,7 @@ build_flags =
 lib_deps = 
 
 [env:BECom_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 upload_speed = 921600


### PR DESCRIPTION
### What
This PR updates the ESP32 base to the latest available version

### Why
Latest and greatest ESP32 backbone is always a good idea. Full list of changelog here: https://github.com/espressif/arduino-esp32/releases/tag/3.3.8

### How
We update v3.3.7 -> v3.3.8

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
