### PR TITLE
Fronius: Increase comm timeout from 3min to 5min

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -136,7 +136,7 @@ void BydModbusInverter::verify_temperature() {
 
 void BydModbusInverter::verify_inverter_modbus() {
   // Every 60 seconds, the Gen24 writes to this 401 register, alternating between 00FF and FF00.
-  // We sample the register every 60 seconds. Incase the value has not changed for 3 minutes, we raise an event
+  // We sample the register every 60 seconds. Incase the value has not changed for 5 minutes, we raise an event
   unsigned long currentMillis = millis();
 
   if (currentMillis - previousMillis60s >= INTERVAL_60_S) {

--- a/Software/src/inverter/BYD-MODBUS.h
+++ b/Software/src/inverter/BYD-MODBUS.h
@@ -23,7 +23,7 @@ class BydModbusInverter : public ModbusInverterProtocol {
   const uint16_t MAX_POWER = 40960;
 
   static const int HISTORY_LENGTH =
-      3;  // Amount of samples(minutes) that needs to match for register to be considered stale
+      5;  // Amount of samples(minutes) that needs to match for register to be considered stale
   unsigned long previousMillis60s = 0;  // will store last time a 60s event occured
   uint32_t user_configured_max_discharge_W = 0;
   uint32_t user_configured_max_charge_W = 0;


### PR DESCRIPTION
### What
This PR increases comm timeout for Fronius

### Why
False positives might be triggered with current implementation. Especially problematic since we now open contactors

### How
Increase timeout from 3min -> 5min to reduce risk of false positive

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
