### PR TITLE
Fix: stop Preferences reporting bogus errors

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -53,32 +53,36 @@ class BatteryEmulatorSettingsStore {
     settingsUpdated = true;
   }
 
-  uint32_t getUInt(const char* name, uint32_t defaultValue) { return settings.getUInt(name, defaultValue); }
+  uint32_t getUInt(const char* name, uint32_t defaultValue) {
+    return settings.isKey(name) ? settings.getUInt(name, defaultValue) : defaultValue;
+  }
 
   void saveUInt(const char* name, uint32_t value) {
-    auto oldValue = settings.getUInt(name, std::numeric_limits<uint32_t>::max());
+    auto oldValue = getUInt(name, std::numeric_limits<uint32_t>::max());
     settings.putUInt(name, value);
     settingsUpdated = settingsUpdated || value != oldValue;
   }
 
   bool settingExists(const char* name) { return settings.isKey(name); }
 
-  bool getBool(const char* name, bool defaultValue = false) { return settings.getBool(name, defaultValue); }
+  bool getBool(const char* name, bool defaultValue = false) {
+    return settings.isKey(name) ? settings.getBool(name, defaultValue) : defaultValue;
+  }
 
   void saveBool(const char* name, bool value) {
-    auto oldValue = settings.getBool(name, false);
+    auto oldValue = getBool(name, false);
     settings.putBool(name, value);
     settingsUpdated = settingsUpdated || value != oldValue;
   }
 
-  String getString(const char* name) { return settings.getString(name, String()); }
+  String getString(const char* name) { return getString(name, ""); }
 
   String getString(const char* name, const char* defaultValue) {
-    return settings.getString(name, String(defaultValue));
+    return settings.isKey(name) ? settings.getString(name, defaultValue) : String(defaultValue);
   }
 
   void saveString(const char* name, const char* value) {
-    auto oldValue = settings.getString(name);
+    auto oldValue = getString(name, "");
     settings.putString(name, value);
     settingsUpdated = settingsUpdated || String(value) != oldValue;
   }


### PR DESCRIPTION
### What
The Arduino-ESP32 Preferences library prints errors when a key is read from NVM that doesn't exist yet.

The error is bogus, there's even a defaultValue arg for it to return if the key isn't found, but it doesn't look like it is going to be fixed anytime soon.

So call `isKey` first on every read to avoid triggering the message.

### Why
Confuses people, might also be causing perf issues (due to it always being printed to serial regardless of whether you have serial debugging enabled).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
