### PR TITLE
Fix: Reduce TASK_OVERRUNs by phasing tasks

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -416,7 +416,7 @@ void core_loop(void*) {
   esp_task_wdt_add(NULL);  // Register this task with WDT
   TickType_t xLastWakeTime = xTaskGetTickCount();
   const TickType_t xFrequency = pdMS_TO_TICKS(1);  // Convert 1ms to ticks
-  int loopPhase;
+  int loopPhase = 0;
 
   while (true) {
     START_TIME_MEASUREMENT(all);

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -416,9 +416,9 @@ void core_loop(void*) {
   esp_task_wdt_add(NULL);  // Register this task with WDT
   TickType_t xLastWakeTime = xTaskGetTickCount();
   const TickType_t xFrequency = pdMS_TO_TICKS(1);  // Convert 1ms to ticks
+  int loopPhase;
 
   while (true) {
-
     START_TIME_MEASUREMENT(all);
     START_TIME_MEASUREMENT(comm);
 
@@ -430,7 +430,8 @@ void core_loop(void*) {
 
     // Process
     currentMillis = millis();
-    if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {
+    loopPhase = 1 - loopPhase;  // Spread out slower tasks across multiple iterations
+    if (currentMillis - previousMillis10ms >= INTERVAL_10_MS && loopPhase == 0) {
       if ((currentMillis - previousMillis10ms >= INTERVAL_10_MS_DELAYED) &&
           (milliseconds(currentMillis) > esp32hal->BOOTUP_TIME())) {
         set_event(EVENT_TASK_OVERRUN, (currentMillis - previousMillis10ms));
@@ -455,7 +456,7 @@ void core_loop(void*) {
       }
     }
 
-    if (currentMillis - previousMillisUpdateVal >= INTERVAL_1_S) {
+    if (currentMillis - previousMillisUpdateVal >= INTERVAL_1_S && loopPhase == 1) {
       previousMillisUpdateVal = currentMillis;  // Order matters on the update_loop!
       if (datalayer.system.info.performance_measurement_active) {
         START_TIME_MEASUREMENT(values);


### PR DESCRIPTION
### What
Add a `loopPhase` counter to the core loop, and only run the 10ms task when it is 0, and the 1s task when it is 1, to greatly reduce the chance of TASK_OVERRUNs.

(There are other ways of doing this, this approach might be too weird! - I'm also still investigating other options...)

### Why
The 10ms and 1s tasks in the core loop can take 2-3ms each to run. Normally this isn't a problem, but occasionally they both run in the same loop iteration, making the loop time >5ms.

Due to how TASK_OVERRUN is detected, a loop iteration taking >5ms can sometimes trigger a TASK_OVERRUN. When all these things align, one occurs. This happens very infrequently, but the events are still concerning to users.

By ensuring that the 10ms and 1s tasks can never happen in the same loop iteration, the margin is doubled, so TASK_OVERRUNs should be much rarer - and a sign of something actually bad happening.

(There is scope to apply this further - spreading out multiple batteries and inverter, etc).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
