### PR TITLE
Nissan LEAF: Add crude low 12V warning for Nissan LEAF

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -160,6 +160,13 @@ void NissanLeafBattery::
     }
   }
 
+  if (datalayer_battery->status.cell_max_voltage_mV > 60000 || datalayer_battery->status.cell_min_voltage_mV > 60000) {
+    set_event(EVENT_12V_LOW, 0);
+    //This is a bit of a hack, but we don't have a dedicated event for "12V low" and this is the first indicator of low 12V
+  } else {
+    clear_event(EVENT_12V_LOW);
+  }
+
   if (battery_HeatExist) {
     if (battery_Heating_Stop) {
       set_event(EVENT_BATTERY_WARMED_UP, 0);


### PR DESCRIPTION
### What
This PR implements a crude low 12V warning for Nissan LEAF batteries

### Why
First sign of low 12V on Nissan LEAF batteries is corrupted Cell Min/Max readings, happens at approx ~11.2 volt

<img width="508" height="117" alt="image" src="https://github.com/user-attachments/assets/ca80807c-ee43-41ed-bb1d-31dc5a6e1577" />

### How
If we see a glitched value, fire off a "Low 12V" Event! This lets the user know to check the 12V battery/source

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
