### PR TITLE
Checks: add smoothing to free-heap checks

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -159,6 +159,8 @@ void update_calculated_values(unsigned long currentMillis) {
 
   /*Update free heap*/
   datalayer.system.info.CPU_free_heap = ESP.getFreeHeap();
+  datalayer.system.info.CPU_free_heap_smoothed =
+      (datalayer.system.info.CPU_free_heap_smoothed * 3 + datalayer.system.info.CPU_free_heap) / 4;
 
   /* Check is remote set limits have timed out */
   if (currentMillis > datalayer.battery.settings.remote_set_timestamp + datalayer.battery.settings.remote_set_timeout) {

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -273,6 +273,7 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
   float CPU_temperature = 0;
   /** ESP32 free heap amount, for displaying on webserver and for safeties */
   uint32_t CPU_free_heap = 0;
+  uint32_t CPU_free_heap_smoothed = 131072;  // Start above the warning threshold
 
   /** uint8_t, enumeration which CAN interface should be used for log playback */
   uint8_t can_replay_interface = CAN_NATIVE;

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -41,7 +41,7 @@ void update_machineryprotection() {
     clear_event(EVENT_CPU_OVERHEATED);  //Hysteresis on the clearing
   }
 
-  if (datalayer.system.info.CPU_free_heap < 62000) {
+  if (datalayer.system.info.CPU_free_heap_smoothed < 62000) {
     set_event(EVENT_LOW_HEAP_MEMORY, (datalayer.system.info.CPU_free_heap / 1000));
   } else {
     clear_event(EVENT_LOW_HEAP_MEMORY);


### PR DESCRIPTION
### What
The free-heap warning is triggering randomly for people. I think this is because it compares the exact value at the moment that it is sampled. If you happen to load the settings page (which itself gobbles 40-50kb of RAM briefly) at the same time as the value is checked, then you will get a warning.

This adds some basic smoothing, so that it will only generate the warnings if the level is consistently too low, not just a brief blip.

### Why
Reduce phantom warnings which cause unnecessary concern. Fixes #2240


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
