### PR TITLE
Stellantis CMP Smart: Add advanced reset commands (Clear crash/isolation)

### DIFF
--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -524,6 +524,36 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
     //transmit_can_frame(&CMP_231);  // Battery Preconditioning (Apparently not needed for contactor closing?)
     //transmit_can_frame(&CMP_422);  // (Apparently not needed for contactor closing?)
     //transmit_can_frame(&CMP_4A2);  //Should we send plugged in, or unplugged? (Apparently not needed for contactor closing?)
+
+    if (UserRequestDTCreset) {
+      transmit_can_frame(&CMP_CLEAR_ALL_DTC);
+      UserRequestDTCreset = false;
+    }
+    if (UserRequestCrashReset) {
+      if (CrashResetStatemachine == 0) {
+        transmit_can_frame(&CMP_DIAG_START);
+        CrashResetStatemachine = 1;
+      }
+      if (CrashResetStatemachine == 2) {
+        transmit_can_frame(&CMP_CRASH_RESET_START);
+        CrashResetStatemachine = 3;
+      }
+      if (CrashResetStatemachine == 4) {
+        transmit_can_frame(&CMP_CRASH_RESET_PROGRESS);
+        CrashResetStatemachine = 5;
+      }
+
+      timeSpentCrashReset++;
+      if (timeSpentCrashReset > 15) {  //Timeout, if command takes more than 1.5s to complete
+        UserRequestCrashReset = false;
+        CrashResetStatemachine = COMPLETED_STATE;
+        timeSpentCrashReset = COMPLETED_STATE;
+      }
+    }
+    if (UserRequestIsolationClear) {
+      transmit_can_frame(&CMP_CLEAR_ISOLATION);
+      UserRequestIsolationClear = false;
+    }
   }
 
   // Send 1s messages
@@ -541,18 +571,6 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&CMP_552);
     //This message is odd. Non periodic, but increments 10 per cycle. Might be enough to send it once every second
     */
-    if (UserRequestDTCreset) {
-      transmit_can_frame(&CMP_CLEAR_ALL_DTC);
-      UserRequestDTCreset = false;
-    }
-    if (UserRequestCrashReset) {
-      transmit_can_frame(&CMP_CRASH_RESET);
-      UserRequestCrashReset = false;
-    }
-    if (UserRequestIsolationClear) {
-      transmit_can_frame(&CMP_CLEAR_ISOLATION);
-      UserRequestIsolationClear = false;
-    }
   }
 }
 

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -532,6 +532,7 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
       transmit_can_frame(&CMP_CLEAR_ALL_DTC);
       UserRequestDTCreset = false;
     }
+
     if (UserRequestCrashReset) {
       if (CrashResetStatemachine == 0) {
         transmit_can_frame(&CMP_DIAG_START);
@@ -553,6 +554,7 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
         timeSpentCrashReset = COMPLETED_STATE;
       }
     }
+
     if (UserRequestIsolationClear) {
       transmit_can_frame(&CMP_CLEAR_ISOLATION);
       UserRequestIsolationClear = false;

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -383,6 +383,9 @@ void CmpSmartCarBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x694:  // Poll reply
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      if (UserRequestCrashReset) {
+        CrashResetStatemachine++;
+      }
       break;
     case 0x795:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -541,9 +541,17 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&CMP_552);
     //This message is odd. Non periodic, but increments 10 per cycle. Might be enough to send it once every second
     */
-    if (datalayer_extended.stellantisCMPsmart.UserRequestDTCreset) {
+    if (UserRequestDTCreset) {
       transmit_can_frame(&CMP_CLEAR_ALL_DTC);
-      datalayer_extended.stellantisCMPsmart.UserRequestDTCreset = false;
+      UserRequestDTCreset = false;
+    }
+    if (UserRequestCrashReset) {
+      transmit_can_frame(&CMP_CRASH_RESET);
+      UserRequestCrashReset = false;
+    }
+    if (UserRequestIsolationClear) {
+      transmit_can_frame(&CMP_CLEAR_ISOLATION);
+      UserRequestIsolationClear = false;
     }
   }
 }

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.h
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.h
@@ -137,19 +137,14 @@ class CmpSmartCarBattery : public CanBattery {
                                  .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF}};
   CAN_frame CMP_CRASH_RESET_START = {.FD = false,
                                      .ext_ID = false,
-                                     .DLC = 6,
+                                     .DLC = 5,
                                      .ID = 0x6B4,
-                                     .data = {0x04, 0x31, 0x01, 0x06, 0x02, 0x03}};
+                                     .data = {0x04, 0x31, 0x01, 0x06, 0x02}};
   CAN_frame CMP_CRASH_RESET_PROGRESS = {.FD = false,
                                         .ext_ID = false,
-                                        .DLC = 6,
+                                        .DLC = 5,
                                         .ID = 0x6B4,
-                                        .data = {0x04, 0x31, 0x03, 0x06, 0x02, 0x03}};
-  CAN_frame CMP_COLLISION_RESET = {.FD = false,
-                                   .ext_ID = false,
-                                   .DLC = 5,
-                                   .ID = 0x6B4,
-                                   .data = {0x04, 0x31, 0x01, 0xDF, 0x60}};
+                                        .data = {0x04, 0x31, 0x03, 0x06, 0x02}};
   CAN_frame CMP_CLEAR_ISOLATION = {.FD = false,
                                    .ext_ID = false,
                                    .DLC = 5,

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.h
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.h
@@ -29,7 +29,13 @@ class CmpSmartCarBattery : public CanBattery {
   bool supports_charged_energy() { return true; }
 
   bool supports_reset_DTC() { return true; }
-  void reset_DTC() { datalayer_extended.stellantisCMPsmart.UserRequestDTCreset = true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
+  bool supports_clear_isolation() { return true; }
+  void clear_isolation() { UserRequestIsolationClear = true; }
+
+  bool supports_reset_crash() { return true; }
+  void reset_crash() { UserRequestCrashReset = true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
@@ -129,6 +135,21 @@ class CmpSmartCarBattery : public CanBattery {
                                  .DLC = 5,
                                  .ID = 0x6B4,
                                  .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF}};
+  CAN_frame CMP_CRASH_RESET = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 6,
+                               .ID = 0x6B4,
+                               .data = {0x04, 0x31, 0x01, 0x06, 0x02, 0x03}};
+  CAN_frame CMP_COLLISION_RESET = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 5,
+                                   .ID = 0x6B4,
+                                   .data = {0x04, 0x31, 0x01, 0xDF, 0x60}};
+  CAN_frame CMP_CLEAR_ISOLATION = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 5,
+                                   .ID = 0x6B4,
+                                   .data = {0x04, 0x31, 0x01, 0x06, 0x0F}};
   uint32_t vehicle_time_counter = 0x088B390B;  //Taken from log on 19thOctober2025
   uint32_t main_contactor_cycle_count = 0;
   uint32_t QC_contactor_cycle_count = 0;
@@ -234,5 +255,9 @@ class CmpSmartCarBattery : public CanBattery {
   bool cooling_enabled = false;
   bool battery_minimum_voltage_reached_warning = false;
   bool alert_low_battery_energy = false;
+
+  bool UserRequestDTCreset = false;       /** User requesting DTC reset via WebUI*/
+  bool UserRequestIsolationClear = false; /** User requesting isolation fault clear via WebUI*/
+  bool UserRequestCrashReset = false;     /** User requesting crash reset via WebUI*/
 };
 #endif

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.h
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.h
@@ -135,11 +135,16 @@ class CmpSmartCarBattery : public CanBattery {
                                  .DLC = 5,
                                  .ID = 0x6B4,
                                  .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF}};
-  CAN_frame CMP_CRASH_RESET = {.FD = false,
-                               .ext_ID = false,
-                               .DLC = 6,
-                               .ID = 0x6B4,
-                               .data = {0x04, 0x31, 0x01, 0x06, 0x02, 0x03}};
+  CAN_frame CMP_CRASH_RESET_START = {.FD = false,
+                                     .ext_ID = false,
+                                     .DLC = 6,
+                                     .ID = 0x6B4,
+                                     .data = {0x04, 0x31, 0x01, 0x06, 0x02, 0x03}};
+  CAN_frame CMP_CRASH_RESET_PROGRESS = {.FD = false,
+                                        .ext_ID = false,
+                                        .DLC = 6,
+                                        .ID = 0x6B4,
+                                        .data = {0x04, 0x31, 0x03, 0x06, 0x02, 0x03}};
   CAN_frame CMP_COLLISION_RESET = {.FD = false,
                                    .ext_ID = false,
                                    .DLC = 5,
@@ -150,6 +155,12 @@ class CmpSmartCarBattery : public CanBattery {
                                    .DLC = 5,
                                    .ID = 0x6B4,
                                    .data = {0x04, 0x31, 0x01, 0x06, 0x0F}};
+  static constexpr CAN_frame CMP_DIAG_START = {.FD = false,
+                                               .ext_ID = false,
+                                               .DLC = 3,
+                                               .ID = 0x6B4,
+                                               .data = {0x02, 0x10, 0x03}};
+  //Start diagnostic session (extended diagnostic session, mode 0x10 with sub-mode 0x03)
   uint32_t vehicle_time_counter = 0x088B390B;  //Taken from log on 19thOctober2025
   uint32_t main_contactor_cycle_count = 0;
   uint32_t QC_contactor_cycle_count = 0;
@@ -199,6 +210,10 @@ class CmpSmartCarBattery : public CanBattery {
   int16_t battery_temperature_minimum = 0;
   int16_t battery_current_dA = 0;
 
+  uint8_t CrashResetStatemachine = 0;
+  uint8_t timeSpentCrashReset = 0;
+  static const uint8_t NOT_SAMPLED_YET = 255;
+  static const uint8_t COMPLETED_STATE = 0;
   uint8_t tempval = 0;
   uint8_t startup_increment = 0;
   uint8_t active_DTC_code = 0;

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -1242,26 +1242,6 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
 
     } else if (UserRequestCollisionReset) {
 
-      if (CollisionResetStatemachine == 0) {
-        transmit_can_frame(&ECMP_DIAG_START);
-        CollisionResetStatemachine = 1;
-      }
-      if (CollisionResetStatemachine == 2) {
-        transmit_can_frame(&ECMP_COLLISION_RESET_START);
-        CollisionResetStatemachine = 3;
-      }
-      if (CollisionResetStatemachine == 4) {
-        transmit_can_frame(&ECMP_COLLISION_RESET_PROGRESS);
-        CollisionResetStatemachine = 5;
-      }
-
-      timeSpentCollisionReset++;
-      if (timeSpentCollisionReset > 40) {  //Timeout, if command takes more than 10s to complete
-        UserRequestCollisionReset = false;
-        CollisionResetStatemachine = COMPLETED_STATE;
-        timeSpentCollisionReset = COMPLETED_STATE;
-      }
-
     } else if (UserRequestIsolationReset) {
 
       if (IsolationResetStatemachine == 0) {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -289,7 +289,6 @@ struct DATALAYER_INFO_CMPSMART {
   bool rcd_line_active = false;
   bool power_auth = false;
   bool battery_balancing_active = false;
-  bool UserRequestDTCreset = false; /** User requesting DTC reset via WebUI*/
 };
 
 struct DATALAYER_INFO_ECMP {


### PR DESCRIPTION
### What
This PR implements advanced reset commands for the Stellantis CMP Smart Car platform

### Why
To be able to clear level 5 faults that prevent battery from being used

### How
New buttons added to the "More Battery Info" page

<img width="659" height="119" alt="image" src="https://github.com/user-attachments/assets/71a5071f-cef6-47bb-86e8-d07d7d1f934f" />

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
