### PR TITLE
Stark CMR: Support for add-on MCP2515 (3-CAN)

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -56,6 +56,18 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_18; }
   virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_35; }
 
+  // CAN_ADDON
+  // SCK input of MCP2515
+  virtual gpio_num_t MCP2515_SCK() { return GPIO_NUM_14; }
+  // SDI input of MCP2515
+  virtual gpio_num_t MCP2515_MOSI() { return GPIO_NUM_12; }
+  // SDO output of MCP2515
+  virtual gpio_num_t MCP2515_MISO() { return GPIO_NUM_34; }
+  // CS input of MCP2515
+  virtual gpio_num_t MCP2515_CS() { return GPIO_NUM_15; }
+  // INT output of MCP2515
+  virtual gpio_num_t MCP2515_INT() { return GPIO_NUM_13; }
+
   // Contactor handling
   virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_32; }
   virtual gpio_num_t NEGATIVE_CONTACTOR_PIN() { return GPIO_NUM_33; }
@@ -83,7 +95,8 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
   std::vector<comm_interface> available_interfaces() {
-    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanFdNative};
+    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
+            comm_interface::CanFdNative};
   }
 
   virtual const char* name_for_comm_interface(comm_interface comm) {
@@ -93,7 +106,7 @@ class StarkHal : public Esp32Hal {
       case comm_interface::CanFdNative:
         return "CAN FD 2 (Native)";
       case comm_interface::CanAddonMcp2515:
-        return "";
+        return "MCP2515 (GPIO add-on)";
       case comm_interface::CanFdAddonMcp2518:
         return "";
       case comm_interface::Modbus:


### PR DESCRIPTION
### What
This PR implements support for add-on MCP2515 (3-CAN) for the Stark CMR

### Why
User requested feature to run more battery packs on the same board

### How
Dropdown added for new interface

<img width="594" height="219" alt="image" src="https://github.com/user-attachments/assets/b38e93be-72f2-4532-a935-864098856e97" />

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
