### PR TITLE
BMW i3: Set startup voltage limit wide to avoid incorrect events

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -568,8 +568,8 @@ void BmwI3Battery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
 
-  //Before we have started up and detected which battery is in use, use 60AH values
-  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_60AH;
+  //Before we have started up and detected which battery is in use, use the widest limits
+  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_120AH;
   datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_60AH;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 


### PR DESCRIPTION
### What
This PR sets startup voltage limits wide on the BMW i3 integration

### Why
If user reboots BE with a 94/120AH i3 battery, the instantly applied 60AH 395Vmax will cause incorrect events to occur

<img width="813" height="333" alt="image" src="https://github.com/user-attachments/assets/e864b081-c1d2-4191-ace8-725610ea58d3" />


### How
We fix this by applying same logic as other implementations, start out with allowing a wider range before actual battery type has been determined

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
