### PR TITLE
Volkswagen MEB: Add ODIS bridge mode

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -94,6 +94,8 @@ const char* name_for_battery_type(BatteryType type) {
       return KiaHyundaiHybridBattery::Name;
     case BatteryType::Meb:
       return MebBattery::Name;
+    case BatteryType::MebOdisBridge:
+      return MebOdisBridge::Name;
 #ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return Mg5Battery::Name;
@@ -213,6 +215,8 @@ Battery* create_battery(BatteryType type) {
       return new KiaHyundaiHybridBattery();
     case BatteryType::Meb:
       return new MebBattery();
+    case BatteryType::MebOdisBridge:
+      return new MebOdisBridge();
 #ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return new Mg5Battery();

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -40,6 +40,7 @@ void setup_shunt();
 #include "KIA-HYUNDAI-64-BATTERY.h"
 #include "KIA-HYUNDAI-HYBRID-BATTERY.h"
 #include "MEB-BATTERY.h"
+#include "MEB-ODIS-BRIDGE.h"
 #include "MG-5-BATTERY.h"
 #include "MG-HS-PHEV-BATTERY.h"
 #include "NISSAN-LEAF-BATTERY.h"

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -57,6 +57,7 @@ enum class BatteryType {
   GeelySea = 50,
   ThunderstruckBMS = 51,
   EnnoidBMS = 52,
+  MebOdisBridge = 53,
   Highest
 };
 

--- a/Software/src/battery/MEB-ODIS-BRIDGE.cpp
+++ b/Software/src/battery/MEB-ODIS-BRIDGE.cpp
@@ -1,0 +1,25 @@
+#include "MEB-ODIS-BRIDGE.h"
+#include "../battery/BATTERIES.h"
+#include "../communication/can/comm_can.h"
+#include "../datalayer/datalayer.h"
+#include "../devboard/utils/events.h"
+
+void MebOdisBridge::update_values() {
+  datalayer.system.info.can_ODIS_bridge_active = true;
+  //Nothing to update, passive gateway mode
+  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+}
+
+void MebOdisBridge::handle_incoming_can_frame(CAN_frame rx_frame) {
+  //TODO, move handling from comm_can.cpp into here in some smart way
+}
+
+void MebOdisBridge::transmit_can(unsigned long currentMillis) {
+  //No periodic sending for this protocol
+}
+
+void MebOdisBridge::setup(void) {  // Performs one time setup at startup
+  strncpy(datalayer.system.info.battery_protocol, Name, 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
+  datalayer.system.info.can_ODIS_bridge_active = true;
+}

--- a/Software/src/battery/MEB-ODIS-BRIDGE.h
+++ b/Software/src/battery/MEB-ODIS-BRIDGE.h
@@ -1,0 +1,19 @@
+#ifndef MEB_ODIS_BRIDGE_H
+#define MEB_ODIS_BRIDGE_H
+
+#include "../system_settings.h"
+#include "CanBattery.h"
+
+class MebOdisBridge : public CanBattery {
+ public:
+  virtual void setup(void);
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void update_values();
+  virtual void transmit_can(unsigned long currentMillis);
+
+  static constexpr const char* Name = "MEB ODIS Bridge";
+
+ private:
+};
+
+#endif

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -316,6 +316,11 @@ void receive_frame_can_native() {  // This section checks if we have a complete 
 
       //message incoming, pass it on to the handler
       map_can_frame_to_variable(&rx_frame, CAN_NATIVE);
+
+      if (datalayer.system.info.can_ODIS_bridge_active) {
+        //Incoming Native CAN message. Pass it as-is to the CANFD interface
+        transmit_can_frame_to_interface(&rx_frame, CANFD_ADDON_MCP2518);
+      }
     }
   }
 }
@@ -346,6 +351,15 @@ void receive_frame_canfd_addon() {  // This section checks if we have a complete
     //message incoming, pass it on to the handler
     map_can_frame_to_variable(&rx_frame, CANFD_ADDON_MCP2518);
     map_can_frame_to_variable(&rx_frame, CANFD_NATIVE);
+
+    if (datalayer.system.info.can_ODIS_bridge_active) {
+      //ODIS: Incoming CAN-FD message. Format it as normal CAN, and send to Native CAN
+      if (rx_frame.DLC > 8) {
+        rx_frame.DLC = 8;
+      }
+      rx_frame.FD = false;
+      transmit_can_frame_to_interface(&rx_frame, CAN_NATIVE);
+    }
   }
 }
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -301,6 +301,8 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
   bool performance_measurement_active = false;
   bool equipment_stop_active = false;  //Has user enabled equipment stop?
   bool start_precharging = false;      //Is precharge ongoing?
+  /** bool, determines if ODIS CAN relay mode should be active */
+  bool can_ODIS_bridge_active = false;
 };
 
 struct DATALAYER_SYSTEM_STATUS_TYPE {

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -76,7 +76,7 @@ enum BMSResetState {
 // Set by battery each time we get a CAN message. Decrements every second. When reaching 0, sets event
 
 enum CAN_Interface {
-  // Native CAN port on the LilyGo & Stark hardware
+  // Native CAN port on the LilyGo T-CAN & Stark hardware, CAN-B on LilyGo T-2CAN
   CAN_NATIVE = 0,
 
   // Native CANFD port on the Stark CMR hardware

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(tests
     ../Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
     ../Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
     ../Software/src/battery/MEB-BATTERY.cpp
+    ../Software/src/battery/MEB-ODIS-BRIDGE.cpp
     ../Software/src/battery/MG-5-BATTERY.cpp
     ../Software/src/battery/MG-HS-PHEV-BATTERY.cpp
     ../Software/src/battery/NISSAN-LEAF-BATTERY.cpp


### PR DESCRIPTION
### What
This PR Adds ODIS bridge mode

### Why
So users no longer have to use an old precompiled build of BE from 2025 to get bridge mode to work

### How
ODIS relay bridge gateway mode, or whatever you want to call it, is now enabled when you enable the Battery mode "MEB ODIS Bridge"

<img width="611" height="135" alt="image" src="https://github.com/user-attachments/assets/d3852fde-324a-4f14-af06-fb76669cdd65" />


This mode will forward CAN messages between the Native CAN , to the CAN-FD port

NOTE, only forwarding from Native CAN (Native CAN port on the LilyGo T-CAN & Stark hardware, CAN-**B** on LilyGo T-2CAN) , onto whatever CAN-FD port is available.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
