### PR TITLE
Zoe2: Remove general battery caution event

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -86,11 +86,12 @@ void RenaultZoeGen2Battery::update_values() {
     }
   }
 
+  /* Removed until we have a way to clear failures
   if (battery_slave_failures > 0) {
     set_event(EVENT_BATTERY_CAUTION, 0);
   } else {
     clear_event(EVENT_BATTERY_CAUTION);
-  }
+  }*/
 
   // Update webserver datalayer
   datalayer_extended.zoePH2.battery_soc = battery_soc;


### PR DESCRIPTION
### What
This PR removes general battery caution event for Zoe2

### Why
We have no way to clear failed module, so the general caution  event was permanently on for some users

### How
Remove the check for now, uncommented

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
