### PR TITLE
Bugfix: MQTT Added 'sensor.' prefix for default_entity_id

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -191,6 +191,10 @@ static String generateButtonAutoConfigTopic(const char* subtype) {
   return "homeassistant/button/" + topic_name + "/" + String(subtype) + "/config";
 }
 
+static String generateSensorDefaultEntityId(const String& object_id) {
+  return "sensor." + object_id;
+}
+
 void set_common_discovery_attributes(JsonDocument& doc) {
   doc["device"]["identifiers"][0] = device_id;
   doc["device"]["manufacturer"] = "DalaTech";
@@ -204,8 +208,9 @@ void set_common_discovery_attributes(JsonDocument& doc) {
 
 void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, const String& state_topic,
                                     const String& default_entity_id_prefix, const String& battery_name_suffix) {
+  const String default_entity_object_id = default_entity_id_prefix + "battery_voltage_cell" + String(cellNumber);
   doc["name"] = "Battery" + battery_name_suffix + " Cell Voltage " + String(cellNumber);
-  doc["default_entity_id"] = default_entity_id_prefix + "battery_voltage_cell" + String(cellNumber);
+  doc["default_entity_id"] = generateSensorDefaultEntityId(default_entity_object_id);
   doc["unique_id"] = topic_name + default_entity_id_prefix + "_battery_voltage_cell" + String(cellNumber);
   doc["device_class"] = "voltage";
   doc["state_class"] = "measurement";
@@ -293,7 +298,8 @@ static bool publish_common_info(void) {
       doc["name"] = config.name;
       doc["state_topic"] = state_topic;
       doc["unique_id"] = topic_name + "_" + String(config.default_entity_id);
-      doc["default_entity_id"] = default_entity_id_prefix + String(config.default_entity_id);
+      const String default_entity_object_id = default_entity_id_prefix + String(config.default_entity_id);
+      doc["default_entity_id"] = generateSensorDefaultEntityId(default_entity_object_id);
       doc["value_template"] = config.value_template;
       if (config.unit != nullptr && strlen(config.unit) > 0) {
         doc["unit_of_measurement"] = config.unit;
@@ -486,7 +492,7 @@ bool publish_events() {
     doc["name"] = "Event";
     doc["state_topic"] = state_topic;
     doc["unique_id"] = topic_name + "_event";
-    doc["default_entity_id"] = default_entity_id_prefix + "event";
+    doc["default_entity_id"] = generateSensorDefaultEntityId(default_entity_id_prefix + "event");
     doc["value_template"] =
         "{{ value_json.event_type ~ ' (c:' ~ value_json.count ~ ',m:' ~  value_json.millis ~ ') ' ~ value_json.message "
         "}}";


### PR DESCRIPTION
### What
Fix for issue: https://github.com/dalathegreat/Battery-Emulator/issues/2300

This PR implements prefix for MQTT default_entity_id

### Why
Currently fresh/new installs of MQTT with BE 10.6+ will display all sensors as `unnamed_device_x`

This fix wil solve this and display them as e.g.: `sensor.be_battery_voltage_cell3`

### How
By adding a 'sensor.` prefix.



> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)

Tested on my own lillygo with HA. 
<img width="1835" height="1178" alt="Screenshot 2026-05-12 at 11 55 40" src="https://github.com/user-attachments/assets/1fec641a-b958-4a0f-8e8d-aa097bcc01b9" />
<img width="611" height="878" alt="Screenshot 2026-05-12 at 11 54 26" src="https://github.com/user-attachments/assets/e600c59f-d17e-42d7-8134-7bfdcf5f2aa9" />


Example of MQTT message in my case:

```
{
  "name": "Battery Cell Voltage 1",
  "default_entity_id": "sensor.be_battery_voltage_cell1",
  "unique_id": "BEbe__battery_voltage_cell1",
  "device_class": "voltage",
  "state_class": "measurement",
  "state_topic": "BE/spec_data",
  "unit_of_measurement": "V",
  "value_template": "{{ value_json.cell_voltages[0] }}",
  "device": {
    "identifiers": [
      "battery-emulator"
    ],
    "manufacturer": "DalaTech",
    "model": "BatteryEmulator",
    "name": "Battery Emulator"
  },
  "availability": [
    {
      "topic": "BE/status"
    }
  ],
  "payload_available": "online",
  "payload_not_available": "offline",
  "enabled_by_default": true
}
```
