### PR TITLE
Improvement: Update compiler warning check ESP32 version to 3.3.8

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = ./Software
 
 [env:compiler_warning_check]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder


### PR DESCRIPTION
### What
This PR updates the build system ESP32 version from v3.3.2 -> v3.3.8

### Why
Versions between 3.3.3 to 3.3.7 had compiler warnings active, and could not be used

### How
Thankfully 3.3.8 can now again be used!

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
