### PR TITLE
Refactor: Rename bms_status -> system_status

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -34,8 +34,7 @@ void BmwI3Battery::end_balancing() {
   UserRequestBalancingMillis = 0;
   cmdState = SOC;
   battery_info_available = false;
-  datalayer.system.status.system_status =
-      ACTIVE;  //TODO this is not a good variable to use since EVENTS will overwrite it
+  set_event(EVENT_BALANCING_END, 0);
 }
 
 void BmwI3Battery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
@@ -50,8 +49,6 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
   // so the safety check (EVENT_CAN_BATTERY_MISSING) does not trigger
   if (UserRequestBalancing == EXECUTING) {
     datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-    datalayer.system.status.system_status =
-        STANDBY;  //TODO this is not a good variable to use since EVENTS will overwrite it
   }
 
   // Map internal balancing state to datalayer balancing_status

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -34,7 +34,8 @@ void BmwI3Battery::end_balancing() {
   UserRequestBalancingMillis = 0;
   cmdState = SOC;
   battery_info_available = false;
-  datalayer_battery->status.bms_status = ACTIVE;
+  datalayer.system.status.system_status =
+      ACTIVE;  //TODO this is not a good variable to use since EVENTS will overwrite it
 }
 
 void BmwI3Battery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
@@ -49,7 +50,8 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
   // so the safety check (EVENT_CAN_BATTERY_MISSING) does not trigger
   if (UserRequestBalancing == EXECUTING) {
     datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-    datalayer_battery->status.bms_status = STANDBY;
+    datalayer.system.status.system_status =
+        STANDBY;  //TODO this is not a good variable to use since EVENTS will overwrite it
   }
 
   // Map internal balancing state to datalayer balancing_status
@@ -333,7 +335,7 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
       BMW_13E_counter++;
       BMW_13E.data.u8[4] = BMW_13E_counter;
 
-      if (datalayer_battery->status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
       } else if (allows_contactor_closing) {
         //If battery is not in Fault mode, and we are allowed to control contactors, we allow contactor to close by sending 10B
         *allows_contactor_closing = true;

--- a/Software/src/battery/BMW-SBOX.cpp
+++ b/Software/src/battery/BMW-SBOX.cpp
@@ -80,7 +80,7 @@ void BmwSbox::transmit_can(unsigned long currentMillis) {
   if (currentMillis - LastMsgTime >= INTERVAL_20_MS) {
     LastMsgTime = currentMillis;
     // First check if we have any active errors, incase we do, turn off the battery
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       timeSpentInFaultedMode++;
     } else {
       timeSpentInFaultedMode = 0;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -462,7 +462,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     // Set close contactors to allowed (Useful for crashed packs, started via contactor control thru GPIO)
     if (allows_contactor_closing) {
-      if (datalayer_battery->status.bms_status == ACTIVE) {
+      if (datalayer.system.status.system_status == ACTIVE) {
         *allows_contactor_closing = true;
       } else {  // Fault state, open contactors!
         *allows_contactor_closing = false;

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -478,7 +478,7 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
       CMP_351.data.u8[1] = 0x10;
       CMP_351.data.u8[2] = 0x10;
     } else {  //Normal handling of 351 message according to we need to open/close contactors
-      if (datalayer_battery->status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
         //Open contactors
         CMP_351.data.u8[0] = 0xA6;
         CMP_351.data.u8[1] = 0x10;
@@ -507,7 +507,7 @@ void CmpSmartCarBattery::transmit_can(unsigned long currentMillis) {
       CMP_211.data.u8[4] = 0x17;    //Ready mode (unsure why this opens contactors)
     } else {                        //Normal handling of close/open
 
-      if (datalayer_battery->status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
         //Open contactors
         CMP_211.data.u8[4] = 0x17;  //Ready mode (unsure why this opens contactors) (Bit 1 is insulation turn-off)
       } else {                      //Close contactors

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -39,7 +39,7 @@ void EcmpBattery::update_values() {
     datalayer_battery->status.voltage_dV = battery_voltage * 10;
 
     // If High Precision Curent is avilable, use it
-    if (pid_current != NOT_SAMPLED_YET && datalayer.battery.status.bms_status != FAULT) {
+    if (pid_current != NOT_SAMPLED_YET && datalayer.system.status.system_status != FAULT) {
       datalayer_battery->status.current_dA = (int16_t)(pid_current / 100);
     } else {
       datalayer_battery->status.current_dA = -(battery_current * 10);
@@ -1292,7 +1292,7 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
 
     } else {  //Normal PID polling goes here
 
-      if (datalayer.battery.status.bms_status != FAULT) {  //Stop PID polling if battery is in FAULT mode
+      if (datalayer.system.status.system_status != FAULT) {  //Stop PID polling if we are in FAULT mode
 
         // Sample High Precison Current every other time
         if (HighPrecisionCurrentSampling) {
@@ -1666,7 +1666,7 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
 
     counter_10ms = (counter_10ms + 1) % 16;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       //Make vehicle appear as in idle HV state. Useful for clearing DTCs
       ECMP_0F2.data = {0x7D, 0x00, 0x4E, 0x20, 0x00, 0x00, 0x60, 0x0D};
       ECMP_17B.data = {0x00, 0x00, 0x00, 0x7E, 0x78, 0x00, 0x00, 0x0F};
@@ -1699,7 +1699,7 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis20 >= INTERVAL_20_MS) {
     previousMillis20 = currentMillis;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       //Open contactors!
       ECMP_0F0.data.u8[1] = 0x00;
     } else {  // Not in faulted mode, Close contactors!
@@ -1716,7 +1716,7 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
     previousMillis50 = currentMillis;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       //Make vehicle appear as in idle HV state. Useful for clearing DTCs
       ECMP_27A.data = {0x4F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     } else {
@@ -1733,7 +1733,7 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
     counter_100ms = (counter_100ms + 1) % 16;
     counter_010 = (counter_010 + 1) % 8;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       //Make vehicle appear as in idle HV state. Useful for clearing DTCs
 #ifdef SIMULATE_ENTIRE_VEHICLE_ECMP
       ECMP_31E.data.u8[0] = 0x48;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -295,7 +295,7 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis20 >= INTERVAL_20_MS) {
     previousMillis20 = currentMillis;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       FORD_25B.data.u8[2] = 0x01;
     } else {
       FORD_25B.data.u8[2] = 0x09;

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -159,7 +159,7 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
           KIA64_7E4_poll.data.u8[3] = (uint8_t)(POLL_ECU_VERSION & 0x00FF);
           poll_data_pid = 0;
         }
-        if (datalayer.battery.status.bms_status == FAULT) {
+        if (datalayer.system.status.system_status == FAULT) {
           //If we are in fault mode, request contactors to open via UDS
           open_state++;
           if (open_state == 1) {  //Enter elevated mode
@@ -469,7 +469,7 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
 void KiaHyundai64Battery::transmit_can(unsigned long currentMillis) {
 
-  if (!startedUp || (datalayer.battery.status.bms_status == FAULT)) {
+  if (!startedUp || (datalayer.system.status.system_status == FAULT)) {
     return;  // Don't send any CAN messages towards battery until it has started up. Also stop sending if we are in critical FAULT mode
   }
 

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -993,7 +993,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     } else if ((first_can_msg > 0 && currentMillis > first_can_msg + 1000 && BMS_mode != 7) ||
                datalayer.system.info.equipment_stop_active) {  //FAULT STATE, open contactors
 
-      if (datalayer.battery.status.bms_status != FAULT && datalayer.battery.status.real_bms_status == BMS_STANDBY &&
+      if (datalayer.system.status.system_status != FAULT && datalayer.battery.status.real_bms_status == BMS_STANDBY &&
           !datalayer.system.info.equipment_stop_active) {
         datalayer.system.info.start_precharging = true;
       }

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -644,7 +644,7 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
 
-    if (datalayer.battery.status.bms_status != FAULT                  // Fault, so open contactors!
+    if (datalayer.system.status.system_status != FAULT                // Fault, so open contactors!
         && userRequestContactorClose == true                          // User requested contactor closing
         && datalayer.system.status.inverter_allows_contactor_closing  // Inverter requests contactor closing
     ) {

--- a/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
+++ b/Software/src/battery/MG-HS-PHEV-BATTERY.cpp
@@ -166,7 +166,7 @@ void MgHsPHEVBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         clear_event(EVENT_BATTERY_ISOLATION);
       }
 
-      if (datalayer_battery->status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
         // If in fault state, don't try resetting things yet as it'll turn the
         // BMS off and we'll lose CAN info
       } else if ((rx_frame.data.u8[0] == 0x02 || rx_frame.data.u8[0] == 0x06) && rx_frame.data.u8[1] == 0x01) {
@@ -333,7 +333,7 @@ void MgHsPHEVBattery::transmit_can(unsigned long currentMillis) {
     // Leave the contactors open
     MG_HS_8A.data.u8[5] = 0x00;
 #else
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       // Fault, so open contactors!
       MG_HS_8A.data.u8[5] = 0x00;
     } else if (!datalayer.system.status.inverter_allows_contactor_closing) {

--- a/Software/src/battery/RIVIAN-BATTERY.cpp
+++ b/Software/src/battery/RIVIAN-BATTERY.cpp
@@ -205,8 +205,9 @@ void RivianBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis10 >= (INTERVAL_200_MS)) {
     previousMillis10 = currentMillis;
 
-    //If we want to close contactors, and preconditions are met
-    if ((datalayer.system.status.inverter_allows_contactor_closing) && (datalayer.battery.status.bms_status != FAULT)) {
+    //If we want to close contactors, and system allows for it
+    if ((datalayer.system.status.inverter_allows_contactor_closing) &&
+        (datalayer.system.status.system_status != FAULT)) {
       //Standby -> Ready Mode
       if (BMS_state == STANDBY || BMS_state == SLEEP) {
         RIVIAN_150.data.u8[0] = 0x03;

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -251,7 +251,7 @@ void RjxzsBms::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
     previousMillis10s = currentMillis;
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       // Incase we loose BMS comms, resend CAN start
       setup_completed = false;
     }

--- a/Software/src/battery/SONO-BATTERY.cpp
+++ b/Software/src/battery/SONO-BATTERY.cpp
@@ -117,7 +117,7 @@ void SonoBattery::transmit_can(unsigned long currentMillis) {
     //VCU Command message
     SONO_400.data.u8[0] = 0x15;  //Charging enabled bit01, dischargign enabled bit23, dc charging bit45
 
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       SONO_400.data.u8[0] = 0x14;  //Charging DISABLED
     }
     transmit_can_frame(&SONO_400);

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -851,7 +851,7 @@ void TeslaBattery::
 
   //Safety checks for CAN message sending
   if ((datalayer.system.status.inverter_allows_contactor_closing == true) &&
-      (datalayer.battery.status.bms_status != FAULT) && (!datalayer.system.info.equipment_stop_active)) {
+      (datalayer.system.status.system_status != FAULT) && (!datalayer.system.info.equipment_stop_active)) {
     // Carry on: 0x221 DRIVE state & reset power down timer
     vehicleState = CAR_DRIVE;
     powerDownSeconds = 9;
@@ -1873,7 +1873,7 @@ void TeslaBattery::transmit_can(unsigned long currentMillis) {
 
     if (user_selected_tesla_digital_HVIL) {  //Special Digital HVIL mode for S/X 2024+ batteries
       if ((datalayer.system.status.inverter_allows_contactor_closing) &&
-          (datalayer.battery.status.bms_status != FAULT)) {
+          (datalayer.system.status.system_status != FAULT)) {
         transmit_can_frame(&can_msg_1CF[index_1CF]);
         index_1CF = (index_1CF + 1) % 8;
         transmit_can_frame(&can_msg_118[index_118]);

--- a/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
+++ b/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
@@ -377,7 +377,7 @@ void TeslaLegacyBattery::transmit_can(unsigned long currentMillis) {
     return;  //All cellvoltages not read yet, do not proceed with contactor closing
   }
 
-  if ((datalayer.system.status.inverter_allows_contactor_closing) && (datalayer.battery.status.bms_status != FAULT)) {
+  if ((datalayer.system.status.inverter_allows_contactor_closing) && (datalayer.system.status.system_status != FAULT)) {
     if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
       previousMillis100 = currentMillis;
 

--- a/Software/src/battery/THINK-BATTERY.cpp
+++ b/Software/src/battery/THINK-BATTERY.cpp
@@ -133,7 +133,7 @@ void ThinkBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
     previousMillis200 = currentMillis;
 
-    if (datalayer.battery.status.bms_status != FAULT) {
+    if (datalayer.system.status.system_status != FAULT) {
       transmit_can_frame(&PCU_310);
       transmit_can_frame(&PCU_311);
     }

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -255,7 +255,7 @@ void VolvoSpaBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&VOLVO_536);  //Send 0x536 Network managing frame to keep BMS alive
     transmit_can_frame(&VOLVO_372);  //Send 0x372 ECMAmbientTempCalculated
 
-    if ((datalayer.battery.status.bms_status == ACTIVE) && startedUp) {
+    if ((datalayer.system.status.system_status == ACTIVE) && startedUp) {
       datalayer.system.status.battery_allows_contactor_closing = true;
       transmit_can_frame(&VOLVO_140_CLOSE);  //Send 0x140 Close contactors message
     } else {  //datalayer.battery.status.bms_status == FAULT , OR inverter requested opening contactors, OR system not started yet
@@ -276,7 +276,7 @@ void VolvoSpaBattery::transmit_can(unsigned long currentMillis) {
   }
   if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
     previousMillis60s = currentMillis;
-    if (datalayer.battery.status.bms_status == ACTIVE) {
+    if (datalayer.system.status.system_status == ACTIVE) {
       readCellVoltages();
     }
   }

--- a/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
@@ -474,7 +474,7 @@ void VolvoSpaHybridBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&VOLVO_536);  //Send 0x536 Network managing frame to keep BMS alive
     transmit_can_frame(&VOLVO_372);  //Send 0x372 ECMAmbientTempCalculated
 
-    if ((datalayer.battery.status.bms_status == ACTIVE) && startedUp) {
+    if ((datalayer.system.status.system_status == ACTIVE) && startedUp) {
       datalayer.system.status.battery_allows_contactor_closing = true;
       //transmit_can_frame(&VOLVO_140_CLOSE);  //Send 0x140 Close contactors message
     } else {  //datalayer.battery.status.bms_status == FAULT , OR inverter requested opening contactors, OR system not started yet
@@ -495,10 +495,8 @@ void VolvoSpaHybridBattery::transmit_can(unsigned long currentMillis) {
   }
   if (currentMillis - previousMillis60s >= INTERVAL_60_S) {
     previousMillis60s = currentMillis;
-    if (true) {
-      readCellVoltages();
-      logging.println("Requesting cell voltages");
-    }
+    readCellVoltages();
+    logging.println("Requesting cell voltages");
   }
 }
 

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -163,7 +163,7 @@ void handle_contactors() {
 
   if (contactor_control_enabled) {
     // First check if we have any active errors, incase we do, turn off the battery
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       timeSpentInFaultedMode++;
     } else {
       timeSpentInFaultedMode = 0;

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -125,7 +125,7 @@ void handle_precharge_control(unsigned long currentMillis) {
         datalayer.system.info.start_precharging = false;
       } else if ((datalayer.battery.status.real_bms_status != BMS_STANDBY &&
                   datalayer.battery.status.real_bms_status != BMS_ACTIVE) ||
-                 datalayer.battery.status.bms_status != ACTIVE || datalayer.system.info.equipment_stop_active) {
+                 datalayer.system.status.system_status != ACTIVE || datalayer.system.info.equipment_stop_active) {
         pinMode(hia4v1_pin, OUTPUT);
         digitalWrite(hia4v1_pin, LOW);
         digitalWrite(inverter_disconnect_contactor_pin, CONTACTOR_ON);
@@ -144,7 +144,7 @@ void handle_precharge_control(unsigned long currentMillis) {
       // If equipment stop is activated, or BE is in a non-active state, or the
       // BMS has gone back to standby (eg, after a BMS reset), then we'll allow
       // the precharge to be restarted.
-      if (datalayer.system.info.equipment_stop_active || datalayer.battery.status.bms_status != ACTIVE ||
+      if (datalayer.system.info.equipment_stop_active || datalayer.system.status.system_status != ACTIVE ||
           datalayer.battery.status.real_bms_status == BMS_STANDBY) {
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_IDLE;
         logging.printf("Precharge: equipment stop activated -> IDLE\n");
@@ -155,7 +155,7 @@ void handle_precharge_control(unsigned long currentMillis) {
       // This is not used anymore?
       if (!datalayer.system.status.battery_allows_contactor_closing ||
           !datalayer.system.status.inverter_allows_contactor_closing || datalayer.system.info.equipment_stop_active ||
-          datalayer.battery.status.bms_status != FAULT) {
+          datalayer.system.status.system_status != FAULT) {
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_IDLE;
         pinMode(hia4v1_pin, OUTPUT);
         digitalWrite(hia4v1_pin, LOW);

--- a/Software/src/core/parallel_safety.cpp
+++ b/Software/src/core/parallel_safety.cpp
@@ -15,7 +15,7 @@ void check_parallel_battery_safety(uint8_t batteryNumber) {
     if (voltage_diff_battery2_towards_main <= 15) {  // If we are within 1.5V between the batteries
       clear_event(EVENT_VOLTAGE_DIFFERENCE);
       secondsOutOfVoltageSyncBattery2 = 0;
-      if (datalayer.battery.status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
         // If main battery is in fault state, disengage the second battery
         datalayer.system.status.battery2_allowed_contactor_closing = false;
       } else {  // If main battery is OK, allow second battery to join
@@ -44,7 +44,7 @@ void check_parallel_battery_safety(uint8_t batteryNumber) {
     if (voltage_diff_battery3_towards_main <= 15) {  // If we are within 1.5V between the batteries
       clear_event(EVENT_VOLTAGE_DIFFERENCE);
       secondsOutOfVoltageSyncBattery3 = 0;
-      if (datalayer.battery.status.bms_status == FAULT) {
+      if (datalayer.system.status.system_status == FAULT) {
         // If main battery is in fault state, disengage the second battery
         datalayer.system.status.battery3_allowed_contactor_closing = false;
       } else {  // If main battery is OK, allow second battery to join

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -102,8 +102,7 @@ struct DATALAYER_BATTERY_STATUS_TYPE {
    * we report the battery as missing entirely on the CAN bus.
    */
   uint8_t CAN_battery_still_alive = CAN_STILL_ALIVE;
-  /** The current system status, which for now still has the name bms_status */
-  bms_status_enum bms_status = ACTIVE;
+
   /** The current battery status, which for now has the name real_bms_status */
   real_bms_status_enum real_bms_status = BMS_DISCONNECTED;
   /** LED mode, customizable by user */
@@ -360,6 +359,8 @@ struct DATALAYER_SYSTEM_STATUS_TYPE {
   bool contactors_battery3_engaged = false;
   /** State of BMS reset sequence */
   BMSResetState bms_reset_status = BMS_RESET_IDLE;
+  /** The current system status, usually pending between ACTIVE and FAULT, but there are more enums. Used to signal incase we have a critical fault active, or if we should proceed operating */
+  system_status_enum system_status = ACTIVE;
 };
 
 struct DATALAYER_SYSTEM_TYPE {

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -359,7 +359,7 @@ struct DATALAYER_SYSTEM_STATUS_TYPE {
   bool contactors_battery3_engaged = false;
   /** State of BMS reset sequence */
   BMSResetState bms_reset_status = BMS_RESET_IDLE;
-  /** The current system status, usually pending between ACTIVE and FAULT, but there are more enums. Used to signal incase we have a critical fault active, or if we should proceed operating */
+  /** The current system status, determined by which Events are active, usually pending between ACTIVE and FAULT, but there are more enums. Used to signal incase we have a critical fault active, or if we should proceed operating */
   system_status_enum system_status = ACTIVE;
 };
 

--- a/Software/src/devboard/espnow/espnow.h
+++ b/Software/src/devboard/espnow/espnow.h
@@ -103,8 +103,6 @@ struct BATTERY_STATUS_TYPE {
    * we report the battery as missing entirely on the CAN bus.
    */
   uint8_t CAN_battery_still_alive = CAN_STILL_ALIVE;
-  /** The current system status, which for now still has the name bms_status */
-  bms_status_enum bms_status = ACTIVE;
   /** The current battery status, which for now has the name real_bms_status */
   real_bms_status_enum real_bms_status = BMS_DISCONNECTED;
   /** LED mode, customizable by user */

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -334,7 +334,7 @@ static bool publish_common_info(void) {
     }
 
   } else {
-    doc["bms_status"] = getBMSStatus(datalayer.battery.status.bms_status);
+    doc["bms_status"] = getBMSStatus(datalayer.system.status.system_status);
     doc["pause_status"] = get_emulator_pause_status();
 
     //only publish these values if BMS is active and we are comunication  with the battery (can send CAN messages to the battery)

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -57,7 +57,7 @@ void update_machineryprotection() {
   if (battery) {
 
     // Pause function is on OR we have a critical fault event active
-    if (emulator_pause_request_ON || (datalayer.battery.status.bms_status == FAULT)) {
+    if (emulator_pause_request_ON || (datalayer.system.status.system_status == FAULT)) {
       datalayer.battery.status.max_discharge_power_W = 0;
       datalayer.battery.status.max_charge_power_W = 0;
     }
@@ -166,7 +166,7 @@ void update_machineryprotection() {
 
     // Battery is empty. Do not allow further discharge.
     // Normally the BMS will send 0W allowed, but this acts as an additional layer of safety
-    if (datalayer.battery.status.bms_status == ACTIVE) {
+    if (datalayer.system.status.system_status == ACTIVE) {
       if (datalayer.battery.status.reported_soc == 0 ||
           datalayer.battery.status.real_soc == 0) {  //Either Scaled OR Real SOC% value is 0.00%, time to stop
         if (!battery_empty_event_fired) {

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -477,17 +477,17 @@ static void update_bms_status(void) {
     case EVENT_LEVEL_INFO:
     case EVENT_LEVEL_WARNING:
     case EVENT_LEVEL_DEBUG:
-      datalayer.battery.status.bms_status = ACTIVE;
+      datalayer.system.status.system_status = ACTIVE;
       break;
     case EVENT_LEVEL_UPDATE:
-      datalayer.battery.status.bms_status = UPDATING;
+      datalayer.system.status.system_status = UPDATING;
       break;
     case EVENT_LEVEL_ERROR:
       // Normally FAULT mode is set if a catastrophic event has triggered, but incase user has forced a recovery charge, we override any FAULT and continue temporarily in active mode
       if (datalayer.battery.settings.user_requests_forced_charging_recovery_mode) {
-        datalayer.battery.status.bms_status = ACTIVE;  //Edge case which is active for 30min max
+        datalayer.system.status.system_status = ACTIVE;  //Edge case which is active for 30min max
       } else {
-        datalayer.battery.status.bms_status = FAULT;  //We will in 99.999% of the time go here
+        datalayer.system.status.system_status = FAULT;  //We will in 99.999% of the time go here
       }
       break;
     default:

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -1,7 +1,7 @@
 #include "types.h"
 
-// Function to get string representation of bms_status_enum
-std::string getBMSStatus(bms_status_enum status) {
+// Function to get string representation of system_status_enum
+std::string getBMSStatus(system_status_enum status) {
   switch (status) {
     case STANDBY:
       return "STANDBY";

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -7,7 +7,7 @@
 using milliseconds = std::chrono::milliseconds;
 using duration = std::chrono::duration<unsigned long, std::ratio<1, 1000>>;
 
-enum bms_status_enum { STANDBY = 0, INACTIVE = 1, DARKSTART = 2, ACTIVE = 3, FAULT = 4, UPDATING = 5 };
+enum system_status_enum { STANDBY = 0, INACTIVE = 1, DARKSTART = 2, ACTIVE = 3, FAULT = 4, UPDATING = 5 };
 enum real_bms_status_enum { BMS_DISCONNECTED = 0, BMS_STANDBY = 1, BMS_ACTIVE = 2, BMS_FAULT = 3 };
 enum balancing_status_enum {
   BALANCING_STATUS_UNKNOWN = 0,
@@ -114,7 +114,7 @@ typedef struct {
   frameDirection direction;
 } CAN_log_frame;
 
-std::string getBMSStatus(bms_status_enum status);
+std::string getBMSStatus(system_status_enum status);
 
 #ifdef HW_LILYGO2CAN
 /* Configurable GPIO options (device specific) */

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1114,7 +1114,7 @@ String processor(const String& var) {
       }
 
       content += "<h4>System status: ";
-      switch (datalayer.battery.status.bms_status) {
+      switch (datalayer.system.status.system_status) {
         case ACTIVE:
           content += String("OK");
           break;
@@ -1142,7 +1142,7 @@ String processor(const String& var) {
 
       if (battery2) {
         content += "<div style='flex: 1; background-color: ";
-        switch (datalayer.battery.status.bms_status) {
+        switch (datalayer.system.status.system_status) {
           case ACTIVE:
             content += "#2D3F2F;";
             break;
@@ -1230,7 +1230,7 @@ String processor(const String& var) {
         content += "</div>";
         if (battery3) {
           content += "<div style='flex: 1; background-color: ";
-          switch (datalayer.battery.status.bms_status) {
+          switch (datalayer.system.status.system_status) {
             case ACTIVE:
               content += "#2D3F2F;";
               break;
@@ -1333,7 +1333,7 @@ String processor(const String& var) {
     }
 
     content += "<h4>Emulator allows contactor closing: ";
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       content += "<span style='color: red;'>&#10005;</span>";
     } else {
       content += "<span>&#10003;</span>";

--- a/Software/src/inverter/AFORE-CAN.cpp
+++ b/Software/src/inverter/AFORE-CAN.cpp
@@ -30,17 +30,17 @@ void AforeCanInverter::
   AFORE_351.data.u8[3] = SOCMIN;
   AFORE_351.data.u8[4] = 0x03;  //Bit0 and Bit1 set
   if ((datalayer.battery.status.max_charge_current_dA == 0) || (datalayer.battery.status.reported_soc == 10000) ||
-      (datalayer.battery.status.bms_status == FAULT)) {
+      (datalayer.system.status.system_status == FAULT)) {
     AFORE_351.data.u8[4] &= ~0x01;  // Remove Bit0 (clear) Charge enable flag
   }
   if ((datalayer.battery.status.max_discharge_current_dA == 0) || (datalayer.battery.status.reported_soc == 0) ||
-      (datalayer.battery.status.bms_status == FAULT)) {
+      (datalayer.system.status.system_status == FAULT)) {
     AFORE_351.data.u8[4] &= ~0x02;  // Remove Bit1 (clear) Discharge enable flag
   }
   // Bit5-7 is BMS working status.
   //A value of 0 here is INIT, 1 = Normal operation, 2 = standby/sleep, 3 = warning, 4 = fault, rest is reserved
   AFORE_351.data.u8[4] &= ~(0xE0);  // Clear bits 5, 6, and 7 (11100000)
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     AFORE_351.data.u8[4] |= 0x80;  // Set bits 5-7 to 0b100 (Fault = 4)
   } else {                         // Normal mode
     AFORE_351.data.u8[4] |= 0x20;  // Set Bit5 to 1 (Normal operation)

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -78,12 +78,12 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   // Use the smaller value, battery reported value OR user configured value
   max_charge_W = std::min(datalayer.battery.status.max_charge_power_W, user_configured_max_charge_W);
 
-  if (datalayer.battery.status.bms_status == ACTIVE) {
+  if (datalayer.system.status.system_status == ACTIVE) {
     mbPV[308] = datalayer.battery.status.voltage_dV;
   } else {
     mbPV[308] = 0;
   }
-  mbPV[300] = datalayer.battery.status.bms_status;
+  mbPV[300] = datalayer.system.status.system_status;
   mbPV[302] = 128 + bms_char_dis_status;
   if (datalayer.battery.status.reported_soc < 100) {
     mbPV[303] = 100;  //Force SOC to never go below 1% to avoid overdischarge

--- a/Software/src/inverter/FERROAMP-CAN.cpp
+++ b/Software/src/inverter/FERROAMP-CAN.cpp
@@ -55,7 +55,7 @@ void FerroampCanInverter::
   FERROAMP_4211.data.u8[7] = (datalayer.battery.status.soh_pptt / 100);
 
   // Status=Bit 0,1,2= 0:Sleep, 1:Charge, 2:Discharge 3:Idle. Bit3 ForceChargeReq. Bit4 Balance charge Request
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     FERROAMP_4251.data.u8[0] = (0x00);  // Sleep
   } else if (datalayer.battery.status.reported_current_dA < 0) {
     FERROAMP_4251.data.u8[0] = (0x01);  // Charge
@@ -118,7 +118,7 @@ void FerroampCanInverter::
   FERROAMP_4271.data.u8[3] = (datalayer.battery.status.temperature_min_dC >> 8);
 
   //In case we run into any errors/faults, we can set charge / discharge forbidden
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     FERROAMP_4281.data.u8[0] = 0xAA;
     FERROAMP_4281.data.u8[1] = 0xAA;
     FERROAMP_4281.data.u8[2] = 0xAA;

--- a/Software/src/inverter/FOXESS-CAN.cpp
+++ b/Software/src/inverter/FOXESS-CAN.cpp
@@ -88,7 +88,7 @@ void FoxessCanInverter::
   // when at 0 indicates charge is possible - additional note there is something more to it than this,
   // it's not as straight forward - needs more testing to find what sets/unsets bit0 of byte0
   if ((datalayer.battery.status.max_charge_current_dA == 0) || (datalayer.battery.status.reported_soc == 10000) ||
-      (datalayer.battery.status.bms_status == FAULT)) {
+      (datalayer.system.status.system_status == FAULT)) {
     FOXESS_1876.data.u8[0] = 0x01;
   } else {  //continue using battery
     FOXESS_1876.data.u8[0] = 0x00;
@@ -104,7 +104,7 @@ void FoxessCanInverter::
 
   //BMS_ErrorsBrand
   //0x1877 b0 appears to be an error code, 0x02 when pack is in error.
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     FOXESS_1877.data.u8[0] = (uint8_t)0x02;
   } else {
     FOXESS_1877.data.u8[0] = (uint8_t)0;

--- a/Software/src/inverter/GROWATT-HV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-HV-CAN.cpp
@@ -91,13 +91,13 @@ void GrowattHvInverter::
     GROWATT_3110.data.u8[7] = (GROWATT_3110.data.u8[7] | 0b00000001);
   }
   if ((datalayer.battery.status.max_charge_current_dA == 0) || (datalayer.battery.status.reported_soc == 10000) ||
-      (datalayer.battery.status.bms_status == FAULT)) {
+      (datalayer.system.status.system_status == FAULT)) {
     GROWATT_3110.data.u8[7] = (GROWATT_3110.data.u8[7] | 0b01000000);  // No Charge
   } else {                                                             //continue using battery
     GROWATT_3110.data.u8[7] = (GROWATT_3110.data.u8[7] | 0b00000000);  // Charge allowed
   }
   if ((datalayer.battery.status.max_discharge_current_dA == 0) || (datalayer.battery.status.reported_soc == 0) ||
-      (datalayer.battery.status.bms_status == FAULT)) {
+      (datalayer.system.status.system_status == FAULT)) {
     GROWATT_3110.data.u8[7] = (GROWATT_3110.data.u8[7] | 0b00100000);  // No Discharge
   } else {                                                             //continue using battery
     GROWATT_3110.data.u8[7] = (GROWATT_3110.data.u8[7] | 0b00000000);  // Discharge allowed

--- a/Software/src/inverter/GROWATT-LV-CAN.cpp
+++ b/Software/src/inverter/GROWATT-LV-CAN.cpp
@@ -82,7 +82,7 @@ void GrowattLvInverter::
   GROWATT_314.data.u8[7] = 0;
 
   //Request charge/discharge
-  if (datalayer.battery.status.bms_status == ACTIVE) {
+  if (datalayer.system.status.system_status == ACTIVE) {
     GROWATT_319.data.u8[0] =
         0xC0;  //Bit7 charge enabled, Bit 6 discharge enabled (bit5 req force charge, bit 4 req force charge 2)
   } else {

--- a/Software/src/inverter/GROWATT-WIT-CAN.cpp
+++ b/Software/src/inverter/GROWATT-WIT-CAN.cpp
@@ -77,7 +77,7 @@ void GrowattWitInverter::update_values() {
 
   // Byte 0: BMS Working Status
   // 0=Init, 1=Standby, 2=Charging, 3=Discharging, 4=Shutdown, 5=Fault, 6=Upgrade
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     GROWATT_1AC5.data.u8[0] = 5;  // Fault
   } else if (datalayer.battery.status.current_dA > 5) {
     GROWATT_1AC5.data.u8[0] = 2;  // Charging (current > 0.5A)
@@ -92,7 +92,7 @@ void GrowattWitInverter::update_values() {
   // Bit 1: 0=Force charge OFF, 1=Force charge ON
   uint8_t charge_flag = 0x00;
   if (datalayer.battery.status.max_charge_current_dA == 0 || datalayer.battery.status.reported_soc >= 10000 ||  // 100%
-      datalayer.battery.status.bms_status == FAULT) {
+      datalayer.system.status.system_status == FAULT) {
     charge_flag |= 0x01;  // Prohibit charge
   }
   GROWATT_1AC5.data.u8[1] = charge_flag;
@@ -103,7 +103,7 @@ void GrowattWitInverter::update_values() {
   // Bit 3: 0=Normal, 1=Soft starting
   uint8_t discharge_flag = 0x00;
   if (datalayer.battery.status.max_discharge_current_dA == 0 || datalayer.battery.status.reported_soc == 0 ||
-      datalayer.battery.status.bms_status == FAULT) {
+      datalayer.system.status.system_status == FAULT) {
     discharge_flag |= 0x01;  // Prohibit discharge
   }
   GROWATT_1AC5.data.u8[2] = discharge_flag;
@@ -463,7 +463,7 @@ void GrowattWitInverter::update_values() {
   uint16_t discharge_protection = 0;
 
   // Check for fault conditions and set appropriate bits
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     // Set general fault indicators
     charge_protection |= 0x01;     // Cell overvoltage protection
     discharge_protection |= 0x01;  // Cell undervoltage protection
@@ -523,7 +523,7 @@ void GrowattWitInverter::update_values() {
   uint16_t generic_protection = 0;
 
   // Set fault code if BMS is in fault state
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     fault_code |= 0x01;  // Cell fault
   }
 

--- a/Software/src/inverter/PYLON-CAN.cpp
+++ b/Software/src/inverter/PYLON-CAN.cpp
@@ -45,7 +45,7 @@ void PylonInverter::
   }
 
   //In case run into a FAULT state, let inverter know to stop any charge/discharge
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     PYLON_428X.data.u8[0] = 0xAA;  //Charge forbidden
     PYLON_428X.data.u8[1] = 0xAA;  //Discharge forbidden
   }
@@ -133,7 +133,7 @@ void PylonInverter::
   }
 
   // Status=Bit 0,1,2= 0:Sleep, 1:Charge, 2:Discharge 3:Idle. Bit3 ForceChargeReq. Bit4 Balance charge Request
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     PYLON_425X.data.u8[0] = (0x00);  // Sleep
   } else if (datalayer.battery.status.reported_current_dA < 0) {
     PYLON_425X.data.u8[0] = (0x01);  // Charge

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -58,7 +58,7 @@ void PylonLvInverter::update_values() {
     PYLON_359.data.u8[0] |= 0x0C;
   if (datalayer.battery.status.voltage_dV <= datalayer.battery.info.min_design_voltage_dV)
     PYLON_359.data.u8[0] |= 0x04;
-  if (datalayer.battery.status.bms_status == FAULT)
+  if (datalayer.system.status.system_status == FAULT)
     PYLON_359.data.u8[1] |= 0x80;
   if (datalayer.battery.status.reported_current_dA <= -1 * datalayer.battery.status.max_charge_current_dA)
     PYLON_359.data.u8[1] |= 0x01;
@@ -81,7 +81,7 @@ void PylonLvInverter::update_values() {
     PYLON_359.data.u8[3] |= 0x01;
 
   PYLON_35C.data.u8[0] = 0xC0;  // enable charging and discharging
-  if (datalayer.battery.status.bms_status == FAULT)
+  if (datalayer.system.status.system_status == FAULT)
     PYLON_35C.data.u8[0] = 0x00;  // disable all
   else if (datalayer.battery.status.voltage_dV < datalayer.battery.info.min_design_voltage_dV)
     PYLON_35C.data.u8[0] = 0xA0;  // enable charing, set charge immediately

--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -44,7 +44,7 @@ void PylonLV485InverterProtocol::update_values() {
 
   max_discharge_i_dA = datalayer.battery.status.max_discharge_current_dA;
 
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     //If we are in FAULT mode, do not allow charging or discharging
     charge_allowed = false;
     discharge_allowed = false;

--- a/Software/src/inverter/SCHNEIDER-CAN.cpp
+++ b/Software/src/inverter/SCHNEIDER-CAN.cpp
@@ -30,7 +30,7 @@ void SchneiderInverter::
         ((datalayer.battery.info.reported_total_capacity_Wh / datalayer.battery.status.voltage_dV) * 100);
   }
   /* Set active commands/warnings/faults/state*/
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     state = STATE_FAULTED;
     //TODO: Map warnings and faults incase an event is set. Low prio, but nice to have
     commands = COMMAND_STOP;

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -54,7 +54,7 @@ void SmaBydHInverter::
   SMA_4D8.data.u8[4] = (temperature_average >> 8);
   SMA_4D8.data.u8[5] = (temperature_average & 0x00FF);
   //Battery ready
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     SMA_4D8.data.u8[6] = STOP_STATE;
   } else {
     SMA_4D8.data.u8[6] = READY_STATE;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -58,7 +58,7 @@ void SmaBydHvsInverter::
   SMA_4D8.data.u8[4] = (temperature_average >> 8);
   SMA_4D8.data.u8[5] = (temperature_average & 0x00FF);
   //Battery ready
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     SMA_4D8.data.u8[6] = STOP_STATE;
   } else {
     SMA_4D8.data.u8[6] = READY_STATE;

--- a/Software/src/inverter/SMA-LV-CAN.cpp
+++ b/Software/src/inverter/SMA-LV-CAN.cpp
@@ -99,7 +99,7 @@ void SmaLvInverter::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&SMA_35F);
 
     //Remote quick stop (optional)
-    if (datalayer.battery.status.bms_status == FAULT) {
+    if (datalayer.system.status.system_status == FAULT) {
       transmit_can_frame(&SMA_00F);
       //After receiving this message, Sunny Island will immediately go into standby.
       //Please send start command, to start again. Manual start is also possible.

--- a/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
+++ b/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
@@ -54,7 +54,7 @@ void SmaSBSBydHvsInverter::
   SMA_4D8.data.u8[4] = (temperature_average >> 8);
   SMA_4D8.data.u8[5] = (temperature_average & 0x00FF);
   //Battery ready
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     SMA_4D8.data.u8[6] = STOP_STATE;
   } else {
     SMA_4D8.data.u8[6] = READY_STATE;

--- a/Software/src/inverter/SOL-ARK-LV-CAN.cpp
+++ b/Software/src/inverter/SOL-ARK-LV-CAN.cpp
@@ -62,7 +62,7 @@ void SolArkLvInverter::update_values() {
     SOLARK_359.data.u8[0] |= 0x0C;
   if (datalayer.battery.status.voltage_dV <= datalayer.battery.info.min_design_voltage_dV)
     SOLARK_359.data.u8[0] |= 0x04;
-  if (datalayer.battery.status.bms_status == FAULT)
+  if (datalayer.system.status.system_status == FAULT)
     SOLARK_359.data.u8[1] |= 0x80;
   if (datalayer.battery.status.reported_current_dA <= -1 * datalayer.battery.status.max_charge_current_dA)
     SOLARK_359.data.u8[1] |= 0x01;
@@ -71,7 +71,7 @@ void SolArkLvInverter::update_values() {
   // TODO: Not enabled in this integration yet. See Pylon protocol for example integration
 
   SOLARK_35C.data.u8[0] = 0xC0;  // enable charging and discharging
-  if (datalayer.battery.status.bms_status == FAULT)
+  if (datalayer.system.status.system_status == FAULT)
     SOLARK_35C.data.u8[0] = 0x00;  // disable all
   else if (datalayer.battery.settings.user_set_voltage_limits_active &&
            datalayer.battery.status.voltage_dV > datalayer.battery.settings.max_user_set_charge_voltage_dV)

--- a/Software/src/inverter/SOLXPOW-CAN.cpp
+++ b/Software/src/inverter/SOLXPOW-CAN.cpp
@@ -34,7 +34,7 @@ void SolxpowInverter::
   }
 
   //In case run into a FAULT state, let inverter know to stop any charge/discharge
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     SOLXPOW_4280.data.u8[0] = 0xAA;  //Charge forbidden
     SOLXPOW_4280.data.u8[1] = 0xAA;  //Discharge forbidden
   }
@@ -62,7 +62,7 @@ void SolxpowInverter::
   SOLXPOW_4210.data.u8[7] = (datalayer.battery.status.soh_pptt / 100);
 
   // Status=Bit 0,1,2= 0:Sleep, 1:Charge, 2:Discharge 3:Idle. Bit3 ForceChargeReq. Bit4 Balance charge Request
-  if (datalayer.battery.status.bms_status == FAULT) {
+  if (datalayer.system.status.system_status == FAULT) {
     SOLXPOW_4250.data.u8[0] = (0x00);  // Sleep
   } else if (datalayer.battery.status.reported_current_dA < 0) {
     SOLXPOW_4250.data.u8[0] = (0x01);  // Charge

--- a/test/voltage_sync_tests.cpp
+++ b/test/voltage_sync_tests.cpp
@@ -12,7 +12,7 @@ class VoltageSyncTest : public ::testing::Test {
     datalayer.battery.status.voltage_dV = 3700;   // 370.0V
     datalayer.battery2.status.voltage_dV = 3700;  // 370.0V
     datalayer.battery3.status.voltage_dV = 3700;  // 370.0V
-    datalayer.battery.status.bms_status = ACTIVE;
+    datalayer.system.status.system_status = ACTIVE;
     datalayer.system.status.battery2_allowed_contactor_closing = true;
     datalayer.system.status.battery3_allowed_contactor_closing = true;
   }
@@ -82,7 +82,7 @@ TEST_F(VoltageSyncTest, Battery3DisconnectedAfterVoltageDriftTimeout) {
 TEST_F(VoltageSyncTest, Battery1FaultDisengagesBattery2) {
   datalayer.battery.status.voltage_dV = 3700;
   datalayer.battery2.status.voltage_dV = 3700;  // In sync
-  datalayer.battery.status.bms_status = FAULT;
+  datalayer.system.status.system_status = FAULT;
 
   check_parallel_battery_safety(2);
   EXPECT_FALSE(datalayer.system.status.battery2_allowed_contactor_closing);


### PR DESCRIPTION
### What
This PR refactors the bms_status

### Why
When development started, bms_status was used to convey system status. Once we started to support multiple batteries, issues started to pop up related to which bms_status we should write and listen to (battery.bms_status or battery2.bms_status?)

### How
We solve this by removing the bms_status from the battery status struct, and moving it to the system status struct. At the same time we rename it from bms_status -> system_status

Bonus, we fix a bug in the BMW i3 handler which would write to this status incorrectly

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
