### PR TITLE
MCP2515_Lite fixes: type conversion, risk of dropping frames, dlc limit, speed change

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -8,6 +8,7 @@
 #include "src/devboard/safety/safety.h"
 #include "src/devboard/sdcard/sdcard.h"
 #include "src/devboard/utils/logging.h"
+#include "utils.h"
 
 #include <esp_private/periph_ctrl.h>
 
@@ -253,9 +254,9 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
       }
     } break;
     case CAN_ADDON_MCP2515: {
-      // MCP2515CANFrame has the same layout as CAN_frame so we can avoid a copy.
-      // (This is probably UB but seems to work, and will be obvious if it doesn't).
-      send_ok_2515 = can2515->sendFrame((MCP2515_Lite_Frame&)*tx_frame);
+      MCP2515_Lite_Frame mcp2515_frame;
+      copy_can_frame_to_mcp2515_lite_frame(*tx_frame, mcp2515_frame);
+      send_ok_2515 = can2515->sendFrame(mcp2515_frame);
       if (!send_ok_2515) {
         datalayer.system.info.can_2515_send_fail = true;
       }
@@ -321,14 +322,13 @@ void receive_frame_can_native() {  // This section checks if we have a complete 
 }
 
 void receive_frame_can_addon() {  // This section checks if we have a complete CAN message incoming on add-on CAN port
-  CAN_frame rx_frame;             // Struct with our CAN format
+  MCP2515_Lite_Frame rx_frame;
+  CAN_frame full_frame;
 
-  // MCP2515_Lite_Frame has the same layout as CAN_frame so we can avoid a copy
-  // (with some minor UB).
   int count = 0;
-  while (can2515->receiveFrame((MCP2515_Lite_Frame&)rx_frame) && count++ < 16) {
-    // Successfully received a message, pass it on to the handler
-    map_can_frame_to_variable(&rx_frame, CAN_ADDON_MCP2515);
+  while (count++ < 16 && can2515->receiveFrame(rx_frame)) {
+    copy_mcp2515_lite_frame_to_can_frame(rx_frame, full_frame);
+    map_can_frame_to_variable(&full_frame, CAN_ADDON_MCP2515);
   }
 }
 

--- a/Software/src/communication/can/utils.h
+++ b/Software/src/communication/can/utils.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../../devboard/utils/types.h"
+#include "../../lib/mcp2515_lite/mcp2515_lite.h"
+
+#include <cstring>  // for memcpy
+
+// Check the struct layout matches closely enough to be able to memcpy (which
+// then gets optimized out)
+static_assert(sizeof(MCP2515_Lite_Frame) <= sizeof(CAN_frame), "MCP2515_Lite_Frame must fit within CAN_frame");
+static_assert(offsetof(MCP2515_Lite_Frame, fd) == offsetof(CAN_frame, FD), "fd/FD field offset mismatch");
+static_assert(offsetof(MCP2515_Lite_Frame, ext) == offsetof(CAN_frame, ext_ID), "ext/ext_ID field offset mismatch");
+static_assert(offsetof(MCP2515_Lite_Frame, dlc) == offsetof(CAN_frame, DLC), "dlc/DLC field offset mismatch");
+static_assert(offsetof(MCP2515_Lite_Frame, id) == offsetof(CAN_frame, ID), "id/ID field offset mismatch");
+static_assert(offsetof(MCP2515_Lite_Frame, data) == offsetof(CAN_frame, data), "data field offset mismatch");
+
+static inline void copy_can_frame_to_mcp2515_lite_frame(const CAN_frame& source, MCP2515_Lite_Frame& target) {
+  memcpy(&target, &source, sizeof(MCP2515_Lite_Frame));
+  target.fd = false;  // MCP2515 does not support CAN-FD
+}
+
+static inline void copy_mcp2515_lite_frame_to_can_frame(const MCP2515_Lite_Frame& source, CAN_frame& target) {
+  memcpy(&target, &source, sizeof(MCP2515_Lite_Frame));
+  target.FD = false;  // MCP2515 does not support CAN-FD
+  // The remaining bytes in CAN_frame.data will be left as-is
+}

--- a/Software/src/lib/mcp2515_lite/mcp2515_lite.cpp
+++ b/Software/src/lib/mcp2515_lite/mcp2515_lite.cpp
@@ -153,6 +153,8 @@ bool MCP2515_Lite::receiveFrame(MCP2515_Lite_Frame& msg) {
 void MCP2515_Lite::changeSpeed(const MCP2515_Lite_Speed& new_speed) {
     _next_speed = new_speed;
     _speed_change_pending = true;
+    // Wake the task to enact the speed change
+    xTaskNotifyGive(_can_task_handle);
 }
 
 void MCP2515_Lite::pause(bool paused) {
@@ -239,7 +241,7 @@ void MCP2515_Lite::canTask(void* pvParameters) {
                         can_frame.ext = false;
                         can_frame.id = unpackStandardId(&rx_frame[1]);
                     }
-                    can_frame.dlc = rx_frame[5] & 0x0F;
+                    can_frame.dlc = rx_frame[5] > 8 ? 8 : rx_frame[5]; // 8 bytes maximum
                     memcpy(can_frame.data, &rx_frame[6], can_frame.dlc);
                     
                     if(xQueueSend(self->_rx_queue, &can_frame, 0) != pdTRUE) {


### PR DESCRIPTION
### What

This fixes some minor MCP2515_Lite issues:

- Some questionable aliasing/type-punning conversion to/from CAN_frame - this now uses static_assert and memcpy, which should be compliant and future-proof (the memcpy gets optimized out). (reported by @cray9000) 
- A potential buffer overread (under heavy RX) that might have dropped CAN frames. (reported by @cray9000) 
- Clamps received message DLC to 8, avoiding a out-of-bounds write (although that would only result from SPI corruption).
- Wakes up the process on speed change (rather than waiting for timeout or the next rx/tx).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
