### PR TITLE
Dacia Spring: Add override charge/discharge power setting for CMFA platform

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -42,9 +42,28 @@ void CmfaEvBattery::
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
 
-  datalayer_battery->status.max_discharge_power_W = discharge_power_w;
+  //Some packs are locked and do not report allowed charge power, in this case we need to use the user specified override value
+  //instead of the value sent from the BMS
+  if (datalayer.battery.status.override_charge_power_W > 0) {
+    if (datalayer_battery->status.real_soc > 9900) {
+      datalayer_battery->status.max_charge_power_W = 0;
+    } else if (datalayer_battery->status.real_soc >
+               user_set_rampdown_SOC) {  // When real SOC is between 90-99%, ramp the value between Max<->0
+      datalayer_battery->status.max_charge_power_W =
+          datalayer.battery.status.override_charge_power_W *
+          (1 - (datalayer_battery->status.real_soc - user_set_rampdown_SOC) / (10000.0 - user_set_rampdown_SOC));
+    }
+  } else {
+    datalayer_battery->status.max_charge_power_W = charge_power_w;  //Use value sent from BMS
+  }
 
-  datalayer_battery->status.max_charge_power_W = charge_power_w;
+  //Some packs are locked and do not report allowed discharge power, in this case we need to use the user specified override value
+  //instead of the value sent from the BMS
+  if (datalayer.battery.status.override_discharge_power_W > 0) {
+    datalayer_battery->status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
+  } else {
+    datalayer_battery->status.max_discharge_power_W = discharge_power_w;  //Use value sent from BMS
+  }
 
   datalayer_battery->status.temperature_min_dC = (lowest_cell_temperature * 10);
 

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -52,6 +52,8 @@ void CmfaEvBattery::
       datalayer_battery->status.max_charge_power_W =
           datalayer.battery.status.override_charge_power_W *
           (1 - (datalayer_battery->status.real_soc - user_set_rampdown_SOC) / (10000.0 - user_set_rampdown_SOC));
+    } else {
+      datalayer_battery->status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
     }
   } else {
     datalayer_battery->status.max_charge_power_W = charge_power_w;  //Use value sent from BMS

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -235,7 +235,7 @@ class CmfaEvBattery : public CanBattery {
 
   uint8_t heartbeat = 0;   //Alternates between 0x55 and 0xAA every 5th frame
   uint8_t heartbeat2 = 0;  //Alternates between 0x55 and 0xAA every 5th frame
-  uint32_t SOC_raw = 0;
+  uint32_t SOC_raw = 20000;
   uint16_t SOH = 99;
   int16_t current = 0;
   uint16_t pack_voltage = 500;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1197,6 +1197,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     form[data-battery="3"] .if-estimated, 
     form[data-battery="4"] .if-estimated, 
     form[data-battery="6"] .if-estimated, 
+    form[data-battery="8"] .if-estimated, 
     form[data-battery="14"] .if-estimated, 
     form[data-battery="16"] .if-estimated, 
     form[data-battery="24"] .if-estimated,


### PR DESCRIPTION
### What
This PR implements override charge/discharge power setting for CMFA platform

### Why
Some BMS send 0W allowed  charge, and 0W allowed discharge all the time, making the battery unusable. Fixes #2298

### How
We fix this with a new config option, 
- Manual charging power, watt
- Manual discharge power, watt
- Rampdown SOC, pptt

<img width="685" height="274" alt="image" src="https://github.com/user-attachments/assets/7cb93594-6c3e-4ea2-8199-7fba27b91a73" />

If values are set to 0 W, we use BMS sent value like before

If the battery is unavailable and always report 0W, user can set their own values

<img width="662" height="201" alt="image" src="https://github.com/user-attachments/assets/c9142c0c-74d8-4fce-8914-a212be5374f2" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
