### PR TITLE
fix/byd-calibration-ah-default-from-bms

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -221,6 +221,11 @@ void BydAttoBattery::
     datalayer_bydatto->BMC_SOC_original_calibration = BMC_SOC_original_calibration;
     datalayer_bydatto->BMS_capacity_current_calibration = BMS_capacity_current_calibration;
     datalayer_bydatto->BMC_SOC_current_calibration = BMC_SOC_current_calibration;
+    // Pre-fill from BMS on first read so the web page shows real pack AH, not the 150AH default
+    if (!calibrationAH_seeded && BMS_capacity_current_calibration > 0) {
+      datalayer_bydatto->calibrationTargetAH = BMS_capacity_current_calibration / 100;
+      calibrationAH_seeded = true;
+    }
     datalayer_bydatto->chargePower = BMS_allowed_charge_power;
     datalayer_bydatto->charge_times = BMS_charge_times;
     datalayer_bydatto->dischargePower = BMS_allowed_discharge_power;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -205,6 +205,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t secondsSinceStartup = 0;
 
   bool BMS_voltage_available = false;
+  bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};
   uint16_t battery_cellvoltages[MAX_AMOUNT_CELLS] = {0};


### PR DESCRIPTION
### What
When a user opens the "More Battery Info" page and hits Calibrate Now, the calibration also writes the pack AH (capacity) value. The AH field defaults to 150AH hardcoded in the struct, so if the user doesn't change it, their real pack capacity gets overwritten.

### Why
The BMS already knows the current packs capacity based on its history and the manual calibration fields should show this value by default; so users aren't silently writing a default value and overwriting their true SOH value.

### How
Added a calibrationAH_seeded flag. The first time BMS_capacity_current_calibration comes back non-zero from a poll (within a few seconds of boot), calibrationTargetAH is set from the live BMS value instead of the 150AH default. The flag ensures subsequent polls don't overwrite any value the user has manually changed.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)