### PR TITLE
Add Waveshare ESP32-S3 RS485 CAN hardware target

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -34,7 +34,7 @@
 #include "src/inverter/INVERTERS.h"
 
 #if !defined(HW_LILYGO) && !defined(HW_LILYGO2CAN) && !defined(HW_STARK) && !defined(HW_3LB) && !defined(HW_BECOM) && \
-    !defined(HW_DEVKIT)
+    !defined(HW_WAVESHARE) && !defined(HW_DEVKIT)
 #error You must select a target hardware!
 #endif
 
@@ -68,7 +68,7 @@ void register_transmitter(Transmitter* transmitter) {
 void init_serial() {
   // Init Serial monitor
   Serial.begin(115200);
-#if (HW_LILYGO2CAN || HW_BECOM)
+#if (HW_LILYGO2CAN || HW_BECOM || HW_WAVESHARE)
   // Wait up to 100ms for Serial to be available. On the ESP32S3 Serial is
   // provided by the USB controller, so will only work if the board is connected
   // to a computer.
@@ -594,6 +594,8 @@ void setup() {
 
   init_precharge_control();
 
+  init_rs485();
+
   setup_charger();
   setup_inverter();
   setup_battery();
@@ -601,8 +603,6 @@ void setup() {
 
   // Init CAN only after any CAN receivers have had a chance to register.
   init_CAN();
-
-  init_rs485();
 
   init_equipment_stop_button();
 

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include "../battery/BATTERIES.h"
 #include "../datalayer/datalayer.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 
@@ -184,7 +185,7 @@ void DalyBms::transmit_rs485(unsigned long currentMillis) {
     tx_buff[3] = 8;
     tx_buff[12] = calculate_checksum(tx_buff);
     dump_buff("transmitting: ", tx_buff, 13);
-    rs485_write(tx_buff, 13);
+    Serial2.write(tx_buff, 13);
     nextCommand++;
     if (nextCommand > 0x98)
       nextCommand = 0x90;

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -87,14 +87,7 @@ void DalyBms::setup(void) {  // Performs one time setup at startup
   datalayer.battery.info.min_cell_voltage_mV = user_selected_min_cell_voltage_mV;
   datalayer.system.status.battery_allows_contactor_closing = true;
 
-  auto rx_pin = esp32hal->RS485_RX_PIN();
-  auto tx_pin = esp32hal->RS485_TX_PIN();
-
-  if (!esp32hal->alloc_pins(Name, rx_pin, tx_pin)) {
-    return;
-  }
-
-  Serial2.begin(baud_rate(), SERIAL_8N1, rx_pin, tx_pin);
+  rs485_begin(Name, Serial2, baud_rate(), SERIAL_8N1);
 }
 
 uint8_t calculate_checksum(uint8_t buff[12]) {
@@ -191,7 +184,7 @@ void DalyBms::transmit_rs485(unsigned long currentMillis) {
     tx_buff[3] = 8;
     tx_buff[12] = calculate_checksum(tx_buff);
     dump_buff("transmitting: ", tx_buff, 13);
-    Serial2.write(tx_buff, 13);
+    rs485_write(tx_buff, 13);
     nextCommand++;
     if (nextCommand > 0x98)
       nextCommand = 0x90;

--- a/Software/src/battery/DALY-BMS.cpp
+++ b/Software/src/battery/DALY-BMS.cpp
@@ -2,8 +2,8 @@
 #include <Arduino.h>
 #include <cstdint>
 #include "../battery/BATTERIES.h"
-#include "../datalayer/datalayer.h"
 #include "../communication/rs485/comm_rs485.h"
+#include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -4,14 +4,33 @@
 
 #include <list>
 
+static gpio_num_t rs485_de_pin = GPIO_NUM_NC;
+static bool rs485_de_active_high = true;
+static bool rs485_control_pins_initialized = false;
+
+static uint8_t rs485_tx_level() {
+  return rs485_de_active_high ? HIGH : LOW;
+}
+
+static uint8_t rs485_rx_level() {
+  return rs485_de_active_high ? LOW : HIGH;
+}
+
 bool init_rs485() {
 
   auto en_pin = esp32hal->RS485_EN_PIN();
   auto se_pin = esp32hal->RS485_SE_PIN();
   auto pin_5v_en = esp32hal->PIN_5V_EN();
+  rs485_de_pin = esp32hal->RS485_DE_PIN();
+  rs485_de_active_high = esp32hal->RS485_DE_ACTIVE_HIGH();
 
   if (!esp32hal->alloc_pins_ignore_unused("RS485", en_pin, se_pin, pin_5v_en)) {
-    DEBUG_PRINTF("Modbus failed to allocate pins\n");
+    DEBUG_PRINTF("RS485 failed to allocate static enable pins\n");
+    return true;  //Early return, we do not set the pins
+  }
+
+  if (rs485_de_pin != GPIO_NUM_NC && !esp32hal->alloc_pins("RS485 DE", rs485_de_pin)) {
+    DEBUG_PRINTF("RS485 failed to allocate DE pin\n");
     return true;  //Early return, we do not set the pins
   }
 
@@ -30,10 +49,54 @@ bool init_rs485() {
     digitalWrite(pin_5v_en, HIGH);
   }
 
-  // Inverters and batteries are expected to initialize their serial port in their setup-function
-  // for RS485 or Modbus comms.
+  if (rs485_de_pin != GPIO_NUM_NC) {
+    pinMode(rs485_de_pin, OUTPUT);
+    digitalWrite(rs485_de_pin, rs485_rx_level());
+  }
 
+  rs485_control_pins_initialized = true;
+
+  // Inverters and batteries initialize the serial port in their setup-function.
   return true;
+}
+
+bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint32_t config) {
+  auto rx_pin = esp32hal->RS485_RX_PIN();
+  auto tx_pin = esp32hal->RS485_TX_PIN();
+
+  if (!esp32hal->alloc_pins(owner, rx_pin, tx_pin)) {
+    return false;
+  }
+
+  serial.begin(baud, config, rx_pin, tx_pin);
+  rs485_set_direction(false);
+  return true;
+}
+
+void rs485_set_direction(bool transmit) {
+  if (!rs485_control_pins_initialized || rs485_de_pin == GPIO_NUM_NC) {
+    return;
+  }
+
+  digitalWrite(rs485_de_pin, transmit ? rs485_tx_level() : rs485_rx_level());
+}
+
+size_t rs485_write(const uint8_t* data, size_t len) {
+  if (rs485_de_pin == GPIO_NUM_NC) {
+    return Serial2.write(data, len);
+  }
+
+  rs485_set_direction(true);
+  delayMicroseconds(10);
+  size_t written = Serial2.write(data, len);
+  Serial2.flush();
+  delayMicroseconds(10);
+  rs485_set_direction(false);
+  return written;
+}
+
+size_t rs485_write(const char* data, size_t len) {
+  return rs485_write(reinterpret_cast<const uint8_t*>(data), len);
 }
 
 static std::list<Rs485Receiver*> receivers;

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -1,20 +1,19 @@
 #include "comm_rs485.h"
 #include <Arduino.h>
 #include "../../devboard/hal/hal.h"
+#include "driver/uart.h"
 
 #include <list>
 
+// All current Battery-Emulator RS485 users use Serial2/UART2.  For boards with
+// a real DE/~RE pin (for example Waveshare ESP32-S3-RS485-CAN with SP3485EN),
+// we let the ESP-IDF UART driver control RTS in UART_MODE_RS485_HALF_DUPLEX.
+// This keeps the existing Serial2.write() path and the Arduino/ESP32 UART
+// locking behavior intact instead of wrapping writes in a separate function.
+static constexpr uart_port_t RS485_UART_NUM = UART_NUM_2;
+
 static gpio_num_t rs485_de_pin = GPIO_NUM_NC;
 static bool rs485_de_active_high = true;
-static bool rs485_control_pins_initialized = false;
-
-static uint8_t rs485_tx_level() {
-  return rs485_de_active_high ? HIGH : LOW;
-}
-
-static uint8_t rs485_rx_level() {
-  return rs485_de_active_high ? LOW : HIGH;
-}
 
 bool init_rs485() {
 
@@ -50,11 +49,12 @@ bool init_rs485() {
   }
 
   if (rs485_de_pin != GPIO_NUM_NC) {
+    // Idle receive state until the UART driver takes over this pin as RTS/DE
+    // in rs485_begin().  UART_MODE_RS485_HALF_DUPLEX asserts RTS high while the
+    // UART FIFO is transmitting and deasserts it after the last bit was sent.
     pinMode(rs485_de_pin, OUTPUT);
-    digitalWrite(rs485_de_pin, rs485_rx_level());
+    digitalWrite(rs485_de_pin, rs485_de_active_high ? LOW : HIGH);
   }
-
-  rs485_control_pins_initialized = true;
 
   // Inverters and batteries initialize the serial port in their setup-function.
   return true;
@@ -69,34 +69,26 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
   }
 
   serial.begin(baud, config, rx_pin, tx_pin);
-  rs485_set_direction(false);
+
+  if (rs485_de_pin != GPIO_NUM_NC) {
+    if (!rs485_de_active_high) {
+      DEBUG_PRINTF("RS485 active-low DE is not supported by UART RS485 mode\n");
+      return false;
+    }
+
+    // Configure UART2 RTS as RS485 driver-enable.  This is intentionally done
+    // after Serial2.begin(), because Serial2.begin() configures the UART pins.
+    const esp_err_t pin_result = uart_set_pin(RS485_UART_NUM, tx_pin, rx_pin, rs485_de_pin, UART_PIN_NO_CHANGE);
+    const esp_err_t mode_result = uart_set_mode(RS485_UART_NUM, UART_MODE_RS485_HALF_DUPLEX);
+
+    if (pin_result != ESP_OK || mode_result != ESP_OK) {
+      DEBUG_PRINTF("RS485 UART half-duplex setup failed, pin_result=%d, mode_result=%d\n", static_cast<int>(pin_result),
+                   static_cast<int>(mode_result));
+      return false;
+    }
+  }
+
   return true;
-}
-
-void rs485_set_direction(bool transmit) {
-  if (!rs485_control_pins_initialized || rs485_de_pin == GPIO_NUM_NC) {
-    return;
-  }
-
-  digitalWrite(rs485_de_pin, transmit ? rs485_tx_level() : rs485_rx_level());
-}
-
-size_t rs485_write(const uint8_t* data, size_t len) {
-  if (rs485_de_pin == GPIO_NUM_NC) {
-    return Serial2.write(data, len);
-  }
-
-  rs485_set_direction(true);
-  delayMicroseconds(10);
-  size_t written = Serial2.write(data, len);
-  Serial2.flush();
-  delayMicroseconds(10);
-  rs485_set_direction(false);
-  return written;
-}
-
-size_t rs485_write(const char* data, size_t len) {
-  return rs485_write(reinterpret_cast<const uint8_t*>(data), len);
 }
 
 static std::list<Rs485Receiver*> receivers;

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -1,16 +1,23 @@
 #include "comm_rs485.h"
 #include <Arduino.h>
 #include "../../devboard/hal/hal.h"
+#ifndef UNIT_TEST
 #include "driver/uart.h"
+#endif
 
 #include <list>
 
-// All current Battery-Emulator RS485 users use Serial2/UART2.  For boards with
+// All current Battery-Emulator RS485 users use Serial2/UART2. For boards with
 // a real DE/~RE pin (for example Waveshare ESP32-S3-RS485-CAN with SP3485EN),
 // we let the ESP-IDF UART driver control RTS in UART_MODE_RS485_HALF_DUPLEX.
 // This keeps the existing Serial2.write() path and the Arduino/ESP32 UART
 // locking behavior intact instead of wrapping writes in a separate function.
+//
+// Host unit tests do not have ESP-IDF UART headers or hardware, so the actual
+// UART RS485 mode setup is compiled only for firmware builds.
+#ifndef UNIT_TEST
 static constexpr uart_port_t RS485_UART_NUM = UART_NUM_2;
+#endif
 
 static gpio_num_t rs485_de_pin = GPIO_NUM_NC;
 static bool rs485_de_active_high = true;
@@ -88,6 +95,7 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
       return false;
     }
 
+#ifndef UNIT_TEST
     // Configure UART2 RTS as RS485 driver-enable.  This is intentionally done
     // after Serial2.begin(), because Serial2.begin() configures the UART pins.
     const esp_err_t pin_result = uart_set_pin(RS485_UART_NUM, tx_pin, rx_pin, rs485_de_pin, UART_PIN_NO_CHANGE);
@@ -98,6 +106,12 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
                    static_cast<int>(mode_result));
       return false;
     }
+#else
+    // Host unit tests only verify that the common RS485 initialization compiles
+    // and keeps the existing Serial2.begin()/Serial2.write() path. The ESP-IDF
+    // UART driver owns the RTS/DE timing in firmware builds.
+    DEBUG_PRINTF("RS485 UART half-duplex setup skipped in UNIT_TEST\n");
+#endif
   }
 
   return true;

--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -25,12 +25,16 @@ bool init_rs485() {
 
   if (!esp32hal->alloc_pins_ignore_unused("RS485", en_pin, se_pin, pin_5v_en)) {
     DEBUG_PRINTF("RS485 failed to allocate static enable pins\n");
-    return true;  //Early return, we do not set the pins
+    // Leave RS485 DE disabled rather than bypassing HAL pin ownership later in rs485_begin().
+    rs485_de_pin = GPIO_NUM_NC;
+    return true;  // Safe to call even when RS485 is not used.
   }
 
   if (rs485_de_pin != GPIO_NUM_NC && !esp32hal->alloc_pins("RS485 DE", rs485_de_pin)) {
     DEBUG_PRINTF("RS485 failed to allocate DE pin\n");
-    return true;  //Early return, we do not set the pins
+    // Do not let uart_set_pin() claim a pin that the HAL allocator rejected.
+    rs485_de_pin = GPIO_NUM_NC;
+    return true;  // Safe to call even when RS485 is not used.
   }
 
   if (en_pin != GPIO_NUM_NC) {
@@ -71,6 +75,14 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
   serial.begin(baud, config, rx_pin, tx_pin);
 
   if (rs485_de_pin != GPIO_NUM_NC) {
+    // The current Battery-Emulator RS485 stack is wired to Serial2/UART2.
+    // Keep this explicit because UART_MODE_RS485_HALF_DUPLEX configures a UART port,
+    // not the HardwareSerial object itself.
+    if (&serial != &Serial2) {
+      DEBUG_PRINTF("RS485 half-duplex DE is only supported on Serial2/UART2\n");
+      return false;
+    }
+
     if (!rs485_de_active_high) {
       DEBUG_PRINTF("RS485 active-low DE is not supported by UART RS485 mode\n");
       return false;

--- a/Software/src/communication/rs485/comm_rs485.h
+++ b/Software/src/communication/rs485/comm_rs485.h
@@ -3,11 +3,10 @@
 
 #include <Arduino.h>
 #include <HardwareSerial.h>
-#include <stddef.h>
 #include <stdint.h>
 
 /**
- * @brief Initialization of RS485
+ * @brief Initialization of RS485 control pins.
  *
  * @param[in] void
  *
@@ -18,23 +17,11 @@ bool init_rs485();
 /**
  * @brief Initialize a HardwareSerial port with the board-specific RS485 RX/TX pins.
  *
- * This also leaves the optional half-duplex DE pin in receive mode.
+ * If the selected HAL exposes RS485_DE_PIN(), UART2 is configured in ESP-IDF
+ * UART_MODE_RS485_HALF_DUPLEX so the UART driver controls RTS/DE around the
+ * existing Serial2.write() calls.
  */
 bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint32_t config = SERIAL_8N1);
-
-/**
- * @brief Set the RS485 driver direction. The eModbus library uses this as RTS callback.
- *
- * @param transmit true = transmit mode, false = receive mode
- */
-void rs485_set_direction(bool transmit);
-
-/**
- * @brief Write a complete frame to Serial2, toggling half-duplex DE when available.
- */
-size_t rs485_write(const uint8_t* data, size_t len);
-size_t rs485_write(const char* data, size_t len);
-
 
 // Defines an interface for any object that needs to receive a signal to handle RS485 comm.
 // Can be extended later for more complex operation.

--- a/Software/src/communication/rs485/comm_rs485.h
+++ b/Software/src/communication/rs485/comm_rs485.h
@@ -1,6 +1,11 @@
 #ifndef _COMM_RS485_H_
 #define _COMM_RS485_H_
 
+#include <Arduino.h>
+#include <HardwareSerial.h>
+#include <stddef.h>
+#include <stdint.h>
+
 /**
  * @brief Initialization of RS485
  *
@@ -9,6 +14,27 @@
  * @return Safe to call even if rs485 is not used
  */
 bool init_rs485();
+
+/**
+ * @brief Initialize a HardwareSerial port with the board-specific RS485 RX/TX pins.
+ *
+ * This also leaves the optional half-duplex DE pin in receive mode.
+ */
+bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint32_t config = SERIAL_8N1);
+
+/**
+ * @brief Set the RS485 driver direction. The eModbus library uses this as RTS callback.
+ *
+ * @param transmit true = transmit mode, false = receive mode
+ */
+void rs485_set_direction(bool transmit);
+
+/**
+ * @brief Write a complete frame to Serial2, toggling half-duplex DE when available.
+ */
+size_t rs485_write(const uint8_t* data, size_t len);
+size_t rs485_write(const char* data, size_t len);
+
 
 // Defines an interface for any object that needs to receive a signal to handle RS485 comm.
 // Can be extended later for more complex operation.

--- a/Software/src/devboard/hal/hal.cpp
+++ b/Software/src/devboard/hal/hal.cpp
@@ -20,6 +20,9 @@ void init_hal() {
 #elif defined(HW_BECOM)
 #include "hw_becom.h"
   esp32hal = new BEComHal();
+#elif defined(HW_WAVESHARE)
+#include "hw_waveshare.h"
+  esp32hal = new WaveshareS3Rs485CanHal();
 #elif defined(HW_DEVKIT)
 #include "hw_devkit.h"
   esp32hal = new DevKitHal();

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -97,6 +97,11 @@ class Esp32Hal {
   virtual gpio_num_t RS485_RX_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t RS485_SE_PIN() { return GPIO_NUM_NC; }
 
+  // Direction pin for half-duplex RS485 transceivers with DE and /RE tied together.
+  // Default polarity: HIGH = transmit, LOW = receive.
+  virtual gpio_num_t RS485_DE_PIN() { return GPIO_NUM_NC; }
+  virtual bool RS485_DE_ACTIVE_HIGH() { return true; }
+
   virtual gpio_num_t CAN_TX_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t CAN_RX_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t CAN_SE_PIN() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -1,0 +1,61 @@
+#ifndef __HW_WAVESHARE_H__
+#define __HW_WAVESHARE_H__
+
+#include "hal.h"
+
+class WaveshareS3Rs485CanHal : public Esp32Hal {
+ public:
+  const char* name() { return "Waveshare ESP32-S3-RS485-CAN"; }
+
+  virtual gpio_num_t CAN_TX_PIN() { return GPIO_NUM_15; }
+  virtual gpio_num_t CAN_RX_PIN() { return GPIO_NUM_16; }
+  virtual gpio_num_t CAN_SE_PIN() { return GPIO_NUM_NC; }
+
+  virtual gpio_num_t RS485_TX_PIN() { return GPIO_NUM_17; }
+  virtual gpio_num_t RS485_RX_PIN() { return GPIO_NUM_18; }
+
+  // SP3485 DE and /RE are tied together on this board.
+  // HIGH = transmit, LOW = receive. Do not use RS485_EN_PIN for this signal.
+  virtual gpio_num_t RS485_DE_PIN() { return GPIO_NUM_21; }
+
+  virtual gpio_num_t RS485_EN_PIN() { return GPIO_NUM_NC; }
+  virtual gpio_num_t RS485_SE_PIN() { return GPIO_NUM_NC; }
+  virtual gpio_num_t PIN_5V_EN() { return GPIO_NUM_NC; }
+
+  virtual gpio_num_t LED_PIN() { return GPIO_NUM_NC; }
+
+  std::vector<comm_interface> available_interfaces() {
+    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative};
+  }
+
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::CanNative:
+        return "CAN (Native)";
+      case comm_interface::CanFdNative:
+        return "";
+      case comm_interface::CanAddonMcp2515:
+        return "";
+      case comm_interface::CanFdAddonMcp2518:
+        return "";
+      case comm_interface::Modbus:
+        return "Modbus";
+      case comm_interface::RS485:
+        return "RS485";
+      case comm_interface::Highest:
+        return "";
+    }
+    return Esp32Hal::name_for_comm_interface(comm);
+  }
+};
+
+#define HalClass WaveshareS3Rs485CanHal
+
+/* ----- Error checks below, don't change (can't be moved to separate file) ----- */
+#ifndef HW_CONFIGURED
+#define HW_CONFIGURED
+#else
+#error Multiple HW defined! Please select a single HW
+#endif
+
+#endif

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -17,24 +17,35 @@
 #define HEARTBEAT_DEVIATION 50  // 0.05 * 1000
 #define SCALE_FACTOR 1000
 
-static LED* led;
+static LED* led = nullptr;
 
 uint16_t map_int(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
 bool led_init(void) {
-  if (!esp32hal->alloc_pins("LED", esp32hal->LED_PIN())) {
+  gpio_num_t led_pin = esp32hal->LED_PIN();
+
+  if (led_pin == GPIO_NUM_NC) {
+    DEBUG_PRINTF("No LED configured for selected HW. Skipping LED setup.\n");
+    return true;
+  }
+
+  if (!esp32hal->alloc_pins("LED", led_pin)) {
     DEBUG_PRINTF("LED setup failed\n");
     return false;
   }
 
-  led = new LED(datalayer.battery.status.led_mode, esp32hal->LED_PIN(), esp32hal->LED_MAX_BRIGHTNESS());
+  led = new LED(datalayer.battery.status.led_mode, led_pin, esp32hal->LED_MAX_BRIGHTNESS());
 
   return true;
 }
 
 void led_exe(void) {
+  if (led == nullptr) {
+    return;
+  }
+
   led->exe();
 }
 

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -1,9 +1,9 @@
 #include "BYD-MODBUS.h"
 #include "../battery/BATTERIES.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
-#include "../communication/rs485/comm_rs485.h"
 #include "../inverter/INVERTERS.h"
 
 // For modbus register definitions, see https://gitlab.com/pelle8/inverter_resources/-/blob/main/byd_registers_modbus_rtu.md

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -3,6 +3,7 @@
 #include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../inverter/INVERTERS.h"
 
 // For modbus register definitions, see https://gitlab.com/pelle8/inverter_resources/-/blob/main/byd_registers_modbus_rtu.md
@@ -169,14 +170,9 @@ bool BydModbusInverter::setup(void) {  // Performs one time setup at startup ove
   // Init Serial2 connected to the RTU Modbus
   RTUutils::prepareHardwareSerial(Serial2);
 
-  auto rx_pin = esp32hal->RS485_RX_PIN();
-  auto tx_pin = esp32hal->RS485_TX_PIN();
-
-  if (!esp32hal->alloc_pins(Name, rx_pin, tx_pin)) {
+  if (!rs485_begin(Name, Serial2, 9600, SERIAL_8N1)) {
     return false;
   }
-
-  Serial2.begin(9600, SERIAL_8N1, rx_pin, tx_pin);
 
   // Start ModbusRTU background task
   MBserver.begin(Serial2, esp32hal->MODBUS_CORE());

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -1,7 +1,7 @@
 #include "KOSTAL-RS485.h"
 #include "../battery/BATTERIES.h"
-#include "../datalayer/datalayer.h"
 #include "../communication/rs485/comm_rs485.h"
+#include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 #include "INVERTERS.h"

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -66,7 +66,7 @@ static void null_stuffer(uint8_t* lfc, int len) {
 
 static void send_kostal(uint8_t* frame, int len) {
   dbg_frame(frame, len, "TX");
-  Serial2.write(frame, len);
+  rs485_write(frame, len);
 }
 
 static uint8_t calculate_kostal_crc(byte* lfc, int len) {
@@ -316,14 +316,5 @@ bool KostalInverterProtocol::setup(void) {  // Performs one time setup at startu
   setInverterAllowsContactorClosing(false);
   dbg_message("inverter_allows_contactor_closing -> false");
 
-  auto rx_pin = esp32hal->RS485_RX_PIN();
-  auto tx_pin = esp32hal->RS485_TX_PIN();
-
-  if (!esp32hal->alloc_pins(Name, rx_pin, tx_pin)) {
-    return false;
-  }
-
-  Serial2.begin(baud_rate(), SERIAL_8N1, rx_pin, tx_pin);
-
-  return true;
+  return rs485_begin(Name, Serial2, baud_rate(), SERIAL_8N1);
 }

--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -1,6 +1,7 @@
 #include "KOSTAL-RS485.h"
 #include "../battery/BATTERIES.h"
 #include "../datalayer/datalayer.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 #include "INVERTERS.h"
@@ -66,7 +67,7 @@ static void null_stuffer(uint8_t* lfc, int len) {
 
 static void send_kostal(uint8_t* frame, int len) {
   dbg_frame(frame, len, "TX");
-  rs485_write(frame, len);
+  Serial2.write(frame, len);
 }
 
 static uint8_t calculate_kostal_crc(byte* lfc, int len) {

--- a/Software/src/inverter/ModbusInverterProtocol.cpp
+++ b/Software/src/inverter/ModbusInverterProtocol.cpp
@@ -1,14 +1,11 @@
 #include "ModbusInverterProtocol.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../devboard/utils/logging.h"
 #include "../lib/eModbus-eModbus/ModbusServerRTU.h"
 
-// Fill up the RS485 DE pin with -1 if not available
-// The library ignores it if its defibe to -1
-#ifndef RS485_DE_PIN
-#define RS485_DE_PIN -1
-#endif
-// Creates a ModbusRTU server instance with 2000ms timeout
-ModbusInverterProtocol::ModbusInverterProtocol(int serverId) : MBserver(2000, RS485_DE_PIN) {
+// Creates a ModbusRTU server instance with 2000ms timeout.
+// The RS485 layer provides the runtime HAL-based DE/RE callback.
+ModbusInverterProtocol::ModbusInverterProtocol(int serverId) : MBserver(2000, rs485_set_direction) {
   _serverId = serverId;
 
   MBserver.registerWorker(_serverId, READ_HOLD_REGISTER,

--- a/Software/src/inverter/ModbusInverterProtocol.cpp
+++ b/Software/src/inverter/ModbusInverterProtocol.cpp
@@ -1,11 +1,14 @@
 #include "ModbusInverterProtocol.h"
-#include "../communication/rs485/comm_rs485.h"
 #include "../devboard/utils/logging.h"
 #include "../lib/eModbus-eModbus/ModbusServerRTU.h"
 
-// Creates a ModbusRTU server instance with 2000ms timeout.
-// The RS485 layer provides the runtime HAL-based DE/RE callback.
-ModbusInverterProtocol::ModbusInverterProtocol(int serverId) : MBserver(2000, rs485_set_direction) {
+// Fill up the RS485 DE pin with -1 if not available
+// The library ignores it if its defibe to -1
+#ifndef RS485_DE_PIN
+#define RS485_DE_PIN -1
+#endif
+// Creates a ModbusRTU server instance with 2000ms timeout
+ModbusInverterProtocol::ModbusInverterProtocol(int serverId) : MBserver(2000, RS485_DE_PIN) {
   _serverId = serverId;
 
   MBserver.registerWorker(_serverId, READ_HOLD_REGISTER,

--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -7,18 +7,14 @@
 
 bool PylonLV485InverterProtocol::setup() {
   // Initialize Serial2 with proper pins from HAL
-  auto rx_pin = esp32hal->RS485_RX_PIN();
-  auto tx_pin = esp32hal->RS485_TX_PIN();
-
-  if (!esp32hal->alloc_pins(Name, rx_pin, tx_pin)) {
-    logging.println("Failed to allocate RS485 pins!");
+  if (!rs485_begin(Name, Serial2, baud_rate(), SERIAL_8N1)) {
+    logging.println("Failed to initialize RS485 pins!");
     return false;
   }
 
   //initialize safe defaults before we start receiving real data
   datalayer.battery.status.voltage_dV = 480;  // 48.0V
 
-  Serial2.begin(baud_rate(), SERIAL_8N1, rx_pin, tx_pin);
   return true;
 }
 
@@ -164,7 +160,7 @@ void PylonLV485InverterProtocol::handle_command_61() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
+  rs485_write(full_frame.c_str(), full_frame.length());
 }
 
 void PylonLV485InverterProtocol::handle_command_62() {
@@ -190,7 +186,7 @@ void PylonLV485InverterProtocol::handle_command_62() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
+  rs485_write(full_frame.c_str(), full_frame.length());
 
   if (datalayer.system.info.web_logging_active) {
     // logging.printf("[FakePylontech485] Frame TX 0x62: %s\n", full_frame.c_str());
@@ -212,7 +208,7 @@ void PylonLV485InverterProtocol::handle_command_63() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
+  rs485_write(full_frame.c_str(), full_frame.length());
 
   last_cmd63_ms = millis();
 }

--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -1,6 +1,7 @@
 #include "PYLON-LV-RS485.h"
 #include "../battery/BATTERIES.h"
 #include "../datalayer/datalayer.h"
+#include "../communication/rs485/comm_rs485.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 #include "INVERTERS.h"
@@ -160,7 +161,7 @@ void PylonLV485InverterProtocol::handle_command_61() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  rs485_write(full_frame.c_str(), full_frame.length());
+  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
 }
 
 void PylonLV485InverterProtocol::handle_command_62() {
@@ -186,7 +187,7 @@ void PylonLV485InverterProtocol::handle_command_62() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  rs485_write(full_frame.c_str(), full_frame.length());
+  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
 
   if (datalayer.system.info.web_logging_active) {
     // logging.printf("[FakePylontech485] Frame TX 0x62: %s\n", full_frame.c_str());
@@ -208,7 +209,7 @@ void PylonLV485InverterProtocol::handle_command_63() {
   std::string checksum = calculate_checksum(frame_data);
   std::string full_frame = "~" + frame_data + checksum + "\r";
 
-  rs485_write(full_frame.c_str(), full_frame.length());
+  Serial2.write((const uint8_t*)full_frame.c_str(), full_frame.length());
 
   last_cmd63_ms = millis();
 }

--- a/Software/src/inverter/PYLON-LV-RS485.cpp
+++ b/Software/src/inverter/PYLON-LV-RS485.cpp
@@ -1,7 +1,7 @@
 #include "PYLON-LV-RS485.h"
 #include "../battery/BATTERIES.h"
-#include "../datalayer/datalayer.h"
 #include "../communication/rs485/comm_rs485.h"
+#include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "../devboard/utils/events.h"
 #include "INVERTERS.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -126,6 +126,8 @@ board_build.arduino.partitions = default_16MB.csv
 
 ; Waveshare ESP32-S3-RS485-CAN:
 ; ESP32-S3R8 = 8MB Octal/OPI PSRAM, board has 16MB Flash.
+; RS485_DE_PIN is intentionally not defined as a build flag here.
+; The HAL exposes GPIO21 and comm_rs485.cpp configures UART2 in RS485 half-duplex mode.
 board_build.arduino.memory_type = qio_opi
 
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,4 +113,38 @@ build_flags =
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
     -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
-lib_deps = 
+lib_deps =
+
+[env:waveshare_330]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+board = esp32s3_flash_16MB
+monitor_speed = 115200
+upload_speed = 921600
+monitor_filters = default, time, log2file, esp32_exception_decoder
+
+board_build.arduino.partitions = default_16MB.csv
+
+; Waveshare ESP32-S3-RS485-CAN:
+; ESP32-S3R8 = 8MB Octal/OPI PSRAM, board has 16MB Flash.
+board_build.arduino.memory_type = qio_opi
+
+framework = arduino
+
+build_flags =
+    -I include
+    -Wimplicit-fallthrough
+    -Wextra
+    -Wall
+    -DHW_WAVESHARE
+    -DBOARD_HAS_PSRAM
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DARDUINO_RUNNING_CORE=1
+    -DARDUINO_EVENT_RUNNING_CORE=1
+    -fno-exceptions
+    -fno-rtti
+    -ffunction-sections
+    -fdata-sections
+    -Wl,--gc-sections
+
+lib_deps =


### PR DESCRIPTION
### What
This PR implements ...
[Feature request] Add Waveshare ESP32-S3-RS485-CAN as supported hardware target #2334

### Why
I think this board would be a very useful addition for the project community: it is affordable, easy to source, roughly in the same practical price class as other ESP32 CAN/RS485 boards, has CAN and RS485 onboard, offers much more memory headroom through ESP32-S3R8 with 16 MB flash and 8 MB PSRAM, and is already documented/tested in a similar open-source BMS context.

The required code changes are may also generally useful because they make the RS485 layer to support: AutoDirection boards such as LilyGo keep their existing behavior, while boards with explicit DE/RE control such as Waveshare can be handled correctly.

This would make waveshare_330 a good standard target next to lilygo_330, not a replacement for Stark or other higher-end multi-CAN hardware.

### How
https://github.com/dalathegreat/Battery-Emulator/issues/2334

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
