### PR TITLE
BYD-CAN: compute rated/remaining Ah from nominal voltage

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -22,10 +22,8 @@ void BydCanInverter::
     nominal_voltage_dV = datalayer.battery.status.voltage_dV;
   }
   if (nominal_voltage_dV > 10) {
-    remaining_capacity_ah =
-        (datalayer.battery.status.reported_remaining_capacity_Wh * 100UL) / nominal_voltage_dV;
-    fully_charged_capacity_ah =
-        (datalayer.battery.info.reported_total_capacity_Wh * 100UL) / nominal_voltage_dV;
+    remaining_capacity_ah = (datalayer.battery.status.reported_remaining_capacity_Wh * 100UL) / nominal_voltage_dV;
+    fully_charged_capacity_ah = (datalayer.battery.info.reported_total_capacity_Wh * 100UL) / nominal_voltage_dV;
   }
 
   //Map values to CAN messages

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -12,12 +12,20 @@ void BydCanInverter::
   temperature_average =
       ((datalayer.battery.status.temperature_max_dC + datalayer.battery.status.temperature_min_dC) / 2);
 
-  /* Calculate capacity, Amp hours(Ah) = Watt hours (Wh) / Voltage (V)*/
-  if (datalayer.battery.status.voltage_dV > 10) {  // Only update value when we have voltage available to avoid div0
+  /* Calculate capacity in 0.1 Ah units. Use nominal (mid-design) voltage so the rated value
+   * is stable across SOC; multiply before divide to avoid integer truncation. Fall back to
+   * current pack voltage when design limits aren't set yet (generic BMS without configured
+   * BATTPVMAX/MIN, or BMS that hasn't reported its limits). */
+  uint16_t nominal_voltage_dV =
+      (datalayer.battery.info.max_design_voltage_dV + datalayer.battery.info.min_design_voltage_dV) / 2;
+  if (nominal_voltage_dV < 100) {
+    nominal_voltage_dV = datalayer.battery.status.voltage_dV;
+  }
+  if (nominal_voltage_dV > 10) {
     remaining_capacity_ah =
-        ((datalayer.battery.status.reported_remaining_capacity_Wh / datalayer.battery.status.voltage_dV) * 100);
+        (datalayer.battery.status.reported_remaining_capacity_Wh * 100UL) / nominal_voltage_dV;
     fully_charged_capacity_ah =
-        ((datalayer.battery.info.total_capacity_Wh / datalayer.battery.status.voltage_dV) * 100);
+        (datalayer.battery.info.reported_total_capacity_Wh * 100UL) / nominal_voltage_dV;
   }
 
   //Map values to CAN messages


### PR DESCRIPTION
### What
This PR stabilises the rated/remaining Ah values that BYD-CAN writes into
0x150 bytes 4–7. Previously the values wobbled with SOC and were noticeably
inaccurate — e.g. on a Deye SUN-50K a 50880 Wh pack at 86% SOC displayed
**120.0 Ah** while a smaller 44400 Wh pack at 26% SOC displayed **130.0 Ah**,
because the larger pack was at higher voltage and integer division truncated
~8.8 Ah of precision.

### Why
The Ah values were computed from the **current** pack voltage (drifts with
SOC, so the "rated" value was never stable), used `(Wh / V) * 100` ordering
(integer division truncated before scaling, dropping resolution), and used
raw `total_capacity_Wh` instead of `reported_*` (the user's SOC window was
honoured for `remaining` but not for `fully_charged`). This was an oversight
from #568 that the `aad51ee4` sweep across other inverters missed.

The BYD HVS protocol expects `fully_charged_capacity_ah` to be a static
nameplate value with `remaining ≈ rated × SOC`. Deye additionally uses this
rated Ah to derive its internal charge/discharge current limits, so a
wobbling value affects more than just the display.

### How
- Use **nominal voltage** (`(max_design + min_design) / 2`) instead of
  current `voltage_dV` — same pattern already used in `KOSTAL-RS485.cpp`.
  Keeps the rated Ah stable across SOC.
- Use **`reported_total_capacity_Wh`** for the fully-charged field so the
  user's SOC window is reflected consistently with the remaining-Wh side.
- Reorder to **multiply-before-divide** (`(Wh * 100UL) / V`) — same fix
  pattern used in `GROWATT-WIT-CAN.cpp`. Eliminates the integer
  truncation that produced the 8.8 Ah drop in the example above.
- **Fallback** to current `voltage_dV` when design limits aren't set yet
  (generic-BMS drivers with empty `BATTPVMAX/BATTPVMIN`, or BMS-driven
  drivers like PYLON/SIMPBMS before the BMS reports its cutoffs).
  Preserves the prior behaviour for those users instead of regressing
  them to 0 Ah.
- Keeps the existing `> 10` guard against div-by-zero as the final
  safety net for the case where even the fallback voltage isn't yet
  available (very early boot, before any BMS data).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
