### PR TITLE
BMW i3: Improve robustness of automatic AH detection for 60AH packs

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -232,7 +232,7 @@ void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_energy_content_maximum_Wh = (((rx_frame.data.u8[6] & 0x0F) << 8) | rx_frame.data.u8[5]) * 20;
       if (battery_energy_content_maximum_Wh > 33000) {
         detectedBattery = BATTERY_120AH;
-      } else if (battery_energy_content_maximum_Wh > 20000) {
+      } else if (battery_energy_content_maximum_Wh > 22050) {
         detectedBattery = BATTERY_94AH;
       } else {
         detectedBattery = BATTERY_60AH;


### PR DESCRIPTION
### What
This PR improves the robustness of the automatic BMW i3 capacity detection

### Why
Fixes #925 

### How
It was noticed by havrla that there is an edge  case where 60AH packs will report 22040Wh before getting ready. This would incorrectly mark them as 94AH packs. We fix this by modifying one line of code to check for this

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
