### PR TITLE
Improvement: Make fno-rtti a cxxflag only

### DIFF
--- a/Software/src/communication/rs485/comm_rs485.cpp
+++ b/Software/src/communication/rs485/comm_rs485.cpp
@@ -59,6 +59,7 @@ bool init_rs485() {
     digitalWrite(pin_5v_en, HIGH);
   }
 
+#ifndef SMALL_FLASH_DEVICE  // Hack to not include this for the LilyGo T-CAN485 which has limited memory (adds 2K)
   if (rs485_de_pin != GPIO_NUM_NC) {
     // Idle receive state until the UART driver takes over this pin as RTS/DE
     // in rs485_begin().  UART_MODE_RS485_HALF_DUPLEX asserts RTS high while the
@@ -66,6 +67,7 @@ bool init_rs485() {
     pinMode(rs485_de_pin, OUTPUT);
     digitalWrite(rs485_de_pin, rs485_de_active_high ? LOW : HIGH);
   }
+#endif
 
   // Inverters and batteries initialize the serial port in their setup-function.
   return true;
@@ -94,7 +96,8 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
       DEBUG_PRINTF("RS485 active-low DE is not supported by UART RS485 mode\n");
       return false;
     }
-
+#ifndef SMALL_FLASH_DEVICE  // Hack to not include this for the LilyGo T-CAN485 which has limited memory (adds 2K)
+                            // This board has no DE pin so we can safely skip it here
 #ifndef UNIT_TEST
     // Configure UART2 RTS as RS485 driver-enable.  This is intentionally done
     // after Serial2.begin(), because Serial2.begin() configures the UART pins.
@@ -111,6 +114,7 @@ bool rs485_begin(const char* owner, HardwareSerial& serial, uint32_t baud, uint3
     // and keeps the existing Serial2.begin()/Serial2.write() path. The ESP-IDF
     // UART driver owns the RTS/DE timing in firmware builds.
     DEBUG_PRINTF("RS485 UART half-duplex setup skipped in UNIT_TEST\n");
+#endif
 #endif
   }
 

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -27,7 +27,6 @@ bool led_init(void) {
   gpio_num_t led_pin = esp32hal->LED_PIN();
 
   if (led_pin == GPIO_NUM_NC) {
-    DEBUG_PRINTF("No LED configured for selected HW. Skipping LED setup.\n");
     return true;
   }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall -Werror
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-;   -fno-rtti ; was avoided as we receive some warnings from gcc because the flags seems to be common for gcc and g++ in platformio (unfortunately)
+build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:esp32devkit_330] 
@@ -37,7 +37,8 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
-    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:lilygo_330]
@@ -51,7 +52,8 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
-    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections 
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections 
+build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:stark_330]
@@ -65,7 +67,8 @@ board_build.arduino.memory_type = qio_qspi
 board_build.partitions = default_8MB.csv
 framework = arduino
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
-    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:lilygo_2CAN_330]
@@ -90,7 +93,8 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
-    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:BECom_330]
@@ -112,5 +116,6 @@ build_flags =
     -D ARDUINO_USB_CDC_ON_BOOT=1 ;1 is to use the USB port as a serial port
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
-    -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections
+    -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
+build_cxxflags = -fno-rtti
 lib_deps = 


### PR DESCRIPTION
### What
This PR makes fno-rtti a cxxflag only

### Why
The flag caused ~60 compiler warnings, cluttering the build system, along with making the terminal harder to read

```
cc1: warning: command-line option '-fno-rtti' is valid for C++/D/ObjC++ but not for C
Compiling .pio/build/stark_330/FrameworkArduino/esp32-hal-bt.c.o
cc1: warning: command-line option '-fno-rtti' is valid for C++/D/ObjC++ but not for C
Compiling .pio/build/stark_330/FrameworkArduino/esp32-hal-cpu.c.o
cc1: warning: command-line option '-fno-rtti' is valid for C++/D/ObjC++ but not for C
.... and repeat for 60 lines
```
### How
We make it apply only to C++ files

`build_cxxflags = -fno-rtti`

BONUS: This makes it possible to use exact same build_flags on the compiler warning check!

BONUS2: This PR also adds some ifdefs to the comm_rs485.cpp which saves 2.4k of memory on limited flash devices

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
