### PR TITLE
BYD CAN: Add message 0x191 to handler

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -145,6 +145,10 @@ void BydCanInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       inverter_timestamp = ((rx_frame.data.u8[0] << 24) | (rx_frame.data.u8[1] << 16) | (rx_frame.data.u8[2] << 8) |
                             rx_frame.data.u8[3]);
       break;
+    case 0x191:
+      inverterStartedUp = true;
+      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+      break;
     default:
       break;
   }


### PR DESCRIPTION
### What
This PR adds message 0x191 to the BYD CAN handler

### Why
Good to have it in the handler, we can detect inverter still alive when sending this

### How
New case added for it

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
