### PR TITLE
CMFA: Improve current resolution, tidy FP math

### DIFF
--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -11,8 +11,7 @@ Same goes for low point, when 10% is reached we report 0% */
 
 uint16_t CmfaEvBattery::rescale_raw_SOC(uint32_t raw_SOC) {
 
-  uint32_t calc_soc;
-  calc_soc = (raw_SOC * 0.25);
+  uint32_t calc_soc = raw_SOC / 4;
   if (calc_soc > MAXSOC) {  //Constrain if needed
     calc_soc = MAXSOC;
   }
@@ -32,7 +31,7 @@ void CmfaEvBattery::
 
   datalayer_battery->status.real_soc = rescale_raw_SOC(SOC_raw);
 
-  datalayer_battery->status.current_dA = current * 10;
+  datalayer_battery->status.current_dA = (((int32_t)current_raw * 10) / 4) - 5000;
 
   datalayer_battery->status.voltage_dV = pack_voltage * 5;
 
@@ -51,7 +50,7 @@ void CmfaEvBattery::
                user_set_rampdown_SOC) {  // When real SOC is between 90-99%, ramp the value between Max<->0
       datalayer_battery->status.max_charge_power_W =
           datalayer.battery.status.override_charge_power_W *
-          (1 - (datalayer_battery->status.real_soc - user_set_rampdown_SOC) / (10000.0 - user_set_rampdown_SOC));
+          (1 - (datalayer_battery->status.real_soc - user_set_rampdown_SOC) / (10000.0f - user_set_rampdown_SOC));
     } else {
       datalayer_battery->status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
     }
@@ -106,7 +105,7 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {  //These frames are transmitted by the battery
     case 0x127:           //10ms , Same structure as old Zoe 0x155 message!
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      current = (((((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2]) * 0.25) - 500);
+      current_raw = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2];
       SOC_raw = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
       pack_voltage = (((rx_frame.data.u8[6] & 0x03) << 8) | rx_frame.data.u8[7]);
       break;
@@ -170,13 +169,13 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               (uint32_t)((rx_frame.data.u8[5] << 16) | (rx_frame.data.u8[6] << 8) | (rx_frame.data.u8[7]));
           break;
         case PID_POLL_HIGHEST_CELL_VOLTAGE:
-          highest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563);
+          highest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563f);
           break;
         case PID_POLL_CELL_NUMBER_HIGHEST_VOLTAGE:
           highest_cell_voltage_number = rx_frame.data.u8[4];
           break;
         case PID_POLL_LOWEST_CELL_VOLTAGE:
-          lowest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563);
+          lowest_cell_voltage_mv = (uint16_t)(((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 0.976563f);
           break;
         case PID_POLL_CELL_NUMBER_LOWEST_VOLTAGE:
           lowest_cell_voltage_number = rx_frame.data.u8[4];
@@ -253,7 +252,7 @@ void CmfaEvBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               cellvoltage_reading = 10;
               set_event(EVENT_BATTERY_FUSE, cellnumber);
             }
-            datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading * 0.976563;
+            datalayer_battery->status.cell_voltages_mV[cellnumber] = cellvoltage_reading * 0.976563f;
           }
 
           break;

--- a/Software/src/battery/CMFA-EV-BATTERY.h
+++ b/Software/src/battery/CMFA-EV-BATTERY.h
@@ -237,7 +237,7 @@ class CmfaEvBattery : public CanBattery {
   uint8_t heartbeat2 = 0;  //Alternates between 0x55 and 0xAA every 5th frame
   uint32_t SOC_raw = 20000;
   uint16_t SOH = 99;
-  int16_t current = 0;
+  int16_t current_raw = 2000;
   uint16_t pack_voltage = 500;
   int16_t highest_cell_temperature = 0;
   int16_t lowest_cell_temperature = 0;


### PR DESCRIPTION
### What
The CMFA integration was rounding current (down) to the nearest amp. Now it is to the nearest 0.25A.

Also change some double math to float.

(saves 104 bytes!)

Needs testing by someone with a CMFA.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
