### PR TITLE
Relion LV: Add contactor control via CAN

### DIFF
--- a/Software/src/battery/RELION-LV-BATTERY.cpp
+++ b/Software/src/battery/RELION-LV-BATTERY.cpp
@@ -220,7 +220,7 @@ void RelionBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
 
-    if ((datalayer.system.status.system_status == FAULT) && !(*allows_contactor_closing)) {
+    if ((datalayer.system.status.system_status == FAULT) || !(*allows_contactor_closing)) {
       RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x02;  // Open contactors in case of fault
     } else {
       RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x01;  // Close contactors if no fault

--- a/Software/src/battery/RELION-LV-BATTERY.cpp
+++ b/Software/src/battery/RELION-LV-BATTERY.cpp
@@ -215,7 +215,19 @@ void RelionBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 }
 
 void RelionBattery::transmit_can(unsigned long currentMillis) {
-  // No periodic sending for this protocol
+
+  // Send 500ms CAN Message
+  if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
+    previousMillis500ms = currentMillis;
+
+    if (datalayer.system.status.system_status == FAULT) {
+      RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x02;  // Open contactors in case of fault
+    } else {
+      RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x01;  // Close contactors if no fault
+    }
+
+    transmit_can_frame(&RELION_CONTACTOR_MESSAGE);
+  }
 }
 
 void RelionBattery::setup(void) {  // Performs one time setup at startup

--- a/Software/src/battery/RELION-LV-BATTERY.cpp
+++ b/Software/src/battery/RELION-LV-BATTERY.cpp
@@ -220,7 +220,7 @@ void RelionBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis500ms >= INTERVAL_500_MS) {
     previousMillis500ms = currentMillis;
 
-    if (datalayer.system.status.system_status == FAULT) {
+    if ((datalayer.system.status.system_status == FAULT) && !(*allows_contactor_closing)) {
       RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x02;  // Open contactors in case of fault
     } else {
       RELION_CONTACTOR_MESSAGE.data.u8[0] = 0x01;  // Close contactors if no fault
@@ -258,5 +258,6 @@ void RelionBattery::setup(void) {  // Performs one time setup at startup
   } else {
     datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   }
+
   datalayer.system.status.battery_allows_contactor_closing = true;
 }

--- a/Software/src/battery/RELION-LV-BATTERY.h
+++ b/Software/src/battery/RELION-LV-BATTERY.h
@@ -12,10 +12,15 @@ class RelionBattery : public CanBattery {
   RelionBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan)
       : CanBattery(targetCan, CAN_Speed::CAN_SPEED_250KBPS) {
     datalayer_battery = datalayer_ptr;
+    allows_contactor_closing = &datalayer.system.status.battery2_allowed_contactor_closing;
+    battery_total_voltage = 0;
   }
 
   // Use the default constructor to create the first or single battery.
-  RelionBattery() : CanBattery(CAN_Speed::CAN_SPEED_250KBPS) { datalayer_battery = &datalayer.battery; }
+  RelionBattery() : CanBattery(CAN_Speed::CAN_SPEED_250KBPS) {
+    datalayer_battery = &datalayer.battery;
+    allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
+  }
 
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
@@ -27,6 +32,8 @@ class RelionBattery : public CanBattery {
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   uint16_t estimateSOC();
   uint16_t estimateSOCfromCellvoltage(uint16_t cellVoltage);
+
+  bool* allows_contactor_closing;
 
   static const int MAX_PACK_VOLTAGE_DV = 584;  //58.4V recommended charge voltage. BMS protection steps in at 60.8V
   static const int MIN_PACK_VOLTAGE_DV = 440;  //44.0V Recommended LV disconnect. BMS protection steps in at 40.0V

--- a/Software/src/battery/RELION-LV-BATTERY.h
+++ b/Software/src/battery/RELION-LV-BATTERY.h
@@ -37,6 +37,8 @@ class RelionBattery : public CanBattery {
   static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 150;  // W, what power to allow for top balancing battery
   static const int FLOAT_START_MV = 20;  // mV, how many mV under overvoltage to start float charging
 
+  unsigned long previousMillis500ms = 0;  // will store last time a 500ms CAN Message was sent
+
   const uint16_t SOC[101] = {10000, 9900, 9800, 9700, 9600, 9500, 9400, 9300, 9200, 9100, 9000, 8900, 8800, 8700, 8600,
                              8500,  8400, 8300, 8200, 8100, 8000, 7900, 7800, 7700, 7600, 7500, 7400, 7300, 7200, 7100,
                              7000,  6900, 6800, 6700, 6600, 6500, 6400, 6300, 6200, 6100, 6000, 5900, 5800, 5700, 5600,
@@ -77,6 +79,12 @@ class RelionBattery : public CanBattery {
   int16_t charge_current_A = 0;
   int16_t regen_charge_current_A = 0;
   int16_t discharge_current_A = 0;
+
+  CAN_frame RELION_CONTACTOR_MESSAGE = {.FD = false,
+                                        .ext_ID = true,
+                                        .DLC = 8,
+                                        .ID = 0x18010081,
+                                        .data = {0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 };
 
 #endif


### PR DESCRIPTION
### What
This PR implements contactor control via CAN for Relion LV protocol

### Why
Easier to use, and safer operation

### How
Based on CAN descriptions from manufacturer

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
