### PR TITLE
Improve balancing visualizatiion via MQTT

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -304,10 +304,14 @@ void MebBattery::
   datalayer_extended.meb.rt_cell_undervol = realtime_cell_undervoltage_warning;
   datalayer_extended.meb.rt_cell_imbalance = realtime_cell_imbalance_warning;
   datalayer_extended.meb.rt_battery_unathorized = realtime_warning_battery_unathorized;
-  if (balancing_active == 1 && datalayer_extended.meb.balancing_active != 1)
+  if (balancing_active == 1 && datalayer_extended.meb.balancing_active != 1) {
+    datalayer_battery->status.balancing_status = BALANCING_STATUS_ACTIVE;
     set_event_latched(EVENT_BALANCING_START, 0);
-  if (balancing_active == 2 && datalayer_extended.meb.balancing_active == 1)
+  }
+  if (balancing_active == 2 && datalayer_extended.meb.balancing_active == 1) {
+    datalayer_battery->status.balancing_status = BALANCING_STATUS_READY;
     set_event(EVENT_BALANCING_END, 0);
+  }
   datalayer_extended.meb.balancing_active = balancing_active;
   datalayer_extended.meb.balancing_request = balancing_request;
   datalayer_extended.meb.charging_active = charging_active;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -86,6 +86,7 @@ void RenaultZoeGen2Battery::update_values() {
     datalayer_battery->status.cell_balancing_status[95 - i] = balancing_status_cell[i];
     if (balancing_status_cell[i]) {
       set_event_latched(EVENT_BALANCING_START, (95 - i));
+      datalayer_battery->status.balancing_status = BALANCING_STATUS_ACTIVE;
     }
   }
 
@@ -469,6 +470,7 @@ void RenaultZoeGen2Battery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer_battery->status.balancing_status = BALANCING_STATUS_READY;
 }
 
 void RenaultZoeGen2Battery::transmit_can_frame_376(void) {

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -121,8 +121,10 @@ void RjxzsBms::handle_incoming_can_frame(CAN_frame rx_frame) {
         equalization_starting_voltage = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6];
         if ((status_accounting & 0x020) >> 5) {  //balancing active
           datalayer.battery.status.balancing_status = BALANCING_STATUS_ACTIVE;
+          set_event_latched(EVENT_BALANCING_START, 0);
         } else {  //balancing off
           datalayer.battery.status.balancing_status = BALANCING_STATUS_READY;
+          set_event(EVENT_BALANCING_END, 0);
         }
         if ((rx_frame.data.u8[4] & 0x40) >> 6) {
           charging_active = true;


### PR DESCRIPTION
### What
This PR improves balancing visualization via MQTT for MEB, Zoe2 and RJXZS

### Why
Fixes #2355

### How
We write the datalayer for status.balancing_status properly, which is sent via MQTT

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
