### PR TITLE
Add I2C display pin definitions to StarkHal

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -104,6 +104,10 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_25; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
+  // I2C display
+  virtual gpio_num_t DISPLAY_SDA_PIN() { return GPIO_NUM_14; }
+  virtual gpio_num_t DISPLAY_SCL_PIN() { return GPIO_NUM_17; }
+
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
             comm_interface::CanFdNative};


### PR DESCRIPTION
## Summary
- Adds `DISPLAY_SDA_PIN()` (GPIO 14) and `DISPLAY_SCL_PIN()` (GPIO 17) virtual methods to `StarkHal` for I2C display support

## Test plan
- [ ] Verify I2C display initializes correctly on Stark hardware using the defined pins