### PR TITLE
Add I2C display pin definitions to StarkHal

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -104,6 +104,20 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_25; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
+  // I2C display pins
+  virtual gpio_num_t DISPLAY_SDA_PIN() {
+    if (user_selected_gpioopt1 == GPIOOPT1::I2C_DISPLAY_SSD1306) {
+      return GPIO_NUM_12;
+    }
+    return GPIO_NUM_NC;
+  }
+  virtual gpio_num_t DISPLAY_SCL_PIN() {
+    if (user_selected_gpioopt1 == GPIOOPT1::I2C_DISPLAY_SSD1306) {
+      return GPIO_NUM_14;
+    }
+    return GPIO_NUM_NC;
+  }
+
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
             comm_interface::CanFdNative};


### PR DESCRIPTION
## Summary
- Adds `DISPLAY_SDA_PIN()` and `DISPLAY_SCL_PIN()` virtual methods to `StarkHal`
- Returns GPIO 12 (SDA) and GPIO 14 (SCL) when `GPIOOPT1::I2C_DISPLAY_SSD1306` is selected, otherwise `GPIO_NUM_NC`

## Test plan
- [ ] Verify I2C display (SSD1306) initializes correctly on Stark hardware using the defined pins
- [ ] Verify `GPIO_NUM_NC` is returned when the option is not selected