### PR TITLE
Solax: Add MAC-derived battery identities

### DIFF
--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -127,6 +127,21 @@ void SolaxInverter::transmit_can(unsigned long currentMillis) {
   // No periodic sending used on this protocol, we react only on incoming CAN messages!
 }
 
+// Write 7 uppercase hex ASCII chars (D2..D8) from eFuse MAC, slot index, and frame half (0=1881, 1=1882).
+void solax_pack_identity_ascii(const uint8_t mac[6], uint8_t slot, uint8_t half, uint8_t out[7]) {
+  static const char hex[] = "0123456789ABCDEF";
+  uint8_t mix[4] = {
+      (uint8_t)(mac[0] ^ slot ^ (half * 0x11u)),
+      (uint8_t)(mac[1] ^ slot ^ (half * 0x22u)),
+      (uint8_t)(mac[2] ^ slot ^ (half * 0x33u)),
+      (uint8_t)(mac[3] ^ slot ^ (half * 0x44u)),
+  };
+  for (int i = 0; i < 7; i++) {
+    uint8_t b = mix[i >> 1];
+    out[i] = hex[(b >> ((1 - (i & 1)) * 4)) & 0x0F];
+  }
+}
+
 void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
 
   if (rx_frame.ID == 0x1871) {
@@ -217,8 +232,22 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   }
 
   if (rx_frame.ID == 0x1871 && rx_frame.data.u64 == __builtin_bswap64(0x0500010000000000)) {
-    transmit_can_frame(&SOLAX_1881);
-    transmit_can_frame(&SOLAX_1882);
+    int slot_count = (int)configured_number_of_modules + 1;
+
+    uint64_t mac64 = ESP.getEfuseMac();
+    uint8_t mac[6];
+    for (int i = 0; i < 6; i++) {
+      mac[i] = (uint8_t)(mac64 >> (i * 8));
+    }
+
+    for (int slot = 0; slot < slot_count; slot++) {
+      SOLAX_1881.data.u8[0] = (uint8_t)slot;
+      solax_pack_identity_ascii(mac, (uint8_t)slot, 0, &SOLAX_1881.data.u8[1]);
+      SOLAX_1882.data.u8[0] = (uint8_t)slot;
+      solax_pack_identity_ascii(mac, (uint8_t)slot, 1, &SOLAX_1882.data.u8[1]);
+      transmit_can_frame(&SOLAX_1881);
+      transmit_can_frame(&SOLAX_1882);
+    }
     logging.println("1871 05-frame received from inverter");
   }
   if (rx_frame.ID == 0x1871 && rx_frame.data.u8[0] == (0x03)) {

--- a/Software/src/inverter/SOLAX-CAN.cpp
+++ b/Software/src/inverter/SOLAX-CAN.cpp
@@ -232,7 +232,11 @@ void SolaxInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   }
 
   if (rx_frame.ID == 0x1871 && rx_frame.data.u64 == __builtin_bswap64(0x0500010000000000)) {
-    int slot_count = (int)configured_number_of_modules + 1;
+    uint16_t modules = configured_number_of_modules;
+    if (modules > 254) {
+      modules = 254;
+    }
+    int slot_count = (int)modules + 1;
 
     uint64_t mac64 = ESP.getEfuseMac();
     uint8_t mac[6];

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -148,6 +148,8 @@ class ESPClass {
     // that retrieves the flash chip size.
     return 4 * 1024 * 1024;  // Example: returning 4MB
   }
+
+  uint64_t getEfuseMac() { return 0xAABBCCDDEEFFULL; }
 };
 
 extern ESPClass ESP;


### PR DESCRIPTION
### What
This PR replies to the Solax inverter identity query (0x1871 command 0x05) with a full burst of 0x1881 / 0x1882 CAN frames — one pair per battery slot — instead of a single static pair.

Each frame carries a slot index and seven uppercase hex characters that identify that battery in the stack.

### Why
Solax Cloud expects distinct identifiers per slot so it can tell which physical battery is which in a multi-module stack. The previous implementation always sent one fixed 1881/1882 pair, which is not enough for stacks with more than one battery module.

### How
When command 0x05 is received, the emulator sends (configured_number_of_modules + 1) slot pairs. For each slot, bytes D2–D8 of 1881 and 1882 are filled with seven-character strings derived from the ESP eFuse MAC, the slot index, and which frame half is being sent (1881 vs 1882). Each emulator therefore gets stable, unique IDs without hard-coded serial strings.

### Testing
This has been tested with a VAST X1 connected to Solax Cloud. 
Before the batteries were shown as a single entity which randomly picked one or the other battery for statistics. 
After:
<img width="2097" height="861" alt="image" src="https://github.com/user-attachments/assets/687b3655-7b29-43e6-acfd-f31328a4d4c8" />
<img width="881" height="1458" alt="image" src="https://github.com/user-attachments/assets/72bdf9db-52d6-4d90-a4ad-0ed579ad68a0" />



> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
