### PR TITLE
Zoe Gen1: preserve 0.25 A shunt resolution in reported current

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -18,7 +18,7 @@ void RenaultZoeGen1Battery::
   datalayer_battery->status.real_soc = SOC_polled;
   //datalayer_battery->status.real_soc = LB_Display_SOC; //Alternative would be to use Dash SOC%
 
-  datalayer_battery->status.current_dA = LB_Current * 10;  //Convert A to dA
+  datalayer_battery->status.current_dA = (((int32_t)LB_Current_raw * 10) / 4) - 5000;
 
   //Calculate the remaining Wh amount from SOC% and max Wh value.
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
@@ -79,7 +79,7 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x155:  //10ms - Charging power, current and SOC - Confirmed sent by: Fluence ZE40, Zoe 22/41kWh, Kangoo 33kWh
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       LB_Charging_Power_W = rx_frame.data.u8[0] * 300;
-      LB_Current = (((((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2]) * 0.25) - 500);
+      LB_Current_raw = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2];
       LB_Display_SOC = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
       break;
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -82,7 +82,7 @@ class RenaultZoeGen1Battery : public CanBattery {
   uint32_t LB_Charging_Power_W = 0;
   uint32_t LB_Regen_allowed_W = 0;
   uint32_t LB_Discharge_allowed_W = 0;
-  int16_t LB_Current = 0;
+  int16_t LB_Current_raw = 2000;  // 0x155 raw; 2000 => 0 A
   int16_t LB_Cell_minimum_temperature = 0;
   int16_t LB_Cell_maximum_temperature = 0;
   uint16_t LB_Cell_minimum_voltage = 3700;


### PR DESCRIPTION
### What
This PR preserves the native 0.25 A shunt resolution from the Zoe Gen1 BMS when reporting battery current.

### Why
The shunt value is decoded as 12-bit × 0.25 A/LSB with a −500 A offset. Storing it in an `int16_t` after scaling to whole amps meant |I| < 0.5 A became zero on the inverter. Same `0x155` format as CMFA/Dacia in [#2358](https://github.com/dalathegreat/Battery-Emulator/pull/2358).

### How
Store the raw `0x155` value as `LB_Current_raw` and set `current_dA` to `(((int32_t)LB_Current_raw * 10) / 4) - 5000` (2.5 dA steps), matching the merged CMFA approach.

## Testing
Tested on a Solax X1 VAST with a 22kWh Zoe Gen1.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)