### PR TITLE
Ford MachE: Add More Battery Info page + DTC reset

### DIFF
--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -87,6 +87,17 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
       content += "<h4>Open contactor leak resistance: " +
                  String(datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance) + " kOhm </h4>";
     }
+    if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
+      content += "<h4>Battery age: N/A </h4>";
+    } else {
+      content +=
+          "<h4>Battery age: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " months </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_battery_capacity_ah == 255) {
+      content += "<h4>Capacity: N/A </h4>";
+    } else {
+      content += "<h4>Capacity: " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
+    }
     return content;
   }
 };

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -1,0 +1,94 @@
+#ifndef _FORD_MACH_E_BATTERY_HTML_H
+#define _FORD_MACH_E_BATTERY_HTML_H
+
+#include <cstring>
+#include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
+#include "../devboard/webserver/BatteryHtmlRenderer.h"
+
+class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
+ public:
+  String get_status_html() {
+    String content;
+    content += "<h3>Ford Mach-E Extra Information</h2>";
+    //If values are not sampled yet (255), show "N/A" instead of 255
+    if (datalayer_extended.fordMachE.pid_hvb_temp == 255) {
+      content += "<h4>Average temperature: N/A </h4>";
+    } else {
+      content += "<h4>Average temperature: " + String(datalayer_extended.fordMachE.pid_hvb_temp) + " °C </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_voltage == 255) {
+      content += "<h4>High precision voltage: N/A </h4>";
+    } else {
+      content += "<h4>High precision voltage: " + String(datalayer_extended.fordMachE.pid_hvb_voltage) + " mV </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_soh == 255) {
+      content += "<h4>State of health: N/A </h4>";
+    } else {
+      content += "<h4>State of health: " + String(datalayer_extended.fordMachE.pid_hvb_soh) + " % </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_soc == 255) {
+      content += "<h4>State of charge: N/A </h4>";
+    } else {
+      content += "<h4>State of charge: " + String(datalayer_extended.fordMachE.pid_hvb_soc) + " % </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 255) {
+      content += "<h4>Contactor status: N/A </h4>";
+    } else {
+      content += "<h4>Contactor status: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage == 255) {
+      content += "<h4>Pos contactor leak voltage: N/A </h4>";
+    } else {
+      content += "<h4>Pos contactor leak voltage: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage) + " mV </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage == 255) {
+      content += "<h4>Neg contactor leak voltage: N/A </h4>";
+    } else {
+      content += "<h4>Neg contactor leak voltage: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage) + " mV </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage == 255) {
+      content += "<h4>Pos contactor voltage: N/A </h4>";
+    } else {
+      content +=
+          "<h4>Pos contactor voltage: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage) +
+          " mV </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage == 255) {
+      content += "<h4>Neg contactor voltage: N/A </h4>";
+    } else {
+      content +=
+          "<h4>Neg contactor voltage: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage) +
+          " mV </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance == 255) {
+      content += "<h4>Pos contactor bus leak resistance: N/A </h4>";
+    } else {
+      content += "<h4>Pos contactor bus leak resistance: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance) + " kOhm </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance == 255) {
+      content += "<h4>Neg contactor bus leak resistance: N/A </h4>";
+    } else {
+      content += "<h4>Neg contactor bus leak resistance: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance) + " kOhm </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance == 255) {
+      content += "<h4>Overall contactor leak resistance: N/A </h4>";
+    } else {
+      content += "<h4>Overall contactor leak resistance: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance) + " kOhm </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance == 255) {
+      content += "<h4>Open contactor leak resistance: N/A </h4>";
+    } else {
+      content += "<h4>Open contactor leak resistance: " +
+                 String(datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance) + " kOhm </h4>";
+    }
+    return content;
+  }
+};
+
+#endif

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -35,7 +35,16 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 255) {
       content += "<h4>Contactor status: N/A </h4>";
     } else {
-      content += "<h4>Contactor status: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
+      if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0xA00A8400) {
+        content += "<h4>Contactor status: Interlock Seated OK</h4>";
+      } else if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0) {
+        content += "<h4>Contactor status: Interlock Not evaluated yet</h4>";
+      } else if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0x00000400) {
+        content += "<h4>Contactor status: Interlock OPEN!</h4>";
+      } else {
+        content +=
+            "<h4>Contactor status: Unknown" + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
+      }
     }
     if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage == 255) {
       content += "<h4>Pos contactor leak voltage: N/A </h4>";
@@ -103,9 +112,9 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
       }
     }
     if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
-      content += "<h4>Unknown 1: N/A </h4>";
+      content += "<h4>Calendar age: N/A </h4>";
     } else {
-      content += "<h4>Unknown 1: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
+      content += "<h4>Calendar age: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
     }
     return content;
   }

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -12,109 +12,131 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     String content;
     content += "<h3>Ford Mach-E Extra Information</h2>";
     //If values are not sampled yet (255), show "N/A" instead of 255
+
+    content += "<h4>Average temperature:";
     if (datalayer_extended.fordMachE.pid_hvb_temp == 255) {
-      content += "<h4>Average temperature: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Average temperature: " + String(datalayer_extended.fordMachE.pid_hvb_temp) + " °C </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_temp) + " °C </h4>";
     }
+
+    content += "<h4>High precision voltage:";
     if (datalayer_extended.fordMachE.pid_hvb_voltage == 255) {
-      content += "<h4>High precision voltage: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>High precision voltage: " + String(datalayer_extended.fordMachE.pid_hvb_voltage) + " mV </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_voltage) + " mV </h4>";
     }
+
+    content += "<h4>State of health:";
     if (datalayer_extended.fordMachE.pid_hvb_soh == 255) {
-      content += "<h4>State of health: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>State of health: " + String(datalayer_extended.fordMachE.pid_hvb_soh) + " % </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_soh) + " % </h4>";
     }
+
+    content += "<h4>State of charge:";
     if (datalayer_extended.fordMachE.pid_hvb_soc == 255) {
-      content += "<h4>State of charge: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>State of charge: " + String(datalayer_extended.fordMachE.pid_hvb_soc) + " % </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_soc) + " % </h4>";
     }
+
+    content += "<h4>Contactor status:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 255) {
-      content += "<h4>Contactor status: N/A </h4>";
+      content += "N/A</h4>";
     } else {
       if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0xA00A8400) {
-        content += "<h4>Contactor status: Interlock Seated OK</h4>";
+        content += "Interlock Seated OK</h4>";
       } else if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0) {
-        content += "<h4>Contactor status: Interlock Not evaluated yet</h4>";
+        content += "Interlock Not evaluated yet</h4>";
       } else if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0x00000400) {
-        content += "<h4>Contactor status: Interlock OPEN!</h4>";
+        content += "Interlock OPEN!</h4>";
       } else {
-        content +=
-            "<h4>Contactor status: Unknown" + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
+        content += "Unknown" + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
       }
     }
+
+    content += "<h4>Pos contactor leak voltage:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage == 255) {
-      content += "<h4>Pos contactor leak voltage: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Pos contactor leak voltage: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage) + " mV </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage) + " mV </h4>";
     }
+
+    content += "<h4>Neg contactor leak voltage:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage == 255) {
-      content += "<h4>Neg contactor leak voltage: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Neg contactor leak voltage: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage) + " mV </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage) + " mV </h4>";
     }
+
+    content += "<h4>Pos contactor voltage:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage == 255) {
-      content += "<h4>Pos contactor voltage: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content +=
-          "<h4>Pos contactor voltage: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage) +
-          " mV </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage) + " mV </h4>";
     }
+
+    content += "<h4>Neg contactor voltage:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage == 255) {
-      content += "<h4>Neg contactor voltage: N/A </h4>";
+      content += "N/A</h4>";
+    } else {
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage) + " mV </h4>";
+    }
+
+    content += "<h4>Pos contactor bus leak resistance:";
+    if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance == 255) {
+      content += "N/A</h4>";
     } else {
       content +=
-          "<h4>Neg contactor voltage: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage) +
-          " mV </h4>";
+          " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance) + " kOhm </h4>";
     }
-    if (datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance == 255) {
-      content += "<h4>Pos contactor bus leak resistance: N/A </h4>";
-    } else {
-      content += "<h4>Pos contactor bus leak resistance: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance) + " kOhm </h4>";
-    }
+
+    content += "<h4>Neg contactor bus leak resistance:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance == 255) {
-      content += "<h4>Neg contactor bus leak resistance: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Neg contactor bus leak resistance: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance) + " kOhm </h4>";
+      content +=
+          " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance) + " kOhm </h4>";
     }
+
+    content += "<h4>Overall contactor leak resistance:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance == 255) {
-      content += "<h4>Overall contactor leak resistance: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Overall contactor leak resistance: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance) + " kOhm </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance) + " kOhm </h4>";
     }
+
+    content += "<h4>Open contactor leak resistance:";
     if (datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance == 255) {
-      content += "<h4>Open contactor leak resistance: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Open contactor leak resistance: " +
-                 String(datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance) + " kOhm </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance) + " kOhm </h4>";
     }
+
+    content += "<h4>Capacity:";
     if (datalayer_extended.fordMachE.pid_battery_capacity_ah == 255) {
-      content += "<h4>Capacity: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Capacity: " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
     }
+
+    content += "<h4>Maintenance rebalance status:";
     if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 255) {
-      content += "<h4>Maintenance rebalance status: N/A </h4>";
+      content += "N/A</h4>";
     } else {
       if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x04) {
-        content += "<h4>Maintenance rebalance status: Initializing</h4>";
+        content += " Initializing</h4>";
       } else {
-        content += "<h4>Maintenance rebalance status: " +
-                   String(datalayer_extended.fordMachE.pid_maintenance_rebalance_status) + "</h4>";
+        content += " " + String(datalayer_extended.fordMachE.pid_maintenance_rebalance_status) + "</h4>";
       }
     }
+
+    content += "<h4>Calendar age:";
     if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
-      content += "<h4>Calendar age: N/A </h4>";
+      content += "N/A</h4>";
     } else {
-      content += "<h4>Calendar age: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
     }
     return content;
   }

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -87,16 +87,15 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
       content += "<h4>Open contactor leak resistance: " +
                  String(datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance) + " kOhm </h4>";
     }
-    if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
-      content += "<h4>Battery age: N/A </h4>";
-    } else {
-      content +=
-          "<h4>Battery age: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " months </h4>";
-    }
     if (datalayer_extended.fordMachE.pid_battery_capacity_ah == 255) {
       content += "<h4>Capacity: N/A </h4>";
     } else {
       content += "<h4>Capacity: " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
+    }
+    if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
+      content += "<h4>Unknown 1: N/A </h4>";
+    } else {
+      content += "<h4>Unknown 1: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " months </h4>";
     }
     return content;
   }

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -92,10 +92,20 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += "<h4>Capacity: " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
     }
+    if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 255) {
+      content += "<h4>Maintenance rebalance status: N/A </h4>";
+    } else {
+      if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x04) {
+        content += "<h4>Maintenance rebalance status: Initializing</h4>";
+      } else {
+        content += "<h4>Maintenance rebalance status: " +
+                   String(datalayer_extended.fordMachE.pid_maintenance_rebalance_status) + "</h4>";
+      }
+    }
     if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
       content += "<h4>Unknown 1: N/A </h4>";
     } else {
-      content += "<h4>Unknown 1: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " months </h4>";
+      content += "<h4>Unknown 1: " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
     }
     return content;
   }

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -125,6 +125,8 @@ void FordMachEBattery::update_values() {
       pid_hvb_contactor_negative_bus_leak_resistance;
   datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance = pid_hvb_contactor_overall_leak_resistance;
   datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance = pid_hvb_contactor_open_leak_resistance;
+  datalayer_extended.fordMachE.pid_hvb_calendar_age_months = pid_hvb_calendar_age_months;
+  datalayer_extended.fordMachE.pid_battery_capacity_ah = pid_battery_capacity_ah;
 }
 
 void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -287,7 +289,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x7EC:  //OBD2 diag reply from BMS (Replies to both 7DF and 7E4)
 
       if (rx_frame.data.u8[0] < 0x10) {  //One line response
-        incoming_poll = ((rx_frame.data.u8[2] & 0x0F) << 8) | rx_frame.data.u8[3];
+        incoming_poll = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
       }
 
       if (rx_frame.data.u8[0] == 0x10) {  //Multiframe response, send ACK
@@ -357,6 +359,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_GEAR_COMMANDED:
           break;
         case PID_KEY_STATE:
+          //0x0E = Error
           break;
         case PID_CHARGE_PLUG:
           break;
@@ -379,6 +382,12 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_LORES_ODOMETER:
           break;
         case PID_ENGINE_RUNTIME:
+          break;
+        case PID_HVB_CALENDAR_AGE_MONTHS:
+          pid_hvb_calendar_age_months = rx_frame.data.u8[4];
+          break;
+        case PID_BATTERY_CAPACITY:
+          pid_battery_capacity_ah = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           break;
         default:
           break;
@@ -508,7 +517,7 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     // Update current poll from the array
     currentpoll = poll_commands[poll_index];
-    poll_index = (poll_index + 1) % 33;
+    poll_index = (poll_index + 1) % 35;
 
     FORD_PID_REQUEST_7E4.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
     FORD_PID_REQUEST_7E4.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -385,7 +385,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_ENGINE_RUNTIME:
           break;
         case PID_HVB_CALENDAR_AGE_MONTHS:
-          pid_hvb_calendar_age_months = rx_frame.data.u8[4];
+          pid_hvb_calendar_age_months = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           break;
         case PID_BATTERY_CAPACITY:
           pid_battery_capacity_ah = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -127,6 +127,7 @@ void FordMachEBattery::update_values() {
   datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance = pid_hvb_contactor_open_leak_resistance;
   datalayer_extended.fordMachE.pid_hvb_calendar_age_months = pid_hvb_calendar_age_months;
   datalayer_extended.fordMachE.pid_battery_capacity_ah = pid_battery_capacity_ah;
+  datalayer_extended.fordMachE.pid_maintenance_rebalance_status = pid_maintenance_rebalance_status;
 }
 
 void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -389,6 +390,9 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_BATTERY_CAPACITY:
           pid_battery_capacity_ah = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           break;
+        case PID_MAINTENANCE_REBALANCE_STATUS:
+          pid_maintenance_rebalance_status = rx_frame.data.u8[4];
+          break;
         default:
           break;
       }
@@ -517,7 +521,7 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     // Update current poll from the array
     currentpoll = poll_commands[poll_index];
-    poll_index = (poll_index + 1) % 35;
+    poll_index = (poll_index + 1) % 36;
 
     FORD_PID_REQUEST_7E4.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
     FORD_PID_REQUEST_7E4.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -11,6 +11,8 @@ void FordMachEBattery::update_values() {
 
   if (pid_hvb_soh < 101) {
     datalayer.battery.status.soh_pptt = pid_hvb_soh * 100;
+  } else if (pid_hvb_soh < 128) {
+    datalayer.battery.status.soh_pptt = 10000;
   }
 
   datalayer.battery.status.voltage_dV = battery_voltage * 10;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -9,7 +9,9 @@ void FordMachEBattery::update_values() {
 
   datalayer.battery.status.real_soc = battery_soc;
 
-  //datalayer.battery.status.soh_pptt; //TODO: Locate
+  if (pid_hvb_soh < 101) {
+    datalayer.battery.status.soh_pptt = pid_hvb_soh;
+  }
 
   datalayer.battery.status.voltage_dV = battery_voltage * 10;
 
@@ -106,6 +108,23 @@ void FordMachEBattery::update_values() {
   if (polled_12V < 11800) {
     set_event(EVENT_12V_LOW, 0);
   }
+
+  //Update More Battery Info page
+  datalayer_extended.fordMachE.pid_hvb_temp = pid_hvb_temp;
+  datalayer_extended.fordMachE.pid_hvb_voltage = pid_hvb_voltage;
+  datalayer_extended.fordMachE.pid_hvb_soc = pid_hvb_soc;
+  datalayer_extended.fordMachE.pid_hvb_soh = pid_hvb_soh;
+  datalayer_extended.fordMachE.pid_hvb_contactor_status = pid_hvb_contactor_status;
+  datalayer_extended.fordMachE.pid_hvb_contactor_positive_leak_voltage = pid_hvb_contactor_positive_leak_voltage;
+  datalayer_extended.fordMachE.pid_hvb_contactor_negative_leak_voltage = pid_hvb_contactor_negative_leak_voltage;
+  datalayer_extended.fordMachE.pid_hvb_contactor_positive_voltage = pid_hvb_contactor_positive_voltage;
+  datalayer_extended.fordMachE.pid_hvb_contactor_negative_voltage = pid_hvb_contactor_negative_voltage;
+  datalayer_extended.fordMachE.pid_hvb_contactor_positive_bus_leak_resistance =
+      pid_hvb_contactor_positive_bus_leak_resistance;
+  datalayer_extended.fordMachE.pid_hvb_contactor_negative_bus_leak_resistance =
+      pid_hvb_contactor_negative_bus_leak_resistance;
+  datalayer_extended.fordMachE.pid_hvb_contactor_overall_leak_resistance = pid_hvb_contactor_overall_leak_resistance;
+  datalayer_extended.fordMachE.pid_hvb_contactor_open_leak_resistance = pid_hvb_contactor_open_leak_resistance;
 }
 
 void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -268,17 +287,98 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x7EC:  //OBD2 diag reply from BMS (Replies to both 7DF and 7E4)
 
       if (rx_frame.data.u8[0] < 0x10) {  //One line response
-        pid_reply = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[2];
+        incoming_poll = ((rx_frame.data.u8[2] & 0x0F) << 8) | rx_frame.data.u8[3];
       }
 
       if (rx_frame.data.u8[0] == 0x10) {  //Multiframe response, send ACK
         //transmit_can_frame(&FORD_PID_ACK); //Not seen yet
-        //pid_reply = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
+        //incoming_poll = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
       }
 
-      switch (pid_reply) {
+      switch (incoming_poll) {
         case 0x142:  //12V battery
           polled_12V = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
+          break;
+        case PID_HVB_TEMP:
+          pid_hvb_temp = rx_frame.data.u8[4] - 40;
+          break;
+        case PID_HVB_SOC:
+          pid_hvb_soc = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_STATUS:
+          pid_hvb_contactor_status = (rx_frame.data.u8[4] << 24) | (rx_frame.data.u8[5] << 16) |
+                                     (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
+          break;
+        case PID_HVB_CONTACTOR_POSITIVE_LEAK_VOLTAGE:
+          pid_hvb_contactor_positive_leak_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_NEGATIVE_LEAK_VOLTAGE:
+          pid_hvb_contactor_negative_leak_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_POSITIVE_VOLTAGE:
+          pid_hvb_contactor_positive_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_NEGATIVE_VOLTAGE:
+          pid_hvb_contactor_negative_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_POSITIVE_BUS_LEAK_RESISTANCE:
+          pid_hvb_contactor_positive_bus_leak_resistance = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_NEGATIVE_BUS_LEAK_RESISTANCE:
+          pid_hvb_contactor_negative_bus_leak_resistance = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_OVERALL_LEAK_RESISTANCE:
+          pid_hvb_contactor_overall_leak_resistance = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CONTACTOR_OPEN_LEAK_RESISTANCE:
+          pid_hvb_contactor_open_leak_resistance = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_ETE:
+          pid_hvb_ete = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CURRENT:
+          break;
+        case PID_CHARGER_POWER_LIMIT:
+          break;
+        case PID_HVB_SOH:
+          pid_hvb_soh = rx_frame.data.u8[4] / 2;
+          break;
+        case PID_HVB_VOLTAGE:
+          pid_hvb_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          break;
+        case PID_HVB_CHARGE_VOLTAGE_REQUESTED:
+          break;
+        case PID_HVB_SOC_D:
+          break;
+        case PID_HVB_MAX_CHARGE_CURRENT:
+          break;
+        case PID_HVB_CHARGE_CURRENT_REQUESTED:
+          break;
+        case PID_GEAR_COMMANDED:
+          break;
+        case PID_KEY_STATE:
+          break;
+        case PID_CHARGE_PLUG:
+          break;
+        case PID_CHARGER_OUTPUT_VOLTAGE:
+          break;
+        case PID_CHARGER_STATUS:
+          break;
+        case PID_CHARGER_OUTPUT_CURRENT_MEASURED:
+          break;
+        case PID_EVSE_TYPE:
+          break;
+        case PID_CHARGER_MAX_POWER:
+          break;
+        case PID_CHARGING_STATUS:
+          break;
+        case PID_CHARGER_INPUT_POWER_AVAILABLE:
+          break;
+        case PID_TIME:
+          break;
+        case PID_LORES_ODOMETER:
+          break;
+        case PID_ENGINE_RUNTIME:
           break;
         default:
           break;
@@ -404,7 +504,16 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis250 >= INTERVAL_250_MS) {
     previousMillis250 = currentMillis;
 
-    transmit_can_frame(&FORD_PID_REQUEST_7DF);
+    //transmit_can_frame(&FORD_PID_REQUEST_7DF); 12V battery voltage request
+
+    // Update current poll from the array
+    currentpoll = poll_commands[poll_index];
+    poll_index = (poll_index + 1) % 33;
+
+    FORD_PID_REQUEST_7E4.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
+    FORD_PID_REQUEST_7E4.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);
+
+    transmit_can_frame(&FORD_PID_REQUEST_7E4);
   }
 
   // Send 1s CAN Message
@@ -415,6 +524,11 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&FORD_3C3);
     transmit_can_frame(&FORD_581);
     */
+
+    if (UserRequestDTCreset) {
+      transmit_can_frame(&FORD_DTC_RESET);
+      UserRequestDTCreset = false;  //Reset the flag after sending the DTC reset command
+    }
   }
 }
 

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -10,7 +10,7 @@ void FordMachEBattery::update_values() {
   datalayer.battery.status.real_soc = battery_soc;
 
   if (pid_hvb_soh < 101) {
-    datalayer.battery.status.soh_pptt = pid_hvb_soh;
+    datalayer.battery.status.soh_pptt = pid_hvb_soh * 100;
   }
 
   datalayer.battery.status.voltage_dV = battery_voltage * 10;
@@ -305,7 +305,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           pid_hvb_temp = rx_frame.data.u8[4] - 40;
           break;
         case PID_HVB_SOC:
-          pid_hvb_soc = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          pid_hvb_soc = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 2;
           break;
         case PID_HVB_CONTACTOR_STATUS:
           pid_hvb_contactor_status = (rx_frame.data.u8[4] << 24) | (rx_frame.data.u8[5] << 16) |

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -2,6 +2,7 @@
 #define FORD_MACH_E_BATTERY_H
 #include "../datalayer/datalayer.h"
 #include "CanBattery.h"
+#include "FORD-MACH-E-BATTERY-HTML.h"
 
 class FordMachEBattery : public CanBattery {
  public:
@@ -10,8 +11,14 @@ class FordMachEBattery : public CanBattery {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Ford Mustang Mach-E battery";
+  BatteryHtmlRenderer& get_status_renderer() { return renderer; }
+
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
 
  private:
+  FordMachEHtmlRenderer renderer;
+  bool UserRequestDTCreset = false;
   //90S NMC
   static const int MAX_PACK_VOLTAGE_90S_DV = 3902;
   static const int MIN_PACK_VOLTAGE_90S_DV = 2490;
@@ -65,16 +72,136 @@ class FordMachEBattery : public CanBattery {
 
   uint16_t polled_12V = 12000;
 
+  static const uint8_t NOT_SAMPLED_YET = 255;
+  // BECM Module PID Definitions
+  static const uint16_t PID_HVB_TEMP = 0x4800;
+  static const uint16_t PID_HVB_SOC = 0x4801;
+  static const uint16_t PID_HVB_CONTACTOR_STATUS = 0x4802;
+  static const uint16_t PID_HVB_CONTACTOR_POSITIVE_LEAK_VOLTAGE = 0x4803;
+  static const uint16_t PID_HVB_CONTACTOR_NEGATIVE_LEAK_VOLTAGE = 0x4804;
+  static const uint16_t PID_HVB_CONTACTOR_POSITIVE_VOLTAGE = 0x4805;
+  static const uint16_t PID_HVB_CONTACTOR_NEGATIVE_VOLTAGE = 0x4806;
+  static const uint16_t PID_HVB_CONTACTOR_POSITIVE_BUS_LEAK_RESISTANCE = 0x4811;
+  static const uint16_t PID_HVB_CONTACTOR_NEGATIVE_BUS_LEAK_RESISTANCE = 0x4812;
+  static const uint16_t PID_HVB_CONTACTOR_OVERALL_LEAK_RESISTANCE = 0x4813;
+  static const uint16_t PID_HVB_CONTACTOR_OPEN_LEAK_RESISTANCE = 0x4814;
+  static const uint16_t PID_HVB_ETE = 0x4848;
+  static const uint16_t PID_HVB_CURRENT = 0x48F9;
+  static const uint16_t PID_CHARGER_POWER_LIMIT = 0x48FB;
+  static const uint16_t PID_HVB_SOH = 0x490C;
+  //Shared PIDs with other modules, but also seen in BECM
+  static const uint16_t PID_HVB_VOLTAGE = 0x480D;                   // OBCC, SOBDM, SOBDMC, SOBDMB
+  static const uint16_t PID_HVB_CHARGE_VOLTAGE_REQUESTED = 0x4844;  // OBCC, SOBDM
+  static const uint16_t PID_HVB_SOC_D = 0x4845;                     // OBCC, SOBDM
+  static const uint16_t PID_HVB_MAX_CHARGE_CURRENT = 0x48BC;        // OBCC, SOBDM
+  static const uint16_t PID_HVB_CHARGE_CURRENT_REQUESTED = 0x4842;  // OBCC, SOBDM
+  static const uint16_t PID_GEAR_COMMANDED = 0x1E12;                // GSM, SOBDM, SOBDMC
+  static const uint16_t PID_KEY_STATE = 0x411F;               // GWM, WACM, ACM, HVAC, DSP, APIM, SOBDM, SOBDMC, SOBDMB
+  static const uint16_t PID_CHARGE_PLUG = 0x4843;             // OBCC, SOBDM
+  static const uint16_t PID_CHARGER_OUTPUT_VOLTAGE = 0x484A;  // OBCC, SOBDM
+  static const uint16_t PID_CHARGER_STATUS = 0x484F;          // OBCC, SOBDM
+  static const uint16_t PID_CHARGER_OUTPUT_CURRENT_MEASURED = 0x4850;  // OBCC, SOBDM
+  static const uint16_t PID_EVSE_TYPE = 0x4851;                        // OBCC, SOBDM
+  static const uint16_t PID_CHARGER_MAX_POWER = 0x48C4;                // OBCC, SOBDM
+  static const uint16_t PID_CHARGING_STATUS = 0x484D;                  // SOBDM
+  static const uint16_t PID_CHARGER_INPUT_POWER_AVAILABLE = 0x484E;    // SOBDM
+  static const uint16_t PID_TIME = 0xDD00;                             // many modules
+  static const uint16_t PID_LORES_ODOMETER = 0xDD01;                   // many modules
+  static const uint16_t PID_ENGINE_RUNTIME = 0xF41F;                   // SOBDMB, SOBDMC, PCM
+
+  uint16_t currentpoll = PID_HVB_TEMP;
+  uint8_t poll_index = 0;
+  const uint16_t poll_commands[33] = {PID_HVB_TEMP,
+                                      PID_HVB_SOC,
+                                      PID_HVB_CONTACTOR_STATUS,
+                                      PID_HVB_CONTACTOR_POSITIVE_LEAK_VOLTAGE,
+                                      PID_HVB_CONTACTOR_NEGATIVE_LEAK_VOLTAGE,
+                                      PID_HVB_CONTACTOR_POSITIVE_VOLTAGE,
+                                      PID_HVB_CONTACTOR_NEGATIVE_VOLTAGE,
+                                      PID_HVB_CONTACTOR_POSITIVE_BUS_LEAK_RESISTANCE,
+                                      PID_HVB_CONTACTOR_NEGATIVE_BUS_LEAK_RESISTANCE,
+                                      PID_HVB_CONTACTOR_OVERALL_LEAK_RESISTANCE,
+                                      PID_HVB_CONTACTOR_OPEN_LEAK_RESISTANCE,
+                                      PID_HVB_ETE,
+                                      PID_HVB_CURRENT,
+                                      PID_CHARGER_POWER_LIMIT,
+                                      PID_HVB_SOH,
+                                      PID_HVB_VOLTAGE,
+                                      PID_HVB_CHARGE_VOLTAGE_REQUESTED,
+                                      PID_HVB_SOC_D,
+                                      PID_HVB_MAX_CHARGE_CURRENT,
+                                      PID_HVB_CHARGE_CURRENT_REQUESTED,
+                                      PID_GEAR_COMMANDED,
+                                      PID_KEY_STATE,
+                                      PID_CHARGE_PLUG,
+                                      PID_CHARGER_OUTPUT_VOLTAGE,
+                                      PID_CHARGER_STATUS,
+                                      PID_CHARGER_OUTPUT_CURRENT_MEASURED,
+                                      PID_EVSE_TYPE,
+                                      PID_CHARGER_MAX_POWER,
+                                      PID_CHARGING_STATUS,
+                                      PID_CHARGER_INPUT_POWER_AVAILABLE,
+                                      PID_TIME,
+                                      PID_LORES_ODOMETER,
+                                      PID_ENGINE_RUNTIME};
+
+  int16_t pid_hvb_temp = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_soc = NOT_SAMPLED_YET;
+  uint32_t pid_hvb_contactor_status = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_positive_leak_voltage = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_negative_leak_voltage = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_positive_voltage = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_negative_voltage = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_positive_bus_leak_resistance = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_negative_bus_leak_resistance = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_overall_leak_resistance = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_contactor_open_leak_resistance = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_ete = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_current = NOT_SAMPLED_YET;
+  uint16_t pid_charger_power_limit = NOT_SAMPLED_YET;
+  uint8_t pid_hvb_soh = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_voltage = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_charge_voltage_requested = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_soc_d = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_max_charge_current = NOT_SAMPLED_YET;
+  uint16_t pid_hvb_charge_current_requested = NOT_SAMPLED_YET;
+  uint8_t pid_gear_commanded = NOT_SAMPLED_YET;
+  uint8_t pid_key_state = NOT_SAMPLED_YET;
+  uint8_t pid_charge_plug = NOT_SAMPLED_YET;
+  uint8_t pid_charger_output_voltage = NOT_SAMPLED_YET;
+  uint8_t pid_charger_status = NOT_SAMPLED_YET;
+  uint8_t pid_charger_output_current_measured = NOT_SAMPLED_YET;
+  uint8_t pid_evse_type = NOT_SAMPLED_YET;
+  uint8_t pid_charger_max_power = NOT_SAMPLED_YET;
+  uint8_t pid_charging_status = NOT_SAMPLED_YET;
+  uint8_t pid_charger_input_power_available = NOT_SAMPLED_YET;
+  uint8_t pid_time = NOT_SAMPLED_YET;
+  uint8_t pid_lores_odometer = NOT_SAMPLED_YET;
+  uint8_t pid_engine_runtime = NOT_SAMPLED_YET;
+
+  uint16_t poll_state = PID_HVB_TEMP;
+  uint16_t incoming_poll = 0;
+
   CAN_frame FORD_PID_REQUEST_7DF = {.FD = false,
                                     .ext_ID = false,
                                     .DLC = 8,
                                     .ID = 0x7DF,
                                     .data = {0x02, 0x01, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_PID_ACK = {.FD = false,
-                            .ext_ID = false,
-                            .DLC = 8,
-                            .ID = 0x7DF,
-                            .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_PID_REQUEST_7E4 = {.FD = false,
+                                    .ext_ID = false,
+                                    .DLC = 8,
+                                    .ID = 0x7E4,
+                                    .data = {0x03, 0x22, 0x48, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_PID_ACK_7DF = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x7DF,
+                                .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_DTC_RESET = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x7E4,
+                              .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 
   //Message needed for contactor closing
   CAN_frame FORD_25B = {.FD = false,

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -91,6 +91,7 @@ class FordMachEBattery : public CanBattery {
   static const uint16_t PID_HVB_SOH = 0x490C;
   static const uint16_t PID_HVB_CALENDAR_AGE_MONTHS = 0x48B9;  //Could also be Max voltage battery module ID
   static const uint16_t PID_BATTERY_CAPACITY = 0x485C;
+  static const uint16_t PID_MAINTENANCE_REBALANCE_STATUS = 0x4818;
   //Shared PIDs with other modules, but also seen in BECM
   static const uint16_t PID_HVB_VOLTAGE = 0x480D;                   // OBCC, SOBDM, SOBDMC, SOBDMB
   static const uint16_t PID_HVB_CHARGE_VOLTAGE_REQUESTED = 0x4844;  // OBCC, SOBDM
@@ -122,7 +123,6 @@ static const uint16_t PID_UNKNOWN_7 = 0x4808;
 static const uint16_t PID_UNKNOWN_8 = 0x4809;
 static const uint16_t PID_UNKNOWN_9 = 0x480A;
 static const uint16_t PID_UNKNOWN_10 = 0x4810;
-static const uint16_t PID_UNKNOWN_11 = 0x4818;
 static const uint16_t PID_UNKNOWN_12 = 0x481D;
 static const uint16_t PID_UNKNOWN_13 = 0x483E;
 static const uint16_t PID_UNKNOWN_14 = 0x483F;
@@ -153,7 +153,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
 
   uint16_t currentpoll = PID_HVB_TEMP;
   uint8_t poll_index = 0;
-  const uint16_t poll_commands[35] = {PID_HVB_TEMP,
+  const uint16_t poll_commands[36] = {PID_HVB_TEMP,
                                       PID_HVB_SOC,
                                       PID_HVB_CONTACTOR_STATUS,
                                       PID_HVB_CONTACTOR_POSITIVE_LEAK_VOLTAGE,
@@ -187,7 +187,8 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                                       PID_LORES_ODOMETER,
                                       PID_ENGINE_RUNTIME,
                                       PID_HVB_CALENDAR_AGE_MONTHS,
-                                      PID_BATTERY_CAPACITY};
+                                      PID_BATTERY_CAPACITY,
+                                      PID_MAINTENANCE_REBALANCE_STATUS};
 
   int16_t pid_hvb_temp = NOT_SAMPLED_YET;
   uint32_t pid_hvb_soc = NOT_SAMPLED_YET;
@@ -224,6 +225,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
   uint8_t pid_engine_runtime = NOT_SAMPLED_YET;
   uint8_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;  //Could be max module voltage PID?
   uint16_t pid_battery_capacity_ah = NOT_SAMPLED_YET;
+  uint8_t pid_maintenance_rebalance_status = NOT_SAMPLED_YET;
 
   uint16_t poll_state = PID_HVB_TEMP;
   uint16_t incoming_poll = 0;
@@ -238,11 +240,6 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                                     .DLC = 8,
                                     .ID = 0x7E4,
                                     .data = {0x03, 0x22, 0x48, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_PID_ACK_7DF = {.FD = false,
-                                .ext_ID = false,
-                                .DLC = 8,
-                                .ID = 0x7DF,
-                                .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame FORD_DTC_RESET = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -89,6 +89,8 @@ class FordMachEBattery : public CanBattery {
   static const uint16_t PID_HVB_CURRENT = 0x48F9;
   static const uint16_t PID_CHARGER_POWER_LIMIT = 0x48FB;
   static const uint16_t PID_HVB_SOH = 0x490C;
+  static const uint16_t PID_HVB_CALENDAR_AGE_MONTHS = 0x48B9;  //Could also be Max voltage battery module ID
+  static const uint16_t PID_BATTERY_CAPACITY = 0x485C;
   //Shared PIDs with other modules, but also seen in BECM
   static const uint16_t PID_HVB_VOLTAGE = 0x480D;                   // OBCC, SOBDM, SOBDMC, SOBDMB
   static const uint16_t PID_HVB_CHARGE_VOLTAGE_REQUESTED = 0x4844;  // OBCC, SOBDM
@@ -111,7 +113,7 @@ class FordMachEBattery : public CanBattery {
 
   uint16_t currentpoll = PID_HVB_TEMP;
   uint8_t poll_index = 0;
-  const uint16_t poll_commands[33] = {PID_HVB_TEMP,
+  const uint16_t poll_commands[35] = {PID_HVB_TEMP,
                                       PID_HVB_SOC,
                                       PID_HVB_CONTACTOR_STATUS,
                                       PID_HVB_CONTACTOR_POSITIVE_LEAK_VOLTAGE,
@@ -143,7 +145,9 @@ class FordMachEBattery : public CanBattery {
                                       PID_CHARGER_INPUT_POWER_AVAILABLE,
                                       PID_TIME,
                                       PID_LORES_ODOMETER,
-                                      PID_ENGINE_RUNTIME};
+                                      PID_ENGINE_RUNTIME,
+                                      PID_HVB_CALENDAR_AGE_MONTHS,
+                                      PID_BATTERY_CAPACITY};
 
   int16_t pid_hvb_temp = NOT_SAMPLED_YET;
   uint16_t pid_hvb_soc = NOT_SAMPLED_YET;
@@ -178,6 +182,8 @@ class FordMachEBattery : public CanBattery {
   uint8_t pid_time = NOT_SAMPLED_YET;
   uint8_t pid_lores_odometer = NOT_SAMPLED_YET;
   uint8_t pid_engine_runtime = NOT_SAMPLED_YET;
+  uint8_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;
+  uint16_t pid_battery_capacity_ah = NOT_SAMPLED_YET;
 
   uint16_t poll_state = PID_HVB_TEMP;
   uint16_t incoming_poll = 0;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -110,6 +110,46 @@ class FordMachEBattery : public CanBattery {
   static const uint16_t PID_TIME = 0xDD00;                             // many modules
   static const uint16_t PID_LORES_ODOMETER = 0xDD01;                   // many modules
   static const uint16_t PID_ENGINE_RUNTIME = 0xF41F;                   // SOBDMB, SOBDMC, PCM
+  // Unknown PIDs seen in CAN log — not yet decoded
+  /*
+static const uint16_t PID_UNKNOWN_1 = 0x0117;
+static const uint16_t PID_UNKNOWN_2 = 0x0119;
+static const uint16_t PID_UNKNOWN_3 = 0x011A;
+static const uint16_t PID_UNKNOWN_4 = 0x0599;
+static const uint16_t PID_UNKNOWN_5 = 0x05A1;
+static const uint16_t PID_UNKNOWN_6 = 0x05CB;
+static const uint16_t PID_UNKNOWN_7 = 0x4808;
+static const uint16_t PID_UNKNOWN_8 = 0x4809;
+static const uint16_t PID_UNKNOWN_9 = 0x480A;
+static const uint16_t PID_UNKNOWN_10 = 0x4810;
+static const uint16_t PID_UNKNOWN_11 = 0x4818;
+static const uint16_t PID_UNKNOWN_12 = 0x481D;
+static const uint16_t PID_UNKNOWN_13 = 0x483E;
+static const uint16_t PID_UNKNOWN_14 = 0x483F;
+static const uint16_t PID_UNKNOWN_15 = 0x4840;
+static const uint16_t PID_UNKNOWN_16 = 0x4841;
+static const uint16_t PID_UNKNOWN_17 = 0x4846;
+static const uint16_t PID_UNKNOWN_18 = 0x485D;
+static const uint16_t PID_UNKNOWN_19 = 0x4878;
+static const uint16_t PID_UNKNOWN_20 = 0x4898;
+static const uint16_t PID_UNKNOWN_21 = 0x489E;
+static const uint16_t PID_UNKNOWN_22 = 0x48A1;
+static const uint16_t PID_UNKNOWN_23 = 0x48AF;
+static const uint16_t PID_UNKNOWN_24 = 0x48CF;
+static const uint16_t PID_UNKNOWN_25 = 0x48E2;
+static const uint16_t PID_UNKNOWN_26 = 0x48E4;
+static const uint16_t PID_UNKNOWN_27 = 0x4901;
+static const uint16_t PID_UNKNOWN_28 = 0x4903;
+static const uint16_t PID_UNKNOWN_29 = 0x4904;
+static const uint16_t PID_UNKNOWN_30 = 0x5B56;
+static const uint16_t PID_UNKNOWN_31 = 0xD002;
+static const uint16_t PID_UNKNOWN_32 = 0xDD80;
+static const uint16_t PID_UNKNOWN_33 = 0xF404;
+static const uint16_t PID_UNKNOWN_34 = 0xF405;
+static const uint16_t PID_UNKNOWN_35 = 0xF40C;
+static const uint16_t PID_UNKNOWN_36 = 0xF40D;
+static const uint16_t PID_UNKNOWN_37 = 0xF449;
+*/
 
   uint16_t currentpoll = PID_HVB_TEMP;
   uint8_t poll_index = 0;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -150,7 +150,7 @@ class FordMachEBattery : public CanBattery {
                                       PID_BATTERY_CAPACITY};
 
   int16_t pid_hvb_temp = NOT_SAMPLED_YET;
-  uint16_t pid_hvb_soc = NOT_SAMPLED_YET;
+  uint32_t pid_hvb_soc = NOT_SAMPLED_YET;
   uint32_t pid_hvb_contactor_status = NOT_SAMPLED_YET;
   uint16_t pid_hvb_contactor_positive_leak_voltage = NOT_SAMPLED_YET;
   uint16_t pid_hvb_contactor_negative_leak_voltage = NOT_SAMPLED_YET;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -182,7 +182,7 @@ class FordMachEBattery : public CanBattery {
   uint8_t pid_time = NOT_SAMPLED_YET;
   uint8_t pid_lores_odometer = NOT_SAMPLED_YET;
   uint8_t pid_engine_runtime = NOT_SAMPLED_YET;
-  uint8_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;
+  uint8_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;  //Could be max module voltage PID?
   uint16_t pid_battery_capacity_ah = NOT_SAMPLED_YET;
 
   uint16_t poll_state = PID_HVB_TEMP;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -89,7 +89,7 @@ class FordMachEBattery : public CanBattery {
   static const uint16_t PID_HVB_CURRENT = 0x48F9;
   static const uint16_t PID_CHARGER_POWER_LIMIT = 0x48FB;
   static const uint16_t PID_HVB_SOH = 0x490C;
-  static const uint16_t PID_HVB_CALENDAR_AGE_MONTHS = 0x48B9;  //Could also be Max voltage battery module ID
+  static const uint16_t PID_HVB_CALENDAR_AGE_MONTHS = 0x4810;
   static const uint16_t PID_BATTERY_CAPACITY = 0x485C;
   static const uint16_t PID_MAINTENANCE_REBALANCE_STATUS = 0x4818;
   //Shared PIDs with other modules, but also seen in BECM
@@ -111,6 +111,7 @@ class FordMachEBattery : public CanBattery {
   static const uint16_t PID_TIME = 0xDD00;                             // many modules
   static const uint16_t PID_LORES_ODOMETER = 0xDD01;                   // many modules
   static const uint16_t PID_ENGINE_RUNTIME = 0xF41F;                   // SOBDMB, SOBDMC, PCM
+  static const uint16_t PID_TIME_SINCE_MODULE_POWER_UP_OR_RESET = 0xD002;
   // Unknown PIDs seen in CAN log — not yet decoded
   /*
 static const uint16_t PID_UNKNOWN_1 = 0x0117;
@@ -122,7 +123,6 @@ static const uint16_t PID_UNKNOWN_6 = 0x05CB;
 static const uint16_t PID_UNKNOWN_7 = 0x4808;
 static const uint16_t PID_UNKNOWN_8 = 0x4809;
 static const uint16_t PID_UNKNOWN_9 = 0x480A;
-static const uint16_t PID_UNKNOWN_10 = 0x4810;
 static const uint16_t PID_UNKNOWN_12 = 0x481D;
 static const uint16_t PID_UNKNOWN_13 = 0x483E;
 static const uint16_t PID_UNKNOWN_14 = 0x483F;
@@ -142,7 +142,7 @@ static const uint16_t PID_UNKNOWN_27 = 0x4901;
 static const uint16_t PID_UNKNOWN_28 = 0x4903;
 static const uint16_t PID_UNKNOWN_29 = 0x4904;
 static const uint16_t PID_UNKNOWN_30 = 0x5B56;
-static const uint16_t PID_UNKNOWN_31 = 0xD002;
+static const uint16_t PID_UNKNOWN_30 = 0x48B9;  //Could be Max voltage battery module ID ?
 static const uint16_t PID_UNKNOWN_32 = 0xDD80;
 static const uint16_t PID_UNKNOWN_33 = 0xF404;
 static const uint16_t PID_UNKNOWN_34 = 0xF405;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -409,6 +409,7 @@ struct DATALAYER_INFO_FORD_MACH_E {
   uint16_t pid_hvb_voltage = 0;
   uint8_t pid_hvb_calendar_age_months = 0;
   uint16_t pid_battery_capacity_ah = 0;
+  uint8_t pid_maintenance_rebalance_status = 0;
 };
 
 struct DATALAYER_INFO_GEELY_GEOMETRY_C {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -407,6 +407,8 @@ struct DATALAYER_INFO_FORD_MACH_E {
   uint16_t pid_hvb_contactor_open_leak_resistance = 0;
   uint8_t pid_hvb_soh = 0;
   uint16_t pid_hvb_voltage = 0;
+  uint8_t pid_hvb_calendar_age_months = 0;
+  uint16_t pid_battery_capacity_ah = 0;
 };
 
 struct DATALAYER_INFO_GEELY_GEOMETRY_C {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -393,6 +393,22 @@ struct DATALAYER_INFO_ECMP {
   uint8_t pid_battery_serial[13] = {0};
 };
 
+struct DATALAYER_INFO_FORD_MACH_E {
+  int16_t pid_hvb_temp = 0;
+  uint16_t pid_hvb_soc = 0;
+  uint32_t pid_hvb_contactor_status = 0;
+  uint16_t pid_hvb_contactor_positive_leak_voltage = 0;
+  uint16_t pid_hvb_contactor_negative_leak_voltage = 0;
+  uint16_t pid_hvb_contactor_positive_voltage = 0;
+  uint16_t pid_hvb_contactor_negative_voltage = 0;
+  uint16_t pid_hvb_contactor_positive_bus_leak_resistance = 0;
+  uint16_t pid_hvb_contactor_negative_bus_leak_resistance = 0;
+  uint16_t pid_hvb_contactor_overall_leak_resistance = 0;
+  uint16_t pid_hvb_contactor_open_leak_resistance = 0;
+  uint8_t pid_hvb_soh = 0;
+  uint16_t pid_hvb_voltage = 0;
+};
+
 struct DATALAYER_INFO_GEELY_GEOMETRY_C {
   /** int16_t */
   /** Module temperatures 1-6 */
@@ -973,6 +989,7 @@ class DataLayerExtended {
   DATALAYER_INFO_CMFAEV CMFAEV;
   DATALAYER_INFO_CMPSMART stellantisCMPsmart;
   DATALAYER_INFO_ECMP stellantisECMP;
+  DATALAYER_INFO_FORD_MACH_E fordMachE;
   DATALAYER_INFO_GEELY_GEOMETRY_C geometryC;
   DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64;
   DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64_2;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -395,7 +395,7 @@ struct DATALAYER_INFO_ECMP {
 
 struct DATALAYER_INFO_FORD_MACH_E {
   int16_t pid_hvb_temp = 0;
-  uint16_t pid_hvb_soc = 0;
+  uint32_t pid_hvb_soc = 0;
   uint32_t pid_hvb_contactor_status = 0;
   uint16_t pid_hvb_contactor_positive_leak_voltage = 0;
   uint16_t pid_hvb_contactor_negative_leak_voltage = 0;


### PR DESCRIPTION
### What
This PR implements PID polling + DTC reset for the MachE integration

### Why
Make it possible to clear faults and get contactor closing working on packs with DTCs active

### How
More Battery Info page added

<img width="451" height="515" alt="image" src="https://github.com/user-attachments/assets/860cf347-6332-4a4e-b624-2009ca5b1b64" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
