### PR TITLE
Ford MachE: Filter out SOH 0% reads

### DIFF
--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -127,6 +127,8 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x04) {
         content += " Initializing</h4>";
+      } else if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x03) {
+        content += " Successfully</h4>";
       } else {
         content += " " + String(datalayer_extended.fordMachE.pid_maintenance_rebalance_status) + "</h4>";
       }

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -346,7 +346,9 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_CHARGER_POWER_LIMIT:
           break;
         case PID_HVB_SOH:
-          pid_hvb_soh = rx_frame.data.u8[4] / 2;
+          if (rx_frame.data.u8[4] > 0) {
+            pid_hvb_soh = rx_frame.data.u8[4] / 2;
+          }
           break;
         case PID_HVB_VOLTAGE:
           pid_hvb_voltage = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];


### PR DESCRIPTION
### What
This PR skips reading SOH 0%

### Why
Ford MachE can return 0% SOH in some rare cases when value is unavailable

### How
We skip reading if it is 0

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
