### PR TITLE
Support for LilyGo T-2CAN FD variant

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -196,12 +196,24 @@ bool init_CAN() {
 
     auto cs_pin = esp32hal->MCP2517_CS();
     auto int_pin = esp32hal->MCP2517_INT();
+    auto int0_pin = esp32hal->MCP2517_INT0();
+    auto int1_pin = esp32hal->MCP2517_INT1();
 
-    if (!esp32hal->alloc_pins("CANFD", cs_pin, int_pin)) {
+    if (!esp32hal->alloc_pins("CANFD", cs_pin)) {
       return false;
     }
+    if (int_pin != GPIO_NUM_NC) {
+      if (!esp32hal->alloc_pins("CANFD", int_pin)) {
+        return false;
+      }
+    } else {
+      if (!esp32hal->alloc_pins("CANFD", int0_pin, int1_pin)) {
+        return false;
+      }
+    }
 
-    canfd = new ACAN2517FD(cs_pin, SPI2517, int_pin);
+    canfd = new ACAN2517FD(cs_pin, SPI2517, int_pin != GPIO_NUM_NC ? int_pin : 255,
+                           int0_pin != GPIO_NUM_NC ? int0_pin : 255, int1_pin != GPIO_NUM_NC ? int1_pin : 255);
 
     logging.println("CAN FD add-on (ESP32+MCP2517) selected");
     auto bitRate = (int)speed * 1000UL;

--- a/Software/src/devboard/hal/hal.cpp
+++ b/Software/src/devboard/hal/hal.cpp
@@ -1,6 +1,9 @@
 #include "hal.h"
 
 #include <Arduino.h>
+#ifndef UNIT_TEST
+#include <SPI.h>
+#endif
 
 Esp32Hal* esp32hal = nullptr;
 

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -126,6 +126,8 @@ class Esp32Hal {
   virtual gpio_num_t MCP2517_SDO() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_NC; }
+  virtual gpio_num_t MCP2517_INT0() { return GPIO_NUM_NC; }
+  virtual gpio_num_t MCP2517_INT1() { return GPIO_NUM_NC; }
 
   // 2nd CANFD Interface: MCP2517/8
   virtual gpio_num_t MCP2517_CS2() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -54,19 +54,21 @@ class LilyGo2CANHal : public Esp32Hal {
   virtual gpio_num_t RS485_RX_PIN() { return GPIO_NUM_44; }
 
   // Built In MCP2515 CAN_ADDON
-  virtual gpio_num_t MCP2515_SCK() { return GPIO_NUM_12; }
-  virtual gpio_num_t MCP2515_MOSI() { return GPIO_NUM_11; }
-  virtual gpio_num_t MCP2515_MISO() { return GPIO_NUM_13; }
-  virtual gpio_num_t MCP2515_CS() { return GPIO_NUM_10; }
-  virtual gpio_num_t MCP2515_INT() { return GPIO_NUM_8; }
-  virtual gpio_num_t MCP2515_RST() { return GPIO_NUM_9; }
+  virtual gpio_num_t MCP2515_SCK() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_12; }
+  virtual gpio_num_t MCP2515_MOSI() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_11; }
+  virtual gpio_num_t MCP2515_MISO() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_13; }
+  virtual gpio_num_t MCP2515_CS() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_10; }
+  virtual gpio_num_t MCP2515_INT() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_8; }
+  virtual gpio_num_t MCP2515_RST() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_9; }
 
   // CANFD_ADDON defines for MCP2517
-  virtual gpio_num_t MCP2517_SCK() { return GPIO_NUM_38; }
-  virtual gpio_num_t MCP2517_SDI() { return GPIO_NUM_42; }
-  virtual gpio_num_t MCP2517_SDO() { return GPIO_NUM_37; }
-  virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_41; }
-  virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_39; }
+  virtual gpio_num_t MCP2517_SCK() { return is_fd() ? GPIO_NUM_12 : GPIO_NUM_38; }
+  virtual gpio_num_t MCP2517_SDI() { return is_fd() ? GPIO_NUM_11 : GPIO_NUM_42; }
+  virtual gpio_num_t MCP2517_SDO() { return is_fd() ? GPIO_NUM_13 : GPIO_NUM_37; }
+  virtual gpio_num_t MCP2517_CS() { return is_fd() ? GPIO_NUM_10 : GPIO_NUM_41; }
+  virtual gpio_num_t MCP2517_INT() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_39; }
+  virtual gpio_num_t MCP2517_INT0() { return is_fd() ? GPIO_NUM_9 : GPIO_NUM_NC; }
+  virtual gpio_num_t MCP2517_INT1() { return is_fd() ? GPIO_NUM_3 : GPIO_NUM_NC; }
 
   // Contactor handling
   virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_48; }
@@ -150,9 +152,9 @@ class LilyGo2CANHal : public Esp32Hal {
       case comm_interface::CanFdNative:
         return "";
       case comm_interface::CanAddonMcp2515:
-        return "CAN A (MCP2515)";
+        return is_fd() ? "" : "CAN A (MCP2515)";
       case comm_interface::CanFdAddonMcp2518:
-        return "CAN FD (MCP2518 add-on)";
+        return is_fd() ? "CAN FD A (MCP2518)" : "CAN FD (MCP2518 add-on)";
       case comm_interface::Modbus:
         return "Modbus (Add-on)";
       case comm_interface::RS485:
@@ -162,6 +164,71 @@ class LilyGo2CANHal : public Esp32Hal {
       default:
         return Esp32Hal::name_for_comm_interface(comm);
     }
+  }
+
+  bool is_fd() {
+    // Return true if this is the MCP2518FD variant of the T-2CAN.
+    // Takes 2ms on first call, will be fast thereafter.
+
+    if (have_detected) {
+      return has_mcp2518fd;
+    }
+
+    has_mcp2518fd = detect_fd();
+    have_detected = true;
+    return has_mcp2518fd;
+  }
+
+ private:
+  bool have_detected = false;
+  bool has_mcp2518fd = false;
+
+  bool detect_fd() {
+    // Detect whether this is the T-2CAN with MCP2515 (non-FD) or MCP2518FD (FD)
+    // by assuming it is a MCP2515, attempting to reset and reading CANSTAT.
+
+    const int IO9 = GPIO_NUM_9;
+    const int CS = GPIO_NUM_10;
+    const int MISO = GPIO_NUM_13;
+    const int MOSI = GPIO_NUM_11;
+    const int SCK = GPIO_NUM_12;
+
+    pinMode(IO9, INPUT_PULLDOWN);        // Reset (if MCP2515)
+    vTaskDelay(1 / portTICK_PERIOD_MS);  // Wait for reset
+    pinMode(IO9, INPUT_PULLUP);          // Deassert reset
+
+    pinMode(CS, OUTPUT);
+    digitalWrite(CS, HIGH);              // Ensure CS is high to start with
+    vTaskDelay(1 / portTICK_PERIOD_MS);  // Wait for chip to settle
+
+    SPISettings _settings(100000, MSBFIRST, SPI_MODE0);
+    SPIClass _spi(HSPI);
+    _spi.begin(SCK, MISO, MOSI);
+
+    // Read MCP2515 CANSTAT register
+    const uint8_t tx_data[] = {0x03, 0x0E, 0x00};
+    uint8_t rx_data[3] = {0};
+
+    _spi.beginTransaction(_settings);
+    digitalWrite(CS, LOW);
+    _spi.transferBytes(tx_data, rx_data, 3);
+    digitalWrite(CS, HIGH);
+    _spi.endTransaction();
+
+    pinMode(CS, INPUT);  // Set CS back to high impedance
+
+    _spi.end();
+
+    // MCP2515 will return 0x80, MCP2518FD will return something else.
+    bool detected_fd = rx_data[2] != 0x80;
+
+    if (detected_fd) {
+      logging.printf("2CAN FD detected (ret=%d)\n", rx_data[2]);
+    } else {
+      logging.printf("2CAN non-FD detected (ret=%d)\n", rx_data[2]);
+    }
+
+    return detected_fd;
   }
 };
 

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
@@ -201,11 +201,15 @@ static inline void turnOnInterrupts() {
 
 ACAN2517FD::ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                         SPIClass & inSPI, // Hardware SPI object
-                        const uint8_t inINT) : // INT output of MCP2517FD
+                        const uint8_t inINT, // INT output of MCP2517FD
+                        const uint8_t inINT0,
+                        const uint8_t inINT1) :
 mSPISettings (),
 mSPI (inSPI),
 mCS (inCS),
 mINT (inINT),
+mINT0 (inINT0),
+mINT1 (inINT1),
 mUsesTXQ (false),
 mHardwareTxFIFOFull (false),
 mRxInterruptEnabled (true),
@@ -252,12 +256,18 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
   if ((mINT != 255) && (itPin == NOT_AN_INTERRUPT)) {
     errorCode = kINTPinIsNotAnInterrupt ;
   }
+  const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
+  const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
+  if((mINT0 != 255 && itPin0 == NOT_AN_INTERRUPT) || (mINT1 != 255 && itPin1 == NOT_AN_INTERRUPT)) {
+    errorCode = kINTPinIsNotAnInterrupt ;
+  }
+
 //----------------------------------- Check interrupt service routine is not null
-  if ((mINT != 255) && (inInterruptServiceRoutine == NULL)) {
+  if ((mINT != 255 || mINT0 != 255 || mINT1 != 255) && (inInterruptServiceRoutine == NULL)) {
     errorCode |= kISRIsNull ;
   }
 //----------------------------------- Check consistency between ISR and INT pin
-  if ((mINT == 255) && (inInterruptServiceRoutine != NULL)) {
+  if ((mINT == 255) && (mINT0 == 255) && (mINT1 == 255) && (inInterruptServiceRoutine != NULL)) {
     errorCode |= kISRNotNullAndNoIntPin ;
   }
 //----------------------------------- Check TXQ size is <= 32
@@ -303,6 +313,12 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
   if (errorCode == 0) {
     if (mINT != 255) { // 255 means interrupt is not used (thanks to Tyler Lewis)
       pinMode (mINT, INPUT_PULLUP) ;
+    }
+    if (mINT0 != 255) {
+      pinMode (mINT0, INPUT_PULLUP) ;
+    }
+    if (mINT1 != 255) {
+      pinMode (mINT1, INPUT_PULLUP) ;
     }
     initCS () ;
   //----------------------------------- Set SPI clock to 800 kHz
@@ -405,6 +421,12 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
     }
     if (inSettings.mINTIsOpenDrain) {
       data8 |= 1 << 6 ; // INTOD
+    }
+    if (mINT0 != 255) {
+      data8 &= ~(1 << 0) ; // PM0
+    }
+    if (mINT1 != 255) {
+      data8 &= ~(1 << 1) ; // PM1
     }
     writeRegister8 (IOCON_REGISTER_24_31, data8) ; // DS20005688B, page 24
   //----------------------------------- Configure ISO CRC Enable bit
@@ -540,6 +562,15 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
         attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ; // Thank to Flole998
         mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
       #endif
+    } else if( mINT0 != 255 && mINT1 != 255 ) {
+      const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
+      const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
+      #ifdef ARDUINO_ARCH_ESP32
+        attachInterrupt (itPin0, inInterruptServiceRoutine, FALLING) ;
+        attachInterrupt (itPin1, inInterruptServiceRoutine, FALLING) ;
+      #else
+        #error Unsupported
+      #endif
     }
   // If you begin() multiple times without constructor,
   // mHardwareTxFIFOFull = true will block the transmitter.
@@ -561,6 +592,11 @@ bool ACAN2517FD::end (void) {
     if (mINT != 255) { // 255 means interrupt is not used
       const int8_t itPin = digitalPinToInterrupt (mINT) ;
       detachInterrupt (itPin) ; // Available for ESP32 and Arduino
+    } else if( mINT0 != 255 && mINT1 != 255 ) {
+      const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
+      const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
+      detachInterrupt (itPin0) ;
+      detachInterrupt (itPin1) ;
     }
   //--- Request configuration mode
     bool wait = true ;
@@ -802,7 +838,7 @@ bool ACAN2517FD::receive (CANFDMessage & outMessage) {
       turnOffInterrupts () ;
       const bool hasReceivedMessage = mDriverReceiveBuffer.remove (outMessage) ;
     //--- If receive interrupt is disabled, enable it (added in release 2.17)
-      if (mINT == 255) { // No interrupt pin
+      if (mINT == 255 && mINT0 == 255 && mINT1 == 255) { // No interrupt is used
         mRxInterruptEnabled = true ;
         isr_poll_core () ; // Perform polling
       }else if (!mRxInterruptEnabled) {
@@ -999,7 +1035,7 @@ void ACAN2517FD::receiveInterrupt (void) {
 //--- If mDriverReceiveBuffer is full, disable receive interrupt (added in release 2.17)
   if (mDriverReceiveBuffer.isFull ()) {
     mRxInterruptEnabled = false ;
-    if (mINT != 255) {
+    if (mINT != 255 || mINT0 != 255 || mINT1 != 255) {
       uint8_t data8 = readRegister8Assume_SPI_transaction (INT_REGISTER + 2) ;
       data8 &= ~ (1 << 1) ; // Receive FIFO Interrupt disable
       writeRegister8Assume_SPI_transaction (INT_REGISTER + 2, data8) ;

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
@@ -37,7 +37,9 @@ class ACAN2517FD {
 
   public: ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                       SPIClass & inSPI, // Hardware SPI object
-                      const uint8_t inINT) ; // INT output of MCP2517FD
+                      const uint8_t inINT,
+                      const uint8_t inINT0 = 255,
+                      const uint8_t inINT1 = 255);
 
 //······················································································································
 //   begin method (returns 0 if no error)
@@ -144,6 +146,8 @@ class ACAN2517FD {
   private: SPIClass & mSPI ;
   private: const uint8_t mCS ;
   private: const uint8_t mINT ;
+  private: const uint8_t mINT0 ;
+  private: const uint8_t mINT1 ;
   private: bool mUsesTXQ ;
   private: bool mHardwareTxFIFOFull ;
   private: bool mRxInterruptEnabled ; // Added in 2.1.7


### PR DESCRIPTION
### What
LilyGo are now selling the FD variant of the 2CAN:
[https://lilygo.cc/products/t-2can?variant=52597538259125](https://lilygo.cc/products/t-2can?variant=52597538259125)
This code attempts to add support for this board.

### How
Attempts to read MCP2515's CANSTAT register after a reset, which will differ depending on whether it is a MCP2515 or MCP2518FD. (Note: previously tried using GPIO level tricks but this wouldn't have worked).

**The first person to get one of these boards can test this PR and report back on whether it is successful.**

This doesn't currently enable the use of an external MCP2515 on the FD board - I think it would be better to incorporate the BECom dual-FD changes and allow a second MCP2518 on the external pins, to allow 2xFD instead.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
