### PR TITLE
Improvement: Add hysteresis to low heap event

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -26,10 +26,16 @@ battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
 
 void update_machineryprotection() {
+  //Check if we start to get low on memory
+  static uint8_t hysteresisHeapSeconds = 0;
   if (datalayer.system.info.CPU_free_heap < 62000) {
-    set_event(EVENT_LOW_HEAP_MEMORY, (datalayer.system.info.CPU_free_heap / 1000));
+    hysteresisHeapSeconds++;
+    if (hysteresisHeapSeconds > 5) {  //Trigger after X seconds of low heap, to prevent false positives during spikes
+      set_event(EVENT_LOW_HEAP_MEMORY, (datalayer.system.info.CPU_free_heap / 1000));
+    }
   } else {
     clear_event(EVENT_LOW_HEAP_MEMORY);
+    hysteresisHeapSeconds = 0;
   }
 
   // Check health status of CAN interfaces


### PR DESCRIPTION
### What
This PR adds hysteresis to low heap event

### Why
To avoid false positives while reloading the settings page on the webserver. Fixes #2240 

### How
Now we only fire the low heap event if we are running low for more than 5 consecutive seconds

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
