### PR TITLE
Waveshare: add GPIO 1/2 configurable option for status LED or I2C display

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -166,6 +166,9 @@ void init_stored_settings() {
 #ifdef HW_STARK
   user_selected_gpioopt5 = (GPIOOPT5)settings.getUInt("GPIOOPT5", 0);
 #endif
+#ifdef HW_WAVESHARE
+  user_selected_gpioopt6 = (GPIOOPT6)settings.getUInt("GPIOOPT6", 0);
+#endif
 
   precharge_control_enabled = settings.getBool("EXTPRECHARGE", false);
   precharge_inverter_normally_open_contactor = settings.getBool("NOINVDISC", false);

--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -22,7 +22,12 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
   virtual gpio_num_t RS485_SE_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t PIN_5V_EN() { return GPIO_NUM_NC; }
 
-  virtual gpio_num_t LED_PIN() { return GPIO_NUM_NC; }
+  virtual gpio_num_t LED_PIN() {
+    if (user_selected_gpioopt6 == GPIOOPT6::I2C_DISPLAY_SSD1306) {
+      return GPIO_NUM_NC;
+    }
+    return GPIO_NUM_2;
+  }
 
   // Contactor handling
   virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_3; }
@@ -38,8 +43,18 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_9; }
 
   // i2c display
-  virtual gpio_num_t DISPLAY_SDA_PIN() { return GPIO_NUM_1; }
-  virtual gpio_num_t DISPLAY_SCL_PIN() { return GPIO_NUM_2; }
+  virtual gpio_num_t DISPLAY_SDA_PIN() {
+    if (user_selected_gpioopt6 == GPIOOPT6::I2C_DISPLAY_SSD1306) {
+      return GPIO_NUM_1;
+    }
+    return GPIO_NUM_NC;
+  }
+  virtual gpio_num_t DISPLAY_SCL_PIN() {
+    if (user_selected_gpioopt6 == GPIOOPT6::I2C_DISPLAY_SSD1306) {
+      return GPIO_NUM_2;
+    }
+    return GPIO_NUM_NC;
+  }
 
   // CANFD add-on defines for MCP2517
   virtual gpio_num_t MCP2517_SCK() { return GPIO_NUM_10; }

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -28,3 +28,6 @@ GPIOOPT4 user_selected_gpioopt4 = GPIOOPT4::DEFAULT_SD_CARD;
 #ifdef HW_STARK
 GPIOOPT5 user_selected_gpioopt5 = GPIOOPT5::DEFAULT_BMS_POWER_23;
 #endif
+#ifdef HW_WAVESHARE
+GPIOOPT6 user_selected_gpioopt6 = GPIOOPT6::DEFAULT_STATUS_LED;
+#endif

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -160,6 +160,16 @@ enum class GPIOOPT5 {
 };
 extern GPIOOPT5 user_selected_gpioopt5;
 #endif
+#ifdef HW_WAVESHARE
+enum class GPIOOPT6 {
+  // Waveshare: GPIO2 = Status LED (default)
+  DEFAULT_STATUS_LED = 0,
+  // Waveshare: GPIO1 = I2C SDA, GPIO2 = I2C SCL
+  I2C_DISPLAY_SSD1306 = 1,
+  Highest
+};
+extern GPIOOPT6 user_selected_gpioopt6;
+#endif
 extern GPIOOPT2 user_selected_gpioopt2;
 extern GPIOOPT3 user_selected_gpioopt3;
 extern GPIOOPT4 user_selected_gpioopt4;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -193,6 +193,18 @@ const char* name_for_gpioopt5(GPIOOPT5 option) {
   }
 }
 #endif
+#ifdef HW_WAVESHARE
+const char* name_for_gpioopt6(GPIOOPT6 option) {
+  switch (option) {
+    case GPIOOPT6::DEFAULT_STATUS_LED:
+      return "Status LED (GPIO2)";
+    case GPIOOPT6::I2C_DISPLAY_SSD1306:
+      return "I2C Display SSD1306 (GPIO1=SDA, GPIO2=SCL)";
+    default:
+      return nullptr;
+  }
+}
+#endif
 
 // Special unicode characters
 const char* TRUE_CHAR_CODE = "\u2713";   //&#10003";
@@ -319,6 +331,12 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
   if (var == "GPIOOPT5") {
     return options_for_enum_with_none((GPIOOPT5)settings.getUInt("GPIOOPT5", (int)GPIOOPT5::DEFAULT_BMS_POWER_23),
                                       name_for_gpioopt5, GPIOOPT5::DEFAULT_BMS_POWER_23);
+  }
+#endif
+#ifdef HW_WAVESHARE
+  if (var == "GPIOOPT6") {
+    return options_for_enum_with_none((GPIOOPT6)settings.getUInt("GPIOOPT6", (int)GPIOOPT6::DEFAULT_STATUS_LED),
+                                      name_for_gpioopt6, GPIOOPT6::DEFAULT_STATUS_LED);
   }
 #endif
   // All other values are wrapped by html_escape to avoid HTML injection.
@@ -1013,6 +1031,18 @@ const char* getCANInterfaceName(CAN_Interface interface) {
   )rawliteral"
 #else
 #define GPIOOPT5_SETTING ""
+#endif
+
+#ifdef HW_WAVESHARE
+#define GPIOOPT6_SETTING \
+  R"rawliteral(
+    <label for="GPIOOPT6">GPIO 1/2 function:</label>
+    <select id="GPIOOPT6" name="GPIOOPT6">
+      %GPIOOPT6%
+    </select>
+  )rawliteral"
+#else
+#define GPIOOPT6_SETTING ""
 #endif
 
 #define SETTINGS_HTML_SCRIPTS \
@@ -1741,7 +1771,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         )rawliteral" GPIOOPT3_SETTING R"rawliteral(
         )rawliteral" GPIOOPT4_SETTING R"rawliteral(
         )rawliteral" GPIOOPT5_SETTING R"rawliteral(
-          
+        )rawliteral" GPIOOPT6_SETTING R"rawliteral(
+
         </div>
         </div>
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -411,6 +411,7 @@ void init_webserver() {
       "PWMFREQ",    "PWMHOLD",     "GTWCOUNTRY", "GTWMAPREG",   "GTWCHASSIS",  "GTWPACK",   "LEDMODE",     "GPIOOPT1",
       "GPIOOPT2",   "GPIOOPT3",    "INVSUNTYPE", "GPIOOPT4",    "CTVNOM",      "CTANOM",    "CTATTEN",     "PYLONBAUD",
       "PYLONBRAND", "DALYPWRPCT",  "DALYPWRDV",  "DALYDVSTART", "DALYPWRDEG",  "DALYPWR0C", "RAMPDOWNSOC", "GPIOOPT5",
+      "GPIOOPT6",
   };
 
   const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",


### PR DESCRIPTION
### What
Adds a "GPIO 1/2 function" dropdown to the Settings page for the Waveshare ESP32-S3-RS485-CAN board, letting users choose between a status LED or an I2C SSD1306 display on those two pins.  This is situated directly behind the USB C connector.

### Why
GPIO 1 and 2 on the Waveshare board can serve two different purposes — a status LED (GPIO 2) or an I2C display (GPIO 1 = SDA, GPIO 2 = SCL) — but previously the assignment was hard-coded with no way to switch without recompiling. This gives users the flexibility to use whichever hardware they have connected.

### How
Follows the existing GPIOOPT pattern used by other boards (LilyGO2CAN, Stark). Adds a new GPIOOPT6 setting stored in NVM, exposed as a dropdown in the Hardware config section of the Settings page. The Waveshare HAL reads the setting at runtime and returns the appropriate GPIO numbers for LED_PIN, DISPLAY_SDA_PIN, and DISPLAY_SCL_PIN accordingly.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
