### PR TITLE
MG5/ZS/MarvelR fixes

### DIFF
--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -213,7 +213,16 @@ void Mg5Battery::
 }
 
 void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  //datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  // We start polling with UDS ID 0x7DF, the generic broadcast one. Our first
+  // reply will indicate what the BMS-specific one is, which we switch to.
+  if (uds_address == 0x7DF && rx_frame.ID == 0x789) {
+    uds_address = 0x781;
+    logging.println("MG5: Detected UDS address 0x781");
+  } else if (uds_address == 0x7DF && rx_frame.ID == 0x7ED) {
+    uds_address = 0x7E5;
+    logging.println("MG5: Detected UDS address 0x7E5");
+  }
+
   switch (rx_frame.ID) {
     case 0x297: {                                                          //BMS state
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
@@ -351,6 +360,7 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x620:
       break;
+    case 0x7ED:
     case 0x789: {  // response from UDS diagnostic service (ISO-TP)
 
       uint8_t pciByte = rx_frame.data.u8[0];  // 0x10/0x21/etc.
@@ -566,6 +576,7 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
             if (toStore)
               storeUDSPayload(&rx_frame.data.u8[2], toStore);
 
+            MG5_781_RQ_CONTINUE_MULTIFRAME.ID = uds_address;
             transmit_can_frame(&MG5_781_RQ_CONTINUE_MULTIFRAME);
             uds_timeout_ms = UDS_TIMEOUT_AFTER_FF_MS;  // extend while MF running
           }
@@ -583,6 +594,7 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
           gUDSContext.receivedInBatch++;
           if (gUDSContext.receivedInBatch == 3) {
+            MG5_781_RQ_CONTINUE_MULTIFRAME.ID = uds_address;
             transmit_can_frame(&MG5_781_RQ_CONTINUE_MULTIFRAME);
             gUDSContext.receivedInBatch = 0;
           }
@@ -682,6 +694,7 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
 
   if (uds_tx_in_flight == false) {     // No UDS transaction is in progress
     if (userRequestReadDTC == true) {  // DTC requested by user
+        MG5_781_RQ_DTCs.ID = uds_address;
       transmit_can_frame(&MG5_781_RQ_DTCs);
       uds_tx_in_flight = true;                    //singal that a UDS transaction is in progress
       uds_req_started_ms = currentMillis;         //timestamp when request was sent for timeout tracking
@@ -690,6 +703,7 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
 
     } else {
       if (userRequestClearDTC == true) {  // Clear DTC requested by user
+          MG5_781_CLEAR_DTCs.ID = uds_address;
         transmit_can_frame(&MG5_781_CLEAR_DTCs);
         uds_tx_in_flight = true;                    //singal that a UDS transaction is in progress
         uds_req_started_ms = currentMillis;         //timestamp when request was sent for timeout tracking
@@ -701,6 +715,7 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
           previousMillisPID = currentMillis;
           // normal single-frame poll round-robin
           uds_slow_req_id_counter = increment_uds_req_id_counter(uds_slow_req_id_counter, numSlowUDSreqs);
+            UDS_REQUESTS_SLOW[uds_slow_req_id_counter]->ID = uds_address;
           transmit_can_frame(UDS_REQUESTS_SLOW[uds_slow_req_id_counter]);
           uds_tx_in_flight = true;
           uds_req_started_ms = currentMillis;
@@ -712,6 +727,7 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
     // Timeout / retry Session Control ------------------------------------
     if ((currentMillis - uds_req_started_ms) > uds_timeout_ms) {
       // re-enter Extended Session
+        MG5_781_ses_ctrl.ID = uds_address;
       transmit_can_frame(&MG5_781_ses_ctrl);
       uds_tx_in_flight = true;
       uds_req_started_ms = currentMillis;

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -223,6 +223,8 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
     logging.println("MG5: Detected UDS address 0x7E5");
   }
 
+  uint32_t v, i;
+
   switch (rx_frame.ID) {
     case 0x297: {                                                          //BMS state
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;  // Let system know battery is sending CAN
@@ -312,15 +314,17 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if ((((rx_frame.data.u8[4] & 0x0F) << 8) | rx_frame.data.u8[5]) != 0) {
         // 3AC message contains a nonzero voltage (so must have come from PTCAN)
 
-        // battery voltage
+        // Battery voltage
         v = (((rx_frame.data.u8[4] & 0x0F) << 8) | rx_frame.data.u8[5]);
-        if (v > 0 && v < 4000) {
-          datalayer.battery.status.voltage_dV = v * 2.5;
-        }
         // Current
-        v = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);
-        if (v > 0 && v < 0xf000) {
-          datalayer.battery.status.current_dA = -(v - 20000) * 0.5;
+        i = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);
+
+        if (v > 0 && v < 2400 && i > 16000 && i < 24000) {
+          // 3AC message contains a credible voltage and current (so must have come from PTCAN)
+          // (voltage between 0 and 600V, current between -200A and +200A)
+
+          datalayer.battery.status.voltage_dV = (v * 5) / 2;
+          datalayer.battery.status.current_dA = -(i - 20000) / 2;
         }
 
         // SOC

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -651,14 +651,14 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
 }
 
 void Mg5Battery::transmit_can(unsigned long currentMillis) {
-  //Send 10ms message
-  if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
-    previousMillis10 = currentMillis;
+  static int8_t send_phase = -1;
+  if (++send_phase > 3) {
+    send_phase = 0;
   }
 
-  // Send 100ms CAN Message
-  if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
-    previousMillis100 = currentMillis;
+  // Send 10ms CAN Message
+  if (currentMillis - previousMillis10 >= INTERVAL_10_MS && send_phase == 0) {
+    previousMillis10 = currentMillis;
 
     if (datalayer.system.status.system_status != FAULT                // Fault, so open contactors!
         && userRequestContactorClose == true                          // User requested contactor closing
@@ -666,6 +666,15 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
     ) {
       MG5_8A.data.u8[5] = 0x02;  // Command to close contactors
       //logging.println("contactor close command sent");
+
+      if (warmupCounter < 110) {
+        // Keep the 1 asserted for 110 messages
+        MG5_8A.data.u8[6] = 0x10 | eightAcycle;
+        warmupCounter++;
+      } else {
+        MG5_8A.data.u8[6] = 0x30 | eightAcycle;
+      }
+
       if (contactorClosed == false) {
         // Just changed to closed
         contactorClosed = true;
@@ -675,13 +684,24 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
       }
     } else {
       contactorClosed = false;
+      warmupCounter = 0;
       MG5_8A.data.u8[5] = 0x00;  // Command to open contactors
       //userRequestClearDTC = true; //clear DTCs to be able to close the contactors afterwards
       //logging.println("conctactor open command sent");
+
+      MG5_8A.data.u8[6] = 0x10 | eightAcycle;
     }
 
-    transmit_can_frame(&MG5_1F1);
+    MG5_8A.data.u8[7] = (MG5_8A.data.u8[0] ^ MG5_8A.data.u8[1] ^ MG5_8A.data.u8[2] ^ MG5_8A.data.u8[3] ^
+                         MG5_8A.data.u8[4] ^ MG5_8A.data.u8[5] ^ MG5_8A.data.u8[6]);
+    eightAcycle = (eightAcycle + 1) & 0xF;
+
     transmit_can_frame(&MG5_8A);
+  }
+
+  if (currentMillis - previousMillis20 >= INTERVAL_20_MS && send_phase == 1) {
+    previousMillis20 = currentMillis;
+    transmit_can_frame(&MG5_1F1);
   }
 
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
@@ -696,46 +716,48 @@ void Mg5Battery::transmit_can(unsigned long currentMillis) {
     previousMillis2000 = currentMillis;
   }
 
-  if (uds_tx_in_flight == false) {     // No UDS transaction is in progress
-    if (userRequestReadDTC == true) {  // DTC requested by user
+  if (send_phase == 2) {
+    if (uds_tx_in_flight == false) {     // No UDS transaction is in progress
+      if (userRequestReadDTC == true) {  // DTC requested by user
         MG5_781_RQ_DTCs.ID = uds_address;
-      transmit_can_frame(&MG5_781_RQ_DTCs);
-      uds_tx_in_flight = true;                    //singal that a UDS transaction is in progress
-      uds_req_started_ms = currentMillis;         //timestamp when request was sent for timeout tracking
-      uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;  //increase timeout for multi-frame response
-      logging.println("UDS DTC RQ sent");
-
-    } else {
-      if (userRequestClearDTC == true) {  // Clear DTC requested by user
-          MG5_781_CLEAR_DTCs.ID = uds_address;
-        transmit_can_frame(&MG5_781_CLEAR_DTCs);
+        transmit_can_frame(&MG5_781_RQ_DTCs);
         uds_tx_in_flight = true;                    //singal that a UDS transaction is in progress
         uds_req_started_ms = currentMillis;         //timestamp when request was sent for timeout tracking
         uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;  //increase timeout for multi-frame response
-        logging.println("UDS Clear DTC RQ sent");
+        logging.println("UDS DTC RQ sent");
+
       } else {
-        // Time to send next PID request, DTC has priority since it is slower
-        if (currentMillis - previousMillisPID >= UDS_PID_REFRESH_MS) {
-          previousMillisPID = currentMillis;
-          // normal single-frame poll round-robin
-          uds_slow_req_id_counter = increment_uds_req_id_counter(uds_slow_req_id_counter, numSlowUDSreqs);
+        if (userRequestClearDTC == true) {  // Clear DTC requested by user
+          MG5_781_CLEAR_DTCs.ID = uds_address;
+          transmit_can_frame(&MG5_781_CLEAR_DTCs);
+          uds_tx_in_flight = true;                    //singal that a UDS transaction is in progress
+          uds_req_started_ms = currentMillis;         //timestamp when request was sent for timeout tracking
+          uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;  //increase timeout for multi-frame response
+          logging.println("UDS Clear DTC RQ sent");
+        } else {
+          // Time to send next PID request, DTC has priority since it is slower
+          if (currentMillis - previousMillisPID >= UDS_PID_REFRESH_MS) {
+            previousMillisPID = currentMillis;
+            // normal single-frame poll round-robin
+            uds_slow_req_id_counter = increment_uds_req_id_counter(uds_slow_req_id_counter, numSlowUDSreqs);
             UDS_REQUESTS_SLOW[uds_slow_req_id_counter]->ID = uds_address;
-          transmit_can_frame(UDS_REQUESTS_SLOW[uds_slow_req_id_counter]);
-          uds_tx_in_flight = true;
-          uds_req_started_ms = currentMillis;
-          uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;
+            transmit_can_frame(UDS_REQUESTS_SLOW[uds_slow_req_id_counter]);
+            uds_tx_in_flight = true;
+            uds_req_started_ms = currentMillis;
+            uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;
+          }
         }
       }
-    }
-  } else {  // UDS transaction in progress
-    // Timeout / retry Session Control ------------------------------------
-    if ((currentMillis - uds_req_started_ms) > uds_timeout_ms) {
-      // re-enter Extended Session
+    } else {  // UDS transaction in progress
+      // Timeout / retry Session Control ------------------------------------
+      if ((currentMillis - uds_req_started_ms) > uds_timeout_ms) {
+        // re-enter Extended Session
         MG5_781_ses_ctrl.ID = uds_address;
-      transmit_can_frame(&MG5_781_ses_ctrl);
-      uds_tx_in_flight = true;
-      uds_req_started_ms = currentMillis;
-      uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;
+        transmit_can_frame(&MG5_781_ses_ctrl);
+        uds_tx_in_flight = true;
+        uds_req_started_ms = currentMillis;
+        uds_timeout_ms = UDS_TIMEOUT_BEFORE_FF_MS;
+      }
     }
   }
 }

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -49,7 +49,6 @@ class Mg5Battery : public CanBattery {
 
   uint16_t soc = 0;
   uint16_t cell_id = 0;
-  uint16_t v = 0;
   uint16_t cellVoltageValidTime = 0;
   static const uint8_t CELL_VOLTAGE_TIMEOUT = 10;  // in seconds
 

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -35,6 +35,7 @@ class Mg5Battery : public CanBattery {
   static const int TOTAL_BATTERY_CAPACITY_WH = 52500;  // 52.5 kWh
 
   unsigned long previousMillis10 = 0;   // will store last time a 10ms CAN Message was send
+  unsigned long previousMillis20 = 0;   // will store last time a 20ms CAN Message was send
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis200 = 0;
   unsigned long previousMillis1000 = 0;
@@ -54,6 +55,8 @@ class Mg5Battery : public CanBattery {
 
   uint8_t transmitIndex = 0;  //For polling switchcase
   uint8_t previousState = 0;
+  uint8_t eightAcycle = 0;
+  uint8_t warmupCounter = 0;
 
   const int MaxChargePower = 11000;  // Maximum allowable charge power for the battery cells, excluding the taper,
   const int StartChargeTaper = 90;   // Battery percentage above which the charge power will taper to zero
@@ -258,7 +261,7 @@ class Mg5Battery : public CanBattery {
                        .ext_ID = false,
                        .DLC = 8,
                        .ID = 0x1F1,
-                       .data = {0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                       .data = {0x0E, 0x00, 0x00, 0x00, 0x08, 0x72, 0x00, 0x00}};
 
   //Setup Fast UDS values to poll for
   //CAN_frame* UDS_REQUESTS_FAST[0] = {};

--- a/Software/src/battery/MG-5-BATTERY.h
+++ b/Software/src/battery/MG-5-BATTERY.h
@@ -67,6 +67,8 @@ class Mg5Battery : public CanBattery {
   const int StartDischargeTaper = 10;      // Battery percentage below which the discharge power will taper to zero
   const float DischargeTaperExponent = 1;  // Shape of discharge power taper to zero. 1 is linear. >1 red
 
+  uint16_t uds_address = 0x7DF;
+
   // poll counters
   int uds_slow_req_id_counter = -1;
 


### PR DESCRIPTION
### What
This PR makes some tweaks to the MG5 integration:

- Adds UDS autodetection (to support some ZS/MarvelR batteries)
- Filters out some erroneous voltage/current frames
- Simulates the 8A 'warmup' process better, adds rolling counter and checksums
- More data in 1F1

### Why
Should resolve some of the issues people are having due to strange differences between MG5 packs across the range.

The plan is still to replace all the MG integrations with a slimmer one (to also allow MG5 to go in the T-CAN485 build) but that isn't finished yet.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
