### PR TITLE
Ford: Improve scaling of values in more battery info page

### DIFF
--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -24,7 +24,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     if (datalayer_extended.fordMachE.pid_hvb_voltage == 255) {
       content += "N/A</h4>";
     } else {
-      content += " " + String(datalayer_extended.fordMachE.pid_hvb_voltage) + " mV </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_voltage / 100.0, 2) + " V </h4>";
     }
 
     content += "<h4>State of health:";
@@ -38,7 +38,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     if (datalayer_extended.fordMachE.pid_hvb_soc == 255) {
       content += "N/A</h4>";
     } else {
-      content += " " + String(datalayer_extended.fordMachE.pid_hvb_soc) + " % </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_soc / 1000.0, 3) + " % </h4>";
     }
 
     content += "<h4>Contactor status:";
@@ -52,7 +52,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
       } else if (datalayer_extended.fordMachE.pid_hvb_contactor_status == 0x00000400) {
         content += "Interlock OPEN!</h4>";
       } else {
-        content += "Unknown" + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
+        content += "Unknown enumeration: " + String(datalayer_extended.fordMachE.pid_hvb_contactor_status) + "</h4>";
       }
     }
 
@@ -118,7 +118,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     if (datalayer_extended.fordMachE.pid_battery_capacity_ah == 255) {
       content += "N/A</h4>";
     } else {
-      content += " " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah) + " AH+1 </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_battery_capacity_ah / 10.0, 1) + " Ah </h4>";
     }
 
     content += "<h4>Maintenance rebalance status:";
@@ -138,7 +138,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     if (datalayer_extended.fordMachE.pid_hvb_calendar_age_months == 255) {
       content += "N/A</h4>";
     } else {
-      content += " " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months) + " </h4>";
+      content += " " + String(datalayer_extended.fordMachE.pid_hvb_calendar_age_months / 100.0, 0) + " Months </h4>";
     }
     return content;
   }

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -127,6 +127,8 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x04) {
         content += " Initializing</h4>";
+      } else if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x01) {
+        content += " In progress</h4>";
       } else if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x02) {
         content += " Successfully</h4>";
       } else {

--- a/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY-HTML.h
@@ -127,7 +127,7 @@ class FordMachEHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x04) {
         content += " Initializing</h4>";
-      } else if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x03) {
+      } else if (datalayer_extended.fordMachE.pid_maintenance_rebalance_status == 0x02) {
         content += " Successfully</h4>";
       } else {
         content += " " + String(datalayer_extended.fordMachE.pid_maintenance_rebalance_status) + "</h4>";

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -305,7 +305,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           polled_12V = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
           break;
         case PID_HVB_TEMP:
-          pid_hvb_temp = rx_frame.data.u8[4] - 40;
+          pid_hvb_temp = rx_frame.data.u8[4] - 50;
           break;
         case PID_HVB_SOC:
           pid_hvb_soc = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) * 2;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -389,7 +389,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case PID_ENGINE_RUNTIME:
           break;
         case PID_HVB_CALENDAR_AGE_MONTHS:
-          pid_hvb_calendar_age_months = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          pid_hvb_calendar_age_months = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 2;
           break;
         case PID_BATTERY_CAPACITY:
           pid_battery_capacity_ah = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -232,12 +232,12 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
 
       //Celltemperatures
-      cell_temperature[0] = ((rx_frame.data.u8[2] - 40) / 2);
-      cell_temperature[1] = ((rx_frame.data.u8[3] - 40) / 2);
-      cell_temperature[2] = ((rx_frame.data.u8[4] - 40) / 2);
-      cell_temperature[3] = ((rx_frame.data.u8[5] - 40) / 2);
-      cell_temperature[4] = ((rx_frame.data.u8[6] - 40) / 2);
-      cell_temperature[5] = ((rx_frame.data.u8[7] - 40) / 2);
+      cell_temperature[0] = ((rx_frame.data.u8[2] - 30) / 2);
+      cell_temperature[1] = ((rx_frame.data.u8[3] - 30) / 2);
+      cell_temperature[2] = ((rx_frame.data.u8[4] - 30) / 2);
+      cell_temperature[3] = ((rx_frame.data.u8[5] - 30) / 2);
+      cell_temperature[4] = ((rx_frame.data.u8[6] - 30) / 2);
+      cell_temperature[5] = ((rx_frame.data.u8[7] - 30) / 2);
       break;
     case 0x4a4:  //1s
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -151,6 +151,7 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x24c:  //100ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_soc = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
+      display_soc = rx_frame.data.u8[6] / 2;
       break;
     case 0x24d:  //100ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -72,6 +72,8 @@ class FordMachEBattery : public CanBattery {
 
   uint16_t polled_12V = 12000;
 
+  uint8_t display_soc = 0;
+
   static const uint8_t NOT_SAMPLED_YET = 255;
   // BECM Module PID Definitions
   static const uint16_t PID_HVB_TEMP = 0x4800;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -223,7 +223,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
   uint8_t pid_time = NOT_SAMPLED_YET;
   uint8_t pid_lores_odometer = NOT_SAMPLED_YET;
   uint8_t pid_engine_runtime = NOT_SAMPLED_YET;
-  uint8_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;  //Could be max module voltage PID?
+  uint16_t pid_hvb_calendar_age_months = NOT_SAMPLED_YET;
   uint16_t pid_battery_capacity_ah = NOT_SAMPLED_YET;
   uint8_t pid_maintenance_rebalance_status = NOT_SAMPLED_YET;
 

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -425,7 +425,7 @@ struct DATALAYER_INFO_FORD_MACH_E {
   uint16_t pid_hvb_contactor_open_leak_resistance = 0;
   uint8_t pid_hvb_soh = 0;
   uint16_t pid_hvb_voltage = 0;
-  uint8_t pid_hvb_calendar_age_months = 0;
+  uint16_t pid_hvb_calendar_age_months = 0;
   uint16_t pid_battery_capacity_ah = 0;
   uint8_t pid_maintenance_rebalance_status = 0;
 };


### PR DESCRIPTION
### What
This PR implements ...

### Why
Why does it do it?

### How
- Total pack voltage shown as Voltage with two decimals, instead of mV
- SOC shows with 3 decimals, instead of pptt
- Unknown enumeration of contactor expanded
- Calendar age in months now sampled correctly

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
