### PR TITLE
Waveshare: Add MEB precharge pins to HAL

### DIFF
--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -42,6 +42,10 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_8; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_9; }
 
+  // Automatic precharging
+  virtual gpio_num_t HIA4V1_PIN() { return GPIO_NUM_5; }
+  virtual gpio_num_t INVERTER_DISCONNECT_CONTACTOR_PIN() { return GPIO_NUM_3; }
+
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {
     if (user_selected_gpioopt6 == GPIOOPT6::I2C_DISPLAY_SSD1306) {


### PR DESCRIPTION
### What
This PR implements precharge pins to HAL for Waveshare

### Why
Fixes #2420 

### How
- HIA4V1_PIN = 5
- INVERTER_DISCONNECT_CONTACTOR_PIN = 3

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
