### PR TITLE
Bugfix: CANFD restart not work

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -454,7 +454,6 @@ void stop_can() {
 
   if (canfd) {
     canfd->end();
-    SPI2517.end();
   }
 }
 
@@ -468,8 +467,8 @@ void restart_can() {
   }
 
   if (canfd) {
-    SPI2517.begin();
     canfd->begin(*settings2517, [] { canfd->isr(); });
+    canfd->poll();
   }
 }
 


### PR DESCRIPTION
The SPI driver doesn't need to be reinitialized on stop_can() and restart_can().

### What
This fixes the CANFD resume.

### Why
SPI bus configuration was lost.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
