### PR TITLE
Feature: Extend BYD Atto3 auto-cal and diagnostics to second battery

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -653,10 +653,10 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
                                      0x2E,
                                      0x1F,
                                      0xFC,
-                                     (uint8_t)(datalayer_extended.bydAtto3.calibrationTargetSOC * 100),
-                                     (uint8_t)((datalayer_extended.bydAtto3.calibrationTargetSOC * 100) >> 8),
-                                     (uint8_t)(datalayer_extended.bydAtto3.calibrationTargetAH * 100),
-                                     (uint8_t)((datalayer_extended.bydAtto3.calibrationTargetAH * 100) >> 8)};
+                                     (uint8_t)(datalayer_bydatto->calibrationTargetSOC * 100),
+                                     (uint8_t)((datalayer_bydatto->calibrationTargetSOC * 100) >> 8),
+                                     (uint8_t)(datalayer_bydatto->calibrationTargetAH * 100),
+                                     (uint8_t)((datalayer_bydatto->calibrationTargetAH * 100) >> 8)};
         transmit_can_frame(&ATTO_3_7E7_RESET_SOC);
         stateMachineCalibrateSOC = NOT_RUNNING;
         break;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -11,7 +11,7 @@ class BydAttoBattery : public CanBattery {
  public:
   // Use this constructor for the second battery.
   BydAttoBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_BYDATTO3* extended, CAN_Interface targetCan)
-      : CanBattery(targetCan), renderer(extended) {
+      : CanBattery(targetCan), renderer(extended, "2") {
     datalayer_battery = datalayer_ptr;
     datalayer_bydatto = extended;
     allows_contactor_closing = nullptr;

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -139,7 +139,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += " onchange='toggleAutoCalSOCEnabled" + s + "()'> (default ON)</h4>";
     content += "<h4>Auto-calibrate trigger drift: <input type='number' id='driftPercent" + s + "' value='";
     content += String(byd_datalayer->auto_calibrate_soc_drift_percent);
-    content += "' min='1' max='20'> &percnt; <button onclick='setAutoCalDriftPercent" + s + "()'>Save Drift &percnt;</button></h4>";
+    content += "' min='1' max='20'> &percnt; <button onclick='setAutoCalDriftPercent" + s +
+               "()'>Save Drift &percnt;</button></h4>";
 
     // Auto-calibration live status panel
     {

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -7,68 +7,13 @@
 
 class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
  public:
-  BydAtto3HtmlRenderer(DATALAYER_INFO_BYDATTO3* dl) : byd_datalayer(dl) {}
+  BydAtto3HtmlRenderer(DATALAYER_INFO_BYDATTO3* dl, const String& sfx = "") : byd_datalayer(dl), s(sfx) {}
 
   String get_status_html() {
     String content;
 
-    content += "<script>";
-    content += "function editComplete() {";
-    content += "  alert('Update successful!');";
-    content += "  setTimeout(function() { location.reload(); }, 1000);";
-    content += "}";
-    content += "function editError() {";
-    content += "  alert('Update failed. Please try again.');";
-    content += "}";
-    content += "function editCalTargetSOC(){";
-    content += "  var value=prompt('Enter calibration target SOC (0 to 100):');";
-    content += "  if(value!==null){";
-    content += "    var numValue=parseFloat(value);";
-    content += "    if(!isNaN(numValue) && numValue>=0 && numValue<=100){";
-    content += "      var xhr=new XMLHttpRequest();";
-    content += "      xhr.onload=editComplete;";
-    content += "      xhr.onerror=editError;";
-    content += "      xhr.open('GET','/editCalTargetSOC?value='+numValue,true);";
-    content += "      xhr.send();";
-    content += "    }else{";
-    content += "      alert('Invalid value. Please enter a value between 0 and 100.');";
-    content += "    }";
-    content += "  }";
-    content += "}";
-    content += "function editCalTargetAH(){";
-    content += "  var value=prompt('Enter calibration target AH:');";
-    content += "  if(value!==null){";
-    content += "    var numValue=parseFloat(value);";
-    content += "    if(!isNaN(numValue) && numValue>0){";
-    content += "      var xhr=new XMLHttpRequest();";
-    content += "      xhr.onload=editComplete;";
-    content += "      xhr.onerror=editError;";
-    content += "      xhr.open('GET','/editCalTargetAH?value='+numValue,true);";
-    content += "      xhr.send();";
-    content += "    }else{";
-    content += "      alert('Invalid value. Please enter a positive number.');";
-    content += "    }";
-    content += "  }";
-    content += "}";
-    content += "function toggleAutoCalSOCEnabled(){";
-    content += "  var enabled = document.getElementById('autoCalEnabled').checked ? 1 : 0;";
-    content += "  var xhr=new XMLHttpRequest();";
-    content += "  xhr.onload=editComplete;";
-    content += "  xhr.onerror=editError;";
-    content += "  xhr.open('GET','/editBydAtto3AutoCalEnabled?value='+enabled,true);";
-    content += "  xhr.send();";
-    content += "}";
-    content += "function setAutoCalDriftPercent(){";
-    content += "  var percent = document.getElementById('driftPercent').value;";
-    content += "  var xhr=new XMLHttpRequest();";
-    content += "  xhr.onload=editComplete;";
-    content += "  xhr.onerror=editError;";
-    content += "  xhr.open('GET','/editBydAtto3AutoCalDriftPercent?value='+percent,true);";
-    content += "  xhr.send();";
-    content += "}";
-    content += "</script>";
-
-    content += "<h4>Detected cells: " + String(datalayer.battery.info.number_of_cells) + "</h4>";
+    const auto& dl_bat = s.length() ? datalayer.battery2 : datalayer.battery;
+    content += "<h4>Detected cells: " + String(dl_bat.info.number_of_cells) + "</h4>";
     content += "<h4>Charging battery state: ";
     switch (byd_datalayer->discharge_status) {
       case 0:
@@ -189,12 +134,12 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>SOC original: " + String(byd_datalayer->BMC_SOC_original_calibration) + "&percnt;</h4>";
     content += "<h4>SOC current: " + String(byd_datalayer->BMC_SOC_current_calibration) + "&percnt;</h4>";
 
-    content += "<h4>Auto-calibrate SOC to 100% when full: <input type='checkbox' id='autoCalEnabled' ";
+    content += "<h4>Auto-calibrate SOC to 100&percnt; when full: <input type='checkbox' id='autoCalEnabled" + s + "' ";
     content += (byd_datalayer->auto_calibrate_soc_enabled ? "checked" : "");
-    content += " onchange='toggleAutoCalSOCEnabled()'> (default ON)</h4>";
-    content += "<h4>Auto-calibrate trigger drift: <input type='number' id='driftPercent' value='";
+    content += " onchange='toggleAutoCalSOCEnabled" + s + "()'> (default ON)</h4>";
+    content += "<h4>Auto-calibrate trigger drift: <input type='number' id='driftPercent" + s + "' value='";
     content += String(byd_datalayer->auto_calibrate_soc_drift_percent);
-    content += "' min='1' max='20'> % <button onclick='setAutoCalDriftPercent()'>Save Drift %</button></h4>";
+    content += "' min='1' max='20'> &percnt; <button onclick='setAutoCalDriftPercent" + s + "()'>Save Drift &percnt;</button></h4>";
 
     // Auto-calibration live status panel
     {
@@ -268,8 +213,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
       content += "SOC drift:</td>";
       content += value_td;
       content += byd_datalayer->autocal_crit_drift ? "<span style='color:#3fb950'>" : "";
-      content += String(byd_datalayer->autocal_drift_percent, 1) + "% / threshold " +
-                 String(byd_datalayer->auto_calibrate_soc_drift_percent) + "%";
+      content += String(byd_datalayer->autocal_drift_percent, 1) + "&percnt; / threshold " +
+                 String(byd_datalayer->auto_calibrate_soc_drift_percent) + "&percnt;";
       content += byd_datalayer->autocal_crit_drift ? "</span>" : "";
       content += "</td></tr>";
 
@@ -286,16 +231,72 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     }
 
     content += "<h4>Calibration target SOC: " + String(byd_datalayer->calibrationTargetSOC) +
-               "&percnt;"
-               " </span><button onclick='editCalTargetSOC()'>Edit</button></h4>";
+               "&percnt; <button onclick='editCalTargetSOC" + s + "()'>Edit</button></h4>";
     content += "<h4>Calibration target capacity: " + String(byd_datalayer->calibrationTargetAH) +
-               " AH</span><button onclick='editCalTargetAH()'>Edit</button></h4>";
+               " AH <button onclick='editCalTargetAH" + s + "()'>Edit</button></h4>";
+
+    content += "<script>";
+    content += "function editComplete() {";
+    content += "  alert('Update successful!');";
+    content += "  setTimeout(function() { location.reload(); }, 1000);";
+    content += "}";
+    content += "function editError() {";
+    content += "  alert('Update failed. Please try again.');";
+    content += "}";
+    content += "function editCalTargetSOC" + s + "(){";
+    content += "  var value=prompt('Enter calibration target SOC (0 to 100):');";
+    content += "  if(value!==null){";
+    content += "    var numValue=parseFloat(value);";
+    content += "    if(!isNaN(numValue) && numValue>=0 && numValue<=100){";
+    content += "      var xhr=new XMLHttpRequest();";
+    content += "      xhr.onload=editComplete;";
+    content += "      xhr.onerror=editError;";
+    content += "      xhr.open('GET','/editCalTargetSOC" + s + "?value='+numValue,true);";
+    content += "      xhr.send();";
+    content += "    }else{";
+    content += "      alert('Invalid value. Please enter a value between 0 and 100.');";
+    content += "    }";
+    content += "  }";
+    content += "}";
+    content += "function editCalTargetAH" + s + "(){";
+    content += "  var value=prompt('Enter calibration target AH:');";
+    content += "  if(value!==null){";
+    content += "    var numValue=parseFloat(value);";
+    content += "    if(!isNaN(numValue) && numValue>0){";
+    content += "      var xhr=new XMLHttpRequest();";
+    content += "      xhr.onload=editComplete;";
+    content += "      xhr.onerror=editError;";
+    content += "      xhr.open('GET','/editCalTargetAH" + s + "?value='+numValue,true);";
+    content += "      xhr.send();";
+    content += "    }else{";
+    content += "      alert('Invalid value. Please enter a positive number.');";
+    content += "    }";
+    content += "  }";
+    content += "}";
+    content += "function toggleAutoCalSOCEnabled" + s + "(){";
+    content += "  var enabled = document.getElementById('autoCalEnabled" + s + "').checked ? 1 : 0;";
+    content += "  var xhr=new XMLHttpRequest();";
+    content += "  xhr.onload=editComplete;";
+    content += "  xhr.onerror=editError;";
+    content += "  xhr.open('GET','/editBydAtto3AutoCalEnabled" + s + "?value='+enabled,true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function setAutoCalDriftPercent" + s + "(){";
+    content += "  var percent = document.getElementById('driftPercent" + s + "').value;";
+    content += "  var xhr=new XMLHttpRequest();";
+    content += "  xhr.onload=editComplete;";
+    content += "  xhr.onerror=editError;";
+    content += "  xhr.open('GET','/editBydAtto3AutoCalDriftPercent" + s + "?value='+percent,true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "</script>";
 
     return content;
   }
 
  private:
   DATALAYER_INFO_BYDATTO3* byd_datalayer;
+  String s;
 };
 
 #endif

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -229,6 +229,9 @@ void init_stored_settings() {
   datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent =
       constrain(settings.getUInt("BYDAUTOCALDRIFT", 5), 1u, 20u);
   datalayer_extended.bydAtto3.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN", true);
+  datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent =
+      constrain(settings.getUInt("BYDAUTOCALDRFT2", 5), 1u, 20u);
+  datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN2", true);
 }
 
 void store_settings_equipment_stop() {
@@ -252,4 +255,6 @@ void store_settings() {
   settings.saveUInt("BMSRESETDUR", datalayer.battery.settings.user_set_bms_reset_duration_ms);
   settings.saveUInt("BYDAUTOCALDRIFT", datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent);
   settings.saveBool("BYDAUTOCALEN", datalayer_extended.bydAtto3.auto_calibrate_soc_enabled);
+  settings.saveUInt("BYDAUTOCALDRFT2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent);
+  settings.saveBool("BYDAUTOCALEN2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled);
 }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -301,11 +301,12 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
     doc["dc_dc_current" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     doc["dc_dc_voltage" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;
   }
-  if (suffix.length() == 0u && supports_byd_autocal_metrics(::battery)) {
-    doc["autocal_taper" + suffix] = datalayer_extended.bydAtto3.autocal_crit_taper;
-    doc["autocal_dwell_s" + suffix] = datalayer_extended.bydAtto3.autocal_dwell_accumulated_ms / 1000u;
-    doc["autocal_cooldown_ready" + suffix] = datalayer_extended.bydAtto3.autocal_crit_cooldown_ready;
-    doc["autocal_soc_drift" + suffix] = datalayer_extended.bydAtto3.autocal_drift_percent;
+  if (supports_byd_autocal_metrics(::battery)) {
+    const DATALAYER_INFO_BYDATTO3& byd = (suffix == "_2") ? datalayer_extended.bydAtto3_2 : datalayer_extended.bydAtto3;
+    doc["autocal_taper" + suffix] = byd.autocal_crit_taper;
+    doc["autocal_dwell_s" + suffix] = byd.autocal_dwell_accumulated_ms / 1000u;
+    doc["autocal_cooldown_ready" + suffix] = byd.autocal_crit_cooldown_ready;
+    doc["autocal_soc_drift" + suffix] = byd.autocal_drift_percent;
   }
 }
 

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -108,8 +108,9 @@ String advanced_battery_processor(const String& var) {
     }
 
     if (battery2) {
+      content += "<hr>";
       content += "<h4>Values from battery 2</h4>";
-      content += "<h4 style='color: #f39c12;'>⚠️ Advanced detailed info is currently limited to the Main Battery.</h4>";
+      content += battery2->get_status_renderer().get_status_html();
       render_command_buttons(battery2, 1);
     }
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -603,7 +603,7 @@ void init_webserver() {
         datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent = (uint8_t)value;
         Preferences prefs;
         prefs.begin("batterySettings", false);
-        prefs.putUChar("BYDAUTOCALDRIFT", (uint8_t)value);
+        prefs.putUInt("BYDAUTOCALDRIFT", (uint8_t)value);
         prefs.end();
       }
     }
@@ -613,6 +613,41 @@ void init_webserver() {
   // Route for editing AH Calibration BYD
   update_string_setting("/editCalTargetAH", [](String value) {
     datalayer_extended.bydAtto3.calibrationTargetAH = static_cast<uint16_t>(value.toFloat());
+  });
+
+  // Battery 2 auto-calibration routes
+  update_string_setting("/editCalTargetSOC2", [](String value) {
+    datalayer_extended.bydAtto3_2.calibrationTargetSOC = static_cast<uint16_t>(value.toFloat());
+  });
+
+  update_string_setting("/editCalTargetAH2", [](String value) {
+    datalayer_extended.bydAtto3_2.calibrationTargetAH = static_cast<uint16_t>(value.toFloat());
+  });
+
+  def_route_with_auth("/editBydAtto3AutoCalEnabled2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      bool enabled = request->getParam("value")->value().toInt() != 0;
+      datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled = enabled;
+      Preferences prefs;
+      prefs.begin("batterySettings", false);
+      prefs.putBool("BYDAUTOCALEN2", enabled);
+      prefs.end();
+    }
+    request->send(200, "text/plain", "OK");
+  });
+
+  def_route_with_auth("/editBydAtto3AutoCalDriftPercent2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      int value = request->getParam("value")->value().toInt();
+      if (value >= 1 && value <= 20) {
+        datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent = (uint8_t)value;
+        Preferences prefs;
+        prefs.begin("batterySettings", false);
+        prefs.putUInt("BYDAUTOCALDRFT2", (uint8_t)value);
+        prefs.end();
+      }
+    }
+    request->send(200, "text/plain", "OK");
   });
 
   // Route for editing SOCMin


### PR DESCRIPTION
### What
Extends the BYD Atto3's auto-calibration controls and extended diagnostics to the second battery. Each pack now has its own auto-cal enable/drift settings, calibration targets, live status panel, MQTT entities, and NVM-persisted settings, instead of those being battery-1 only.

### Why
After my auto-calibration PR went live, dual-battery BYD users hit a crash (#2422) and had no way to see or calibrate their second pack — the advanced page just showed a "limited to main battery" notice. The SOC-reset command was also hardcoded to battery 1's targets, so calibrating battery 2 would have sent the wrong values to its BMS.

### How
* Gave battery 2 its own bydAtto3_2 struct and a real pointer (was nullptr — the crash).
* Made the renderer, web routes, NVM keys, and MQTT metrics suffix-aware.
* Pointed the SOC-reset frame at the per-battery struct instead of battery 1.
* Fixed drift % being saved as UChar but read as UInt, so it survives reboot.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
