### PR TITLE
BYD battery: Filter out glitched SOH readings for BYD

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -418,8 +418,10 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x444:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
-      if (rx_frame.data.u8[4] < 24) {  //Filter out glitched readings
-        BMS_SOH = rx_frame.data.u8[4];
+      if (rx_frame.data.u8[4] > 24) {     //Filter out glitched readings. Needs to be larger than 24%
+        if (rx_frame.data.u8[4] < 101) {  //Also needs to be smaller than 100%
+          BMS_SOH = rx_frame.data.u8[4];
+        }
       }
       //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
       BMS_voltage_available = true;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -418,7 +418,9 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x444:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
-      BMS_SOH = rx_frame.data.u8[4];
+      if (rx_frame.data.u8[4] < 24) {  //Filter out glitched readings
+        BMS_SOH = rx_frame.data.u8[4];
+      }
       //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
       BMS_voltage_available = true;
       break;

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -188,7 +188,7 @@ void update_machineryprotection() {
 
     // Battery is extremely degraded, not fit for secondlifestorage!
     if (datalayer.battery.status.soh_pptt < 2500) {
-      set_event(EVENT_SOH_LOW, datalayer.battery.status.soh_pptt);
+      set_event(EVENT_SOH_LOW, (datalayer.battery.status.soh_pptt / 100));
     } else {
       clear_event(EVENT_SOH_LOW);
     }


### PR DESCRIPTION
### What
This PR filters out glitched SOH% readings for BYD

### Why
Happens for some users

<img width="481" height="141" alt="image" src="https://github.com/user-attachments/assets/17af179b-2461-4969-b0ce-8a2614e42dff" />

### How
Filter out abnormally low values, while still allowing event to fire

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
