### PR TITLE
Library :books: Update ESP32 to v3.3.9

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 src_dir = ./Software
 
 [env:compiler_warning_check]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -27,7 +27,7 @@ build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:esp32devkit_330] 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -42,7 +42,7 @@ build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough
 lib_deps = 
 
 [env:lilygo_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -57,7 +57,7 @@ build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:stark_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32dev
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -72,7 +72,7 @@ build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
 lib_deps = 
 
 [env:lilygo_2CAN_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
@@ -98,7 +98,7 @@ build_flags =
 lib_deps = 
 
 [env:BECom_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 upload_speed = 921600
@@ -121,7 +121,7 @@ build_flags =
 lib_deps =
 
 [env:waveshare_330]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32s3_flash_16MB
 monitor_speed = 115200
 upload_speed = 921600

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall -Werror
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:esp32devkit_330] 
@@ -38,7 +38,7 @@ board_build.partitions = min_spiffs.csv
 framework = arduino
 build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:lilygo_330]
@@ -68,7 +68,7 @@ board_build.partitions = default_8MB.csv
 framework = arduino
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:lilygo_2CAN_330]
@@ -94,7 +94,7 @@ build_flags =
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps = 
 
 [env:BECom_330]
@@ -117,7 +117,7 @@ build_flags =
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps =
 
 [env:waveshare_330]
@@ -152,6 +152,6 @@ build_flags =
     -ffunction-sections
     -fdata-sections
     -Wl,--gc-sections
-build_cxxflags = -fno-rtti
+;build_cxxflags = -fno-rtti
 lib_deps =
 


### PR DESCRIPTION
### What
This PR updates the ESP32 backbone to v3.3.9

### Why
To get latest and greatest platform fixes

### How
3.3.8 -> 3.3.9

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
