### PR TITLE
Feature: Add DTC clearing for many battteries

### DIFF
--- a/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.cpp
@@ -431,7 +431,12 @@ void BoltAmperaBattery::transmit_can(unsigned long currentMillis) {
     BOLT_POLL_7E7.data.u8[2] = (uint8_t)((currentpoll_7E7 & 0xFF00) >> 8);
     BOLT_POLL_7E7.data.u8[3] = (uint8_t)(currentpoll_7E7 & 0x00FF);
 
-    transmit_can_frame(&BOLT_POLL_7E7);
+    if (UserRequestDTCreset) {
+      transmit_can_frame(&BOLT_CLEAR_DTC);
+      UserRequestDTCreset = false;
+    } else {  //Normal poll
+      transmit_can_frame(&BOLT_POLL_7E7);
+    }
   }
 
   //Send 120ms message

--- a/Software/src/battery/BOLT-AMPERA-BATTERY.h
+++ b/Software/src/battery/BOLT-AMPERA-BATTERY.h
@@ -31,13 +31,17 @@ class BoltAmperaBattery : public CanBattery {
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
   BoltAmperaHtmlRenderer renderer;
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_BOLTAMPERA* datalayer_boltampera;
   bool* allows_contactor_closing;
-  static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 500;
+  bool UserRequestDTCreset = false;
 
+  static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 500;
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2510;
   static const int MAX_CELL_DEVIATION_MV = 150;
@@ -212,6 +216,11 @@ class BoltAmperaBattery : public CanBattery {
                             .DLC = 8,
                             .ID = 0x7E7,
                             .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame BOLT_CLEAR_DTC = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x7E7,
+                              .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 
   // Other PID requests in the vehicle
   // All HV ECUs - 0x101

--- a/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.cpp
+++ b/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.cpp
@@ -640,7 +640,12 @@ void GeelyGeometryCBattery::transmit_can(unsigned long currentMillis) {
         break;
     }
 
-    transmit_can_frame(&GEELY_POLL);
+    if (UserRequestDTCreset) {
+      transmit_can_frame(&GEELY_CLEAR_DTC);
+      UserRequestDTCreset = false;
+    } else {
+      transmit_can_frame(&GEELY_POLL);
+    }
   }
 }
 

--- a/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
+++ b/Software/src/battery/GEELY-GEOMETRY-C-BATTERY.h
@@ -28,11 +28,16 @@ class GeelyGeometryCBattery : public CanBattery {
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
   GeelyGeometryCHtmlRenderer renderer;
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_GEELY_GEOMETRY_C* datalayer_geometryc;
+
+  bool UserRequestDTCreset = false;
 
   static const int POLL_SOC = 0x4B35;
   static const int POLL_CC2_VOLTAGE = 0x4BCF;
@@ -193,6 +198,11 @@ class GeelyGeometryCBattery : public CanBattery {
                          .DLC = 8,
                          .ID = 0x7E2,
                          .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame GEELY_CLEAR_DTC = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7E2,
+                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
   uint16_t poll_pid = POLL_SOC;
   uint16_t incoming_poll = 0;
   uint8_t counter_10ms = 0;

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.cpp
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.cpp
@@ -333,7 +333,12 @@ void HyundaiIoniq28Battery::transmit_can(unsigned long currentMillis) {
         break;
     }
 
-    transmit_can_frame(&IONIQ_7E4_POLL);
+    if (UserRequestDTCreset) {
+      transmit_can_frame(&IONIQ_CLEAR_DTC);
+      UserRequestDTCreset = false;
+    } else {
+      transmit_can_frame(&IONIQ_7E4_POLL);
+    }
   }
 
   //Send 100ms message

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
@@ -26,10 +26,15 @@ class HyundaiIoniq28Battery : public CanBattery {
   int16_t get_power_relay_temperature() const;
   uint8_t get_battery_management_mode() const;
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
   HyundaiIoniq28BatteryHtmlRenderer renderer;
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;
+
+  bool UserRequestDTCreset = false;
 
   static const int MAX_PACK_VOLTAGE_DV = 4050;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2880;
@@ -108,6 +113,11 @@ class HyundaiIoniq28Battery : public CanBattery {
                              .DLC = 8,
                              .ID = 0x7E4,
                              .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame IONIQ_CLEAR_DTC = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7E4,
+                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 };
 
 #endif

--- a/Software/src/battery/KIA-64FD-BATTERY.cpp
+++ b/Software/src/battery/KIA-64FD-BATTERY.cpp
@@ -396,7 +396,12 @@ void Kia64FDBattery::transmit_can(unsigned long currentMillis) {
       KIA64FD_7E4.data.u8[3] = KIA_7E4_COUNTER;
 
       if (ok_start_polling_battery) {
-        transmit_can_frame(&KIA64FD_7E4);
+        if (UserRequestDTCreset) {
+          transmit_can_frame(&KIA64FD_CLEAR_DTC);
+          UserRequestDTCreset = false;
+        } else {  //Normal poll
+          transmit_can_frame(&KIA64FD_7E4);
+        }
       }
 
       KIA_7E4_COUNTER++;

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -13,7 +13,11 @@ class Kia64FDBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Kia 64kWh FD battery";
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
+  bool UserRequestDTCreset = false;
   uint16_t estimateSOC(uint16_t packVoltage, uint16_t cellCount, int16_t currentAmps);
   uint16_t estimateSOCFromCell(uint16_t cellVoltage);
   uint8_t calculateCRC(CAN_frame rx_frame, uint8_t length, uint8_t initial_value);
@@ -605,6 +609,11 @@ class Kia64FDBattery : public CanBattery {
       .DLC = 8,
       .ID = 0x7E4,
       .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
+  CAN_frame KIA64FD_CLEAR_DTC = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x7E4,
+                                 .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 };
 
 #endif

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -483,6 +483,11 @@ void KiaHyundai64Battery::transmit_can(unsigned long currentMillis) {
       transmit_can_frame(&KIA64_57F);
       transmit_can_frame(&KIA64_2A1);
     }
+
+    if (UserRequestDTCreset) {
+      UserRequestDTCreset = false;
+      transmit_can_frame(&KIA64_CLEAR_DTC);
+    }
   }
 
   // Send 10ms CAN Message

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -33,11 +33,16 @@ class KiaHyundai64Battery : public CanBattery {
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
   KiaHyundai64HtmlRenderer renderer;
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_KIAHYUNDAI64* datalayer_battery_extended;
+
+  bool UserRequestDTCreset = false;
 
   // If not null, this battery decides when the contactor can be closed and writes the value here.
   bool* allows_contactor_closing;
@@ -152,6 +157,11 @@ class KiaHyundai64Battery : public CanBattery {
       .DLC = 8,
       .ID = 0x7E4,
       .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};  //Ack frame, correct PID is returned
+  CAN_frame KIA64_CLEAR_DTC = {.FD = false,
+                               .ext_ID = false,
+                               .DLC = 8,
+                               .ID = 0x7E4,
+                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
   static const int POLL_GROUP_1 = 0x0101;
   static const int POLL_GROUP_2 = 0x0102;
   static const int POLL_GROUP_3 = 0x0103;

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.cpp
@@ -299,6 +299,11 @@ void KiaHyundaiHybridBattery::transmit_can(unsigned long currentMillis) {
     previousMillis100 = currentMillis;
 
     transmit_can_frame(&KIA_523);
+
+    if (UserRequestDTCreset) {
+      UserRequestDTCreset = false;
+      transmit_can_frame(&KIA_CLEAR_DTC);
+    }
   }
 
   // Send 1000ms CAN Message

--- a/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-HYBRID-BATTERY.h
@@ -10,7 +10,11 @@ class KiaHyundaiHybridBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Kia/Hyundai Hybrid";
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
+  bool UserRequestDTCreset = false;
   static const int MAX_PACK_VOLTAGE_HEV_DV = 2550;
   static const int MIN_PACK_VOLTAGE_HEV_DV = 1700;
   static const int MAX_PACK_VOLTAGE_PHEV_DV = 4040;
@@ -49,6 +53,11 @@ class KiaHyundaiHybridBattery : public CanBattery {
                            .DLC = 8,
                            .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
                            .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame KIA_CLEAR_DTC = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x7E4,
+                             .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
   CAN_frame KIA_200 = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -210,12 +210,16 @@ void NissanLeafBattery::
     datalayer_nissan->challengeFailed = challengeFailed;
 
     // Update requests from webserver datalayer
-    if (datalayer_nissan->UserRequestSOHreset) {
+    if (UserRequestSOHreset) {
       stateMachineClearSOH = 0;  //Start the statemachine
-      datalayer_nissan->UserRequestSOHreset = false;
+      UserRequestSOHreset = false;
     }
 
 #endif
+    if (UserRequestDTCreset) {
+      UserRequestDTCreset = false;
+      transmit_can_frame(&LEAF_CLEAR_DTC);
+    }
   }
 }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -33,7 +33,9 @@ class NissanLeafBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
 
   bool supports_reset_SOH();
-  void reset_SOH() { datalayer_extended.nissanleaf.UserRequestSOHreset = true; }
+  void reset_SOH() { UserRequestSOHreset = true; }
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
 
   bool soc_plausible() {
     // When pack voltage is close to max, and SOC% is still low (<65.0%), SOC is not plausible
@@ -47,6 +49,8 @@ class NissanLeafBattery : public CanBattery {
   uint8_t calculate_crc(CAN_frame& frame);
 
  private:
+  bool UserRequestDTCreset = false;
+  bool UserRequestSOHreset = false;
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2600;
   static const int MAX_CELL_DEVIATION_MV = 150;
@@ -131,6 +135,11 @@ class NissanLeafBattery : public CanBattery {
                                       .DLC = 8,
                                       .ID = 0x79B,
                                       .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+  CAN_frame LEAF_CLEAR_DTC = {.FD = false,
+                              .ext_ID = false,
+                              .DLC = 8,
+                              .ID = 0x79B,
+                              .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 
   // The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
   // groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.cpp
@@ -210,7 +210,12 @@ void RenaultKangooBattery::transmit_can(unsigned long currentMillis) {
         break;
     }
 
-    transmit_can_frame(&KANGOO_79B_Poll);
+    if (UserRequestDTCreset) {
+      UserRequestDTCreset = false;
+      transmit_can_frame(&KANGOO_CLEAR_DTC);
+    } else {  //Normal polling if no DTC reset request
+      transmit_can_frame(&KANGOO_79B_Poll);
+    }
   }
 }
 

--- a/Software/src/battery/RENAULT-KANGOO-BATTERY.h
+++ b/Software/src/battery/RENAULT-KANGOO-BATTERY.h
@@ -13,7 +13,11 @@ class RenaultKangooBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Renault Kangoo";
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestDTCreset = true; }
+
  private:
+  bool UserRequestDTCreset = false;
   static const int MAX_PACK_VOLTAGE_DV = 4150;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2500;
   static const int MAX_CELL_DEVIATION_MV = 150;
@@ -68,6 +72,11 @@ class RenaultKangooBattery : public CanBattery {
                                    .DLC = 8,
                                    .ID = 0x79B,
                                    .data = {0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame KANGOO_CLEAR_DTC = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x79B,
+                                .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 
   unsigned long previousMillis10 = 0;    // will store last time a 10ms CAN Message was sent
   unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was sent

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -611,7 +611,12 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
 
     ZOE_POLL_79B.data.u8[2] = current_poll;
 
-    transmit_can_frame(&ZOE_POLL_79B);
+    if (UserRequestedDTCReset == true) {
+      transmit_can_frame(&ZOE_CLEAR_DTC);
+      UserRequestedDTCReset = false;
+    } else {
+      transmit_can_frame(&ZOE_POLL_79B);
+    }
   }
 }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -33,8 +33,13 @@ class RenaultZoeGen1Battery : public CanBattery {
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestedDTCReset = true; }
+
  private:
   RenaultZoeGen1HtmlRenderer renderer;
+
+  bool UserRequestedDTCReset = false;
 
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 3000;
@@ -67,6 +72,11 @@ class RenaultZoeGen1Battery : public CanBattery {
                            .DLC = 8,
                            .ID = 0x79B,
                            .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ZOE_CLEAR_DTC = {.FD = false,
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = 0x79B,
+                             .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 
 #define GROUP1_CELLVOLTAGES_1_POLL 0x41
 #define GROUP2_CELLVOLTAGES_2_POLL 0x42

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -445,6 +445,10 @@ void RenaultZoeGen2Battery::transmit_can(unsigned long currentMillis) {
     ZOE_POLL_18DADBF1.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
     ZOE_POLL_18DADBF1.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);
 
+    if (UserRequestedDTCReset == true) {
+      UserRequestedDTCReset = false;
+      transmit_can_frame(&ZOE_CLEAR_DTC);  //Send DTC reset command
+    }
     transmit_can_frame(&ZOE_POLL_18DADBF1);
   }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.h
@@ -30,8 +30,9 @@ class RenaultZoeGen2Battery : public CanBattery {
   static constexpr const char* Name = "Renault Zoe Gen2 50kWh";
 
   bool supports_reset_NVROL() { return true; }
-
   void reset_NVROL() { datalayer_extended.zoePH2.UserRequestNVROLReset = true; }
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestedDTCReset = true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
@@ -45,6 +46,8 @@ class RenaultZoeGen2Battery : public CanBattery {
 
   // If not null, this battery decides when the contactor can be closed and writes the value here.
   bool* allows_contactor_closing;
+
+  bool UserRequestedDTCReset = false;
 
   bool is_message_corrupt(CAN_frame rx_frame, uint8_t crc_xor);
 
@@ -293,6 +296,11 @@ class RenaultZoeGen2Battery : public CanBattery {
                                      .DLC = 8,
                                      .ID = 0x18DADBF1,
                                      .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ZOE_CLEAR_DTC = {.FD = false,
+                             .ext_ID = true,
+                             .DLC = 8,
+                             .ID = 0x18DADBF1,
+                             .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
   //NVROL Reset
   CAN_frame ZOE_NVROL_1_18DADBF1 = {.FD = false,
                                     .ext_ID = true,

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.cpp
@@ -313,7 +313,13 @@ void SantaFePhevBattery::transmit_can(unsigned long currentMillis) {
     // PID data is polled after last message sent from battery:
     poll_data_pid = (poll_data_pid % 5) + 1;
     SANTAFE_7E4_poll.data.u8[3] = (uint8_t)poll_data_pid;
-    transmit_can_frame(&SANTAFE_7E4_poll);
+
+    if (UserRequestedDTCReset == true) {
+      transmit_can_frame(&SANTAFE_CLEAR_DTC);
+      UserRequestedDTCReset = false;
+    } else {
+      transmit_can_frame(&SANTAFE_7E4_poll);
+    }
   }
 }
 

--- a/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
+++ b/Software/src/battery/SANTA-FE-PHEV-BATTERY.h
@@ -23,11 +23,16 @@ class SantaFePhevBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Santa Fe PHEV";
 
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { UserRequestedDTCReset = true; }
+
  private:
   DATALAYER_BATTERY_TYPE* datalayer_battery;
 
   // If not null, this battery decides when the contactor can be closed and writes the value here.
   bool* allows_contactor_closing;
+
+  bool UserRequestedDTCReset = false;
 
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2880;
@@ -88,6 +93,11 @@ class SantaFePhevBattery : public CanBattery {
                                .DLC = 8,
                                .ID = 0x7E4,  //Ack frame, correct PID is returned. Flow control message
                                .data = {0x30, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame SANTAFE_CLEAR_DTC = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x7E4,
+                                 .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
 };
 
 #endif

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -785,8 +785,6 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   bool HeatingStart = false;
   /** Heat request sent*/
   bool HeaterSendRequest = false;
-  /** User requesting SOH reset via WebUI*/
-  bool UserRequestSOHreset = false;
   /** True if the crypto challenge response from BMS is signalling a failed attempt*/
   bool challengeFailed = false;
 


### PR DESCRIPTION
### What
This PR implements DTC clear for many integrations

### Why
Clearing DTC is required for many integrations to get contactor closing to operate, or balancing to function

### How
Clear DTC button added for the following integrations

- SantaFe PHEV
- Ampera/Bolt
- Geely Geometry C
- Kia64FD
- Kia/Hyundai 40/64kWh
- Kia Hyundai Hybrid
- Nissan LEAF
- Renault Kangoo
- Renault Zoe Gen1
- Renault Zoe Gen2

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
