### PR TITLE
Add web interface password protection

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -5,6 +5,7 @@
 #include "../../charger/CanCharger.h"
 #include "../../communication/can/comm_can.h"
 #include "../../devboard/mqtt/mqtt.h"
+#include "../../devboard/webserver/webserver.h"
 #include "../../devboard/wifi/wifi.h"
 #include "../../inverter/INVERTERS.h"
 #include "../contactorcontrol/comm_contactorcontrol.h"
@@ -31,6 +32,9 @@ void init_stored_settings() {
 
   ssid = settings.getString("SSID").c_str();
   password = settings.getString("PASSWORD").c_str();
+  http_username = settings.getString("HTTPUSER", "admin").c_str();
+  http_password = settings.getString("HTTPPASS").c_str();
+  webserver_auth = settings.getBool("WEBAUTH", false) && !http_username.empty() && !http_password.empty();
 
   temp = settings.getUInt("BATTERY_WH_MAX", false);
   if (temp != 0) {

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -365,6 +365,18 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getString("PASSWORD");
   }
 
+  if (var == "WEBAUTH") {
+    return settings.getBool("WEBAUTH") ? "checked" : "";
+  }
+
+  if (var == "HTTPUSER") {
+    return settings.getString("HTTPUSER", "admin");
+  }
+
+  if (var == "HTTPPASS") {
+    return settings.getString("HTTPPASS");
+  }
+
   if (var == "SAVEDCLASS") {
     if (!settingsUpdated) {
       return "hidden";
@@ -1380,8 +1392,37 @@ const char* getCANInterfaceName(CAN_Interface interface) {
   <button onclick='goToMainPage()'>Back to main page</button>
   <button onclick="askFactoryReset()">Factory reset</button>
 
+  <script>
+  function validateWebAuthPassword() {
+    const webAuth = document.querySelector('input[name="WEBAUTH"]');
+    const user = document.querySelector('input[name="HTTPUSER"]');
+    const pass = document.querySelector('input[name="HTTPPASS"]');
+    const confirm = document.querySelector('input[name="HTTPPASSCONFIRM"]');
+
+    if (pass.value !== confirm.value) {
+      alert('Web interface passwords do not match.');
+      confirm.focus();
+      return false;
+    }
+
+    if (webAuth.checked && (!user.value || !pass.value)) {
+      alert('Set a username and password before enabling web interface password protection.');
+      (!user.value ? user : pass).focus();
+      return false;
+    }
+
+    return true;
+  }
+
+  function toggleWebPasswordVisibility(show) {
+    const fieldType = show ? 'text' : 'password';
+    document.querySelector('input[name="HTTPPASS"]').type = fieldType;
+    document.querySelector('input[name="HTTPPASSCONFIRM"]').type = fieldType;
+  }
+  </script>
+
 <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>
-        <form action='saveSettings' method='post'>
+        <form action='saveSettings' method='post' onsubmit='return validateWebAuthPassword()'>
 
         <div style='grid-column: span 2; text-align: center; padding-top: 10px;' class="%SAVEDCLASS%">
           <p>Settings saved. Reboot to take the new settings into use.<p> <button type='button' onclick='askReboot()'>Reboot</button>
@@ -1399,6 +1440,34 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label>Password: </label><input type='password' name='PASSWORD' value="%PASSWORD%" 
         pattern="[ -~]{8,63}" 
         title="Password must be 8-63 characters long, printable ASCII only" />
+        </div>
+        </div>
+
+        <div class="settings-card">
+        <h3>Web interface access</h3>
+        <div style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>
+
+        <label>Enable password protection: </label>
+        <input type='checkbox' name='WEBAUTH' value='on' %WEBAUTH%
+        title="Require HTTP Basic authentication for the web interface and OTA page" />
+
+        <label>Username: </label>
+        <input type='text' name='HTTPUSER' value="%HTTPUSER%"
+        pattern="[ -~]{1,32}"
+        title="Web interface username, printable ASCII only" />
+
+        <label>Web interface password: </label>
+        <input type='password' name='HTTPPASS' value="%HTTPPASS%"
+        pattern="[ -~]{0,63}"
+        title="Set a password before enabling password protection. Printable ASCII only" />
+
+        <label>Repeat web interface password: </label>
+        <input type='password' name='HTTPPASSCONFIRM' value="%HTTPPASS%"
+        pattern="[ -~]{0,63}"
+        title="Repeat the web interface password" />
+
+        <label>Show web interface password: </label>
+        <input type='checkbox' onchange='toggleWebPasswordVisibility(this.checked)' />
         </div>
         </div>
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -31,6 +31,7 @@ bool webserver_auth = false;
 
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
+AsyncAuthenticationMiddleware web_auth_middleware;
 
 // Measure OTA progress
 unsigned long ota_progress_millis = 0;
@@ -56,6 +57,10 @@ bool isReplayRunning = false;  // Global flag to track replay state
 bool settingsUpdated = false;
 
 CAN_frame currentFrame = {.FD = true, .ext_ID = false, .DLC = 64, .ID = 0x12F, .data = {0}};
+
+bool webserver_auth_is_ready() {
+  return webserver_auth && !http_username.empty() && !http_password.empty();
+}
 
 void handleFileUpload(AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len,
                       bool final) {
@@ -173,14 +178,21 @@ void canReplayTask(void* param) {
 void def_route_with_auth(const char* uri, AsyncWebServer& serv, WebRequestMethodComposite method,
                          std::function<void(AsyncWebServerRequest*)> handler) {
   serv.on(uri, method, [handler](AsyncWebServerRequest* request) {
-    if (webserver_auth && !request->authenticate(http_username.c_str(), http_password.c_str())) {
-      return request->requestAuthentication();
+    if (webserver_auth_is_ready() && !request->authenticate(http_username.c_str(), http_password.c_str())) {
+      return request->requestAuthentication(AsyncAuthType::AUTH_BASIC, "Battery Emulator");
     }
     handler(request);
   });
 }
 
 void init_webserver() {
+  if (webserver_auth_is_ready()) {
+    web_auth_middleware.setUsername(http_username.c_str());
+    web_auth_middleware.setPassword(http_password.c_str());
+    web_auth_middleware.setRealm("Battery Emulator");
+    web_auth_middleware.setAuthType(AsyncAuthType::AUTH_BASIC);
+    server.addMiddleware(&web_auth_middleware);
+  }
 
   server.on("/logout", HTTP_GET, [](AsyncWebServerRequest* request) { request->send(401); });
 
@@ -401,6 +413,7 @@ void init_webserver() {
       "MQTTTOPICS",   "MQTTCELLV",    "INVICNT",       "GTWRHD",      "DIGITALHVIL", "PERFPROFILE",
       "INTERLOCKREQ", "SOCESTIMATED", "PYLONOFFSET",   "PYLONORDER",  "DEYEBYD",     "NCCONTACTOR",
       "TRIBTR",       "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",  "CTINVERT",    "LOWPASSFILTER",
+      "WEBAUTH",
   };
 
   const char* uintSettingNames[] = {
@@ -415,12 +428,36 @@ void init_webserver() {
   };
 
   const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",
-                                      "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID"};
+                                      "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID",
+                                      "HTTPUSER",     "HTTPPASS"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,
             [boolSettingNames, stringSettingNames, uintSettingNames](AsyncWebServerRequest* request) {
               BatteryEmulatorSettingsStore settings;
+              auto webAuthParam = request->getParam("WEBAUTH", true);
+              auto httpUserParam = request->getParam("HTTPUSER", true);
+              auto httpPassParam = request->getParam("HTTPPASS", true);
+              auto httpPassConfirmParam = request->getParam("HTTPPASSCONFIRM", true);
+
+              bool requestedWebAuth = webAuthParam != nullptr && webAuthParam->value() == "on";
+              String requestedHttpUser =
+                  httpUserParam != nullptr ? httpUserParam->value() : settings.getString("HTTPUSER", "admin");
+              String requestedHttpPass =
+                  httpPassParam != nullptr ? httpPassParam->value() : settings.getString("HTTPPASS");
+              String requestedHttpPassConfirm =
+                  httpPassConfirmParam != nullptr ? httpPassConfirmParam->value() : requestedHttpPass;
+
+              if (requestedHttpPass != requestedHttpPassConfirm) {
+                request->send(400, "text/plain", "Web interface passwords do not match.");
+                return;
+              }
+
+              if (requestedWebAuth && (requestedHttpUser.isEmpty() || requestedHttpPass.isEmpty())) {
+                request->send(400, "text/plain",
+                              "Set a username and password before enabling web interface password protection.");
+                return;
+              }
 
               int numParams = request->params();
               for (int i = 0; i < numParams; i++) {
@@ -670,8 +707,8 @@ void init_webserver() {
     server.on(
         route.c_str(), HTTP_PUT,
         [cmd](AsyncWebServerRequest* request) {
-          if (webserver_auth && !request->authenticate(http_username.c_str(), http_password.c_str())) {
-            return request->requestAuthentication();
+          if (webserver_auth_is_ready() && !request->authenticate(http_username.c_str(), http_password.c_str())) {
+            return request->requestAuthentication(AsyncAuthType::AUTH_BASIC, "Battery Emulator");
           }
         },
         nullptr,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -407,13 +407,12 @@ void init_webserver() {
   });
 
   const char* boolSettingNames[] = {
-      "DBLBTR",       "CNTCTRL",      "CNTCTRLDBL",    "PWMCNTCTRL",  "PERBMSRESET", "SDLOGENABLED",
-      "STATICIP",     "REMBMSRESET",  "EXTPRECHARGE",  "USBENABLED",  "CANLOGUSB",   "WEBENABLED",
-      "CANFDASCAN",   "CANLOGSD",     "WIFIAPENABLED", "MQTTENABLED", "NOINVDISC",   "HADISC",
-      "MQTTTOPICS",   "MQTTCELLV",    "INVICNT",       "GTWRHD",      "DIGITALHVIL", "PERFPROFILE",
-      "INTERLOCKREQ", "SOCESTIMATED", "PYLONOFFSET",   "PYLONORDER",  "DEYEBYD",     "NCCONTACTOR",
-      "TRIBTR",       "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",  "CTINVERT",    "LOWPASSFILTER",
-      "WEBAUTH",
+      "DBLBTR",        "CNTCTRL",      "CNTCTRLDBL",  "PWMCNTCTRL",   "PERBMSRESET",   "SDLOGENABLED", "STATICIP",
+      "REMBMSRESET",   "EXTPRECHARGE", "USBENABLED",  "CANLOGUSB",    "WEBENABLED",    "CANFDASCAN",   "CANLOGSD",
+      "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",   "HADISC",       "MQTTTOPICS",    "MQTTCELLV",    "INVICNT",
+      "GTWRHD",        "DIGITALHVIL",  "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET",  "PYLONORDER",
+      "DEYEBYD",       "NCCONTACTOR",  "TRIBTR",      "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",   "CTINVERT",
+      "LOWPASSFILTER", "WEBAUTH",
   };
 
   const char* uintSettingNames[] = {
@@ -427,9 +426,9 @@ void init_webserver() {
       "GPIOOPT6",
   };
 
-  const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",
-                                      "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID",
-                                      "HTTPUSER",     "HTTPPASS"};
+  const char* stringSettingNames[] = {"APNAME",         "APPASSWORD",   "HOSTNAME",  "MQTTSERVER",
+                                      "MQTTUSER",       "MQTTPASSWORD", "MQTTTOPIC", "MQTTOBJIDPREFIX",
+                                      "MQTTDEVICENAME", "HADEVICEID",   "HTTPUSER",  "HTTPPASS"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -3,11 +3,15 @@
 
 #include <Preferences.h>
 #include <WiFi.h>
+#include <string>
 #include "../../lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
 #include "../../lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h"
 #include "../../lib/mathieucarbou-AsyncTCPSock/src/AsyncTCP.h"
 
 extern const char* version_number;  // The current software version, shown on webserver
+extern std::string http_username;
+extern std::string http_password;
+extern bool webserver_auth;
 
 // Common charger parameters
 extern float charger_stat_HVcur;

--- a/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/Middleware.cpp
+++ b/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/Middleware.cpp
@@ -50,6 +50,27 @@ bool AsyncMiddlewareChain::removeMiddleware(AsyncMiddleware *middleware) {
   return size != _middlewares.size();
 }
 
+void AsyncAuthenticationMiddleware::setUsername(const char *username) {
+  _username = username ? username : "";
+  _hasCreds = _credentials.length() && (_username.length() || _hash);
+}
+
+void AsyncAuthenticationMiddleware::setPassword(const char *password) {
+  _credentials = password ? password : "";
+  _hash = false;
+  _hasCreds = _credentials.length() && _username.length();
+}
+
+void AsyncAuthenticationMiddleware::setPasswordHash(const char *hash) {
+  _credentials = hash ? hash : "";
+  _hash = true;
+  _hasCreds = _credentials.length();
+}
+
+bool AsyncAuthenticationMiddleware::generateHash() {
+  return false;
+}
+
 void AsyncMiddlewareChain::_runChain(AsyncWebServerRequest *request, ArMiddlewareNext finalizer) {
   if (!_middlewares.size()) {
     return finalizer();

--- a/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebRequest.cpp
+++ b/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebRequest.cpp
@@ -14,6 +14,28 @@ static void doNotDelete(AsyncWebServerRequest *) {}
 
 using namespace asyncsrv;
 
+static String base64Encode(const String &input) {
+  static const char *alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  String output;
+  output.reserve(((input.length() + 2) / 3) * 4);
+
+  size_t i = 0;
+  while (i < input.length()) {
+    uint8_t a = static_cast<uint8_t>(input.charAt(i++));
+    bool hasB = i < input.length();
+    uint8_t b = hasB ? static_cast<uint8_t>(input.charAt(i++)) : 0;
+    bool hasC = i < input.length();
+    uint8_t c = hasC ? static_cast<uint8_t>(input.charAt(i++)) : 0;
+
+    output += alphabet[a >> 2];
+    output += alphabet[((a & 0x03) << 4) | (b >> 4)];
+    output += hasB ? alphabet[((b & 0x0F) << 2) | (c >> 6)] : '=';
+    output += hasC ? alphabet[c & 0x3F] : '=';
+  }
+
+  return output;
+}
+
 enum {
   PARSE_REQ_START = 0,
   PARSE_REQ_HEADERS = 1,
@@ -875,7 +897,22 @@ void AsyncWebServerRequest::redirect(const char *url, int code) {
 }
 
 bool AsyncWebServerRequest::authenticate(const char *username, const char *password, const char *realm, bool passwordIsHash) const {
-  return true;
+  (void)realm;
+
+  if (!_authorization.length() || username == NULL || password == NULL) {
+    return false;
+  }
+
+  if (_authMethod == AsyncAuthType::AUTH_BASIC) {
+    String expected = passwordIsHash ? String(password) : base64Encode(String(username) + ":" + String(password));
+    return _authorization.equals(expected);
+  }
+
+  if (passwordIsHash) {
+    return authenticate(password);
+  }
+
+  return false;
 }
 
 bool AsyncWebServerRequest::authenticate(const char *hash) const {
@@ -910,6 +947,9 @@ void AsyncWebServerRequest::requestAuthentication(AsyncAuthType method, const ch
   }
 
   AsyncWebServerResponse *r = _authFailMsg ? beginResponse(401, T_text_html, _authFailMsg) : beginResponse(401);
+  if (method == AsyncAuthType::AUTH_BASIC || method == AsyncAuthType::AUTH_DIGEST) {
+    r->addHeader(T_WWW_AUTH, String(T_BASIC_REALM) + realm + "\"");
+  }
 
   send(r);
 }


### PR DESCRIPTION
## Summary
- add optional HTTP Basic authentication settings for the web interface and OTA endpoints
- require repeated web password entry, with a show-password toggle
- implement Basic auth handling in the vendored ESPAsyncWebServer copy

## Tests
- `platformio run -e lilygo_2CAN_330 -e lilygo_330`
- `platformio run -e compiler_warning_check`