### PR TITLE
Tesla Legacy: Add isolation low warning event

### DIFF
--- a/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
+++ b/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
@@ -111,13 +111,20 @@ void TeslaLegacyBattery::update_values() {
   datalayer.battery.status.max_discharge_power_W =
       (datalayer.battery.status.voltage_dV * battery_max_discharge_current) / 10;
 
-  datalayer.battery.status.temperature_min_dC = battery_min_temp;
+  datalayer.battery.status.temperature_min_dC = (battery_BrickModelTMin * 10);
 
-  datalayer.battery.status.temperature_max_dC = battery_max_temp;
+  datalayer.battery.status.temperature_max_dC = (battery_BrickModelTMax * 10);
 
-  datalayer.battery.status.cell_max_voltage_mV = battery_cell_max_v;
+  datalayer.battery.status.cell_max_voltage_mV = battery_BrickVoltageMax;
 
-  datalayer.battery.status.cell_min_voltage_mV = battery_cell_min_v;
+  datalayer.battery.status.cell_min_voltage_mV = battery_BrickVoltageMin;
+
+  //Check safeties
+  if (battery_BMS_isolationResistance < 100) {  //TODO: limit unknown
+    set_event(EVENT_BATTERY_ISOLATION, battery_BMS_isolationResistance);
+  } else {
+    clear_event(EVENT_BATTERY_ISOLATION);
+  }
 }
 
 void TeslaLegacyBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -168,18 +175,10 @@ void TeslaLegacyBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x332:  //min/max hist values //BattBrickMinMax:
       cellvoltagesRead = true;
 
-      battery_BrickVoltageMax =
-          (((rx_frame.data.u8[1] & (0x0F)) << 8) | (rx_frame.data.u8[0])) * 2;  //to datalayer_extended
-      battery_cell_max_v = battery_BrickVoltageMax;
-      battery_BrickVoltageMin =
-          (((rx_frame.data.u8[5] & (0x0F)) << 8) | (rx_frame.data.u8[4])) * 2;  //to datalayer_extended
-      battery_cell_min_v = battery_BrickVoltageMin;
-
-      battery_BrickModelTMax = ((rx_frame.data.u8[3] * 0.5) - 40);  //to datalayer_extended
-      battery_max_temp = battery_BrickModelTMax * 10;
+      battery_BrickVoltageMax = (((rx_frame.data.u8[1] & (0x0F)) << 8) | (rx_frame.data.u8[0])) * 2;
+      battery_BrickVoltageMin = (((rx_frame.data.u8[5] & (0x0F)) << 8) | (rx_frame.data.u8[4])) * 2;
+      battery_BrickModelTMax = ((rx_frame.data.u8[3] * 0.5) - 40);
       battery_BrickModelTMin = ((rx_frame.data.u8[7] * 0.5) - 40);
-      //to datalayer_extended
-      battery_min_temp = battery_BrickModelTMin * 10;
       break;
     case 0x5D2:
       if (rx_frame.data.u8[0] == 0x0A) {

--- a/Software/src/battery/TESLA-LEGACY-BATTERY.h
+++ b/Software/src/battery/TESLA-LEGACY-BATTERY.h
@@ -60,8 +60,6 @@ class TeslaLegacyBattery : public CanBattery {
   unsigned long previousMillis100 = 0;   // will store last time a 100ms CAN Message was send
   unsigned long previousMillis1000 = 0;  // will store last time a 1s CAN Message was send
   uint32_t BMS_CAC_min = 23160000;
-  uint16_t battery_cell_max_v = 3300;
-  uint16_t battery_cell_min_v = 3300;
   uint16_t battery_soc_ui = 0;
   uint8_t battery_BMS_state = 0;
   bool cellvoltagesRead = false;
@@ -79,12 +77,12 @@ class TeslaLegacyBattery : public CanBattery {
   //0x332: 818 BattBrickMinMax:BMS_bmbMinMax
   int16_t battery_max_temp = 0;  // C*
   int16_t battery_min_temp = 0;  // C*
-  uint16_t battery_BrickVoltageMax = 0;
-  uint16_t battery_BrickVoltageMin = 0;
+  uint16_t battery_BrickVoltageMax = 3300;
+  uint16_t battery_BrickVoltageMin = 3300;
   uint8_t battery_BrickTempMaxNum = 0;
   uint8_t battery_BrickTempMinNum = 0;
-  uint8_t battery_BrickModelTMax = 0;
-  uint8_t battery_BrickModelTMin = 0;
+  int16_t battery_BrickModelTMax = 0;
+  int16_t battery_BrickModelTMin = 0;
   uint8_t battery_BrickVoltageMaxNum = 0;
   uint8_t battery_BrickVoltageMinNum = 0;
   //0x5D2


### PR DESCRIPTION
### What
This PR implements low isolation warning event for Tesla Legacy

### Why
User requested feature on the Discord, to aid troubleshooting why contactors open

### How
We fire off an event if the value is under 100. Setpoint still unsure, testers wanted

BONUS: Some code cleanup

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
