### PR TITLE
Add support for bidirectional charging via CCS

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -472,6 +472,9 @@ void core_loop(void*) {
         if (precharge_control_enabled) {
           handle_precharge_control(currentMillis);  //Drive the hia4v1 via PWM
         }
+        if (battery) {
+          battery->handle_precharge();
+        }
         END_TIME_MEASUREMENT_MAX(10ms, datalayer.system.status.time_10ms_us);
       } else {  //Run 10ms tasks without timing it
         monitor_equipment_stop_button();
@@ -479,6 +482,9 @@ void core_loop(void*) {
         handle_contactors();  // Take care of startup precharge/contactor closing
         if (precharge_control_enabled) {
           handle_precharge_control(currentMillis);  //Drive the hia4v1 via PWM
+        }
+        if (battery) {
+          battery->handle_precharge();
         }
       }
     }

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -148,8 +148,10 @@ const char* name_for_battery_type(BatteryType type) {
       return VolvoSpaBattery::Name;
     case BatteryType::VolvoSpaHybrid:
       return VolvoSpaHybridBattery::Name;
+#ifndef SMALL_FLASH_DEVICE
     case BatteryType::ChargebyteCCSBattery:
       return ChargebyteCCSBattery::Name;
+#endif
     default:
       return nullptr;
   }
@@ -270,8 +272,10 @@ Battery* create_battery(BatteryType type) {
       return new VolvoSpaBattery();
     case BatteryType::VolvoSpaHybrid:
       return new VolvoSpaHybridBattery();
+#ifndef SMALL_FLASH_DEVICE
     case BatteryType::ChargebyteCCSBattery:
       return new ChargebyteCCSBattery();
+#endif
     default:
       return nullptr;
   }

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -148,6 +148,8 @@ const char* name_for_battery_type(BatteryType type) {
       return VolvoSpaBattery::Name;
     case BatteryType::VolvoSpaHybrid:
       return VolvoSpaHybridBattery::Name;
+    case BatteryType::ChargebyteCCSBattery:
+      return ChargebyteCCSBattery::Name;
     default:
       return nullptr;
   }
@@ -268,6 +270,8 @@ Battery* create_battery(BatteryType type) {
       return new VolvoSpaBattery();
     case BatteryType::VolvoSpaHybrid:
       return new VolvoSpaHybridBattery();
+    case BatteryType::ChargebyteCCSBattery:
+      return new ChargebyteCCSBattery();
     default:
       return nullptr;
   }

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -22,6 +22,7 @@ void setup_shunt();
 #include "CHADEMO-BATTERY.h"
 #include "CHADEMO-CT.h"
 #include "CHADEMO-SHUNTS.h"
+#include "CHARGEBYTE-CCS.h"
 #include "CMFA-EV-BATTERY.h"
 #include "CMP-SMART-CAR-BATTERY.h"
 #include "DALY-BMS.h"

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -58,6 +58,7 @@ enum class BatteryType {
   ThunderstruckBMS = 51,
   EnnoidBMS = 52,
   StellantisSmallWide4x4 = 53,
+  ChargebyteCCSBattery = 54,
   Highest
 };
 
@@ -134,6 +135,7 @@ class Battery {
   virtual void chademo_stop() {}
   virtual void initiate_balancing() {}
   virtual void end_balancing() {}
+  virtual void handle_precharge() {}
 
   virtual void set_fake_voltage(float v) {}
   virtual float get_voltage();

--- a/Software/src/battery/CHARGEBYTE-CCS.cpp
+++ b/Software/src/battery/CHARGEBYTE-CCS.cpp
@@ -5,6 +5,18 @@
 /* Do not change code below unless you are sure what you are doing */
 // will store last time a 1s CAN Message was sent
 
+void ChargebyteCCSBattery::setPrechargeVoltage(uint16_t value, bool writeEEPROM) {
+  if (!prechargeDacDev)
+    return;
+
+  uint8_t packet[3];
+  packet[0] = writeEEPROM ? 0x60 : 0x40;
+  packet[1] = value >> 4;
+  packet[2] = (value & 0x0F) << 4;
+
+  i2c_master_transmit(prechargeDacDev, packet, 3, 100 / portTICK_PERIOD_MS);
+}
+
 void ChargebyteCCSBattery::dump_data() {
   logging.print("[CME-CCS] [Status] ");
   logging.print("hasChargebyteError = ");
@@ -47,13 +59,13 @@ void ChargebyteCCSBattery::handle_precharge() {
     if (prechargePos <= 4090)
       prechargePos += 4;
 
-    prechargeDac.setVoltage(prechargePos, false);
+    setPrechargeVoltage(prechargePos);
 
     logging.print("[CME-CCS] setting precharge to ");
     logging.println(prechargePos);
   } else if (prechargePos != 0) {
     prechargePos = 0;
-    prechargeDac.setVoltage(0, false);
+    setPrechargeVoltage(0);
   }
 
   static uint16_t contactorCloseDelay = 0;
@@ -219,11 +231,33 @@ void ChargebyteCCSBattery::setup() {
   datalayer.battery.status.temperature_min_dC = 200;
   datalayer.battery.status.temperature_max_dC = 200;
 
-  prechargeI2C.begin(PRECHARGE_DAC_SDA, PRECHARGE_DAC_SCL, 400000);
-  if (prechargeDac.begin(PRECHARGE_DAC_ADDRESS, &prechargeI2C)) {
-    logging.println("[CME-CCS] successfully initialized I2C DAC");
-  } else {
-    logging.println("[CME-CCS] Failed initializing I2C DAC");
+  i2c_master_bus_config_t bus_config = {
+      .i2c_port = -1,
+      .sda_io_num = (gpio_num_t)PRECHARGE_DAC_SDA,
+      .scl_io_num = (gpio_num_t)PRECHARGE_DAC_SCL,
+      .clk_source = I2C_CLK_SRC_DEFAULT,
+      .glitch_ignore_cnt = 7,
+      .intr_priority = 0,
+      .trans_queue_depth = 0,
+      .flags = {.enable_internal_pullup = true},
+  };
+  if (i2c_new_master_bus(&bus_config, &prechargeI2CBus) != ESP_OK) {
+    logging.println("[CME-CCS] Failed initializing I2C bus for DAC");
+    return;
   }
-  prechargeDac.setVoltage(0, true);  // set 0V output and store in EEPROM
+
+  i2c_device_config_t dev_config = {
+      .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+      .device_address = PRECHARGE_DAC_ADDRESS,
+      .scl_speed_hz = 400000,
+      .scl_wait_us = 0,
+      .flags = {},
+  };
+  if (i2c_master_bus_add_device(prechargeI2CBus, &dev_config, &prechargeDacDev) != ESP_OK) {
+    logging.println("[CME-CCS] Failed adding DAC device");
+    return;
+  }
+
+  logging.println("[CME-CCS] successfully initialized I2C DAC");
+  setPrechargeVoltage(0, true);
 }

--- a/Software/src/battery/CHARGEBYTE-CCS.cpp
+++ b/Software/src/battery/CHARGEBYTE-CCS.cpp
@@ -1,0 +1,229 @@
+#include "CHARGEBYTE-CCS.h"
+#include "../datalayer/datalayer.h"
+#include "./Shunt.h"
+
+/* Do not change code below unless you are sure what you are doing */
+// will store last time a 1s CAN Message was sent
+
+void ChargebyteCCSBattery::dump_data() {
+  logging.print("[CME-CCS] [Status] ");
+  logging.print("hasChargebyteError = ");
+  logging.print(hasChargebyteError);
+  logging.print(", hasLowLevelError = ");
+  logging.print(hasLowLevelError);
+  logging.print(", inPrecharge = ");
+  logging.print(inPrecharge);
+  logging.print(", inCharge = ");
+  logging.print(inCharge);
+  logging.println();
+
+  logging.print("[CME-CCS] [Values] ");
+  logging.print("precharge_dV = ");
+  logging.print(precharge_dV);
+  logging.print(", targetVoltage_dV = ");
+  logging.print(targetVoltage_dV);
+  logging.print(", targetCurrent_dA = ");
+  logging.print(targetCurrent_dA);
+  logging.print(", maxVoltage_dV = ");
+  logging.print(maxVoltage_dV);
+  logging.print(", maxCurrent_dA = ");
+  logging.print(maxCurrent_dA);
+  logging.print(", maxPower_W = ");
+  logging.print(maxPower_W);
+  logging.print(", SOC = ");
+  logging.print(soc);
+  logging.print(", energyCapacity_Wh = ");
+  logging.print(energyCapacity_Wh);
+  logging.println();
+}
+
+// this is called every 10ms. We precharge from 1200 to 4095 in 7.24s which refers to 0 to 500V.
+// according to our tests e.g. a Tesla M3 allows 12 seconds of precharging before aborting
+void ChargebyteCCSBattery::handle_precharge() {
+  static uint16_t prechargePos = 0;
+  if (inPrecharge) {
+    if (prechargePos < 1200)
+      prechargePos = 1200;
+    if (prechargePos <= 4090)
+      prechargePos += 4;
+
+    prechargeDac.setVoltage(prechargePos, false);
+
+    logging.print("[CME-CCS] setting precharge to ");
+    logging.println(prechargePos);
+  } else if (prechargePos != 0) {
+    prechargePos = 0;
+    prechargeDac.setVoltage(0, false);
+  }
+
+  static uint16_t contactorCloseDelay = 0;
+  if (inCharge) {
+    if (contactorCloseDelay == 100)  // start precharging after 1s
+      digitalWrite(CCS_PRECHARGE_CONTACTOR_PIN(), HIGH);
+    else if (contactorCloseDelay == 1000)  // fully connect after 10s
+      digitalWrite(CCS_MAIN_CONCTACTOR_PIN(), HIGH);
+    else if (contactorCloseDelay == 1200)  // turn off precharge contactor to reduce coil consumption
+      digitalWrite(CCS_PRECHARGE_CONTACTOR_PIN(), LOW);
+
+    if (contactorCloseDelay <= 1200)
+      contactorCloseDelay++;
+  } else if (contactorCloseDelay != 0) {
+    digitalWrite(CCS_PRECHARGE_CONTACTOR_PIN(), LOW);
+    digitalWrite(CCS_MAIN_CONCTACTOR_PIN(), LOW);
+    contactorCloseDelay = 0;
+  }
+
+  static bool wasInCharge = false;
+  static uint16_t cpPpDisconnectDelay = 0;
+  if (inCharge) {
+    wasInCharge = true;
+    cpPpDisconnectDelay = 0;
+  } else if (wasInCharge && cpPpDisconnectDelay <= 6200) {
+    if (cpPpDisconnectDelay == 0) {
+      logging.println("Detected charge abort, waiting for 60 seconds...");
+    }
+    if (cpPpDisconnectDelay == 6000) {  // disconnect CP and PP after 10s
+      logging.println("Detected charge abort, disconnecting CP and PP...");
+      digitalWrite(CCS_CP_PP_DISCONNECT_PIN(), HIGH);
+    } else if (cpPpDisconnectDelay >= 6199) {  // reconnect after 1.9 more seconds
+      logging.println("Recovering from charge abort, reconnecting CP and PP...");
+      digitalWrite(CCS_CP_PP_DISCONNECT_PIN(), LOW);
+      wasInCharge = false;
+      cpPpDisconnectDelay = 0;
+    }
+    cpPpDisconnectDelay++;
+  }
+}
+
+void ChargebyteCCSBattery::update_values() {
+  dump_data();
+
+  static uint16_t presentVoltage_dV = 0;
+  if (inPrecharge && precharge_dV <= EVSE_MAX_VOLTAGE && precharge_dV > 0)
+    presentVoltage_dV = precharge_dV;
+  else if (inCharge && user_selected_shunt_type != ShuntType::None)
+    presentVoltage_dV = datalayer.shunt.measured_voltage_dV;
+
+  int32_t presentCurrent_dA = 0;
+  if (inCharge && user_selected_shunt_type != ShuntType::None)
+    presentCurrent_dA = datalayer.shunt.measured_amperage_mA / 100;
+
+  CHARGEBYTE_302.data.u8[0] = (presentCurrent_dA + 32500) & 0xff;
+  CHARGEBYTE_302.data.u8[1] = (presentCurrent_dA + 32500) >> 8;
+  CHARGEBYTE_302.data.u8[2] = presentVoltage_dV & 0xff;
+  CHARGEBYTE_302.data.u8[3] = presentVoltage_dV >> 8;
+
+  if (inPrecharge)
+    datalayer.battery.status.real_bms_status = BMS_STANDBY;
+  else if (inCharge)
+    datalayer.battery.status.real_bms_status = BMS_ACTIVE;
+  else if (hasLowLevelError || hasChargebyteError)
+    datalayer.battery.status.real_bms_status = BMS_FAULT;
+  else
+    datalayer.battery.status.real_bms_status = BMS_DISCONNECTED;
+
+  datalayer.battery.status.real_soc = soc;
+  datalayer.battery.status.voltage_dV = presentVoltage_dV;
+  datalayer.battery.status.current_dA = presentCurrent_dA;
+  datalayer.battery.status.remaining_capacity_Wh = energyCapacity_Wh * soc / 10000;
+  datalayer.battery.info.total_capacity_Wh = energyCapacity_Wh;
+  datalayer.battery.info.max_design_voltage_dV = maxVoltage_dV;
+
+  datalayer.battery.status.max_charge_power_W = maxPower_W;
+  datalayer.battery.status.max_discharge_power_W = maxPower_W;
+}
+
+void ChargebyteCCSBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
+  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  switch (rx_frame.ID) {
+    case 0x100:
+      if ((rx_frame.data.u8[2] >> 4) >= 3)
+        hasLowLevelError = true;
+      else
+        hasLowLevelError = false;
+
+      inPrecharge = false;
+      inCharge = false;
+      if ((rx_frame.data.u8[1] & 0xf) == 5)
+        inPrecharge = true;
+      else if ((rx_frame.data.u8[1] & 0xf) == 6)
+        inCharge = true;
+      break;
+    case 0x102:
+      if (rx_frame.data.u8[1] == 0)
+        hasChargebyteError = false;
+      else
+        hasChargebyteError = true;
+      break;
+    case 0x202:
+      soc = rx_frame.data.u8[0] * 50;
+      break;
+    case 0x201:
+      targetCurrent_dA = ((uint16_t)rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];
+      targetVoltage_dV = ((uint16_t)rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2];
+      precharge_dV = ((uint16_t)rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+      break;
+    case 0x200:
+      maxCurrent_dA = ((uint16_t)rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];
+      maxPower_W = (((uint32_t)rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) * 100;
+      maxVoltage_dV = ((uint16_t)rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
+      break;
+    case 0x203:
+      energyCapacity_Wh = ((uint16_t)rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];
+      break;
+    default:
+      break;
+  }
+}
+
+void ChargebyteCCSBattery::transmit_can(unsigned long now) {
+  static unsigned long previousTransmit = 0;
+  // Send 100ms CAN Message
+  if (now - previousTransmit >= INTERVAL_100_MS) {
+    previousTransmit = now;
+
+    transmit_can_frame(&CHARGEBYTE_300);
+    transmit_can_frame(&CHARGEBYTE_301);
+    transmit_can_frame(&CHARGEBYTE_302);
+    transmit_can_frame(&CHARGEBYTE_303);
+    transmit_can_frame(&CHARGEBYTE_304);
+    transmit_can_frame(&CHARGEBYTE_305);
+    transmit_can_frame(&CHARGEBYTE_306);
+    transmit_can_frame(&CHARGEBYTE_307);
+  }
+}
+
+void ChargebyteCCSBattery::setup() {
+  pinMode(CCS_PRECHARGE_CONTACTOR_PIN(), OUTPUT);
+  pinMode(CCS_MAIN_CONCTACTOR_PIN(), OUTPUT);
+  pinMode(CCS_CP_PP_DISCONNECT_PIN(), OUTPUT);
+  digitalWrite(CCS_PRECHARGE_CONTACTOR_PIN(), LOW);
+  digitalWrite(CCS_MAIN_CONCTACTOR_PIN(), LOW);
+  digitalWrite(CCS_CP_PP_DISCONNECT_PIN(), LOW);
+
+  strncpy(datalayer.system.info.battery_protocol, "CCS using chargebyte CME/CCF", 63);
+  datalayer.system.info.battery_protocol[63] = '\0';
+  datalayer.battery.info.min_design_voltage_dV = 1000;
+  datalayer.battery.info.max_design_voltage_dV = 5000;
+  datalayer.battery.info.max_cell_voltage_mV = 4200;
+  datalayer.battery.info.min_cell_voltage_mV = 3200;
+
+  // fake data
+  datalayer.battery.info.number_of_cells = 4;
+  datalayer.battery.status.cell_voltages_mV[0] = 4000;
+  datalayer.battery.status.cell_voltages_mV[1] = 4000;
+  datalayer.battery.status.cell_voltages_mV[2] = 4000;
+  datalayer.battery.status.cell_voltages_mV[3] = 4000;
+  datalayer.battery.status.cell_min_voltage_mV = 4000;
+  datalayer.battery.status.cell_max_voltage_mV = 4000;
+  datalayer.battery.status.temperature_min_dC = 200;
+  datalayer.battery.status.temperature_max_dC = 200;
+
+  prechargeI2C.begin(PRECHARGE_DAC_SDA, PRECHARGE_DAC_SCL, 400000);
+  if (prechargeDac.begin(PRECHARGE_DAC_ADDRESS, &prechargeI2C)) {
+    logging.println("[CME-CCS] successfully initialized I2C DAC");
+  } else {
+    logging.println("[CME-CCS] Failed initializing I2C DAC");
+  }
+  prechargeDac.setVoltage(0, true);  // set 0V output and store in EEPROM
+}

--- a/Software/src/battery/CHARGEBYTE-CCS.cpp
+++ b/Software/src/battery/CHARGEBYTE-CCS.cpp
@@ -1,3 +1,5 @@
+#ifndef SMALL_FLASH_DEVICE
+
 #include "CHARGEBYTE-CCS.h"
 #include "../datalayer/datalayer.h"
 #include "./Shunt.h"
@@ -261,3 +263,5 @@ void ChargebyteCCSBattery::setup() {
   logging.println("[CME-CCS] successfully initialized I2C DAC");
   setPrechargeVoltage(0, true);
 }
+
+#endif

--- a/Software/src/battery/CHARGEBYTE-CCS.cpp
+++ b/Software/src/battery/CHARGEBYTE-CCS.cpp
@@ -148,7 +148,7 @@ void ChargebyteCCSBattery::update_values() {
 }
 
 void ChargebyteCCSBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
-  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  bool isChargebyteFrame = true;
   switch (rx_frame.ID) {
     case 0x100:
       if ((rx_frame.data.u8[2] >> 4) >= 3)
@@ -186,8 +186,12 @@ void ChargebyteCCSBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       energyCapacity_Wh = ((uint16_t)rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];
       break;
     default:
+      isChargebyteFrame = false;
       break;
   }
+
+  if (isChargebyteFrame)
+    datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
 }
 
 void ChargebyteCCSBattery::transmit_can(unsigned long now) {

--- a/Software/src/battery/CHARGEBYTE-CCS.h
+++ b/Software/src/battery/CHARGEBYTE-CCS.h
@@ -1,0 +1,128 @@
+#ifndef CHARGEBYTE_CCS_BATTERY_H
+#define CHARGEBYTE_CCS_BATTERY_H
+#include "../devboard/hal/hal.h"
+#include "CanBattery.h"
+
+#include <Adafruit_MCP4725.h>
+#include <Wire.h>
+
+class ChargebyteCCSBattery : public CanBattery {
+ public:
+  virtual void setup(void);
+  virtual void handle_precharge(void);
+  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
+  virtual void update_values();
+  virtual void transmit_can(unsigned long currentMillis);
+  static constexpr const char* Name = "Chargebyte CCS V2X";
+
+ private:
+  void dump_data();
+
+  static constexpr const char* EVSE_ID = "DEDIYE42";
+  static const int EVSE_MIN_VOLTAGE = 1500;  // in dV
+  static const int EVSE_MAX_VOLTAGE = 4500;  // in dV
+  static const int EVSE_MAX_CURRENT = 320;   // in dA
+  static const int EVSE_MAX_POWER = 100;     // in 100W
+  static const int MIN_PACK_VOLTAGE_DV = 3000;
+
+  // the following configures pins for precharging the vehicle side
+  // a MCP4725 is used for generating a voltage 0-3.3V
+  // a QC05-5C is used for converting 0-3.3V to 0-500V
+  static const int PRECHARGE_DAC_SDA = 13;        // pin 13 for SDA of precharge MCP4725
+  static const int PRECHARGE_DAC_SCL = 19;        // pin 19 for SCL of precharge MCP4725
+  static const int PRECHARGE_DAC_ADDRESS = 0x61;  // I2C address of precharge MCP4725
+
+  // the following configures pins for precharging the inverter side
+  // battery voltage and two DC contactors are used. negative is connected all the time
+  // we differ from the official STARK CMR pins
+  virtual gpio_num_t CCS_PRECHARGE_CONTACTOR_PIN() { return esp32hal->POSITIVE_CONTACTOR_PIN(); }
+  virtual gpio_num_t CCS_MAIN_CONCTACTOR_PIN() { return esp32hal->NEGATIVE_CONTACTOR_PIN(); }
+  virtual gpio_num_t CCS_CP_PP_DISCONNECT_PIN() { return esp32hal->BMS_POWER(); }
+
+  CAN_frame CHARGEBYTE_307 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x307,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CHARGEBYTE_306 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x306,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CHARGEBYTE_305 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x305,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CHARGEBYTE_304 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x304,
+                              .data = {
+                                  EVSE_ID[0],
+                                  EVSE_ID[1],
+                                  EVSE_ID[2],
+                                  EVSE_ID[3],
+                                  EVSE_ID[4],
+                                  EVSE_ID[5],
+                                  EVSE_ID[6],
+                                  EVSE_ID[7],
+                              }};
+  CAN_frame CHARGEBYTE_303 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x303,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame CHARGEBYTE_302 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x302,
+                              .data = {0x00, 0x00, 0x00, 0x00, 0x09, 0x01, 0x00, 0x00}};
+  CAN_frame CHARGEBYTE_301 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x301,
+                              .data = {
+                                  0x00,
+                                  0x00,
+                                  EVSE_MIN_VOLTAGE & 0xff,
+                                  EVSE_MIN_VOLTAGE >> 8,
+                                  0x32,
+                                  0x32,
+                                  0x00,
+                                  0x00,
+                              }};
+  CAN_frame CHARGEBYTE_300 = {.FD = false,
+                              .ext_ID = true,
+                              .DLC = 8,
+                              .ID = 0x300,
+                              .data = {
+                                  EVSE_MAX_CURRENT & 0xff,
+                                  EVSE_MAX_CURRENT >> 8,
+                                  EVSE_MAX_VOLTAGE & 0xff,
+                                  EVSE_MAX_VOLTAGE >> 8,
+                                  EVSE_MAX_POWER & 0xff,
+                                  EVSE_MAX_POWER >> 8,
+                                  0xE8,
+                                  0x03,
+                              }};
+
+  bool hasChargebyteError = false;
+  bool hasLowLevelError = false;
+  bool inPrecharge = false;
+  bool inCharge = false;
+  uint16_t precharge_dV = 0;
+  uint16_t targetVoltage_dV = 0;
+  uint16_t targetCurrent_dA = 0;
+  uint16_t maxVoltage_dV = 0;
+  uint16_t maxCurrent_dA = 0;
+  uint32_t maxPower_W = 0;
+  uint16_t soc = 0;
+  uint32_t energyCapacity_Wh = 20000;
+
+  // for controlling external precharge board
+  TwoWire prechargeI2C = TwoWire(0);
+  Adafruit_MCP4725 prechargeDac;
+};
+
+#endif

--- a/Software/src/battery/CHARGEBYTE-CCS.h
+++ b/Software/src/battery/CHARGEBYTE-CCS.h
@@ -1,3 +1,5 @@
+#ifndef SMALL_FLASH_DEVICE
+
 #ifndef CHARGEBYTE_CCS_BATTERY_H
 #define CHARGEBYTE_CCS_BATTERY_H
 #include "../devboard/hal/hal.h"
@@ -123,5 +125,7 @@ class ChargebyteCCSBattery : public CanBattery {
   i2c_master_bus_handle_t prechargeI2CBus = nullptr;
   i2c_master_dev_handle_t prechargeDacDev = nullptr;
 };
+
+#endif
 
 #endif

--- a/Software/src/battery/CHARGEBYTE-CCS.h
+++ b/Software/src/battery/CHARGEBYTE-CCS.h
@@ -3,8 +3,7 @@
 #include "../devboard/hal/hal.h"
 #include "CanBattery.h"
 
-#include <Adafruit_MCP4725.h>
-#include <Wire.h>
+#include "driver/i2c_master.h"
 
 class ChargebyteCCSBattery : public CanBattery {
  public:
@@ -17,6 +16,7 @@ class ChargebyteCCSBattery : public CanBattery {
 
  private:
   void dump_data();
+  void setPrechargeVoltage(uint16_t value, bool writeEEPROM = false);
 
   static constexpr const char* EVSE_ID = "DEDIYE42";
   static const int EVSE_MIN_VOLTAGE = 1500;  // in dV
@@ -120,9 +120,8 @@ class ChargebyteCCSBattery : public CanBattery {
   uint16_t soc = 0;
   uint32_t energyCapacity_Wh = 20000;
 
-  // for controlling external precharge board
-  TwoWire prechargeI2C = TwoWire(0);
-  Adafruit_MCP4725 prechargeDac;
+  i2c_master_bus_handle_t prechargeI2CBus = nullptr;
+  i2c_master_dev_handle_t prechargeDacDev = nullptr;
 };
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -70,7 +70,6 @@ build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
 ;build_cxxflags = -fno-rtti
 lib_deps = 
-    adafruit/Adafruit MCP4725@^2.0.2
 
 [env:lilygo_2CAN_330]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -70,6 +70,7 @@ build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
 ;build_cxxflags = -fno-rtti
 lib_deps = 
+    adafruit/Adafruit MCP4725@^2.0.2
 
 [env:lilygo_2CAN_330]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(tests
     ../Software/src/battery/BYD-ATTO-3-BATTERY.cpp
     ../Software/src/battery/CanBattery.cpp
     ../Software/src/battery/CELLPOWER-BMS.cpp
+    ../Software/src/battery/CHARGEBYTE-CCS.cpp
     ../Software/src/battery/CHADEMO-BATTERY.cpp
     ../Software/src/battery/CHADEMO-CT.cpp
     ../Software/src/battery/CHADEMO-SHUNTS.cpp
@@ -184,6 +185,7 @@ add_executable(tests
     emul/serial.cpp
     emul/Arduino.cpp
     emul/freertos/FreeRTOS.cpp
+    emul/driver/i2c_master.cpp
     )
 
 target_link_libraries(tests

--- a/test/emul/driver/i2c_master.cpp
+++ b/test/emul/driver/i2c_master.cpp
@@ -1,0 +1,30 @@
+#include "driver/i2c_master.h"
+
+struct i2c_master_bus_t {};
+struct i2c_master_dev_t {};
+
+static i2c_master_bus_t fake_bus{};
+static i2c_master_dev_t fake_dev{};
+
+esp_err_t i2c_new_master_bus(const i2c_master_bus_config_t* bus_config, i2c_master_bus_handle_t* ret_bus_handle) {
+  (void)bus_config;
+  *ret_bus_handle = &fake_bus;
+  return ESP_OK;
+}
+
+esp_err_t i2c_master_bus_add_device(i2c_master_bus_handle_t bus_handle, const i2c_device_config_t* dev_config,
+                                    i2c_master_dev_handle_t* ret_handle) {
+  (void)bus_handle;
+  (void)dev_config;
+  *ret_handle = &fake_dev;
+  return ESP_OK;
+}
+
+esp_err_t i2c_master_transmit(i2c_master_dev_handle_t dev_handle, const uint8_t* write_buffer, size_t write_size,
+                              int xfer_timeout_ms) {
+  (void)dev_handle;
+  (void)write_buffer;
+  (void)write_size;
+  (void)xfer_timeout_ms;
+  return ESP_OK;
+}

--- a/test/emul/driver/i2c_master.h
+++ b/test/emul/driver/i2c_master.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "freertos/FreeRTOS.h"
+#include "soc/gpio_num.h"
+
+typedef int esp_err_t;
+#define ESP_OK 0
+
+typedef struct i2c_master_bus_t* i2c_master_bus_handle_t;
+typedef struct i2c_master_dev_t* i2c_master_dev_handle_t;
+
+typedef enum {
+  I2C_CLK_SRC_DEFAULT = 0,
+} i2c_clock_source_t;
+
+typedef enum {
+  I2C_ADDR_BIT_LEN_7 = 0,
+  I2C_ADDR_BIT_LEN_10,
+} i2c_addr_bit_len_t;
+
+typedef struct {
+  int i2c_port;
+  gpio_num_t sda_io_num;
+  gpio_num_t scl_io_num;
+  i2c_clock_source_t clk_source;
+  uint8_t glitch_ignore_cnt;
+  int intr_priority;
+  size_t trans_queue_depth;
+  struct {
+    uint32_t enable_internal_pullup : 1;
+  } flags;
+} i2c_master_bus_config_t;
+
+typedef struct {
+  i2c_addr_bit_len_t dev_addr_length;
+  uint16_t device_address;
+  uint32_t scl_speed_hz;
+  uint32_t scl_wait_us;
+  struct {
+  } flags;
+} i2c_device_config_t;
+
+esp_err_t i2c_new_master_bus(const i2c_master_bus_config_t* bus_config, i2c_master_bus_handle_t* ret_bus_handle);
+esp_err_t i2c_master_bus_add_device(i2c_master_bus_handle_t bus_handle, const i2c_device_config_t* dev_config,
+                                    i2c_master_dev_handle_t* ret_handle);
+esp_err_t i2c_master_transmit(i2c_master_dev_handle_t dev_handle, const uint8_t* write_buffer, size_t write_size,
+                              int xfer_timeout_ms);

--- a/test/emul/freertos/FreeRTOS.h
+++ b/test/emul/freertos/FreeRTOS.h
@@ -10,6 +10,8 @@ typedef unsigned int UBaseType_t;
 
 const BaseType_t tskNO_AFFINITY = -1;
 
+#define portTICK_PERIOD_MS 1
+
 extern "C" {
 BaseType_t xTaskCreatePinnedToCore(TaskFunction_t pxTaskCode, const char* const pcName, const uint32_t ulStackDepth,
                                    void* const pvParameters, UBaseType_t uxPriority, TaskHandle_t* const pxCreatedTask,


### PR DESCRIPTION
### What
This PR implements a new "battery" talking to a [chargebyte CME](https://chargebyte.com/products/controllers-modules/evse-controllers/charge-module-e) or [CCF](https://chargebyte.com/products/controllers-modules/evse-controllers/charge-control-f), which handles communication with electric vehicles according to DIN SPEC 70121 and ISO15118.

### Why
This could also be used by DIYers to build bidirectional charging stations and charge/discharge "first-life" vehicles.
Additionally it could be used to work with crashed vehicles for second life use cases (needs vehicle charge controller, but removes the need of reverse engineering the battery protocol).
For us the goal of this code was to discharge vehicles as part of our research paper [published at USENIX VehicleSec'25](https://www.usenix.org/conference/vehiclesec25/presentation/low).

### How
In our test setup we used a Stark CMR, a chargebyte CCF and a 4kW Fronius Primo.
<img width="1280" height="960" alt="photo_2026-06-15_11-31-31" src="https://github.com/user-attachments/assets/baaff488-e978-4bd8-9e48-d103db7fe8a8" />
<img width="960" height="1280" alt="photo_2026-06-15_11-36-06" src="https://github.com/user-attachments/assets/97f0e1ba-81bc-4caa-920c-cbce7b8e6b63" />

For precharging the vehicle side a MCP4725 DAC is used to generate 0-3.3V which is turned to 0-500V by a XPPower Q05-5C.
<img width="960" height="1280" alt="photo_2026-06-15_11-35-16" src="https://github.com/user-attachments/assets/30ce7bdb-bfbb-4577-bf84-7956925f76cd" />

### Open Points / TODOs
- [ ] The vehicle side precharge is currently weirdly integrated. Maybe this could be combined with the MEB precharging codebase to a generic battery-side precharging
- [x] The MCP4725 library is currently included using platformio. I would say this is the way to go, but all other libs seem to be included in the repo directly?
- [x] lilygo flash size is now 99.3%. Maybe disable the new "battery" on small flash devices.

#### Disclaimer
> This code was developed at Technische Hochschule Ingolstadt as part of the research project "Elektromobiles Sicheres Laden" (ESiLa) funded by the Bavarian Ministry of Economic Affairs, Regional Development and Energy under grant DIK0512/01.

personal note: While this might sound scary at first, I got approval from both my supervisor at THI as well as chargebyte to publish this code. The above just has to be stated for funding rule reasons.
