### PR TITLE
fix(kostal-rs485): don't call battery->update_values() on cyclic poll

### DIFF
--- a/Software/src/inverter/KOSTAL-RS485.cpp
+++ b/Software/src/inverter/KOSTAL-RS485.cpp
@@ -265,10 +265,10 @@ void KostalInverterProtocol::receive()  // Runs as fast as possible to handle th
                 int code = RS485_RXFRAME[6] + RS485_RXFRAME[7] * 0x100;
                 if (code == 0x44a && info_sent) {
                   //Send cyclic data
-                  // TODO: Probably not a good idea to use the battery object here like this.
-                  if (battery) {
-                    battery->update_values();
-                  }
+                  // NOTE: do NOT call battery->update_values() here. The core loop already runs it
+                  // once per second; calling it again on every cyclic poll runs the battery's
+                  // per-second logic ~twice as fast. No other inverter does this. The inverter reads
+                  // the datalayer as refreshed by the core loop.
                   update_values();
                   if (f2_startup_count < 15) {
                     f2_startup_count++;


### PR DESCRIPTION


### What
`KostalInverterProtocol::receive()` calls `battery->update_values()` on every
cyclic-data request (`code == 0x44a`), on top of the core loop's regular ~1 Hz
`battery->update_values()` call. This removes that extra call.

### Why
It makes the battery's `update_values()` run roughly twice per second instead of
once. Any per-second / time-based logic inside a battery's `update_values()`
(timers, keep-alive / staleness counters, etc.) then advances at ~2× the intended
rate. No other inverter integration reaches into the battery object like this, and
the existing `// TODO: Probably not a good idea to use the battery object here
like this.` already flagged it.

## Fix
Remove the call. The core loop owns the battery-update cadence; the Kostal
protocol reads the datalayer that the core loop already refreshes each cycle.

## Impact / risk
For batteries whose `update_values()` only maps already-received CAN data into the
datalayer, the only difference is that data is refreshed at the core-loop rate
(~1 Hz) rather than additionally on each cyclic poll — at most ~1 s extra latency,
no change to the values sent to the inverter. Behaviour now matches every other
inverter integration.

## Testing
Tested on a Kostal RS485 inverter with a BMW i3 battery: cyclic data still correct
and time-based battery logic now runs at the intended 1 Hz.