### PR TITLE
Tesla S/3/X/Y: Bugfix; Fix initialization for double battery

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -131,9 +131,9 @@ const char* name_for_battery_type(BatteryType type) {
     case BatteryType::SimpBms:
       return SimpBmsBattery::Name;
     case BatteryType::TeslaModel3Y:
-      return TeslaModel3YBattery::Name;
+      return TeslaBattery::Name3Y;
     case BatteryType::TeslaModelSX:
-      return TeslaModelSXBattery::Name;
+      return TeslaBattery::NameSX;
     case BatteryType::TeslaLegacy:
       return TeslaLegacyBattery::Name;
     case BatteryType::TestFake:
@@ -252,9 +252,8 @@ Battery* create_battery(BatteryType type) {
     case BatteryType::StellantisSmallWide4x4:
       return new StellantisSmallWide4x4Battery();
     case BatteryType::TeslaModel3Y:
-      return new TeslaModel3YBattery();
     case BatteryType::TeslaModelSX:
-      return new TeslaModelSXBattery();
+      return new TeslaBattery();
     case BatteryType::TeslaLegacy:
       return new TeslaLegacyBattery();
     case BatteryType::TestFake:
@@ -342,6 +341,10 @@ void setup_battery() {
         break;
       case BatteryType::TestFake:
         battery2 = new TestFakeBattery(&datalayer.battery2, can_config.battery_double);
+        break;
+      case BatteryType::TeslaModel3Y:
+      case BatteryType::TeslaModelSX:
+        battery2 = new TeslaBattery(&datalayer.battery2, can_config.battery_double);
         break;
       default:
         DEBUG_PRINTF("User tried enabling double battery on non-supported integration!\n");

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2414,7 +2414,7 @@ void TeslaBattery::printFaultCodesIfActive() {
   printDebugIfActive(BMS_a180_SW_ECU_reset_blocked, "ERROR: BMS_a180_SW_ECU_reset_blocked");
 }
 
-void TeslaModel3YBattery::setup(void) {  // Performs one time setup at startup
+void TeslaBattery::setup(void) {  // Performs one time setup at startup
 
   if (allows_contactor_closing) {
     *allows_contactor_closing = true;
@@ -2447,34 +2447,30 @@ void TeslaModel3YBattery::setup(void) {  // Performs one time setup at startup
       break;
   }
 
-  strncpy(datalayer.system.info.battery_protocol, Name, 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
+  //IF 3 / Y
+  if (user_selected_battery_type == BatteryType::TeslaModel3Y) {
+    strncpy(datalayer.system.info.battery_protocol, Name3Y, 63);
+    if (datalayer_battery->info.chemistry == battery_chemistry_enum::LFP) {
+      datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
+      datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
+      datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_LFP;
+      datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_LFP;
+      datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_LFP;
+    } else {
+      datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
+      datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
+      datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
+      datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_NCA_NCM;
+      datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_NCA_NCM;
+    }
+  } else {  //S/X
 
-  if (datalayer_battery->info.chemistry == battery_chemistry_enum::LFP) {
-    datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_LFP;
-    datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_LFP;
-    datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_LFP;
-    datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_LFP;
-    datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_LFP;
-  } else {
-    datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_3Y_NCMA;
-    datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_3Y_NCMA;
+    strncpy(datalayer.system.info.battery_protocol, NameSX, 63);
+    datalayer.system.info.battery_protocol[63] = '\0';
+    datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
+    datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
     datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
     datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_NCA_NCM;
     datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_NCA_NCM;
   }
-}
-
-void TeslaModelSXBattery::setup(void) {
-  if (allows_contactor_closing) {
-    *allows_contactor_closing = true;
-  }
-
-  strncpy(datalayer.system.info.battery_protocol, Name, 63);
-  datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_SX_NCMA;
-  datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_SX_NCMA;
-  datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_NCA_NCM;
-  datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_NCA_NCM;
-  datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_NCA_NCM;
 }

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -27,7 +27,7 @@ class TeslaBattery : public CanBattery {
     allows_contactor_closing = nullptr;
     previous_max_percentage = datalayer_ptr->settings.max_percentage;
   }
-
+  virtual void setup();
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
@@ -46,6 +46,9 @@ class TeslaBattery : public CanBattery {
   bool supports_manual_balancing() { return true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
+
+  static constexpr const char* NameSX = "Tesla Model S/X";
+  static constexpr const char* Name3Y = "Tesla Model 3/Y";
 
  private:
   TeslaHtmlRenderer renderer;
@@ -913,20 +916,6 @@ class TeslaBattery : public CanBattery {
   bool BMS_a174_SW_Charge_Failure = false;
   bool BMS_a179_SW_Hvp_12V_Fault = false;
   bool BMS_a180_SW_ECU_reset_blocked = false;
-};
-
-class TeslaModel3YBattery : public TeslaBattery {
- public:
-  using TeslaBattery::TeslaBattery;
-  static constexpr const char* Name = "Tesla Model 3/Y";
-  virtual void setup(void);
-};
-
-class TeslaModelSXBattery : public TeslaBattery {
- public:
-  using TeslaBattery::TeslaBattery;
-  static constexpr const char* Name = "Tesla Model S/X";
-  virtual void setup(void);
 };
 
 #endif


### PR DESCRIPTION
### What
This PR Fixes initialization for double battery Tesla

### Why
Seems like when we merged the Double Tesla PR, some files from initialization was missing in that PR

### How
This PR makes it possible to actually start double battery operation

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
