### PR TITLE
Experimental dynamic voltage limits for BYD (for Deye primarily)

### DIFF
--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -6,6 +6,19 @@
 
 /* Do not change code below unless you are sure what you are doing */
 
+#define MIN(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a < _b ? _a : _b;      \
+  })
+#define MAX(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a > _b ? _a : _b;      \
+  })
+
 BydVoltageLimits BydCanInverter::calculate_dynamic_voltage_limits() {
   BydVoltageLimits limits = {0, UINT16_MAX};
 
@@ -52,8 +65,8 @@ BydVoltageLimits BydCanInverter::calculate_dynamic_voltage_limits() {
   max_limit_dV -= 8;
   min_limit_dV += 10;
 
-  limits.max_voltage_dV = max(min(max_limit_dV, (int32_t)UINT16_MAX), 0);
-  limits.min_voltage_dV = max(min(min_limit_dV, (int32_t)UINT16_MAX), 0);
+  limits.max_voltage_dV = MAX(MIN(max_limit_dV, UINT16_MAX), 0);
+  limits.min_voltage_dV = MAX(MIN(min_limit_dV, UINT16_MAX), 0);
   return limits;
 }
 

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -6,6 +6,85 @@
 
 /* Do not change code below unless you are sure what you are doing */
 
+BydVoltageLimits BydCanInverter::calculate_dynamic_voltage_limits() {
+  BydVoltageLimits limits = {0, UINT16_MAX};
+
+  if (datalayer.battery.info.number_of_cells == 0)
+    return limits;
+
+  int32_t cell_max_limit_mV = datalayer.battery.info.max_cell_voltage_mV - 100;
+  int32_t max_limit_dV = (cell_max_limit_mV * datalayer.battery.info.number_of_cells) / 100;
+  int32_t cell_min_limit_mV = datalayer.battery.info.min_cell_voltage_mV + 100;
+  int32_t min_limit_dV = (cell_min_limit_mV * datalayer.battery.info.number_of_cells) / 100;
+
+  // Is it better to use the pack voltage since cellvoltages often refresh very slowly?
+  int32_t cell_total_mV = datalayer.battery.status.voltage_dV * 100;
+
+  // for (uint8_t cell_num = 0; cell_num < datalayer.battery.info.number_of_cells; cell_num++) {
+  //   int32_t cell_voltage_mV = datalayer.battery.status.cell_voltages_mV[cell_num];
+  //   if (cell_voltage_mV == 0 || cell_voltage_mV > datalayer.battery.info.max_cell_voltage_mV) {
+  //     // Invalid cell voltage reading, bail
+  //     return UINT16_MAX;
+  //   }
+  //   cell_total_mV += cell_voltage_mV;
+  // }
+  int32_t mean_cell_voltage_mV = cell_total_mV / datalayer.battery.info.number_of_cells;
+
+  // How far is the highest cell above the mean?
+  int32_t deviation_max_mV = datalayer.battery.status.cell_max_voltage_mV - mean_cell_voltage_mV;
+  // Calculate how much to reduce the voltage limit by to account for this
+  // deviation, to avoid overcharging the highest cell.
+  int32_t deviation_reduction_mV = deviation_max_mV * datalayer.battery.info.number_of_cells;
+  if (deviation_reduction_mV > 0) {
+    max_limit_dV -= deviation_reduction_mV / 100;
+  }
+
+  // How far is the lowest cell below the mean?
+  int32_t deviation_min_mV = mean_cell_voltage_mV - datalayer.battery.status.cell_min_voltage_mV;
+  // Calculate how much to increase the voltage limit by to account for this
+  // deviation, to avoid overdischarging the lowest cell.
+  int32_t deviation_increase_mV = deviation_min_mV * datalayer.battery.info.number_of_cells;
+  if (deviation_increase_mV > 0) {
+    min_limit_dV += deviation_increase_mV / 100;
+  }
+
+  // Apply offsets
+  max_limit_dV -= 8;
+  min_limit_dV += 1;
+
+  limits.min_voltage_dV = max(min(min_limit_dV, UINT16_MAX), 0);
+  limits.max_voltage_dV = max(min(max_limit_dV, UINT16_MAX), 0);
+  return limits;
+}
+
+BydVoltageLimits BydCanInverter::calculate_voltage_limits() {
+  // Not sure why offset is subtracted from max and added to min, but this is
+  // what the original code did.
+  uint16_t max_voltage_dV = datalayer.battery.info.max_design_voltage_dV - VOLTAGE_OFFSET_DV;
+  uint16_t min_voltage_dV = datalayer.battery.info.min_design_voltage_dV + VOLTAGE_OFFSET_DV;
+
+  if (datalayer.battery.settings.user_set_voltage_limits_active) {
+    if (datalayer.battery.settings.max_user_set_charge_voltage_dV > 0 &&
+        datalayer.battery.settings.max_user_set_charge_voltage_dV < max_voltage_dV) {
+      max_voltage_dV = datalayer.battery.settings.max_user_set_charge_voltage_dV;
+    }
+    if (datalayer.battery.settings.max_user_set_discharge_voltage_dV > 0 &&
+        datalayer.battery.settings.max_user_set_discharge_voltage_dV > min_voltage_dV) {
+      min_voltage_dV = datalayer.battery.settings.max_user_set_discharge_voltage_dV;
+    }
+  }
+
+  auto dynamic_limits = calculate_dynamic_voltage_limits();
+  if (dynamic_limits.max_voltage_dV < max_voltage_dV) {
+    max_voltage_dV = dynamic_limits.max_voltage_dV;
+  }
+  if (dynamic_limits.min_voltage_dV > min_voltage_dV) {
+    min_voltage_dV = dynamic_limits.min_voltage_dV;
+  }
+
+  return {min_voltage_dV, max_voltage_dV};
+}
+
 void BydCanInverter::
     update_values() {  //This function maps all the values fetched from battery CAN to the correct CAN messages
 
@@ -27,22 +106,28 @@ void BydCanInverter::
     fully_charged_capacity_ah = (datalayer.battery.info.reported_total_capacity_Wh * 100UL) / nominal_voltage_dV;
   }
 
+  auto voltage_limits = calculate_voltage_limits();
+  BYD_110.data.u8[0] = (voltage_limits.max_voltage_dV >> 8);
+  BYD_110.data.u8[1] = (voltage_limits.max_voltage_dV & 0x00FF);
+  BYD_110.data.u8[2] = (voltage_limits.min_voltage_dV >> 8);
+  BYD_110.data.u8[3] = (voltage_limits.min_voltage_dV & 0x00FF);
+
   //Map values to CAN messages
-  if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
-    //Target charge voltage (eg 400.0V = 4000 , 16bits long)
-    BYD_110.data.u8[0] = (datalayer.battery.settings.max_user_set_charge_voltage_dV >> 8);
-    BYD_110.data.u8[1] = (datalayer.battery.settings.max_user_set_charge_voltage_dV & 0x00FF);
-    //Target discharge voltage (eg 300.0V = 3000 , 16bits long)
-    BYD_110.data.u8[2] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV >> 8);
-    BYD_110.data.u8[3] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV & 0x00FF);
-  } else {  //Use the voltage based on battery reported design voltage +- offset to avoid triggering events
-    //Target charge voltage (eg 400.0V = 4000 , 16bits long)
-    BYD_110.data.u8[0] = ((datalayer.battery.info.max_design_voltage_dV - VOLTAGE_OFFSET_DV) >> 8);
-    BYD_110.data.u8[1] = ((datalayer.battery.info.max_design_voltage_dV - VOLTAGE_OFFSET_DV) & 0x00FF);
-    //Target discharge voltage (eg 300.0V = 3000 , 16bits long)
-    BYD_110.data.u8[2] = ((datalayer.battery.info.min_design_voltage_dV + VOLTAGE_OFFSET_DV) >> 8);
-    BYD_110.data.u8[3] = ((datalayer.battery.info.min_design_voltage_dV + VOLTAGE_OFFSET_DV) & 0x00FF);
-  }
+  // if (datalayer.battery.settings.user_set_voltage_limits_active) {  //If user is requesting a specific voltage
+  //   //Target charge voltage (eg 400.0V = 4000 , 16bits long)
+  //   BYD_110.data.u8[0] = (datalayer.battery.settings.max_user_set_charge_voltage_dV >> 8);
+  //   BYD_110.data.u8[1] = (datalayer.battery.settings.max_user_set_charge_voltage_dV & 0x00FF);
+  //   //Target discharge voltage (eg 300.0V = 3000 , 16bits long)
+  //   BYD_110.data.u8[2] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV >> 8);
+  //   BYD_110.data.u8[3] = (datalayer.battery.settings.max_user_set_discharge_voltage_dV & 0x00FF);
+  // } else {  //Use the voltage based on battery reported design voltage +- offset to avoid triggering events
+  //   //Target charge voltage (eg 400.0V = 4000 , 16bits long)
+  //   BYD_110.data.u8[0] = ((datalayer.battery.info.max_design_voltage_dV - VOLTAGE_OFFSET_DV) >> 8);
+  //   BYD_110.data.u8[1] = ((datalayer.battery.info.max_design_voltage_dV - VOLTAGE_OFFSET_DV) & 0x00FF);
+  //   //Target discharge voltage (eg 300.0V = 3000 , 16bits long)
+  //   BYD_110.data.u8[2] = ((datalayer.battery.info.min_design_voltage_dV + VOLTAGE_OFFSET_DV) >> 8);
+  //   BYD_110.data.u8[3] = ((datalayer.battery.info.min_design_voltage_dV + VOLTAGE_OFFSET_DV) & 0x00FF);
+  // }
 
   //Maximum discharge power allowed (Unit: A+1)
   BYD_110.data.u8[4] = (datalayer.battery.status.max_discharge_current_dA >> 8);

--- a/Software/src/inverter/BYD-CAN.cpp
+++ b/Software/src/inverter/BYD-CAN.cpp
@@ -50,10 +50,10 @@ BydVoltageLimits BydCanInverter::calculate_dynamic_voltage_limits() {
 
   // Apply offsets
   max_limit_dV -= 8;
-  min_limit_dV += 1;
+  min_limit_dV += 10;
 
-  limits.min_voltage_dV = max(min(min_limit_dV, UINT16_MAX), 0);
-  limits.max_voltage_dV = max(min(max_limit_dV, UINT16_MAX), 0);
+  limits.max_voltage_dV = max(min(max_limit_dV, (int32_t)UINT16_MAX), 0);
+  limits.min_voltage_dV = max(min(min_limit_dV, (int32_t)UINT16_MAX), 0);
   return limits;
 }
 

--- a/Software/src/inverter/BYD-CAN.h
+++ b/Software/src/inverter/BYD-CAN.h
@@ -4,6 +4,11 @@
 #include "../datalayer/datalayer.h"
 #include "CanInverterProtocol.h"
 
+typedef struct {
+  uint16_t min_voltage_dV;
+  uint16_t max_voltage_dV;
+} BydVoltageLimits;
+
 class BydCanInverter : public CanInverterProtocol {
  public:
   const char* name() override { return Name; }
@@ -12,6 +17,8 @@ class BydCanInverter : public CanInverterProtocol {
   void update_values();
   bool provides_shunt() { return true; }
   void enable_shunt();
+  BydVoltageLimits calculate_dynamic_voltage_limits();
+  BydVoltageLimits calculate_voltage_limits();
   static constexpr const char* Name = "BYD Battery-Box Premium HVS over CAN Bus";
 
  private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(tests
     battery/NissanLeafTest.cpp
     battery/BydAtto3Test.cpp
     battery/foxess_tests.cpp
+    inverter/voltage_limits_tests.cpp
     battery/still_alive_tests.cpp
     battery/VolvoSPATest.cpp
     battery/UdsCanBatteryTest.cpp

--- a/test/inverter/voltage_limits_tests.cpp
+++ b/test/inverter/voltage_limits_tests.cpp
@@ -1,0 +1,438 @@
+#include <gtest/gtest.h>
+
+#include "../../Software/src/datalayer/datalayer.h"
+#include "../../Software/src/inverter/BYD-CAN.h"
+
+static constexpr uint16_t VOLTAGE_OFFSET_DV = 20;
+
+class VoltageLimitsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer.battery.info.number_of_cells = 100;
+    datalayer.battery.info.max_cell_voltage_mV = 4300;
+    datalayer.battery.info.min_cell_voltage_mV = 2700;
+    datalayer.battery.info.max_design_voltage_dV = 4300;
+    datalayer.battery.info.min_design_voltage_dV = 2700;
+
+    datalayer.battery.status.voltage_dV = 3700;
+    datalayer.battery.status.cell_max_voltage_mV = 3700;
+    datalayer.battery.status.cell_min_voltage_mV = 3700;
+    datalayer.battery.settings.user_set_voltage_limits_active = false;
+    datalayer.battery.settings.max_user_set_charge_voltage_dV = 4500;
+    datalayer.battery.settings.max_user_set_discharge_voltage_dV = 3000;
+  }
+
+  BydCanInverter inverter;
+};
+
+// ── Dynamic voltage limits ──────────────────────────────────────────────
+
+TEST_F(VoltageLimitsTest, DynamicLimits_ZeroCells_ReturnsSafeDefaults) {
+  datalayer.battery.info.number_of_cells = 0;
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+  EXPECT_EQ(limits.min_voltage_dV, 0);
+  EXPECT_EQ(limits.max_voltage_dV, UINT16_MAX);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_BalancedCells_ReturnsDesignLimitsMinusOffsets) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3700;
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  uint16_t expected_max = ((4300 - 100) * 100) / 100 - 8;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_HighCellDeviation_ReducesMaxLimit) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3800;
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // Should be within the original bounds
+  EXPECT_LT(limits.max_voltage_dV, datalayer.battery.info.max_design_voltage_dV);
+  EXPECT_GT(limits.max_voltage_dV, datalayer.battery.info.min_design_voltage_dV);
+
+  EXPECT_LT(limits.min_voltage_dV, limits.max_voltage_dV);
+
+  int32_t mean_mV = 3700 * 100 / 100;
+  int32_t deviation_mV = 3800 - mean_mV;
+  int32_t expected_max = ((4300 - 100) * 100) / 100 - (deviation_mV * 100) / 100 - 8;
+
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_LowCellDeviation_IncreasesMinLimit) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3700;
+  datalayer.battery.status.cell_min_voltage_mV = 3600;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // Should be within the original bounds
+  EXPECT_LT(limits.min_voltage_dV, datalayer.battery.info.max_design_voltage_dV);
+  EXPECT_GT(limits.min_voltage_dV, datalayer.battery.info.min_design_voltage_dV);
+
+  EXPECT_LT(limits.min_voltage_dV, limits.max_voltage_dV);
+
+  int32_t mean_mV = 3700 * 100 / 100;
+  int32_t deviation_mV = mean_mV - 3600;
+  int32_t expected_min = ((2700 + 100) * 100) / 100 + (deviation_mV * 100) / 100 + 1;
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_BothDeviations_NarrowsBothLimits) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3850;
+  datalayer.battery.status.cell_min_voltage_mV = 3550;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // Should be within the original bounds
+  EXPECT_LT(limits.min_voltage_dV, datalayer.battery.info.max_design_voltage_dV);
+  EXPECT_GT(limits.min_voltage_dV, datalayer.battery.info.min_design_voltage_dV);
+  EXPECT_LT(limits.max_voltage_dV, datalayer.battery.info.max_design_voltage_dV);
+  EXPECT_GT(limits.max_voltage_dV, datalayer.battery.info.min_design_voltage_dV);
+
+  EXPECT_LT(limits.min_voltage_dV, limits.max_voltage_dV);
+
+  int32_t mean_mV = 3700 * 100 / 100;
+  int32_t dev_max_mV = 3850 - mean_mV;
+  int32_t dev_min_mV = mean_mV - 3550;
+  uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+
+  EXPECT_LE(limits.max_voltage_dV, expected_max);
+  EXPECT_GE(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_NegativeDeviationMaxDoesNotIncreaseLimit) {
+  datalayer.battery.status.cell_max_voltage_mV = 3600;
+  datalayer.battery.status.voltage_dV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  uint16_t expected_max = ((4300 - 100) * 100) / 100 - 8;
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_NegativeDeviationMinDoesNotDecreaseLimit) {
+  datalayer.battery.status.cell_min_voltage_mV = 3750;
+  datalayer.battery.status.voltage_dV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_MaxLimitClampedToZero) {
+  datalayer.battery.info.number_of_cells = 1;
+  datalayer.battery.info.max_cell_voltage_mV = 1;
+  datalayer.battery.status.voltage_dV = 0;
+  datalayer.battery.status.cell_max_voltage_mV = 5000;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  EXPECT_EQ(limits.max_voltage_dV, 0);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_MaxLimitClampedToUINT16_MAX) {
+  datalayer.battery.info.max_cell_voltage_mV = UINT16_MAX;
+  datalayer.battery.info.number_of_cells = 200;
+  datalayer.battery.status.voltage_dV = UINT16_MAX;
+  datalayer.battery.status.cell_max_voltage_mV = 0;
+  datalayer.battery.status.cell_min_voltage_mV = 0;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  EXPECT_EQ(limits.max_voltage_dV, UINT16_MAX);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_MinLimitClampedToZero) {
+  datalayer.battery.info.number_of_cells = 1;
+  datalayer.battery.info.min_cell_voltage_mV = 0;
+  datalayer.battery.status.voltage_dV = 0;
+  datalayer.battery.status.cell_min_voltage_mV = 0;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // min = (0+100)*1/100 + 1 = 1 + 1 = 2
+  EXPECT_EQ(limits.min_voltage_dV, 2);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_MinLimitClampedToUINT16_MAX) {
+  datalayer.battery.info.number_of_cells = 1;
+  datalayer.battery.info.min_cell_voltage_mV = UINT16_MAX;
+  datalayer.battery.status.voltage_dV = 0;
+  datalayer.battery.status.cell_min_voltage_mV = 0;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // min = (65535+100)*1/100 + 1 = 656 + 1 = 657
+  // Not clamped to UINT16_MAX because calculation doesn't overflow
+  EXPECT_EQ(limits.min_voltage_dV, 657);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellPack) {
+  datalayer.battery.info.number_of_cells = 1;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3700;
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // With 1 cell: max = (4300-100)*1/100 - 8 = 42 - 8 = 34
+  // min = (2700+100)*1/100 + 1 = 28 + 1 = 29
+  // But deviation increases min: mean=370000, dev_min=370000-3700=366300, increase=366300*1/100=3663
+  // min = 28 + 3663 + 1 = 3692
+  EXPECT_EQ(limits.max_voltage_dV, 34);
+  EXPECT_EQ(limits.min_voltage_dV, 3692);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellWithDeviation) {
+  datalayer.battery.info.number_of_cells = 1;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3800;
+  datalayer.battery.status.cell_min_voltage_mV = 3600;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // mean = 3700*100/1 = 370000mV
+  // dev_max = 3800-370000 = -366200 (negative, no reduction)
+  // dev_min = 370000-3600 = 366400, increase = 366400*1/100 = 3664
+  // max = (4300-100)*1/100 - 8 = 42 - 8 = 34
+  // min = (2700+100)*1/100 + 3664 + 1 = 28 + 3664 + 1 = 3693
+  EXPECT_EQ(limits.max_voltage_dV, 34);
+  EXPECT_EQ(limits.min_voltage_dV, 3693);
+}
+
+TEST_F(VoltageLimitsTest, DynamicLimits_PackVoltageInconsistentWithCellVoltages) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 4200;           // Pack says 420V
+  datalayer.battery.status.cell_max_voltage_mV = 3700;  // Cells say 3.7V
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  // mean = 4200*100/100 = 4200mV (from pack voltage)
+  // dev_max = 3700-4200 = -500 (negative, no reduction)
+  // dev_min = 4200-3700 = 500, increase = 500*100/100 = 500
+  // max = 4200*100/100 - 8 = 4192
+  // min = 2800*100/100 + 500 + 1 = 3301
+  EXPECT_EQ(limits.max_voltage_dV, 4192);
+  EXPECT_EQ(limits.min_voltage_dV, 3301);
+}
+
+// ── Top-level voltage limits ────────────────────────────────────────────
+
+TEST_F(VoltageLimitsTest, TopLevel_NominalCase_ReturnsDesignLimitsWithOffset) {
+  auto limits = inverter.calculate_voltage_limits();
+
+  // Dynamic limits are narrower than static limits, so they override
+  EXPECT_EQ(limits.max_voltage_dV, 4192);
+  EXPECT_EQ(limits.min_voltage_dV, 2801);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_ChargeLimitApplied) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_charge_voltage_dV = 4000;
+  datalayer.battery.settings.max_user_set_discharge_voltage_dV = 3000;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  EXPECT_EQ(limits.max_voltage_dV, 4000);
+  EXPECT_EQ(limits.min_voltage_dV, 3000);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_ChargeLimitZero_Ignored) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_charge_voltage_dV = 0;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limit ignored, dynamic limits override static limits
+  EXPECT_EQ(limits.max_voltage_dV, 4192);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_ChargeLimitAboveDesign_Ignored) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_charge_voltage_dV = 5500;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limit ignored (above design), dynamic limits override static limits
+  EXPECT_EQ(limits.max_voltage_dV, 4192);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_DischargeLimitZero_Ignored) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_discharge_voltage_dV = 0;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limit ignored, dynamic limits override static limits
+  EXPECT_EQ(limits.min_voltage_dV, 2801);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_DischargeLimitBelowDesign_Ignored) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_discharge_voltage_dV = 1000;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limit ignored (below design), dynamic limits override static limits
+  EXPECT_EQ(limits.min_voltage_dV, 2801);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_UserLimitsNarrowerThanDynamic_Wins) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_charge_voltage_dV = 4000;
+  datalayer.battery.settings.max_user_set_discharge_voltage_dV = 3000;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limits (4000/3000) are narrower than dynamic limits (4192/2801)
+  // User limits should win
+  EXPECT_EQ(limits.max_voltage_dV, 4000);
+  EXPECT_EQ(limits.min_voltage_dV, 3000);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_DynamicLimitsNarrowMax) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 4300;
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  int32_t mean_mV = 3700 * 100 / 100;
+  int32_t dev_max_mV = 4300 - mean_mV;
+  uint16_t dynamic_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
+  EXPECT_EQ(limits.max_voltage_dV, dynamic_max);
+  EXPECT_LT(limits.max_voltage_dV, 5000 - VOLTAGE_OFFSET_DV);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_DynamicLimitsNarrowMin) {
+  datalayer.battery.info.number_of_cells = 100;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.cell_max_voltage_mV = 3700;
+  datalayer.battery.status.cell_min_voltage_mV = 2700;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  int32_t mean_mV = 3700 * 100 / 100;
+  int32_t dev_min_mV = mean_mV - 2700;
+  uint16_t dynamic_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+  EXPECT_EQ(limits.min_voltage_dV, dynamic_min);
+  EXPECT_GT(limits.min_voltage_dV, 2500 + VOLTAGE_OFFSET_DV);
+}
+
+TEST_F(VoltageLimitsTest, TopLevel_DynamicLimitsWider_DoesNotBroaden) {
+  datalayer.battery.info.max_cell_voltage_mV = 5000;
+  datalayer.battery.info.min_cell_voltage_mV = 2000;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  EXPECT_EQ(limits.max_voltage_dV, 4300 - VOLTAGE_OFFSET_DV);
+  EXPECT_EQ(limits.min_voltage_dV, 2700 + VOLTAGE_OFFSET_DV);
+}
+
+// ── Safety corner cases ─────────────────────────────────────────────────
+
+TEST_F(VoltageLimitsTest, CornerCase_ZeroVoltageWithValidCells) {
+  datalayer.battery.status.voltage_dV = 0;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  int32_t mean_mV = 0;
+  int32_t dev_max_mV = 3700 - mean_mV;
+  int32_t dev_min_mV = mean_mV - 3700;
+  uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, CornerCase_MaxCells) {
+  datalayer.battery.info.number_of_cells = MAX_AMOUNT_CELLS;
+  datalayer.battery.info.max_cell_voltage_mV = 4300;
+  datalayer.battery.info.min_cell_voltage_mV = 2700;
+  datalayer.battery.info.max_design_voltage_dV = MAX_AMOUNT_CELLS * 4300 / 100;
+  datalayer.battery.info.min_design_voltage_dV = MAX_AMOUNT_CELLS * 2700 / 100;
+
+  datalayer.battery.status.voltage_dV = 37 * MAX_AMOUNT_CELLS;
+  datalayer.battery.status.cell_max_voltage_mV = 3700;
+  datalayer.battery.status.cell_min_voltage_mV = 3700;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  uint16_t expected_max = ((4300 - 100) * MAX_AMOUNT_CELLS) / 100 - 8;
+  uint16_t expected_min = ((2700 + 100) * MAX_AMOUNT_CELLS) / 100 + 1;
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, CornerCase_CellVoltagesAtDesignLimits) {
+  datalayer.battery.status.cell_max_voltage_mV = 4300;
+  datalayer.battery.status.cell_min_voltage_mV = 2700;
+  datalayer.battery.status.voltage_dV = 3500;
+
+  auto limits = inverter.calculate_dynamic_voltage_limits();
+
+  int32_t mean_mV = 3500 * 100 / 100;
+  int32_t dev_max_mV = 4300 - mean_mV;
+  int32_t dev_min_mV = mean_mV - 2700;
+  uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+
+  EXPECT_EQ(limits.max_voltage_dV, expected_max);
+  EXPECT_EQ(limits.min_voltage_dV, expected_min);
+}
+
+TEST_F(VoltageLimitsTest, CornerCase_UserLimitsAtExtremes) {
+  datalayer.battery.settings.user_set_voltage_limits_active = true;
+  datalayer.battery.settings.max_user_set_charge_voltage_dV = UINT16_MAX;
+  datalayer.battery.settings.max_user_set_discharge_voltage_dV = 0;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  // User limits are ignored when outside valid range, dynamic limits override
+  EXPECT_EQ(limits.max_voltage_dV, 4192);
+  EXPECT_EQ(limits.min_voltage_dV, 2801);
+}
+
+TEST_F(VoltageLimitsTest, CornerCase_DesignLimitsEqual_VoltageAtDesign) {
+  datalayer.battery.info.max_design_voltage_dV = 3700;
+  datalayer.battery.info.min_design_voltage_dV = 3700;
+  datalayer.battery.status.voltage_dV = 3700;
+
+  auto limits = inverter.calculate_voltage_limits();
+
+  EXPECT_EQ(limits.max_voltage_dV, 3700 - VOLTAGE_OFFSET_DV);
+  EXPECT_EQ(limits.min_voltage_dV, 3700 + VOLTAGE_OFFSET_DV);
+}

--- a/test/inverter/voltage_limits_tests.cpp
+++ b/test/inverter/voltage_limits_tests.cpp
@@ -45,7 +45,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_BalancedCells_ReturnsDesignLimitsMinusOf
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
   uint16_t expected_max = ((4300 - 100) * 100) / 100 - 8;
-  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 10;
   EXPECT_EQ(limits.max_voltage_dV, expected_max);
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
 }
@@ -89,7 +89,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_LowCellDeviation_IncreasesMinLimit) {
 
   int32_t mean_mV = 3700 * 100 / 100;
   int32_t deviation_mV = mean_mV - 3600;
-  int32_t expected_min = ((2700 + 100) * 100) / 100 + (deviation_mV * 100) / 100 + 1;
+  int32_t expected_min = ((2700 + 100) * 100) / 100 + (deviation_mV * 100) / 100 + 10;
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
 }
 
@@ -115,7 +115,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_BothDeviations_NarrowsBothLimits) {
   int32_t dev_max_mV = 3850 - mean_mV;
   int32_t dev_min_mV = mean_mV - 3550;
   uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
-  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 10;
 
   EXPECT_LE(limits.max_voltage_dV, expected_max);
   EXPECT_GE(limits.min_voltage_dV, expected_min);
@@ -137,7 +137,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_NegativeDeviationMinDoesNotDecreaseLimit
 
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
-  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 10;
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
 }
 
@@ -172,8 +172,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_MinLimitClampedToZero) {
 
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
-  // min = (0+100)*1/100 + 1 = 1 + 1 = 2
-  EXPECT_EQ(limits.min_voltage_dV, 2);
+  EXPECT_EQ(limits.min_voltage_dV, 11);
 }
 
 TEST_F(VoltageLimitsTest, DynamicLimits_MinLimitClampedToUINT16_MAX) {
@@ -184,9 +183,8 @@ TEST_F(VoltageLimitsTest, DynamicLimits_MinLimitClampedToUINT16_MAX) {
 
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
-  // min = (65535+100)*1/100 + 1 = 656 + 1 = 657
   // Not clamped to UINT16_MAX because calculation doesn't overflow
-  EXPECT_EQ(limits.min_voltage_dV, 657);
+  EXPECT_EQ(limits.min_voltage_dV, 666);
 }
 
 TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellPack) {
@@ -204,7 +202,7 @@ TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellPack) {
   // But deviation increases min: mean=370000, dev_min=370000-3700=366300, increase=366300*1/100=3663
   // min = 28 + 3663 + 1 = 3692
   EXPECT_EQ(limits.max_voltage_dV, 34);
-  EXPECT_EQ(limits.min_voltage_dV, 3692);
+  EXPECT_EQ(limits.min_voltage_dV, 3701);
 }
 
 TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellWithDeviation) {
@@ -217,13 +215,8 @@ TEST_F(VoltageLimitsTest, DynamicLimits_SingleCellWithDeviation) {
 
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
-  // mean = 3700*100/1 = 370000mV
-  // dev_max = 3800-370000 = -366200 (negative, no reduction)
-  // dev_min = 370000-3600 = 366400, increase = 366400*1/100 = 3664
-  // max = (4300-100)*1/100 - 8 = 42 - 8 = 34
-  // min = (2700+100)*1/100 + 3664 + 1 = 28 + 3664 + 1 = 3693
   EXPECT_EQ(limits.max_voltage_dV, 34);
-  EXPECT_EQ(limits.min_voltage_dV, 3693);
+  EXPECT_EQ(limits.min_voltage_dV, 3702);
 }
 
 TEST_F(VoltageLimitsTest, DynamicLimits_PackVoltageInconsistentWithCellVoltages) {
@@ -236,13 +229,8 @@ TEST_F(VoltageLimitsTest, DynamicLimits_PackVoltageInconsistentWithCellVoltages)
 
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
-  // mean = 4200*100/100 = 4200mV (from pack voltage)
-  // dev_max = 3700-4200 = -500 (negative, no reduction)
-  // dev_min = 4200-3700 = 500, increase = 500*100/100 = 500
-  // max = 4200*100/100 - 8 = 4192
-  // min = 2800*100/100 + 500 + 1 = 3301
   EXPECT_EQ(limits.max_voltage_dV, 4192);
-  EXPECT_EQ(limits.min_voltage_dV, 3301);
+  EXPECT_EQ(limits.min_voltage_dV, 3310);
 }
 
 // ── Top-level voltage limits ────────────────────────────────────────────
@@ -252,7 +240,7 @@ TEST_F(VoltageLimitsTest, TopLevel_NominalCase_ReturnsDesignLimitsWithOffset) {
 
   // Dynamic limits are narrower than static limits, so they override
   EXPECT_EQ(limits.max_voltage_dV, 4192);
-  EXPECT_EQ(limits.min_voltage_dV, 2801);
+  EXPECT_EQ(limits.min_voltage_dV, 2810);
 }
 
 TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_ChargeLimitApplied) {
@@ -293,7 +281,7 @@ TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_DischargeLimitZero_Ignored) 
   auto limits = inverter.calculate_voltage_limits();
 
   // User limit ignored, dynamic limits override static limits
-  EXPECT_EQ(limits.min_voltage_dV, 2801);
+  EXPECT_EQ(limits.min_voltage_dV, 2810);
 }
 
 TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_DischargeLimitBelowDesign_Ignored) {
@@ -303,7 +291,7 @@ TEST_F(VoltageLimitsTest, TopLevel_UserLimitsActive_DischargeLimitBelowDesign_Ig
   auto limits = inverter.calculate_voltage_limits();
 
   // User limit ignored (below design), dynamic limits override static limits
-  EXPECT_EQ(limits.min_voltage_dV, 2801);
+  EXPECT_EQ(limits.min_voltage_dV, 2810);
 }
 
 TEST_F(VoltageLimitsTest, TopLevel_UserLimitsNarrowerThanDynamic_Wins) {
@@ -313,7 +301,6 @@ TEST_F(VoltageLimitsTest, TopLevel_UserLimitsNarrowerThanDynamic_Wins) {
 
   auto limits = inverter.calculate_voltage_limits();
 
-  // User limits (4000/3000) are narrower than dynamic limits (4192/2801)
   // User limits should win
   EXPECT_EQ(limits.max_voltage_dV, 4000);
   EXPECT_EQ(limits.min_voltage_dV, 3000);
@@ -346,7 +333,7 @@ TEST_F(VoltageLimitsTest, TopLevel_DynamicLimitsNarrowMin) {
 
   int32_t mean_mV = 3700 * 100 / 100;
   int32_t dev_min_mV = mean_mV - 2700;
-  uint16_t dynamic_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+  uint16_t dynamic_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 10;
   EXPECT_EQ(limits.min_voltage_dV, dynamic_min);
   EXPECT_GT(limits.min_voltage_dV, 2500 + VOLTAGE_OFFSET_DV);
 }
@@ -372,7 +359,7 @@ TEST_F(VoltageLimitsTest, CornerCase_ZeroVoltageWithValidCells) {
   int32_t dev_max_mV = 3700 - mean_mV;
   int32_t dev_min_mV = mean_mV - 3700;
   uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
-  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + 10;
 
   EXPECT_EQ(limits.max_voltage_dV, expected_max);
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
@@ -392,7 +379,7 @@ TEST_F(VoltageLimitsTest, CornerCase_MaxCells) {
   auto limits = inverter.calculate_dynamic_voltage_limits();
 
   uint16_t expected_max = ((4300 - 100) * MAX_AMOUNT_CELLS) / 100 - 8;
-  uint16_t expected_min = ((2700 + 100) * MAX_AMOUNT_CELLS) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * MAX_AMOUNT_CELLS) / 100 + 10;
   EXPECT_EQ(limits.max_voltage_dV, expected_max);
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
 }
@@ -408,7 +395,7 @@ TEST_F(VoltageLimitsTest, CornerCase_CellVoltagesAtDesignLimits) {
   int32_t dev_max_mV = 4300 - mean_mV;
   int32_t dev_min_mV = mean_mV - 2700;
   uint16_t expected_max = ((4300 - 100) * 100) / 100 - (dev_max_mV * 100) / 100 - 8;
-  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 1;
+  uint16_t expected_min = ((2700 + 100) * 100) / 100 + (dev_min_mV * 100) / 100 + 10;
 
   EXPECT_EQ(limits.max_voltage_dV, expected_max);
   EXPECT_EQ(limits.min_voltage_dV, expected_min);
@@ -423,7 +410,7 @@ TEST_F(VoltageLimitsTest, CornerCase_UserLimitsAtExtremes) {
 
   // User limits are ignored when outside valid range, dynamic limits override
   EXPECT_EQ(limits.max_voltage_dV, 4192);
-  EXPECT_EQ(limits.min_voltage_dV, 2801);
+  EXPECT_EQ(limits.min_voltage_dV, 2810);
 }
 
 TEST_F(VoltageLimitsTest, CornerCase_DesignLimitsEqual_VoltageAtDesign) {

--- a/test/inverter_alive_tests.cpp
+++ b/test/inverter_alive_tests.cpp
@@ -8,16 +8,19 @@
 
 // Tests for the inverter CAN aliveness handling in update_machineryprotection().
 //
-// NOTE on ordering: safety.cpp keeps a file-static inverter_detected latch with no
-// reset, so the detection test below must run before any other test in this suite
-// refreshes the counter to >= CAN_STILL_ALIVE. Google Test runs tests within a
-// suite in definition order (as long as shuffling is not enabled), so keep the
-// detection test first in this file.
+// The detection latch in safety.cpp has no reset of its own, so it used to have
+// to be the first test in the file and the suite could not be shuffled. The
+// fixture now clears it directly, the same way battery_alive_tests.cpp clears
+// the battery and charger latches, so these tests are order-independent.
+
+extern bool inverter_detected;
 
 namespace {
 
 void setup_can_inverter_test() {
   datalayer = DataLayer();
+  // Defined in safety.cpp; not exposed via safety.h like the battery latches are.
+  inverter_detected = false;
   reset_all_events();
   init_hal();
   // Avoid tripping the low-heap check (CPU_free_heap defaults to 0)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -7,6 +7,7 @@
 #include "../Software/src/devboard/hal/hal.h"
 #include "../Software/src/devboard/safety/safety.h"
 #include "../Software/src/devboard/utils/events.h"
+#include "../Software/src/inverter/INVERTERS.h"
 
 void RegisterCanLogTests(void);
 void RegisterStillAliveTests(void);
@@ -27,6 +28,12 @@ class DataLayerResetListener : public ::testing::EmptyTestEventListener {
     battery3 = nullptr;
     delete charger;
     charger = nullptr;
+    /* The inverter is the same kind of instance and was the one omission here.
+       It also decides behaviour by TYPE - needs_can_startup_grace() is true for
+       the SMA family and false for the rest - so a test inheriting the previous
+       test's inverter silently runs against the wrong protocol. */
+    delete inverter;
+    inverter = nullptr;
 
     // Selection globals must be owned by each test's own fixture.
     user_selected_second_battery = false;


### PR DESCRIPTION
### What
This PR adds dynamically calculated voltage limits to the BYD inverter CAN integration, primarily for Deye (which otherwise overcharges the batteries).

The limits are dynamically calculated such that the inverter will hit the max pack voltage as the highest cell hits its max cell voltage (and vice versa at the min end).

Cell voltages are hardcoded at the design max-100mV (and min+100mV), so 2.8/4.2V for NMC and 2.9/3.55V for LFP, these might want revisiting.

Also there are arbitrary offsets currently, but these might want to be editable.

Also it's enabled for all BYD integration users, maybe it needs to be selectively enabled.

**TEST WITH CAUTION!** This hasn't been tested on real hardware, keep an eye on it!

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
