### PR TITLE
feature: add webUI check/display for new versions

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -948,6 +948,7 @@ String processor(const String& var) {
 
     // Start content block
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
+    content += "<div id='bxUpd' style='text-align:center'></div>";
     content += "<h4>Software: " + String(version_number);
 
 // Show hardware used:
@@ -1628,6 +1629,30 @@ String processor(const String& var) {
     //Script for refreshing page
     content += "<script>";
     content += "setTimeout(function(){ location.reload(true); }, 15000);";
+    content += "</script>";
+
+    // In-UI update notification (browser-side; skips dev builds, 6h cached) - issue #1660
+    content += "<script>";
+    content += "(function(){var cur='" + String(version_number) + "';";
+    content += "if(cur.indexOf('dev')>=0)return;";
+    content += "var el=document.getElementById('bxUpd');if(!el)return;";
+    content += "function p(v){return v.replace(/^v/,'').split('.').map(function(x){return parseInt(x,10)||0;});}";
+    content +=
+        "function nw(a,b){for(var i=0;i<Math.max(a.length,b.length);i++){var x=a[i]||0,y=b[i]||0;if(x>y)return "
+        "true;if(x<y)return false;}return false;}";
+    content +=
+        "function show(t,u){if(nw(p(t),p(cur)))el.innerHTML=\"<a href='\"+u+\"' target='_blank' "
+        "style='display:inline-block;margin:2px 0 10px;padding:8px 16px;background:#505E67;border:1px solid "
+        "#4caf50;border-radius:10px;color:#fff;font-weight:bold;text-decoration:none'>&#128276; New version \"+t+\" "
+        "available &rarr;</a>\";}";
+    content += "var c=null;try{c=JSON.parse(localStorage.getItem('beUpd'));}catch(e){}var now=Date.now();";
+    content += "if(c&&c.t&&(now-c.t)<21600000){show(c.tag,c.url);return;}";
+    content +=
+        "fetch('https://api.github.com/repos/dalathegreat/Battery-Emulator/releases/latest')."
+        "then(function(r){return r.json();}).then(function(d){if(!d||!d.tag_name)return;"
+        "try{localStorage.setItem('beUpd',JSON.stringify({t:now,tag:d.tag_name,url:d.html_url}));}catch(e){}"
+        "show(d.tag_name,d.html_url);}).catch(function(){});";
+    content += "})();";
     content += "</script>";
 
     return content;


### PR DESCRIPTION
### What
Adds an in-UI "New version available" notification. When a newer release exists, a small pill appears at the top of the web UI linking to the GitHub release page.

### Why
Users who run Battery Emulator but don't follow GitHub or Discord currently miss new releases (requested in #1660). This surfaces updates where people already look — the web UI.

### How
The check runs entirely in the browser, not on the ESP32:

* The served page fetches the GitHub releases/latest API, compares the tag against the running version_number, and shows the pill only if newer.
* Result is cached in localStorage for 6h, so the 15s page auto-refresh doesn't hit GitHub's rate limit.
* Skips dev builds entirely (no fetch, no pill).
* Fails silently when offline / AP-only.
This keeps it lightweight: ~750 bytes of static HTML/JS, no TLS, no extra heap/CPU on the device. The notification inherits the page's existing responsive layout, so it scales fine on mobile.

<img width="812" height="556" alt="image" src="https://github.com/user-attachments/assets/33fee8f1-adb9-4063-9ec3-e7f261d1f371" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
