### PR TITLE
test: ensure compatibility with AppleClang/macOS

### DIFF
--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -59,8 +59,10 @@ class Logging {
   static void print(uint16_t num) { (void)num; }
   static void print(int32_t num) { (void)num; }
   static void print(uint32_t num) { (void)num; }
-  static void print(int64_t num) { (void)num; }
-  static void print(uint64_t num) { (void)num; }
+  static void print(long num) { (void)num; }
+  static void print(unsigned long num) { (void)num; }
+  static void print(long long num) { (void)num; }
+  static void print(unsigned long long num) { (void)num; }
   static void print(float num) { (void)num; }
   static void print(double num) { (void)num; }
   static void print(bool b) { (void)b; }
@@ -93,8 +95,10 @@ class Logging {
   static void println(uint16_t num) { (void)num; }
   static void println(int32_t num) { (void)num; }
   static void println(uint32_t num) { (void)num; }
-  static void println(int64_t num) { (void)num; }
-  static void println(uint64_t num) { (void)num; }
+  static void println(long num) { (void)num; }
+  static void println(unsigned long num) { (void)num; }
+  static void println(long long num) { (void)num; }
+  static void println(unsigned long long num) { (void)num; }
   static void println(float num) { (void)num; }
   static void println(double num) { (void)num; }
   static void println(bool b) { (void)b; }

--- a/test/emul/WString.h
+++ b/test/emul/WString.h
@@ -20,10 +20,11 @@ class String {
   String(String&& other) = default;
 
   // Numeric constructors (Arduino-style)
-  String(uint64_t value) { data = std::to_string(value); }
   String(int value) { data = std::to_string(value); }
   String(unsigned int value) { data = std::to_string(value); }
   String(long value) { data = std::to_string(value); }
+  String(unsigned long value) { data = std::to_string(value); }
+  String(unsigned long long value) { data = std::to_string(value); }
   String(float value) { data = std::to_string(value); }
   String(double value) { data = std::to_string(value); }
 


### PR DESCRIPTION
### What
This PR spells the four distinct native 64-bit-capable types (long / unsigned long / long long / unsigned long long), covering int64_t/uint64_t on every platform, with no duplicate definition.

### Why
To ensure tests compile on macOS.

#### Problem fixed
The unit-test mocks enumerated fixed-width int64_t/uint64_t overloads for String (test/emul/WString.h) and Logging::print/println. On LP64 Linux uint64_t is `unsigned long`. On macOS uint64_t is `unsigned long long`, leaving the native `unsigned long` uncovered. This was rejected by AppleClang 21.
