### PR TITLE
SMA: startup grace period for SMA inverter CAN watchdog

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -12,7 +12,10 @@ static bool battery_full_event_fired = false;
 static bool battery_empty_event_fired = false;
 
 #define MAX_SOH_DEVIATION_PPTT 2500
-#define CELL_CRITICAL_MV 100  // If cells go this much outside design voltage, shut battery down!
+// Some inverters take a while to boot and start sending CAN. Suppress the
+// inverter-missing error during this startup window (measured from power-on).
+#define INVERTER_STARTUP_GRACE_MS 300000  // 300 s
+#define CELL_CRITICAL_MV 100              // If cells go this much outside design voltage, shut battery down!
 #define LOWEST_ALLOWED_CELLVOLTAGE_RECOVERY_CHARGE_MV 2000  //If cells are below this, recovery charge not allowed
 #define MAX_CHARGEPOWER_RECOVERY_CHARGE_DA 50
 #define HYSTERESIS_OFFSET_DV 20
@@ -277,7 +280,10 @@ void update_machineryprotection() {
 
     // Check if the inverter is still sending CAN messages. If we go 60s without messages we raise a warning
     if (!datalayer.system.status.CAN_inverter_still_alive) {
-      set_event(EVENT_CAN_INVERTER_MISSING, can_config.inverter);
+      // Inverters that are slow to boot get a startup grace window before we fault.
+      if (!inverter->needs_can_startup_grace() || millis() > INVERTER_STARTUP_GRACE_MS) {
+        set_event(EVENT_CAN_INVERTER_MISSING, can_config.inverter);
+      }
     } else {
       datalayer.system.status.CAN_inverter_still_alive--;
       clear_event(EVENT_CAN_INVERTER_MISSING);

--- a/Software/src/inverter/InverterProtocol.h
+++ b/Software/src/inverter/InverterProtocol.h
@@ -58,6 +58,9 @@ class InverterProtocol {
 
   virtual bool provides_shunt() { return false; }
   virtual void enable_shunt() {}
+
+  // Some inverters are slow to boot; suppress the CAN-missing fault during a startup grace window.
+  virtual bool needs_can_startup_grace() { return false; }
 };
 
 extern InverterProtocol* inverter;

--- a/Software/src/inverter/SmaInverterBase.h
+++ b/Software/src/inverter/SmaInverterBase.h
@@ -11,6 +11,9 @@ class SmaInverterBase : public CanInverterProtocol {
   SmaInverterBase() { contactorEnablePin = esp32hal->INVERTER_CONTACTOR_ENABLE_PIN(); }
   bool allows_contactor_closing() override { return digitalRead(contactorEnablePin) == 1; }
 
+  // SMA inverters can take a while to boot before they start sending CAN.
+  bool needs_can_startup_grace() override { return true; }
+
   virtual bool setup() override {
     datalayer.system.status.inverter_allows_contactor_closing = false;  // The inverter needs to allow first
 


### PR DESCRIPTION
### What
This PR adds a grace period for the SMA inverter CAN watchdog. This ensures the Battery Emulator does not throw a fault during the start-up of the SMA. The SMA may not send CAN messages during the first couple of minutes (most likely 3 minutes) of start up.

### Why
SMA inverters can take a while to boot before they start sending CAN, so the inverter watchdog (CAN_inverter_still_alive, 60s) would raise the EVENT_CAN_INVERTER_MISSING error at startup before the inverter is even up.

### How
By adding a needs_can_startup_grace() predicate to InverterProtocol (default false) and override it to true in SmaInverterBase, covering all SMA variants.
