### PR TITLE
Stark: Add HAL definition for battery3 contactors

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -1,6 +1,7 @@
 #ifndef __HW_STARK_H__
 #define __HW_STARK_H__
 
+#include "../../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "hal.h"
 
 /*
@@ -22,7 +23,13 @@ class StarkHal : public Esp32Hal {
   const char* name() { return "Stark CMR Module"; }
 
   //Always enable BMS power on Stark CMR, it does not collide with any pin definitions
-  virtual bool always_enable_bms_power() { return true; }
+  //Unless we use triple battery, then the pin is used
+  virtual bool always_enable_bms_power() {
+    if (contactor_control_enabled_triple_battery) {
+      return false;
+    }
+    return true;
+  }
 
   // Not needed, GPIO 16 has hardware pullup for PSRAM compatibility
   virtual gpio_num_t PIN_5V_EN() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -78,7 +78,7 @@ class StarkHal : public Esp32Hal {
     return GPIO_NUM_25;
   }
   virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_19; }
-  virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_NC; }
+  virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_25; }
   virtual gpio_num_t BMS_POWER() {
     if (user_selected_gpioopt5 == GPIOOPT5::BMS_POWER_25) {
       return GPIO_NUM_25;


### PR DESCRIPTION
### What
This PR implements ...

### Why
Why does it do it?

### How
BMS power pin (GPIO_NUM_25) used for Battery3 contactors

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
