### PR TITLE
Add BYD Atto3 DTC List

### DIFF
--- a/web_data/dtc/byd_atto3_dtc.json
+++ b/web_data/dtc/byd_atto3_dtc.json
@@ -3511,6 +3511,12 @@
   },
   {
     "code": null,
+    "dtc": "U0073",
+    "s_dsc": null,
+    "l_dsc": "Control Module Communication Bus \"A\" Off (generic SAE)"
+  },
+  {
+    "code": null,
     "dtc": "U011000",
     "s_dsc": null,
     "l_dsc": "Communication with Motor Control Unit Failed"

--- a/web_data/dtc/byd_atto3_dtc.json
+++ b/web_data/dtc/byd_atto3_dtc.json
@@ -1,3932 +1,657 @@
 [
-  {
-    "code": null,
-    "dtc": "B110811",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Short-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B110913",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B110A02",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester CAN Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B110B07",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Air Pump Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B110C09",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Laser Diode Failure"
-  },
-  {
-    "code": null,
-    "dtc": "B110D09",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Photoelectric Receiving Module Failure"
-  },
-  {
-    "code": null,
-    "dtc": "B110E09",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Temperature and Humidity Module Failure"
-  },
-  {
-    "code": null,
-    "dtc": "B110F09",
-    "s_dsc": null,
-    "l_dsc": "PM2.5 Quick Tester Solenoid Valve Failure"
-  },
-  {
-    "code": null,
-    "dtc": "B111009",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B116212",
-    "s_dsc": null,
-    "l_dsc": "Water Temperature Sensor Short-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B116214",
-    "s_dsc": null,
-    "l_dsc": "Water Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B11BD11",
-    "s_dsc": null,
-    "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B11BD12",
-    "s_dsc": null,
-    "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B11BD13",
-    "s_dsc": null,
-    "l_dsc": "LIN1 Ambient Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B11BD19",
-    "s_dsc": null,
-    "l_dsc": "LIN1 ambient light drive overload"
-  },
-  {
-    "code": null,
-    "dtc": "B11BE11",
-    "s_dsc": null,
-    "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B11BE12",
-    "s_dsc": null,
-    "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B11BE13",
-    "s_dsc": null,
-    "l_dsc": "LIN2 Ambient Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B11BE19",
-    "s_dsc": null,
-    "l_dsc": "LIN2 ambient light drive overload"
-  },
-  {
-    "code": null,
-    "dtc": "B133413",
-    "s_dsc": null,
-    "l_dsc": "Refrigerant Temperature Sensor 2 Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B133511",
-    "s_dsc": null,
-    "l_dsc": "Refrigerant temperature sensor 2 is short to ground"
-  },
-  {
-    "code": null,
-    "dtc": "B133613",
-    "s_dsc": null,
-    "l_dsc": "Open circuit of refrigerant temperature sensor 3"
-  },
-  {
-    "code": null,
-    "dtc": "B133711",
-    "s_dsc": null,
-    "l_dsc": "Refrigerant Temperature Sensor 3 Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B133800",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 1 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133900",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 2 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133A00",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 3 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133B00",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 4 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133C00",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 5 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133D00",
-    "s_dsc": null,
-    "l_dsc": "Solenoid Valve 6 Status Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133E00",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage PTC Relay 1 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B133F00",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage PTC Relay 2 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B134000",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage PTC Relay 3 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B134111",
-    "s_dsc": null,
-    "l_dsc": "Three-way Valve Motor Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B134211",
-    "s_dsc": null,
-    "l_dsc": "Three-way Valve Motor Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B134392",
-    "s_dsc": null,
-    "l_dsc": "Three-way Valve Motor Not Rotating in Place"
-  },
-  {
-    "code": null,
-    "dtc": "B134611",
-    "s_dsc": null,
-    "l_dsc": "Refrigerant Temperature Sensor 1 Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B134613",
-    "s_dsc": null,
-    "l_dsc": "Refrigerant Temperature Sensor 1 Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B134711",
-    "s_dsc": null,
-    "l_dsc": "Air conditioner pressure sensor is short to power"
-  },
-  {
-    "code": null,
-    "dtc": "B134713",
-    "s_dsc": null,
-    "l_dsc": "Air conditioner pressure sensor P1 broken circuit"
-  },
-  {
-    "code": null,
-    "dtc": "B16001B",
-    "s_dsc": null,
-    "l_dsc": "Driver Frontal Airbag Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B160111",
-    "s_dsc": null,
-    "l_dsc": "Driver Frontal Airbag Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B160212",
-    "s_dsc": null,
-    "l_dsc": "Driver Frontal Airbag Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B160A1A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Driver Frontal Airbag Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B16101B",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Frontal Airbag Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B161111",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Frontal Airbag Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B161212",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Frontal Airbag Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B161A1A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Front Passenger Frontal Airbag Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B16201B",
-    "s_dsc": null,
-    "l_dsc": "Driver Side Airbag Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B162111",
-    "s_dsc": null,
-    "l_dsc": "Driver Side Airbag Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B162212",
-    "s_dsc": null,
-    "l_dsc": "Driver Side Airbag Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B162A1A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Driver Side Airbag Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B16301B",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Side Airbag Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B163111",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Side Airbag Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B163212",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Side Airbag Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B163B1B",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Front Passenger Side Airbag Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B16401B",
-    "s_dsc": null,
-    "l_dsc": "Driver Seat Belt Pretensioner Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B164111",
-    "s_dsc": null,
-    "l_dsc": "Driver Seat Belt Pretensioner Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B164212",
-    "s_dsc": null,
-    "l_dsc": "Driver Seat Belt Pretensioner Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B16451A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Driver Seat Belt Pretensioner Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B164A1B",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Seat Belt Pretensioner Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B164B11",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B164C12",
-    "s_dsc": null,
-    "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B164F1A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Front Passenger Seat Belt Pretensioner Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B165400",
-    "s_dsc": null,
-    "l_dsc": "Left front impact sensor not connected"
-  },
-  {
-    "code": null,
-    "dtc": "B165511",
-    "s_dsc": null,
-    "l_dsc": "Left Front Frontal Impact Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B165D00",
-    "s_dsc": null,
-    "l_dsc": "Right Front Impact Sensor Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B165E11",
-    "s_dsc": null,
-    "l_dsc": "Right Front Frontal Impact Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B166600",
-    "s_dsc": null,
-    "l_dsc": "Left Side Impact Sensor Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B166711",
-    "s_dsc": null,
-    "l_dsc": "Left Side Impact Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B166F00",
-    "s_dsc": null,
-    "l_dsc": "Right Side Impact Sensor Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B167011",
-    "s_dsc": null,
-    "l_dsc": "Right Side Impact Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B169416",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169517",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169700",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169800",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169C00",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169D00",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B169F00",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B16A100",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B16AE00",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B16B000",
-    "s_dsc": null,
-    "l_dsc": "SRS_ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B17041B",
-    "s_dsc": null,
-    "l_dsc": "Left Air Curtain Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B170511",
-    "s_dsc": null,
-    "l_dsc": "Left Air Curtain Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B170612",
-    "s_dsc": null,
-    "l_dsc": "Left Air Curtain is Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B17081A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Left Air Curtain Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B170D1B",
-    "s_dsc": null,
-    "l_dsc": "Right Air Curtain Not Connected"
-  },
-  {
-    "code": null,
-    "dtc": "B170E11",
-    "s_dsc": null,
-    "l_dsc": "Right Air Curtain Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B170F12",
-    "s_dsc": null,
-    "l_dsc": "Right Air Curtain Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B17121A",
-    "s_dsc": null,
-    "l_dsc": "Resistance of Right Air Curtain Equaling to 0"
-  },
-  {
-    "code": null,
-    "dtc": "B17A300",
-    "s_dsc": null,
-    "l_dsc": "SRS CAN Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B17A400",
-    "s_dsc": null,
-    "l_dsc": "SRS Hardwire Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4800",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Corner Sensor Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4812",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Power or No Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4814",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4A00",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Right Rear Corner Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4B00",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Center Sensor Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4B12",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Center Sensor Signal Wire Short to Power or Not Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4B14",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Center Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4D00",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Right Rear Center Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4E00",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Center Sensor Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4E12",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Center Sensor Signal Wire Short to Power or Not Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B4E14",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Center Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5000",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Left Rear Center Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5100",
-    "s_dsc": null,
-    "l_dsc": "Internal Fault at Left Rear Corner Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5112",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Angle Sensor Signal Wire Short to Power Supply or No Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5114",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Corner Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5300",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Left Rear Corner Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5400",
-    "s_dsc": null,
-    "l_dsc": "Right Front Corner Sensor Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5412",
-    "s_dsc": null,
-    "l_dsc": "Right Front Corner Sensor Signal Wire Short to Power or Not Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5414",
-    "s_dsc": null,
-    "l_dsc": "Right Front Corner Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5600",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5700",
-    "s_dsc": null,
-    "l_dsc": "Left Front Corner Sensor Internal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5712",
-    "s_dsc": null,
-    "l_dsc": "Left Front Corner Sensor Signal Wire Short to Power or Not Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5714",
-    "s_dsc": null,
-    "l_dsc": "Left Front Corner Sensor Signal Wire Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1B5900",
-    "s_dsc": null,
-    "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "B1BE801",
-    "s_dsc": null,
-    "l_dsc": "Detection Signal of Front Wiper High-speed Switch Hard Wire Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1BF400",
-    "s_dsc": null,
-    "l_dsc": "Front Wiper Reset Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1C0800",
-    "s_dsc": null,
-    "l_dsc": "Rear Wiper Reset Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1C0D12",
-    "s_dsc": null,
-    "l_dsc": "Washing Motor Short-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1C0D13",
-    "s_dsc": null,
-    "l_dsc": "Washing Motor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1C0D71",
-    "s_dsc": null,
-    "l_dsc": "Washing Motor Stalling"
-  },
-  {
-    "code": null,
-    "dtc": "B1C5E11",
-    "s_dsc": null,
-    "l_dsc": "Right Charging Port Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1C5E12",
-    "s_dsc": null,
-    "l_dsc": "Right Charging Port Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1C5E13",
-    "s_dsc": null,
-    "l_dsc": "Right Charging Port Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1C5E19",
-    "s_dsc": null,
-    "l_dsc": "Right charging port light drive overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CAF00",
-    "s_dsc": null,
-    "l_dsc": "Humidity Sensor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDA11",
-    "s_dsc": null,
-    "l_dsc": "Trunk Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDA12",
-    "s_dsc": null,
-    "l_dsc": "Trunk Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDA13",
-    "s_dsc": null,
-    "l_dsc": "Trunk Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDA19",
-    "s_dsc": null,
-    "l_dsc": "Trunk light drive circuit overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDB11",
-    "s_dsc": null,
-    "l_dsc": "Left Front Door Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDB12",
-    "s_dsc": null,
-    "l_dsc": "Left Front Door Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDB13",
-    "s_dsc": null,
-    "l_dsc": "Left Front Door Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDB19",
-    "s_dsc": null,
-    "l_dsc": "Left Front Door Drive Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDD11",
-    "s_dsc": null,
-    "l_dsc": "Right Front Door Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDD12",
-    "s_dsc": null,
-    "l_dsc": "Right Front Door Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDD13",
-    "s_dsc": null,
-    "l_dsc": "Right Front Door Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDD19",
-    "s_dsc": null,
-    "l_dsc": "Right Front Door Drive Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDF11",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDF12",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDF13",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CDF19",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive of Left Exterior Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE011",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE012",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE013",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE019",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive of Left Exterior Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE111",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE112",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE113",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE119",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive of Left Exterior Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE211",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE212",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE213",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE219",
-    "s_dsc": null,
-    "l_dsc": "Left&Right Commutator Motor Drive of Exterior Right Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE311",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE312",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE313",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE319",
-    "s_dsc": null,
-    "l_dsc": "Up&Down Commutator Motor Drive of Exterior Right Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE411",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE412",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE413",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE419",
-    "s_dsc": null,
-    "l_dsc": "Folding Motor Drive of Exterior Right Rearview Mirror Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE911",
-    "s_dsc": null,
-    "l_dsc": "Left Footwell Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE912",
-    "s_dsc": null,
-    "l_dsc": "Left footwell light drive circuit short to power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE913",
-    "s_dsc": null,
-    "l_dsc": "Left footwell light drive circuit is broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CE919",
-    "s_dsc": null,
-    "l_dsc": "Left footwell light drive is overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1CEB11",
-    "s_dsc": null,
-    "l_dsc": "Right Footwell Light Drive Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B1CEB12",
-    "s_dsc": null,
-    "l_dsc": "Right Footwell Light Drive Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B1CEB13",
-    "s_dsc": null,
-    "l_dsc": "Right Footwell Light Drive Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "B1CEB19",
-    "s_dsc": null,
-    "l_dsc": "Right Footwell Light Drive Overload"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0007",
-    "s_dsc": null,
-    "l_dsc": "Volume \"+\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0107",
-    "s_dsc": null,
-    "l_dsc": "Channel \"+\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0207",
-    "s_dsc": null,
-    "l_dsc": "Bluetooth Telephone Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0407",
-    "s_dsc": null,
-    "l_dsc": "\"Mode\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0507",
-    "s_dsc": null,
-    "l_dsc": "\"Voice\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0607",
-    "s_dsc": null,
-    "l_dsc": "Panoramic Image Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0707",
-    "s_dsc": null,
-    "l_dsc": "Volume \"-\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E0807",
-    "s_dsc": null,
-    "l_dsc": "Channel \"-\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E1007",
-    "s_dsc": null,
-    "l_dsc": "EPPROM Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1E1907",
-    "s_dsc": null,
-    "l_dsc": "\"Mute\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E1A07",
-    "s_dsc": null,
-    "l_dsc": "Custom Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E1C07",
-    "s_dsc": null,
-    "l_dsc": "Instrument Menu Return Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E2000",
-    "s_dsc": null,
-    "l_dsc": "Steering Wheel Built-in Vibration Motor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B1E2D07",
-    "s_dsc": null,
-    "l_dsc": "\"Cruise\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E2E07",
-    "s_dsc": null,
-    "l_dsc": "\"Cancel\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E2F07",
-    "s_dsc": null,
-    "l_dsc": "Speed + Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3007",
-    "s_dsc": null,
-    "l_dsc": "Speed -Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3107",
-    "s_dsc": null,
-    "l_dsc": "\"Setting\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3207",
-    "s_dsc": null,
-    "l_dsc": "\"Reset\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3307",
-    "s_dsc": null,
-    "l_dsc": "Time Interval \"-\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3407",
-    "s_dsc": null,
-    "l_dsc": "Time Interval \"+\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B1E3507",
-    "s_dsc": null,
-    "l_dsc": "\"Lane Offset\" Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B222400",
-    "s_dsc": null,
-    "l_dsc": "Sunroof Hall Sensor Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B222401",
-    "s_dsc": null,
-    "l_dsc": "Blinder Motor Hall Sensor Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B225300",
-    "s_dsc": null,
-    "l_dsc": "Sunroof Initialization Lost"
-  },
-  {
-    "code": null,
-    "dtc": "B225407",
-    "s_dsc": null,
-    "l_dsc": "Sunroof Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B225511",
-    "s_dsc": null,
-    "l_dsc": "Sunroof Motor Short (to Ground)"
-  },
-  {
-    "code": null,
-    "dtc": "B225513",
-    "s_dsc": null,
-    "l_dsc": "Sunroof Motor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B225600",
-    "s_dsc": null,
-    "l_dsc": "Sun shade initialization lost"
-  },
-  {
-    "code": null,
-    "dtc": "B225707",
-    "s_dsc": null,
-    "l_dsc": "Blinder Switch Stuck"
-  },
-  {
-    "code": null,
-    "dtc": "B225811",
-    "s_dsc": null,
-    "l_dsc": "Blinder Motor Short (to Ground)"
-  },
-  {
-    "code": null,
-    "dtc": "B225813",
-    "s_dsc": null,
-    "l_dsc": "Blinder Motor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B227C13",
-    "s_dsc": null,
-    "l_dsc": "Interior Front Detection Antenna Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B227D13",
-    "s_dsc": null,
-    "l_dsc": "Interior Middle Detection Antenna Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B227E13",
-    "s_dsc": null,
-    "l_dsc": "Interior Rear Detection Antenna Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B229D16",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of High Frequency Receiver Module Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "B229D17",
-    "s_dsc": null,
-    "l_dsc": "Power Supply of High Frequency Receiver Module Too High"
-  },
-  {
-    "code": null,
-    "dtc": "B22A613",
-    "s_dsc": null,
-    "l_dsc": "Open circuit of the exterior right front detection antenna"
-  },
-  {
-    "code": null,
-    "dtc": "B22A813",
-    "s_dsc": null,
-    "l_dsc": "Exterior Trunk Detection Antenna Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2342",
-    "s_dsc": null,
-    "l_dsc": "Internal Fault of Instrument"
-  },
-  {
-    "code": null,
-    "dtc": "B2343",
-    "s_dsc": null,
-    "l_dsc": "Clock Running Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B234A",
-    "s_dsc": null,
-    "l_dsc": "CAN Bus Receives Incorrect Coolant Temperature Signal"
-  },
-  {
-    "code": null,
-    "dtc": "B234C",
-    "s_dsc": null,
-    "l_dsc": "CAN Bus Does Not Detect Motor Speed Signal"
-  },
-  {
-    "code": null,
-    "dtc": "B234D",
-    "s_dsc": null,
-    "l_dsc": "Information Switching Key Input Device Short-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B236009",
-    "s_dsc": null,
-    "l_dsc": "Display Fault (Backlight Fault) or Display Chip Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B24AB00",
-    "s_dsc": null,
-    "l_dsc": "Light Handle Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B24AC00",
-    "s_dsc": null,
-    "l_dsc": "Wiper Handle Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B24D700",
-    "s_dsc": null,
-    "l_dsc": "Handle Input Power Overvoltage"
-  },
-  {
-    "code": null,
-    "dtc": "B24D800",
-    "s_dsc": null,
-    "l_dsc": "Handle Input Power Undervoltage"
-  },
-  {
-    "code": null,
-    "dtc": "B2A0801",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2A0803",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A0811",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B2A0813",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2013",
-    "s_dsc": null,
-    "l_dsc": "Interior temperature sensor open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2111",
-    "s_dsc": null,
-    "l_dsc": "Interior Temperature Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2213",
-    "s_dsc": null,
-    "l_dsc": "Exterior Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2311",
-    "s_dsc": null,
-    "l_dsc": "Exterior Temperature Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2413",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2511",
-    "s_dsc": null,
-    "l_dsc": "Evaporator Temperature Sensor Circuit Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2712",
-    "s_dsc": null,
-    "l_dsc": "Sunlight Sensor Circuit Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2A12",
-    "s_dsc": null,
-    "l_dsc": "Mode Motor Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2A14",
-    "s_dsc": null,
-    "l_dsc": "Mode Motor Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2A92",
-    "s_dsc": null,
-    "l_dsc": "Mode Motor Not Rotating in Place"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2B12",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Air Mix Motor Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2B14",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Air Mix Motor Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2B92",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Air Mix Motor Not Rotating in Place"
-  },
-  {
-    "code": null,
-    "dtc": "B2A2F09",
-    "s_dsc": null,
-    "l_dsc": "A/C Pipes in High Pressure State or Low Pressure State"
-  },
-  {
-    "code": null,
-    "dtc": "B2A3214",
-    "s_dsc": null,
-    "l_dsc": "Front Blower Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A3314",
-    "s_dsc": null,
-    "l_dsc": "Front Blower Adjustment Signal Harness Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A4B12",
-    "s_dsc": null,
-    "l_dsc": "Circulation Motor Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2A4B14",
-    "s_dsc": null,
-    "l_dsc": "Circulation Motor Short to Ground or Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A4B92",
-    "s_dsc": null,
-    "l_dsc": "Circulation Motor Not Rotating in Place"
-  },
-  {
-    "code": null,
-    "dtc": "B2A5811",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "B2A5813",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Face Outlet Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2A5913",
-    "s_dsc": null,
-    "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB049",
-    "s_dsc": null,
-    "l_dsc": "Current Sampling Circuit Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB149",
-    "s_dsc": null,
-    "l_dsc": "Motor Phase Lost"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB249",
-    "s_dsc": null,
-    "l_dsc": "IPM IGBT Fault"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB349",
-    "s_dsc": null,
-    "l_dsc": "Internal temperature sensor fault"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB41D",
-    "s_dsc": null,
-    "l_dsc": "Internal Current Excessive"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB573",
-    "s_dsc": null,
-    "l_dsc": "Fail to Start Up"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB64B",
-    "s_dsc": null,
-    "l_dsc": "Internal Temperature Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB774",
-    "s_dsc": null,
-    "l_dsc": "Speed Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB81C",
-    "s_dsc": null,
-    "l_dsc": "Phase Voltage Too High"
-  },
-  {
-    "code": null,
-    "dtc": "B2AB997",
-    "s_dsc": null,
-    "l_dsc": "Overload fault"
-  },
-  {
-    "code": null,
-    "dtc": "B2ABA1C",
-    "s_dsc": null,
-    "l_dsc": "Fault at Internal Low-voltage Power"
-  },
-  {
-    "code": null,
-    "dtc": "B2ABB17",
-    "s_dsc": null,
-    "l_dsc": "Voltage of High Voltage Side Overvoltage"
-  },
-  {
-    "code": null,
-    "dtc": "B2ABC16",
-    "s_dsc": null,
-    "l_dsc": "Voltage of High Voltage Side Low"
-  },
-  {
-    "code": null,
-    "dtc": "B2AD616",
-    "s_dsc": null,
-    "l_dsc": "12V Power Supply Undervoltage (Lower Than 9V)"
-  },
-  {
-    "code": null,
-    "dtc": "B2AD617",
-    "s_dsc": null,
-    "l_dsc": "12V Power Supply Overvoltage"
-  },
-  {
-    "code": null,
-    "dtc": "B2FD016",
-    "s_dsc": null,
-    "l_dsc": "Power Supply Voltage Low Alarm"
-  },
-  {
-    "code": null,
-    "dtc": "B2FD017",
-    "s_dsc": null,
-    "l_dsc": "Power Supply Voltage High Alarm"
-  },
-  {
-    "code": null,
-    "dtc": "B2FD14B",
-    "s_dsc": null,
-    "l_dsc": "Wireless Charging Overtemperature Alarm"
-  },
-  {
-    "code": null,
-    "dtc": "C000100",
-    "s_dsc": null,
-    "l_dsc": "CSV Valve 1 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C000200",
-    "s_dsc": null,
-    "l_dsc": "PSV Valve 1 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C000300",
-    "s_dsc": null,
-    "l_dsc": "CSV Valve 2 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C000400",
-    "s_dsc": null,
-    "l_dsc": "PSV Valve 2 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001000",
-    "s_dsc": null,
-    "l_dsc": "Left Front Inlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001100",
-    "s_dsc": null,
-    "l_dsc": "Left Front Outlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001400",
-    "s_dsc": null,
-    "l_dsc": "Right Front Inlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001500",
-    "s_dsc": null,
-    "l_dsc": "Right Front Outlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001800",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Inlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001900",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Outlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001C00",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Inlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C001D00",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Outlet Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C002192",
-    "s_dsc": null,
-    "l_dsc": "Brake Booster Module Pipeline Hydraulic Pressure Below Normal Value"
-  },
-  {
-    "code": null,
-    "dtc": "C002400",
-    "s_dsc": null,
-    "l_dsc": "SSV Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C003100",
-    "s_dsc": null,
-    "l_dsc": "Left Front Wheel Speed Sensor Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C003200",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of Left Front Wheel Speed Sensor Low"
-  },
-  {
-    "code": null,
-    "dtc": "C003400",
-    "s_dsc": null,
-    "l_dsc": "Right Front Wheel Speed Sensor Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C003500",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of Right Front Wheel Speed Sensor Low"
-  },
-  {
-    "code": null,
-    "dtc": "C003700",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Wheel Speed Sensor Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C003800",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of Left Rear Wheel Speed Sensor Low"
-  },
-  {
-    "code": null,
-    "dtc": "C003A00",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Wheel Speed Sensor Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C003B00",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of Right Rear Wheel Speed Sensor Low"
-  },
-  {
-    "code": null,
-    "dtc": "C004900",
-    "s_dsc": null,
-    "l_dsc": "Brake Fluid Level Under Normal Value"
-  },
-  {
-    "code": null,
-    "dtc": "C006A01",
-    "s_dsc": null,
-    "l_dsc": "Yaw Rate Sensor Parameter Wrongly Configured"
-  },
-  {
-    "code": null,
-    "dtc": "C006A02",
-    "s_dsc": null,
-    "l_dsc": "Yaw Rate Sensor Signal Error"
-  },
-  {
-    "code": null,
-    "dtc": "C007500",
-    "s_dsc": null,
-    "l_dsc": "Master Cylinder Position Sensor A Fault/Short Circuit"
-  },
-  {
-    "code": null,
-    "dtc": "C050000",
-    "s_dsc": null,
-    "l_dsc": "Left Front Wheel Speed Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "C050200",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Ground Line"
-  },
-  {
-    "code": null,
-    "dtc": "C050300",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Power Supply Line"
-  },
-  {
-    "code": null,
-    "dtc": "C050400",
-    "s_dsc": null,
-    "l_dsc": "Left Front Wheel Speed Sensor Air Gap Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C050576",
-    "s_dsc": null,
-    "l_dsc": "Incorrect Installation Direction of Left Front Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C050600",
-    "s_dsc": null,
-    "l_dsc": "Right Front Wheel Speed Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "C050800",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Front Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C050900",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Right Front Wheel Speed Sensor Signal Line and Power Supply Line"
-  },
-  {
-    "code": null,
-    "dtc": "C050A00",
-    "s_dsc": null,
-    "l_dsc": "Right Front Wheel Speed Sensor Air Gap Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C050B76",
-    "s_dsc": null,
-    "l_dsc": "Incorrect Installation Direction of Right Front Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C050C00",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Wheel Speed Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "C050E00",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Left Rear Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C050F00",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Left Rear Wheel Speed Sensor Signal Line and Power Supply Line"
-  },
-  {
-    "code": null,
-    "dtc": "C051000",
-    "s_dsc": null,
-    "l_dsc": "Left Rear Wheel Speed Sensor Air Gap Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C051176",
-    "s_dsc": null,
-    "l_dsc": "Incorrect Installation Direction of Left Rear Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C051200",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Wheel Speed Sensor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "C051400",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Rear Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C051500",
-    "s_dsc": null,
-    "l_dsc": "Short Circuit between Right Rear Wheel Speed Sensor Signal Line and Power Supply Line"
-  },
-  {
-    "code": null,
-    "dtc": "C051600",
-    "s_dsc": null,
-    "l_dsc": "Right Rear Wheel Speed Sensor Air Gap Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C051776",
-    "s_dsc": null,
-    "l_dsc": "Incorrect Installation Direction of Right Rear Wheel Speed Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "C051D01",
-    "s_dsc": null,
-    "l_dsc": "Yaw Rate Sensor Wrongly Calibrated"
-  },
-  {
-    "code": null,
-    "dtc": "C052901",
-    "s_dsc": null,
-    "l_dsc": "Steering Angle Sensor Module Lost"
-  },
-  {
-    "code": null,
-    "dtc": "C053D00",
-    "s_dsc": null,
-    "l_dsc": "Pressure Sensor B Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C053E00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Pressure Sensor A Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C053F00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Pressure Sensor A Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C054100",
-    "s_dsc": null,
-    "l_dsc": "Pressure Sensor B Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C054200",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Pressure Sensor B Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C054300",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Pressure Sensor B Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C055000",
-    "s_dsc": null,
-    "l_dsc": "ECU Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C055E00",
-    "s_dsc": null,
-    "l_dsc": "Brake Hydraulic Circuit A Leaky"
-  },
-  {
-    "code": null,
-    "dtc": "C055F92",
-    "s_dsc": null,
-    "l_dsc": "Hydraulic Unit Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C056B00",
-    "s_dsc": null,
-    "l_dsc": "Brake Booster Module Pressure Sensor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C057900",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C057A00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C057F00",
-    "s_dsc": null,
-    "l_dsc": "Brake Booster Motor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "C058200",
-    "s_dsc": null,
-    "l_dsc": "Circuit Signal of Brake Booster Motor Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C058800",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C058900",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C058A00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C059000",
-    "s_dsc": null,
-    "l_dsc": "Supply Current of Brake Booster Motoris Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C059100",
-    "s_dsc": null,
-    "l_dsc": "Supply Current of Brake Booster Motor Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C059400",
-    "s_dsc": null,
-    "l_dsc": "Brake Booster Motor Load Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C05B001",
-    "s_dsc": null,
-    "l_dsc": "Brake Hydraulic Circuit L1 Leaky"
-  },
-  {
-    "code": null,
-    "dtc": "C05C200",
-    "s_dsc": null,
-    "l_dsc": "Brake Booster Motor A Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "C05C24B",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Brake Booster Motor Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C05CA00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too high"
-  },
-  {
-    "code": null,
-    "dtc": "C05CB00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C05CC00",
-    "s_dsc": null,
-    "l_dsc": "Master cylinder position sensor A abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C05CD00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C05CE00",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C05D000",
-    "s_dsc": null,
-    "l_dsc": "Master Cylinder Position Sensor Signal Value Incorrect"
-  },
-  {
-    "code": null,
-    "dtc": "C05D200",
-    "s_dsc": null,
-    "l_dsc": "Master Cylinder Stroke Exceed Expected Value"
-  },
-  {
-    "code": null,
-    "dtc": "C05D500",
-    "s_dsc": null,
-    "l_dsc": "TSV Valve Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C106600",
-    "s_dsc": null,
-    "l_dsc": "Angle Sensor Not Calibrated"
-  },
-  {
-    "code": null,
-    "dtc": "C110009",
-    "s_dsc": null,
-    "l_dsc": "Control Module Main Chip Fault(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "C117009",
-    "s_dsc": null,
-    "l_dsc": "EPB Switch Fault(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "C11A006",
-    "s_dsc": null,
-    "l_dsc": "Actuator Overload(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "C11B013",
-    "s_dsc": null,
-    "l_dsc": "Left Motor or Line Fault(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "C11B113",
-    "s_dsc": null,
-    "l_dsc": "Right Motor or Line Fault(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "C120700",
-    "s_dsc": null,
-    "l_dsc": "Pump Not Returnable"
-  },
-  {
-    "code": null,
-    "dtc": "C12F909",
-    "s_dsc": null,
-    "l_dsc": "Brake Hydraulic Circuit Blocked"
-  },
-  {
-    "code": null,
-    "dtc": "C1A3800",
-    "s_dsc": null,
-    "l_dsc": "System Not Fully Initialized"
-  },
-  {
-    "code": null,
-    "dtc": "C1B6044",
-    "s_dsc": null,
-    "l_dsc": "ECU RAM Fault"
-  },
-  {
-    "code": null,
-    "dtc": "C1B9000",
-    "s_dsc": null,
-    "l_dsc": "Loss of Power Supply"
-  },
-  {
-    "code": null,
-    "dtc": "C1B9C23",
-    "s_dsc": null,
-    "l_dsc": "Main/Auxiliary/Torque Signal Keeping at Low Level"
-  },
-  {
-    "code": null,
-    "dtc": "C1B9C24",
-    "s_dsc": null,
-    "l_dsc": "Main/Auxiliary/Torque Signal Keeping at High Level"
-  },
-  {
-    "code": null,
-    "dtc": "C1B9D21",
-    "s_dsc": null,
-    "l_dsc": "Voltage of Power Supply Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C1B9D22",
-    "s_dsc": null,
-    "l_dsc": "Voltage of Power Supply Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA023",
-    "s_dsc": null,
-    "l_dsc": "Main/Auxiliary Angle Signal Level Constant Low"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA024",
-    "s_dsc": null,
-    "l_dsc": "Main/Auxiliary Angle Signal Level Constant High"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA500",
-    "s_dsc": null,
-    "l_dsc": "ECU Operation Error"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA600",
-    "s_dsc": null,
-    "l_dsc": "ECU Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA700",
-    "s_dsc": null,
-    "l_dsc": "ECU Fails to ROM and Check"
-  },
-  {
-    "code": null,
-    "dtc": "C1BA900",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage of Torque Sensor Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "C1BAA00",
-    "s_dsc": null,
-    "l_dsc": "Motor Drive Circuit Failure"
-  },
-  {
-    "code": null,
-    "dtc": "C1BAB21",
-    "s_dsc": null,
-    "l_dsc": "Output Voltage of Temperature Detection Circuit Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "C1BAB22",
-    "s_dsc": null,
-    "l_dsc": "Output Voltage of Temperature Detection Circuit Too High"
-  },
-  {
-    "code": null,
-    "dtc": "C1BAE00",
-    "s_dsc": null,
-    "l_dsc": "ECU Not Executing Angle Calibration Order"
-  },
-  {
-    "code": null,
-    "dtc": "C1BB200",
-    "s_dsc": null,
-    "l_dsc": "ESP Speed Data Error"
-  },
-  {
-    "code": null,
-    "dtc": "C2A1700",
-    "s_dsc": null,
-    "l_dsc": "Brake Hydraulic Circuit L1 Overcompensation (air Present)"
-  },
-  {
-    "code": null,
-    "dtc": "P056200",
-    "s_dsc": null,
-    "l_dsc": "System Voltage Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P056300",
-    "s_dsc": null,
-    "l_dsc": "System Voltage Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P060400",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Control Module Fault(RAM)"
-  },
-  {
-    "code": null,
-    "dtc": "P060500",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Control Module Fault(ROM)"
-  },
-  {
-    "code": null,
-    "dtc": "P060600",
-    "s_dsc": null,
-    "l_dsc": "ECM/PCM processor fault"
-  },
-  {
-    "code": null,
-    "dtc": "P060700",
-    "s_dsc": null,
-    "l_dsc": "ECU Hardware Failure"
-  },
-  {
-    "code": null,
-    "dtc": "P060B00",
-    "s_dsc": null,
-    "l_dsc": "ECU Hardware Fault(A/D processor)"
-  },
-  {
-    "code": null,
-    "dtc": "P060C00",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Control Module Fault(program running)"
-  },
-  {
-    "code": null,
-    "dtc": "P06B800",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Control Module Fault(NVRAM memory)"
-  },
-  {
-    "code": null,
-    "dtc": "P151100",
-    "s_dsc": null,
-    "l_dsc": "AC High-voltage Interlock Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P151500",
-    "s_dsc": null,
-    "l_dsc": "Water Temperature Sensor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P157016",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage at AC Side"
-  },
-  {
-    "code": null,
-    "dtc": "P157017",
-    "s_dsc": null,
-    "l_dsc": "High Voltage at AC Side"
-  },
-  {
-    "code": null,
-    "dtc": "P157216",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage at DC Side"
-  },
-  {
-    "code": null,
-    "dtc": "P157217",
-    "s_dsc": null,
-    "l_dsc": "High Voltage at DC Side"
-  },
-  {
-    "code": null,
-    "dtc": "P157219",
-    "s_dsc": null,
-    "l_dsc": "DC Side Overcurrent"
-  },
-  {
-    "code": null,
-    "dtc": "P157400",
-    "s_dsc": null,
-    "l_dsc": "Power Supply Device Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P157897",
-    "s_dsc": null,
-    "l_dsc": "CC Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P15794B",
-    "s_dsc": null,
-    "l_dsc": "Temperature Sampling 1 High"
-  },
-  {
-    "code": null,
-    "dtc": "P157A36",
-    "s_dsc": null,
-    "l_dsc": "Low Frequency of Charging Grid"
-  },
-  {
-    "code": null,
-    "dtc": "P157A37",
-    "s_dsc": null,
-    "l_dsc": "High Frequency of Charging Grid"
-  },
-  {
-    "code": null,
-    "dtc": "P157B00",
-    "s_dsc": null,
-    "l_dsc": "AC Side Overcurrent"
-  },
-  {
-    "code": null,
-    "dtc": "P157C00",
-    "s_dsc": null,
-    "l_dsc": "Hardware Protection"
-  },
-  {
-    "code": null,
-    "dtc": "P157E11",
-    "s_dsc": null,
-    "l_dsc": "Outer of Charging Connection Signal Short to Ground"
-  },
-  {
-    "code": null,
-    "dtc": "P157E12",
-    "s_dsc": null,
-    "l_dsc": "Outer of Charging Connection Signal Short to Power"
-  },
-  {
-    "code": null,
-    "dtc": "P157F11",
-    "s_dsc": null,
-    "l_dsc": "AC Output Short-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "P15834B",
-    "s_dsc": null,
-    "l_dsc": "Temperature Sampling 2 High"
-  },
-  {
-    "code": null,
-    "dtc": "P158798",
-    "s_dsc": null,
-    "l_dsc": "Phase Temperature of Charging Port Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P158900",
-    "s_dsc": null,
-    "l_dsc": "Phase Temperature Sampling at Charging Port Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P158A00",
-    "s_dsc": null,
-    "l_dsc": "Electric Lock Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P15FD00",
-    "s_dsc": null,
-    "l_dsc": "High Temperature of Cooling Water"
-  },
-  {
-    "code": null,
-    "dtc": "P15FF00",
-    "s_dsc": null,
-    "l_dsc": "Internal Temperature Sensor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0000",
-    "s_dsc": null,
-    "l_dsc": "Serious Electric Leakage Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0100",
-    "s_dsc": null,
-    "l_dsc": "Common Electric Leakage Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0200",
-    "s_dsc": null,
-    "l_dsc": "BIC1 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0300",
-    "s_dsc": null,
-    "l_dsc": "BIC2 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0400",
-    "s_dsc": null,
-    "l_dsc": "BIC3 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0500",
-    "s_dsc": null,
-    "l_dsc": "BIC4 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0600",
-    "s_dsc": null,
-    "l_dsc": "BIC5 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0700",
-    "s_dsc": null,
-    "l_dsc": "BIC6 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0800",
-    "s_dsc": null,
-    "l_dsc": "BIC7 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0900",
-    "s_dsc": null,
-    "l_dsc": "BIC8 Working Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0C00",
-    "s_dsc": null,
-    "l_dsc": "BIC1 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0D00",
-    "s_dsc": null,
-    "l_dsc": "BIC2 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0E00",
-    "s_dsc": null,
-    "l_dsc": "BIC3 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A0F00",
-    "s_dsc": null,
-    "l_dsc": "BIC4 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A1000",
-    "s_dsc": null,
-    "l_dsc": "BIC5 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A1100",
-    "s_dsc": null,
-    "l_dsc": "BIC6 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A1200",
-    "s_dsc": null,
-    "l_dsc": "BIC7 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A1300",
-    "s_dsc": null,
-    "l_dsc": "BIC8 Voltage Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2000",
-    "s_dsc": null,
-    "l_dsc": "BIC1 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2100",
-    "s_dsc": null,
-    "l_dsc": "BIC2 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2200",
-    "s_dsc": null,
-    "l_dsc": "BIC3 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2300",
-    "s_dsc": null,
-    "l_dsc": "BIC4 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2400",
-    "s_dsc": null,
-    "l_dsc": "BIC5 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2500",
-    "s_dsc": null,
-    "l_dsc": "BIC6 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2600",
-    "s_dsc": null,
-    "l_dsc": "BIC7 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A2700",
-    "s_dsc": null,
-    "l_dsc": "BIC8 Temperature Sampling Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3522",
-    "s_dsc": null,
-    "l_dsc": "Severely high voltage of power battery cell"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3622",
-    "s_dsc": null,
-    "l_dsc": "Power Battery Cell Voltage Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3721",
-    "s_dsc": null,
-    "l_dsc": "Severely low voltage of power battery cell"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3922",
-    "s_dsc": null,
-    "l_dsc": "Power Battery Cell Temperature Seriously High"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3B21",
-    "s_dsc": null,
-    "l_dsc": "Power battery's single-cell temperature seriously low"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3D00",
-    "s_dsc": null,
-    "l_dsc": "Negative Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3E00",
-    "s_dsc": null,
-    "l_dsc": "Main Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A3F00",
-    "s_dsc": null,
-    "l_dsc": "Pre-charging Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A4100",
-    "s_dsc": null,
-    "l_dsc": "Main Contactor Sintering Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A4200",
-    "s_dsc": null,
-    "l_dsc": "Negative Contactor Sintering"
-  },
-  {
-    "code": null,
-    "dtc": "P1A5600",
-    "s_dsc": null,
-    "l_dsc": "12V Supply Input of Battery Management System Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1A5B00",
-    "s_dsc": null,
-    "l_dsc": "Contactor Disconnected Due to Dual-circuit Power Supply Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1A6000",
-    "s_dsc": null,
-    "l_dsc": "High Voltage Interlock 1 Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AC000",
-    "s_dsc": null,
-    "l_dsc": "Collision Alarm of Airbag ECU"
-  },
-  {
-    "code": null,
-    "dtc": "P1AC400",
-    "s_dsc": null,
-    "l_dsc": "Serious Imbalance at Battery"
-  },
-  {
-    "code": null,
-    "dtc": "P1AC900",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Inductive Signal Circuit Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P1ACB07",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Anode Contactor Sintering"
-  },
-  {
-    "code": null,
-    "dtc": "P1ACC07",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Cathode Contactor Sintering"
-  },
-  {
-    "code": null,
-    "dtc": "P1AD44B",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Charging Port 1 Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P1AD54B",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Charging Port 2 Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P1AD698",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Charging Port 3 Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P1AD900",
-    "s_dsc": null,
-    "l_dsc": "Temperature Sampling Point of Charging Port Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1ADE00",
-    "s_dsc": null,
-    "l_dsc": "Battery Cooling Failure Due to Air Conditioner System Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1ADF00",
-    "s_dsc": null,
-    "l_dsc": "Inner Cycle Failure at Battery Due to Air Conditioner System Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AE000",
-    "s_dsc": null,
-    "l_dsc": "Battery Heating Failure Due to Air Conditioner System Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AE400",
-    "s_dsc": null,
-    "l_dsc": "High Voltage Process Ended Due to Abnormal Low-voltage Supply"
-  },
-  {
-    "code": null,
-    "dtc": "P1AE800",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Anode Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AE900",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AF200",
-    "s_dsc": null,
-    "l_dsc": "Voltage Output at DC Charger Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1AF300",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Cabinet Stops Charging Actively"
-  },
-  {
-    "code": null,
-    "dtc": "P1AF400",
-    "s_dsc": null,
-    "l_dsc": "Insufficient Capacity of DC Charging Cabinet"
-  },
-  {
-    "code": null,
-    "dtc": "P1AF800",
-    "s_dsc": null,
-    "l_dsc": "Battery data not updated"
-  },
-  {
-    "code": null,
-    "dtc": "P1AFB00",
-    "s_dsc": null,
-    "l_dsc": "A/C System High Voltage Interlock Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AFC00",
-    "s_dsc": null,
-    "l_dsc": "On-board Charger High Voltage Interlock Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1AFD00",
-    "s_dsc": null,
-    "l_dsc": "DC-DC High Voltage Interlock Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1B1F00",
-    "s_dsc": null,
-    "l_dsc": "Fail to Anti-theft Authentication"
-  },
-  {
-    "code": null,
-    "dtc": "P1B2516",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1B2517",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage at Low Voltage Side Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P1BA000",
-    "s_dsc": null,
-    "l_dsc": "Cruise Configuration Unwritten In"
-  },
-  {
-    "code": null,
-    "dtc": "P1BAC00",
-    "s_dsc": null,
-    "l_dsc": "IGBT Core Common Overtemperature Warning for Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BAC19",
-    "s_dsc": null,
-    "l_dsc": "IGBT Core Serious Overtemperature Warning for Front Drive Motor Control Module (chopper OFF)"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB000",
-    "s_dsc": null,
-    "l_dsc": "Front Drive Motor Overcurrent"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB100",
-    "s_dsc": null,
-    "l_dsc": "IPM Fault at Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB200",
-    "s_dsc": null,
-    "l_dsc": "Common Overtemperature Warning for Front Drive Motor"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB298",
-    "s_dsc": null,
-    "l_dsc": "Serious Overtemperature Warning for Front Drive Motor"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB300",
-    "s_dsc": null,
-    "l_dsc": "IGBT-NTC Common Overtemperature Warning for Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB319",
-    "s_dsc": null,
-    "l_dsc": "IGBT-NTC Serious Overtemperature Warning for Front Drive Motor Control Module(chopper OFF)"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB500",
-    "s_dsc": null,
-    "l_dsc": "High Voltage Side of Front Drive Motor Control Module Undervoltage"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB600",
-    "s_dsc": null,
-    "l_dsc": "High Voltage Side of Front Drive Motor Control Module Overvoltage"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB700",
-    "s_dsc": null,
-    "l_dsc": "Voltage Sampling Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB800",
-    "s_dsc": null,
-    "l_dsc": "Collision Signal Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BB900",
-    "s_dsc": null,
-    "l_dsc": "Cap Opening Protection of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BBA00",
-    "s_dsc": null,
-    "l_dsc": "EEPROM Error of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BBC00",
-    "s_dsc": null,
-    "l_dsc": "DSP Reset Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BBD00",
-    "s_dsc": null,
-    "l_dsc": "Active Release Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BBF00",
-    "s_dsc": null,
-    "l_dsc": "Front Drive Motor Rotary Transformer Fault -Signal Lost"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC000",
-    "s_dsc": null,
-    "l_dsc": "Front Drive Motor Rotary Transformer Fault -Angle Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC100",
-    "s_dsc": null,
-    "l_dsc": "Front Drive Motor Rotary Transformer Fault-Signal Amplitude Decreasing"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC200",
-    "s_dsc": null,
-    "l_dsc": "Phase A of Front Drive Motor Lost"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC300",
-    "s_dsc": null,
-    "l_dsc": "Phase B of Front Drive Motor Lost"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC400",
-    "s_dsc": null,
-    "l_dsc": "Phase C of Front Drive Motor Lost"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC500",
-    "s_dsc": null,
-    "l_dsc": "Hall Current Sensor B Fault at Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC600",
-    "s_dsc": null,
-    "l_dsc": "Hall Current Sensor C Fault at Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC700",
-    "s_dsc": null,
-    "l_dsc": "IPM Radiator of Front Drive Motor Control Module Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC800",
-    "s_dsc": null,
-    "l_dsc": "IGBT Three-phase Temperature Calibration Fault Alarm for Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BC900",
-    "s_dsc": null,
-    "l_dsc": "Hall Current Sensor A Fault at Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BCF00",
-    "s_dsc": null,
-    "l_dsc": "Temperature Sensor Fault of Front Drive Motor-Torque Limitation"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD000",
-    "s_dsc": null,
-    "l_dsc": "Drive DSP1 Crash Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD117",
-    "s_dsc": null,
-    "l_dsc": "Drive CPLD Overvoltage of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD119",
-    "s_dsc": null,
-    "l_dsc": "Drive CPLD Overcurrent of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD200",
-    "s_dsc": null,
-    "l_dsc": "Drive CPLD Detecting IGBT On-axle Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD300",
-    "s_dsc": null,
-    "l_dsc": "Drive CPLD Detecting IGBT Off-axle Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BD400",
-    "s_dsc": null,
-    "l_dsc": "Drive CPLD Running Fault of Front Drive Motor Control Module"
-  },
-  {
-    "code": null,
-    "dtc": "P1BF100",
-    "s_dsc": null,
-    "l_dsc": "IPM Temperature Sampling of Front Drive Motor Control Module Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1BF200",
-    "s_dsc": null,
-    "l_dsc": "Winding Temperature Sensor Sampling at Front Drive Motor Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1D6144",
-    "s_dsc": null,
-    "l_dsc": "EEPROM Error at VCU"
-  },
-  {
-    "code": null,
-    "dtc": "P1D6200",
-    "s_dsc": null,
-    "l_dsc": "Cruise Switch Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1D6600",
-    "s_dsc": null,
-    "l_dsc": "Accelerator Signal Fault-Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1D6A00",
-    "s_dsc": null,
-    "l_dsc": "Stepless Fan Motor Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "P1D6D00",
-    "s_dsc": null,
-    "l_dsc": "DSP Reset Fault of VCU"
-  },
-  {
-    "code": null,
-    "dtc": "P1D7902",
-    "s_dsc": null,
-    "l_dsc": "Collision Alarm"
-  },
-  {
-    "code": null,
-    "dtc": "P1D7B00",
-    "s_dsc": null,
-    "l_dsc": "Throttle Signal Fault-1 Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1D7C00",
-    "s_dsc": null,
-    "l_dsc": "Throttle Signal Fault-2 Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1D8300",
-    "s_dsc": null,
-    "l_dsc": "Limited Power of Vehicle"
-  },
-  {
-    "code": null,
-    "dtc": "P1D8400",
-    "s_dsc": null,
-    "l_dsc": "Water temperature fault (OBC)"
-  },
-  {
-    "code": null,
-    "dtc": "P1D8D00",
-    "s_dsc": null,
-    "l_dsc": "Stepless Fan Motor Stalling, Short-circuited Etc"
-  },
-  {
-    "code": null,
-    "dtc": "P1D8E00",
-    "s_dsc": null,
-    "l_dsc": "Stepless Fan Overtemperature Protection, Electronic Error, Etc"
-  },
-  {
-    "code": null,
-    "dtc": "P1D8F00",
-    "s_dsc": null,
-    "l_dsc": "Stepless Fan Power Supply Overvoltage or Undervoltage"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9016",
-    "s_dsc": null,
-    "l_dsc": "Voltage of Power Battery Cell Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9017",
-    "s_dsc": null,
-    "l_dsc": "Voltage of Power Battery Cell Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9100",
-    "s_dsc": null,
-    "l_dsc": "Total Voltage of Power Battery Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9117",
-    "s_dsc": null,
-    "l_dsc": "Total Voltage of Power Battery Seriously High"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9200",
-    "s_dsc": null,
-    "l_dsc": "Total Voltage of Power Battery Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9216",
-    "s_dsc": null,
-    "l_dsc": "Total Voltage of Power Battery Seriously Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9308",
-    "s_dsc": null,
-    "l_dsc": "Life Frame of Power Battery Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9400",
-    "s_dsc": null,
-    "l_dsc": "Low Voltage Output Line Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9516",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9600",
-    "s_dsc": null,
-    "l_dsc": "Life Frame of Power Battery Abnormal -Counter Out of Order"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9700",
-    "s_dsc": null,
-    "l_dsc": "Life Frame of Power Battery Abnormal -Check Value Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9B00",
-    "s_dsc": null,
-    "l_dsc": "Water Temperature Sensor Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P1D9C00",
-    "s_dsc": null,
-    "l_dsc": "Water Temperature Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC000",
-    "s_dsc": null,
-    "l_dsc": "Voltage Too High at High Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC100",
-    "s_dsc": null,
-    "l_dsc": "Voltage Too Low at High Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC200",
-    "s_dsc": null,
-    "l_dsc": "Voltage Too High at Low Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC300",
-    "s_dsc": null,
-    "l_dsc": "Voltage Too Low at Low Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC400",
-    "s_dsc": null,
-    "l_dsc": "Current Too High at Low Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC600",
-    "s_dsc": null,
-    "l_dsc": "Current Too High at High Voltage Side during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1EC700",
-    "s_dsc": null,
-    "l_dsc": "Hardware Fault during Step-down"
-  },
-  {
-    "code": null,
-    "dtc": "P1ED316",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage at Low Voltage Side Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P1ED317",
-    "s_dsc": null,
-    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P1ED400",
-    "s_dsc": null,
-    "l_dsc": "DC Output Positive Line Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P1ED500",
-    "s_dsc": null,
-    "l_dsc": "AC Electric Leakage"
-  },
-  {
-    "code": null,
-    "dtc": "P1EE000",
-    "s_dsc": null,
-    "l_dsc": "DC Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "P229900",
-    "s_dsc": null,
-    "l_dsc": "Master Cylinder Position Sensor Signal Calibration Error"
-  },
-  {
-    "code": null,
-    "dtc": "P25C600",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too Low"
-  },
-  {
-    "code": null,
-    "dtc": "P25C700",
-    "s_dsc": null,
-    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too High"
-  },
-  {
-    "code": null,
-    "dtc": "P26804B",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Charging Port 1 Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P26814B",
-    "s_dsc": null,
-    "l_dsc": "Temperature of Charging Port 2 Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P26824B",
-    "s_dsc": null,
-    "l_dsc": "Temperature Rise of Charging Port 3 Seriously High"
-  },
-  {
-    "code": null,
-    "dtc": "P26834B",
-    "s_dsc": null,
-    "l_dsc": "Temperature Rise of Charging Port Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P26844B",
-    "s_dsc": null,
-    "l_dsc": "Temperature Rise of Charging Port Seriously High"
-  },
-  {
-    "code": null,
-    "dtc": "P268600",
-    "s_dsc": null,
-    "l_dsc": "High-voltage Interlock Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P268700",
-    "s_dsc": null,
-    "l_dsc": "Power Supply Relay Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P268873",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Anode Contactor Sintering"
-  },
-  {
-    "code": null,
-    "dtc": "P268973",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Cathode Contactor Sintering"
-  },
-  {
-    "code": null,
-    "dtc": "P268A00",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Anode Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P268B00",
-    "s_dsc": null,
-    "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P268C00",
-    "s_dsc": null,
-    "l_dsc": "Voltage of DC Charging Port Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P268D00",
-    "s_dsc": null,
-    "l_dsc": "Connection Signal of AC Charging Gun Inconsistent"
-  },
-  {
-    "code": null,
-    "dtc": "P268E00",
-    "s_dsc": null,
-    "l_dsc": "Voltage Output at DC Charger Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7000",
-    "s_dsc": null,
-    "l_dsc": "General Fault of Voltage Sampling Wire Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7100",
-    "s_dsc": null,
-    "l_dsc": "Serious Fault of Voltage Sampling Wire Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7200",
-    "s_dsc": null,
-    "l_dsc": "General Fault of Temperature Sampling Wire Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7300",
-    "s_dsc": null,
-    "l_dsc": "Serious Fault of Temperature Sampling Wire Broken"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7400",
-    "s_dsc": null,
-    "l_dsc": "Power battery overcharged"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7516",
-    "s_dsc": null,
-    "l_dsc": "Power Battery Pack Undervoltage"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7517",
-    "s_dsc": null,
-    "l_dsc": "Power Battery Pack Overvoltage"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7900",
-    "s_dsc": null,
-    "l_dsc": "Battery pack charging overcurrent alarm"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7B00",
-    "s_dsc": null,
-    "l_dsc": "Shunt Temperature Generally High"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7C00",
-    "s_dsc": null,
-    "l_dsc": "Shunt Temperature Seriously High"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7D00",
-    "s_dsc": null,
-    "l_dsc": "Temperature Sampling Fault of Shunt"
-  },
-  {
-    "code": null,
-    "dtc": "P2B7E00",
-    "s_dsc": null,
-    "l_dsc": "Large Deviation at Current Sampling of Shunt"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8000",
-    "s_dsc": null,
-    "l_dsc": "HVSU_PACK+ Voltage Sampling Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8100",
-    "s_dsc": null,
-    "l_dsc": "HVSU_LINK+ Voltage Sampling Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8200",
-    "s_dsc": null,
-    "l_dsc": "HVSU_LINK-Voltage Sampling Fault"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8500",
-    "s_dsc": null,
-    "l_dsc": "Power Supply of HVSU Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8A00",
-    "s_dsc": null,
-    "l_dsc": "BIC Configuration Inconsistent with Module State"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8E00",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Undervoltage UV"
-  },
-  {
-    "code": null,
-    "dtc": "P2B8F12",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Overvoltage OV"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9000",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Overcurrent (Contactor Channel)"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9100",
-    "s_dsc": null,
-    "l_dsc": "Abnormal DC charging port voltage"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9200",
-    "s_dsc": null,
-    "l_dsc": "Abnormal battery temperature difference"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9211",
-    "s_dsc": null,
-    "l_dsc": "High Side Short to Ground SC (Contactor Channel)"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9212",
-    "s_dsc": null,
-    "l_dsc": "High Side Short to Power OS (Contactor Channel)"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9213",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Open-circuited"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9219",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Overcurrent (HVSU Channel)"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9298",
-    "s_dsc": null,
-    "l_dsc": "High Side Drive Overtemperature"
-  },
-  {
-    "code": null,
-    "dtc": "P2B9400",
-    "s_dsc": null,
-    "l_dsc": "Power Battery Overdischarge"
-  },
-  {
-    "code": null,
-    "dtc": "U0073",
-    "s_dsc": null,
-    "l_dsc": "Control Module Communication Bus \"A\" Off (generic SAE)"
-  },
-  {
-    "code": null,
-    "dtc": "U011000",
-    "s_dsc": null,
-    "l_dsc": "Communication with Motor Control Unit Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U011100",
-    "s_dsc": null,
-    "l_dsc": "Communication with BMC Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U011181",
-    "s_dsc": null,
-    "l_dsc": "Message Data of BMC Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U011182",
-    "s_dsc": null,
-    "l_dsc": "Cycle Counter of BMC Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U011187",
-    "s_dsc": null,
-    "l_dsc": "Communication with Battery Management System (BMS) Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U012187",
-    "s_dsc": null,
-    "l_dsc": "Communication with ABS Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U014081",
-    "s_dsc": null,
-    "l_dsc": "Message Data of BCM Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U014087",
-    "s_dsc": null,
-    "l_dsc": "Communication with BCM Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U014187",
-    "s_dsc": null,
-    "l_dsc": "Communication fault with the complete bus controller"
-  },
-  {
-    "code": null,
-    "dtc": "U0146",
-    "s_dsc": null,
-    "l_dsc": "Communication between Instrument and Gateway Interrupted"
-  },
-  {
-    "code": null,
-    "dtc": "U014B87",
-    "s_dsc": null,
-    "l_dsc": "Communication with DC Charging Cabinet Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U014E87",
-    "s_dsc": null,
-    "l_dsc": "Communication with Security Gateway Module Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U015129",
-    "s_dsc": null,
-    "l_dsc": "Motor Control Module Receiving SRS ,CAN Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U015229",
-    "s_dsc": null,
-    "l_dsc": "Motor Control Module Receiving SRS Hardwire Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U015500",
-    "s_dsc": null,
-    "l_dsc": "Communication Timeout at Combination Instrument"
-  },
-  {
-    "code": null,
-    "dtc": "U015587",
-    "s_dsc": null,
-    "l_dsc": "Communication with Combination Instrument Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U015887",
-    "s_dsc": null,
-    "l_dsc": "Communication with ESP Lost -TRW"
-  },
-  {
-    "code": null,
-    "dtc": "U015987",
-    "s_dsc": null,
-    "l_dsc": "Communication with VTOG Lost -TRW"
-  },
-  {
-    "code": null,
-    "dtc": "U015A38",
-    "s_dsc": null,
-    "l_dsc": "Main/Auxiliary/Torque Signal Period Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U015B02",
-    "s_dsc": null,
-    "l_dsc": "Duty Cycle of Main/Auxiliary Angle Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U015D86",
-    "s_dsc": null,
-    "l_dsc": "Angle signal not available"
-  },
-  {
-    "code": null,
-    "dtc": "U015E31",
-    "s_dsc": null,
-    "l_dsc": "Motor Rotor Position Signal Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U015F86",
-    "s_dsc": null,
-    "l_dsc": "Received ESP Signal Not Available"
-  },
-  {
-    "code": null,
-    "dtc": "U016002",
-    "s_dsc": null,
-    "l_dsc": "Duty Cycle of Main/Auxiliary/Main+Auxiliary Torque Signal Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U0164",
-    "s_dsc": null,
-    "l_dsc": "Communication with Air Conditioning System Lost"
-  },
-  {
-    "code": null,
-    "dtc": "U016400",
-    "s_dsc": null,
-    "l_dsc": "Communication with Air Conditioner Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U016487",
-    "s_dsc": null,
-    "l_dsc": "Communication with Air Conditioner Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U018087",
-    "s_dsc": null,
-    "l_dsc": "Communication with High-side Drive Lost"
-  },
-  {
-    "code": null,
-    "dtc": "U019780",
-    "s_dsc": null,
-    "l_dsc": "Communication with Intelligent Power Brake Control Module Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U01A500",
-    "s_dsc": null,
-    "l_dsc": "Communication with Front Motor Motor Control Unit (FMCU) Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U0245",
-    "s_dsc": null,
-    "l_dsc": "Communication between Instrument Panel and Multimedia Interrupted"
-  },
-  {
-    "code": null,
-    "dtc": "U024500",
-    "s_dsc": null,
-    "l_dsc": "Communication Timeout at Multimedia"
-  },
-  {
-    "code": null,
-    "dtc": "U024582",
-    "s_dsc": null,
-    "l_dsc": "Message Data of Multimedia Abnormal"
-  },
-  {
-    "code": null,
-    "dtc": "U024C87",
-    "s_dsc": null,
-    "l_dsc": "Communication with I-KEY Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U024E87",
-    "s_dsc": null,
-    "l_dsc": "Communication with ESC Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U025387",
-    "s_dsc": null,
-    "l_dsc": "Communication with compressor lost"
-  },
-  {
-    "code": null,
-    "dtc": "U027E01",
-    "s_dsc": null,
-    "l_dsc": "BIC1 Cascade Communication Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U027E02",
-    "s_dsc": null,
-    "l_dsc": "BIC2 Cascade Communication Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U027E03",
-    "s_dsc": null,
-    "l_dsc": "BIC3 Cascade Communication Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U027E04",
-    "s_dsc": null,
-    "l_dsc": "BIC4 Cascade Communication Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U027E05",
-    "s_dsc": null,
-    "l_dsc": "BIC5 Cascade Communication Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U027E06",
-    "s_dsc": null,
-    "l_dsc": "BIC6 Cascade Communication Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U027E07",
-    "s_dsc": null,
-    "l_dsc": "BIC7 Cascade Communication Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U027E08",
-    "s_dsc": null,
-    "l_dsc": "BIC8 Cascade Communication Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U029187",
-    "s_dsc": null,
-    "l_dsc": "Communication with Gear Control Module Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U029787",
-    "s_dsc": null,
-    "l_dsc": "Communication with On-board Charger Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U029800",
-    "s_dsc": null,
-    "l_dsc": "Communication between Battery Manager System and DC Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U029887",
-    "s_dsc": null,
-    "l_dsc": "Communication with DC Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U029F87",
-    "s_dsc": null,
-    "l_dsc": "Communication with OBC Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U02A200",
-    "s_dsc": null,
-    "l_dsc": "Communication with Active Release Module Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U02B087",
-    "s_dsc": null,
-    "l_dsc": "Lost Communication with Humidity Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "U030000",
-    "s_dsc": null,
-    "l_dsc": "ECU Internal Control Module Software Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U043204",
-    "s_dsc": null,
-    "l_dsc": "Communication Timeout at Yaw Rate Sensor"
-  },
-  {
-    "code": null,
-    "dtc": "U1101",
-    "s_dsc": null,
-    "l_dsc": "Communication between Instrument and Combination Switch Interrupted"
-  },
-  {
-    "code": null,
-    "dtc": "U110287",
-    "s_dsc": null,
-    "l_dsc": "Communication with BCM Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U1103",
-    "s_dsc": null,
-    "l_dsc": "Communication between Instrument and SRS Interrupted"
-  },
-  {
-    "code": null,
-    "dtc": "U110387",
-    "s_dsc": null,
-    "l_dsc": "Communication with Airbag ECU Failed"
-  },
-  {
-    "code": null,
-    "dtc": "U20B000",
-    "s_dsc": null,
-    "l_dsc": "BIC1 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B100",
-    "s_dsc": null,
-    "l_dsc": "BIC2 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B200",
-    "s_dsc": null,
-    "l_dsc": "BIC3 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B300",
-    "s_dsc": null,
-    "l_dsc": "BIC4 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B400",
-    "s_dsc": null,
-    "l_dsc": "BIC5 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B500",
-    "s_dsc": null,
-    "l_dsc": "BIC6 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B600",
-    "s_dsc": null,
-    "l_dsc": "BIC7 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B700",
-    "s_dsc": null,
-    "l_dsc": "BIC8 CAN Communication Timeout"
-  },
-  {
-    "code": null,
-    "dtc": "U20B800",
-    "s_dsc": null,
-    "l_dsc": "BIC9 CAN Communication Timeout Fault"
-  },
-  {
-    "code": null,
-    "dtc": "U300000",
-    "s_dsc": null,
-    "l_dsc": "Microprocessor Error in ECU"
-  },
-  {
-    "code": null,
-    "dtc": "U300316",
-    "s_dsc": null,
-    "l_dsc": "Battery Soft Undervoltage Fault(independent)"
-  },
-  {
-    "code": null,
-    "dtc": "U300317",
-    "s_dsc": null,
-    "l_dsc": "Battery Soft Overvoltage Fault(independent)"
-  }
+  {"dtc": "B110811", "l_dsc": "PM2.5 Quick Tester Short-circuited"},
+  {"dtc": "B110913", "l_dsc": "PM2.5 Quick Tester Circuit Broken"},
+  {"dtc": "B110A02", "l_dsc": "PM2.5 Quick Tester CAN Signal Fault"},
+  {"dtc": "B110B07", "l_dsc": "PM2.5 Quick Tester Air Pump Fault"},
+  {"dtc": "B110C09", "l_dsc": "PM2.5 Quick Tester Laser Diode Failure"},
+  {"dtc": "B110D09", "l_dsc": "PM2.5 Quick Tester Photoelectric Receiving Module Failure"},
+  {"dtc": "B110E09", "l_dsc": "PM2.5 Quick Tester Temperature and Humidity Module Failure"},
+  {"dtc": "B110F09", "l_dsc": "PM2.5 Quick Tester Solenoid Valve Failure"},
+  {"dtc": "B111009", "l_dsc": "ECU Internal Fault"},
+  {"dtc": "B116212", "l_dsc": "Water Temperature Sensor Short-circuited"},
+  {"dtc": "B116214", "l_dsc": "Water Temperature Sensor Open-circuited"},
+  {"dtc": "B11BD11", "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Ground"},
+  {"dtc": "B11BD12", "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Power"},
+  {"dtc": "B11BD13", "l_dsc": "LIN1 Ambient Light Drive Circuit Broken"},
+  {"dtc": "B11BD19", "l_dsc": "LIN1 ambient light drive overload"},
+  {"dtc": "B11BE11", "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Ground"},
+  {"dtc": "B11BE12", "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Power"},
+  {"dtc": "B11BE13", "l_dsc": "LIN2 Ambient Light Drive Circuit Broken"},
+  {"dtc": "B11BE19", "l_dsc": "LIN2 ambient light drive overload"},
+  {"dtc": "B133413", "l_dsc": "Refrigerant Temperature Sensor 2 Open-circuited"},
+  {"dtc": "B133511", "l_dsc": "Refrigerant temperature sensor 2 is short to ground"},
+  {"dtc": "B133613", "l_dsc": "Open circuit of refrigerant temperature sensor 3"},
+  {"dtc": "B133711", "l_dsc": "Refrigerant Temperature Sensor 3 Short to Ground"},
+  {"dtc": "B133800", "l_dsc": "Solenoid Valve 1 Status Fault"},
+  {"dtc": "B133900", "l_dsc": "Solenoid Valve 2 Status Fault"},
+  {"dtc": "B133A00", "l_dsc": "Solenoid Valve 3 Status Fault"},
+  {"dtc": "B133B00", "l_dsc": "Solenoid Valve 4 Status Fault"},
+  {"dtc": "B133C00", "l_dsc": "Solenoid Valve 5 Status Fault"},
+  {"dtc": "B133D00", "l_dsc": "Solenoid Valve 6 Status Fault"},
+  {"dtc": "B133E00", "l_dsc": "Low Voltage PTC Relay 1 Fault"},
+  {"dtc": "B133F00", "l_dsc": "Low Voltage PTC Relay 2 Fault"},
+  {"dtc": "B134000", "l_dsc": "Low Voltage PTC Relay 3 Fault"},
+  {"dtc": "B134111", "l_dsc": "Three-way Valve Motor Short to Ground or Open-circuited"},
+  {"dtc": "B134211", "l_dsc": "Three-way Valve Motor Short to Power"},
+  {"dtc": "B134392", "l_dsc": "Three-way Valve Motor Not Rotating in Place"},
+  {"dtc": "B134611", "l_dsc": "Refrigerant Temperature Sensor 1 Short to Ground"},
+  {"dtc": "B134613", "l_dsc": "Refrigerant Temperature Sensor 1 Open-circuited"},
+  {"dtc": "B134711", "l_dsc": "Air conditioner pressure sensor is short to power"},
+  {"dtc": "B134713", "l_dsc": "Air conditioner pressure sensor P1 broken circuit"},
+  {"dtc": "B16001B", "l_dsc": "Driver Frontal Airbag Not Connected"},
+  {"dtc": "B160111", "l_dsc": "Driver Frontal Airbag Short to Ground"},
+  {"dtc": "B160212", "l_dsc": "Driver Frontal Airbag Short to Power"},
+  {"dtc": "B160A1A", "l_dsc": "Resistance of Driver Frontal Airbag Equaling to 0"},
+  {"dtc": "B16101B", "l_dsc": "Front Passenger Frontal Airbag Not Connected"},
+  {"dtc": "B161111", "l_dsc": "Front Passenger Frontal Airbag Short to Ground"},
+  {"dtc": "B161212", "l_dsc": "Front Passenger Frontal Airbag Short to Power"},
+  {"dtc": "B161A1A", "l_dsc": "Resistance of Front Passenger Frontal Airbag Equaling to 0"},
+  {"dtc": "B16201B", "l_dsc": "Driver Side Airbag Not Connected"},
+  {"dtc": "B162111", "l_dsc": "Driver Side Airbag Short to Ground"},
+  {"dtc": "B162212", "l_dsc": "Driver Side Airbag Short to Power"},
+  {"dtc": "B162A1A", "l_dsc": "Resistance of Driver Side Airbag Equaling to 0"},
+  {"dtc": "B16301B", "l_dsc": "Front Passenger Side Airbag Not Connected"},
+  {"dtc": "B163111", "l_dsc": "Front Passenger Side Airbag Short to Ground"},
+  {"dtc": "B163212", "l_dsc": "Front Passenger Side Airbag Short to Power"},
+  {"dtc": "B163B1B", "l_dsc": "Resistance of Front Passenger Side Airbag Equaling to 0"},
+  {"dtc": "B16401B", "l_dsc": "Driver Seat Belt Pretensioner Not Connected"},
+  {"dtc": "B164111", "l_dsc": "Driver Seat Belt Pretensioner Short to Ground"},
+  {"dtc": "B164212", "l_dsc": "Driver Seat Belt Pretensioner Short to Power"},
+  {"dtc": "B16451A", "l_dsc": "Resistance of Driver Seat Belt Pretensioner Equaling to 0"},
+  {"dtc": "B164A1B", "l_dsc": "Front Passenger Seat Belt Pretensioner Not Connected"},
+  {"dtc": "B164B11", "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Ground"},
+  {"dtc": "B164C12", "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Power"},
+  {"dtc": "B164F1A", "l_dsc": "Resistance of Front Passenger Seat Belt Pretensioner Equaling to 0"},
+  {"dtc": "B165400", "l_dsc": "Left front impact sensor not connected"},
+  {"dtc": "B165511", "l_dsc": "Left Front Frontal Impact Sensor Short to Ground"},
+  {"dtc": "B165D00", "l_dsc": "Right Front Impact Sensor Not Connected"},
+  {"dtc": "B165E11", "l_dsc": "Right Front Frontal Impact Sensor Short to Ground"},
+  {"dtc": "B166600", "l_dsc": "Left Side Impact Sensor Not Connected"},
+  {"dtc": "B166711", "l_dsc": "Left Side Impact Sensor Short to Ground"},
+  {"dtc": "B166F00", "l_dsc": "Right Side Impact Sensor Not Connected"},
+  {"dtc": "B167011", "l_dsc": "Right Side Impact Sensor Short to Ground"},
+  {"dtc": "B169416", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169517", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169700", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169800", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169C00", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169D00", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B169F00", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B16A100", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B16AE00", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B16B000", "l_dsc": "SRS_ECU Fault"},
+  {"dtc": "B17041B", "l_dsc": "Left Air Curtain Not Connected"},
+  {"dtc": "B170511", "l_dsc": "Left Air Curtain Short to Ground"},
+  {"dtc": "B170612", "l_dsc": "Left Air Curtain is Short to Power"},
+  {"dtc": "B17081A", "l_dsc": "Resistance of Left Air Curtain Equaling to 0"},
+  {"dtc": "B170D1B", "l_dsc": "Right Air Curtain Not Connected"},
+  {"dtc": "B170E11", "l_dsc": "Right Air Curtain Short to Ground"},
+  {"dtc": "B170F12", "l_dsc": "Right Air Curtain Short to Power"},
+  {"dtc": "B17121A", "l_dsc": "Resistance of Right Air Curtain Equaling to 0"},
+  {"dtc": "B17A300", "l_dsc": "SRS CAN Signal Abnormal"},
+  {"dtc": "B17A400", "l_dsc": "SRS Hardwire Signal Abnormal"},
+  {"dtc": "B1B4800", "l_dsc": "Right Rear Corner Sensor Internal Fault"},
+  {"dtc": "B1B4812", "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Power or No Ground"},
+  {"dtc": "B1B4814", "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B4A00", "l_dsc": "Afterwave Time Fault of Right Rear Corner Sensor"},
+  {"dtc": "B1B4B00", "l_dsc": "Right Rear Center Sensor Internal Fault"},
+  {"dtc": "B1B4B12", "l_dsc": "Right Rear Center Sensor Signal Wire Short to Power or Not Ground"},
+  {"dtc": "B1B4B14", "l_dsc": "Right Rear Center Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B4D00", "l_dsc": "Afterwave Time Fault of Right Rear Center Sensor"},
+  {"dtc": "B1B4E00", "l_dsc": "Left Rear Center Sensor Internal Fault"},
+  {"dtc": "B1B4E12", "l_dsc": "Left Rear Center Sensor Signal Wire Short to Power or Not Ground"},
+  {"dtc": "B1B4E14", "l_dsc": "Left Rear Center Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B5000", "l_dsc": "Afterwave Time Fault of Left Rear Center Sensor"},
+  {"dtc": "B1B5100", "l_dsc": "Internal Fault at Left Rear Corner Sensor"},
+  {"dtc": "B1B5112", "l_dsc": "Left Rear Angle Sensor Signal Wire Short to Power Supply or No Ground"},
+  {"dtc": "B1B5114", "l_dsc": "Left Rear Corner Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B5300", "l_dsc": "Afterwave Time Fault of Left Rear Corner Sensor"},
+  {"dtc": "B1B5400", "l_dsc": "Right Front Corner Sensor Internal Fault"},
+  {"dtc": "B1B5412", "l_dsc": "Right Front Corner Sensor Signal Wire Short to Power or Not Ground"},
+  {"dtc": "B1B5414", "l_dsc": "Right Front Corner Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B5600", "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"},
+  {"dtc": "B1B5700", "l_dsc": "Left Front Corner Sensor Internal Fault"},
+  {"dtc": "B1B5712", "l_dsc": "Left Front Corner Sensor Signal Wire Short to Power or Not Ground"},
+  {"dtc": "B1B5714", "l_dsc": "Left Front Corner Sensor Signal Wire Short to Ground or Open-circuited"},
+  {"dtc": "B1B5900", "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"},
+  {"dtc": "B1BE801", "l_dsc": "Detection Signal of Front Wiper High-speed Switch Hard Wire Fault"},
+  {"dtc": "B1BF400", "l_dsc": "Front Wiper Reset Signal Fault"},
+  {"dtc": "B1C0800", "l_dsc": "Rear Wiper Reset Signal Fault"},
+  {"dtc": "B1C0D12", "l_dsc": "Washing Motor Short-circuited"},
+  {"dtc": "B1C0D13", "l_dsc": "Washing Motor Open-circuited"},
+  {"dtc": "B1C0D71", "l_dsc": "Washing Motor Stalling"},
+  {"dtc": "B1C5E11", "l_dsc": "Right Charging Port Light Drive Circuit Short to Ground"},
+  {"dtc": "B1C5E12", "l_dsc": "Right Charging Port Light Drive Circuit Short to Power"},
+  {"dtc": "B1C5E13", "l_dsc": "Right Charging Port Light Drive Circuit Broken"},
+  {"dtc": "B1C5E19", "l_dsc": "Right charging port light drive overload"},
+  {"dtc": "B1CAF00", "l_dsc": "Humidity Sensor Fault"},
+  {"dtc": "B1CDA11", "l_dsc": "Trunk Light Drive Circuit Short to Ground"},
+  {"dtc": "B1CDA12", "l_dsc": "Trunk Light Drive Circuit Short to Power"},
+  {"dtc": "B1CDA13", "l_dsc": "Trunk Light Drive Circuit Broken"},
+  {"dtc": "B1CDA19", "l_dsc": "Trunk light drive circuit overload"},
+  {"dtc": "B1CDB11", "l_dsc": "Left Front Door Light Drive Circuit Short to Ground"},
+  {"dtc": "B1CDB12", "l_dsc": "Left Front Door Light Drive Circuit Short to Power"},
+  {"dtc": "B1CDB13", "l_dsc": "Left Front Door Light Drive Circuit Broken"},
+  {"dtc": "B1CDB19", "l_dsc": "Left Front Door Drive Overload"},
+  {"dtc": "B1CDD11", "l_dsc": "Right Front Door Light Drive Circuit Short to Ground"},
+  {"dtc": "B1CDD12", "l_dsc": "Right Front Door Light Drive Circuit Short to Power"},
+  {"dtc": "B1CDD13", "l_dsc": "Right Front Door Light Drive Circuit Broken"},
+  {"dtc": "B1CDD19", "l_dsc": "Right Front Door Drive Overload"},
+  {"dtc": "B1CDF11", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"},
+  {"dtc": "B1CDF12", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"},
+  {"dtc": "B1CDF13", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"},
+  {"dtc": "B1CDF19", "l_dsc": "Left&Right Commutator Motor Drive of Left Exterior Rearview Mirror Overload"},
+  {"dtc": "B1CE011", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"},
+  {"dtc": "B1CE012", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"},
+  {"dtc": "B1CE013", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"},
+  {"dtc": "B1CE019", "l_dsc": "Up&Down Commutator Motor Drive of Left Exterior Rearview Mirror Overload"},
+  {"dtc": "B1CE111", "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"},
+  {"dtc": "B1CE112", "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"},
+  {"dtc": "B1CE113", "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Broken"},
+  {"dtc": "B1CE119", "l_dsc": "Folding Motor Drive of Left Exterior Rearview Mirror Overload"},
+  {"dtc": "B1CE211", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Short to Ground"},
+  {"dtc": "B1CE212", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"},
+  {"dtc": "B1CE213", "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Open-circuited"},
+  {"dtc": "B1CE219", "l_dsc": "Left&Right Commutator Motor Drive of Exterior Right Rearview Mirror Overload"},
+  {"dtc": "B1CE311", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"},
+  {"dtc": "B1CE312", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"},
+  {"dtc": "B1CE313", "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Broken"},
+  {"dtc": "B1CE319", "l_dsc": "Up&Down Commutator Motor Drive of Exterior Right Rearview Mirror Overload"},
+  {"dtc": "B1CE411", "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"},
+  {"dtc": "B1CE412", "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"},
+  {"dtc": "B1CE413", "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Broken"},
+  {"dtc": "B1CE419", "l_dsc": "Folding Motor Drive of Exterior Right Rearview Mirror Overload"},
+  {"dtc": "B1CE911", "l_dsc": "Left Footwell Light Drive Circuit Short to Ground"},
+  {"dtc": "B1CE912", "l_dsc": "Left footwell light drive circuit short to power"},
+  {"dtc": "B1CE913", "l_dsc": "Left footwell light drive circuit is broken"},
+  {"dtc": "B1CE919", "l_dsc": "Left footwell light drive is overload"},
+  {"dtc": "B1CEB11", "l_dsc": "Right Footwell Light Drive Circuit Short to Ground"},
+  {"dtc": "B1CEB12", "l_dsc": "Right Footwell Light Drive Circuit Short to Power"},
+  {"dtc": "B1CEB13", "l_dsc": "Right Footwell Light Drive Circuit Broken"},
+  {"dtc": "B1CEB19", "l_dsc": "Right Footwell Light Drive Overload"},
+  {"dtc": "B1E0007", "l_dsc": "Volume \"+\" Switch Stuck"},
+  {"dtc": "B1E0107", "l_dsc": "Channel \"+\" Switch Stuck"},
+  {"dtc": "B1E0207", "l_dsc": "Bluetooth Telephone Switch Stuck"},
+  {"dtc": "B1E0407", "l_dsc": "\"Mode\" Switch Stuck"},
+  {"dtc": "B1E0507", "l_dsc": "\"Voice\" Switch Stuck"},
+  {"dtc": "B1E0607", "l_dsc": "Panoramic Image Switch Stuck"},
+  {"dtc": "B1E0707", "l_dsc": "Volume \"-\" Switch Stuck"},
+  {"dtc": "B1E0807", "l_dsc": "Channel \"-\" Switch Stuck"},
+  {"dtc": "B1E1007", "l_dsc": "EPPROM Fault"},
+  {"dtc": "B1E1907", "l_dsc": "\"Mute\" Switch Stuck"},
+  {"dtc": "B1E1A07", "l_dsc": "Custom Switch Stuck"},
+  {"dtc": "B1E1C07", "l_dsc": "Instrument Menu Return Switch Stuck"},
+  {"dtc": "B1E2000", "l_dsc": "Steering Wheel Built-in Vibration Motor Fault"},
+  {"dtc": "B1E2D07", "l_dsc": "\"Cruise\" Switch Stuck"},
+  {"dtc": "B1E2E07", "l_dsc": "\"Cancel\" Switch Stuck"},
+  {"dtc": "B1E2F07", "l_dsc": "Speed + Switch Stuck"},
+  {"dtc": "B1E3007", "l_dsc": "Speed -Switch Stuck"},
+  {"dtc": "B1E3107", "l_dsc": "\"Setting\" Switch Stuck"},
+  {"dtc": "B1E3207", "l_dsc": "\"Reset\" Switch Stuck"},
+  {"dtc": "B1E3307", "l_dsc": "Time Interval \"-\" Switch Stuck"},
+  {"dtc": "B1E3407", "l_dsc": "Time Interval \"+\" Switch Stuck"},
+  {"dtc": "B1E3507", "l_dsc": "\"Lane Offset\" Switch Stuck"},
+  {"dtc": "B222400", "l_dsc": "Sunroof Hall Sensor Signal Abnormal"},
+  {"dtc": "B222401", "l_dsc": "Blinder Motor Hall Sensor Signal Abnormal"},
+  {"dtc": "B225300", "l_dsc": "Sunroof Initialization Lost"},
+  {"dtc": "B225407", "l_dsc": "Sunroof Switch Stuck"},
+  {"dtc": "B225511", "l_dsc": "Sunroof Motor Short (to Ground)"},
+  {"dtc": "B225513", "l_dsc": "Sunroof Motor Open-circuited"},
+  {"dtc": "B225600", "l_dsc": "Sun shade initialization lost"},
+  {"dtc": "B225707", "l_dsc": "Blinder Switch Stuck"},
+  {"dtc": "B225811", "l_dsc": "Blinder Motor Short (to Ground)"},
+  {"dtc": "B225813", "l_dsc": "Blinder Motor Open-circuited"},
+  {"dtc": "B227C13", "l_dsc": "Interior Front Detection Antenna Open-circuited"},
+  {"dtc": "B227D13", "l_dsc": "Interior Middle Detection Antenna Open-circuited"},
+  {"dtc": "B227E13", "l_dsc": "Interior Rear Detection Antenna Open-circuited"},
+  {"dtc": "B229D16", "l_dsc": "Supply Voltage of High Frequency Receiver Module Too Low"},
+  {"dtc": "B229D17", "l_dsc": "Power Supply of High Frequency Receiver Module Too High"},
+  {"dtc": "B22A613", "l_dsc": "Open circuit of the exterior right front detection antenna"},
+  {"dtc": "B22A813", "l_dsc": "Exterior Trunk Detection Antenna Open-circuited"},
+  {"dtc": "B2342", "l_dsc": "Internal Fault of Instrument"},
+  {"dtc": "B2343", "l_dsc": "Clock Running Fault"},
+  {"dtc": "B234A", "l_dsc": "CAN Bus Receives Incorrect Coolant Temperature Signal"},
+  {"dtc": "B234C", "l_dsc": "CAN Bus Does Not Detect Motor Speed Signal"},
+  {"dtc": "B234D", "l_dsc": "Information Switching Key Input Device Short-circuited"},
+  {"dtc": "B236009", "l_dsc": "Display Fault (Backlight Fault) or Display Chip Fault"},
+  {"dtc": "B24AB00", "l_dsc": "Light Handle Fault"},
+  {"dtc": "B24AC00", "l_dsc": "Wiper Handle Fault"},
+  {"dtc": "B24D700", "l_dsc": "Handle Input Power Overvoltage"},
+  {"dtc": "B24D800", "l_dsc": "Handle Input Power Undervoltage"},
+  {"dtc": "B2A0801", "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Short to Power"},
+  {"dtc": "B2A0803", "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Open-circuited"},
+  {"dtc": "B2A0811", "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Short to Ground"},
+  {"dtc": "B2A0813", "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Open-circuited"},
+  {"dtc": "B2A2013", "l_dsc": "Interior temperature sensor open-circuited"},
+  {"dtc": "B2A2111", "l_dsc": "Interior Temperature Sensor Short to Ground"},
+  {"dtc": "B2A2213", "l_dsc": "Exterior Temperature Sensor Open-circuited"},
+  {"dtc": "B2A2311", "l_dsc": "Exterior Temperature Sensor Short to Ground"},
+  {"dtc": "B2A2413", "l_dsc": "Evaporator Temperature Sensor Open-circuited"},
+  {"dtc": "B2A2511", "l_dsc": "Evaporator Temperature Sensor Circuit Short to Ground"},
+  {"dtc": "B2A2712", "l_dsc": "Sunlight Sensor Circuit Short to Power"},
+  {"dtc": "B2A2A12", "l_dsc": "Mode Motor Short to Power"},
+  {"dtc": "B2A2A14", "l_dsc": "Mode Motor Short to Ground or Open-circuited"},
+  {"dtc": "B2A2A92", "l_dsc": "Mode Motor Not Rotating in Place"},
+  {"dtc": "B2A2B12", "l_dsc": "Driver's Side Air Mix Motor Short to Power"},
+  {"dtc": "B2A2B14", "l_dsc": "Driver's Side Air Mix Motor Short to Ground or Open-circuited"},
+  {"dtc": "B2A2B92", "l_dsc": "Driver's Side Air Mix Motor Not Rotating in Place"},
+  {"dtc": "B2A2F09", "l_dsc": "A/C Pipes in High Pressure State or Low Pressure State"},
+  {"dtc": "B2A3214", "l_dsc": "Front Blower Short to Ground or Open-circuited"},
+  {"dtc": "B2A3314", "l_dsc": "Front Blower Adjustment Signal Harness Short to Ground or Open-circuited"},
+  {"dtc": "B2A4B12", "l_dsc": "Circulation Motor Short to Power"},
+  {"dtc": "B2A4B14", "l_dsc": "Circulation Motor Short to Ground or Open-circuited"},
+  {"dtc": "B2A4B92", "l_dsc": "Circulation Motor Not Rotating in Place"},
+  {"dtc": "B2A5811", "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Short to Ground"},
+  {"dtc": "B2A5813", "l_dsc": "Driver's Side Face Outlet Temperature Sensor Open-circuited"},
+  {"dtc": "B2A5913", "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Open-circuited"},
+  {"dtc": "B2AB049", "l_dsc": "Current Sampling Circuit Fault"},
+  {"dtc": "B2AB149", "l_dsc": "Motor Phase Lost"},
+  {"dtc": "B2AB249", "l_dsc": "IPM IGBT Fault"},
+  {"dtc": "B2AB349", "l_dsc": "Internal temperature sensor fault"},
+  {"dtc": "B2AB41D", "l_dsc": "Internal Current Excessive"},
+  {"dtc": "B2AB573", "l_dsc": "Fail to Start Up"},
+  {"dtc": "B2AB64B", "l_dsc": "Internal Temperature Abnormal"},
+  {"dtc": "B2AB774", "l_dsc": "Speed Abnormal"},
+  {"dtc": "B2AB81C", "l_dsc": "Phase Voltage Too High"},
+  {"dtc": "B2AB997", "l_dsc": "Overload fault"},
+  {"dtc": "B2ABA1C", "l_dsc": "Fault at Internal Low-voltage Power"},
+  {"dtc": "B2ABB17", "l_dsc": "Voltage of High Voltage Side Overvoltage"},
+  {"dtc": "B2ABC16", "l_dsc": "Voltage of High Voltage Side Low"},
+  {"dtc": "B2AD616", "l_dsc": "12V Power Supply Undervoltage (Lower Than 9V)"},
+  {"dtc": "B2AD617", "l_dsc": "12V Power Supply Overvoltage"},
+  {"dtc": "B2FD016", "l_dsc": "Power Supply Voltage Low Alarm"},
+  {"dtc": "B2FD017", "l_dsc": "Power Supply Voltage High Alarm"},
+  {"dtc": "B2FD14B", "l_dsc": "Wireless Charging Overtemperature Alarm"},
+  {"dtc": "C000100", "l_dsc": "CSV Valve 1 Fault"},
+  {"dtc": "C000200", "l_dsc": "PSV Valve 1 Fault"},
+  {"dtc": "C000300", "l_dsc": "CSV Valve 2 Fault"},
+  {"dtc": "C000400", "l_dsc": "PSV Valve 2 Fault"},
+  {"dtc": "C001000", "l_dsc": "Left Front Inlet Valve Fault"},
+  {"dtc": "C001100", "l_dsc": "Left Front Outlet Valve Fault"},
+  {"dtc": "C001400", "l_dsc": "Right Front Inlet Valve Fault"},
+  {"dtc": "C001500", "l_dsc": "Right Front Outlet Valve Fault"},
+  {"dtc": "C001800", "l_dsc": "Left Rear Inlet Valve Fault"},
+  {"dtc": "C001900", "l_dsc": "Left Rear Outlet Valve Fault"},
+  {"dtc": "C001C00", "l_dsc": "Right Rear Inlet Valve Fault"},
+  {"dtc": "C001D00", "l_dsc": "Right Rear Outlet Valve Fault"},
+  {"dtc": "C002192", "l_dsc": "Brake Booster Module Pipeline Hydraulic Pressure Below Normal Value"},
+  {"dtc": "C002400", "l_dsc": "SSV Valve Fault"},
+  {"dtc": "C003100", "l_dsc": "Left Front Wheel Speed Sensor Signal Fault"},
+  {"dtc": "C003200", "l_dsc": "Supply Voltage of Left Front Wheel Speed Sensor Low"},
+  {"dtc": "C003400", "l_dsc": "Right Front Wheel Speed Sensor Signal Fault"},
+  {"dtc": "C003500", "l_dsc": "Supply Voltage of Right Front Wheel Speed Sensor Low"},
+  {"dtc": "C003700", "l_dsc": "Left Rear Wheel Speed Sensor Signal Fault"},
+  {"dtc": "C003800", "l_dsc": "Supply Voltage of Left Rear Wheel Speed Sensor Low"},
+  {"dtc": "C003A00", "l_dsc": "Right Rear Wheel Speed Sensor Signal Fault"},
+  {"dtc": "C003B00", "l_dsc": "Supply Voltage of Right Rear Wheel Speed Sensor Low"},
+  {"dtc": "C004900", "l_dsc": "Brake Fluid Level Under Normal Value"},
+  {"dtc": "C006A01", "l_dsc": "Yaw Rate Sensor Parameter Wrongly Configured"},
+  {"dtc": "C006A02", "l_dsc": "Yaw Rate Sensor Signal Error"},
+  {"dtc": "C007500", "l_dsc": "Master Cylinder Position Sensor A Fault/Short Circuit"},
+  {"dtc": "C050000", "l_dsc": "Left Front Wheel Speed Sensor Open-circuited"},
+  {"dtc": "C050200", "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Ground Line"},
+  {"dtc": "C050300", "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Power Supply Line"},
+  {"dtc": "C050400", "l_dsc": "Left Front Wheel Speed Sensor Air Gap Abnormal"},
+  {"dtc": "C050576", "l_dsc": "Incorrect Installation Direction of Left Front Wheel Speed Sensor"},
+  {"dtc": "C050600", "l_dsc": "Right Front Wheel Speed Sensor Open-circuited"},
+  {"dtc": "C050800", "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Front Wheel Speed Sensor"},
+  {"dtc": "C050900", "l_dsc": "Short Circuit between Right Front Wheel Speed Sensor Signal Line and Power Supply Line"},
+  {"dtc": "C050A00", "l_dsc": "Right Front Wheel Speed Sensor Air Gap Abnormal"},
+  {"dtc": "C050B76", "l_dsc": "Incorrect Installation Direction of Right Front Wheel Speed Sensor"},
+  {"dtc": "C050C00", "l_dsc": "Left Rear Wheel Speed Sensor Open-circuited"},
+  {"dtc": "C050E00", "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Left Rear Wheel Speed Sensor"},
+  {"dtc": "C050F00", "l_dsc": "Short Circuit between Left Rear Wheel Speed Sensor Signal Line and Power Supply Line"},
+  {"dtc": "C051000", "l_dsc": "Left Rear Wheel Speed Sensor Air Gap Abnormal"},
+  {"dtc": "C051176", "l_dsc": "Incorrect Installation Direction of Left Rear Wheel Speed Sensor"},
+  {"dtc": "C051200", "l_dsc": "Right Rear Wheel Speed Sensor Open-circuited"},
+  {"dtc": "C051400", "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Rear Wheel Speed Sensor"},
+  {"dtc": "C051500", "l_dsc": "Short Circuit between Right Rear Wheel Speed Sensor Signal Line and Power Supply Line"},
+  {"dtc": "C051600", "l_dsc": "Right Rear Wheel Speed Sensor Air Gap Abnormal"},
+  {"dtc": "C051776", "l_dsc": "Incorrect Installation Direction of Right Rear Wheel Speed Sensor"},
+  {"dtc": "C051D01", "l_dsc": "Yaw Rate Sensor Wrongly Calibrated"},
+  {"dtc": "C052901", "l_dsc": "Steering Angle Sensor Module Lost"},
+  {"dtc": "C053D00", "l_dsc": "Pressure Sensor B Signal Abnormal"},
+  {"dtc": "C053E00", "l_dsc": "Circuit Voltage of Pressure Sensor A Too Low"},
+  {"dtc": "C053F00", "l_dsc": "Circuit Voltage of Pressure Sensor A Too High"},
+  {"dtc": "C054100", "l_dsc": "Pressure Sensor B Signal Abnormal"},
+  {"dtc": "C054200", "l_dsc": "Circuit Voltage of Pressure Sensor B Too Low"},
+  {"dtc": "C054300", "l_dsc": "Circuit Voltage of Pressure Sensor B Too High"},
+  {"dtc": "C055000", "l_dsc": "ECU Fault"},
+  {"dtc": "C055E00", "l_dsc": "Brake Hydraulic Circuit A Leaky"},
+  {"dtc": "C055F92", "l_dsc": "Hydraulic Unit Fault"},
+  {"dtc": "C056B00", "l_dsc": "Brake Booster Module Pressure Sensor Fault"},
+  {"dtc": "C057900", "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too Low"},
+  {"dtc": "C057A00", "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too High"},
+  {"dtc": "C057F00", "l_dsc": "Brake Booster Motor Open-circuited"},
+  {"dtc": "C058200", "l_dsc": "Circuit Signal of Brake Booster Motor Abnormal"},
+  {"dtc": "C058800", "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too Low"},
+  {"dtc": "C058900", "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too High"},
+  {"dtc": "C058A00", "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Abnormal"},
+  {"dtc": "C059000", "l_dsc": "Supply Current of Brake Booster Motoris Too High"},
+  {"dtc": "C059100", "l_dsc": "Supply Current of Brake Booster Motor Too Low"},
+  {"dtc": "C059400", "l_dsc": "Brake Booster Motor Load Abnormal"},
+  {"dtc": "C05B001", "l_dsc": "Brake Hydraulic Circuit L1 Leaky"},
+  {"dtc": "C05C200", "l_dsc": "Brake Booster Motor A Overtemperature"},
+  {"dtc": "C05C24B", "l_dsc": "Temperature of Brake Booster Motor Too High"},
+  {"dtc": "C05CA00", "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too high"},
+  {"dtc": "C05CB00", "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too Low"},
+  {"dtc": "C05CC00", "l_dsc": "Master cylinder position sensor A abnormal"},
+  {"dtc": "C05CD00", "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too High"},
+  {"dtc": "C05CE00", "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too Low"},
+  {"dtc": "C05D000", "l_dsc": "Master Cylinder Position Sensor Signal Value Incorrect"},
+  {"dtc": "C05D200", "l_dsc": "Master Cylinder Stroke Exceed Expected Value"},
+  {"dtc": "C05D500", "l_dsc": "TSV Valve Fault"},
+  {"dtc": "C106600", "l_dsc": "Angle Sensor Not Calibrated"},
+  {"dtc": "C110009", "l_dsc": "Control Module Main Chip Fault(independent)"},
+  {"dtc": "C117009", "l_dsc": "EPB Switch Fault(independent)"},
+  {"dtc": "C11A006", "l_dsc": "Actuator Overload(independent)"},
+  {"dtc": "C11B013", "l_dsc": "Left Motor or Line Fault(independent)"},
+  {"dtc": "C11B113", "l_dsc": "Right Motor or Line Fault(independent)"},
+  {"dtc": "C120700", "l_dsc": "Pump Not Returnable"},
+  {"dtc": "C12F909", "l_dsc": "Brake Hydraulic Circuit Blocked"},
+  {"dtc": "C1A3800", "l_dsc": "System Not Fully Initialized"},
+  {"dtc": "C1B6044", "l_dsc": "ECU RAM Fault"},
+  {"dtc": "C1B9000", "l_dsc": "Loss of Power Supply"},
+  {"dtc": "C1B9C23", "l_dsc": "Main/Auxiliary/Torque Signal Keeping at Low Level"},
+  {"dtc": "C1B9C24", "l_dsc": "Main/Auxiliary/Torque Signal Keeping at High Level"},
+  {"dtc": "C1B9D21", "l_dsc": "Voltage of Power Supply Too Low"},
+  {"dtc": "C1B9D22", "l_dsc": "Voltage of Power Supply Too High"},
+  {"dtc": "C1BA023", "l_dsc": "Main/Auxiliary Angle Signal Level Constant Low"},
+  {"dtc": "C1BA024", "l_dsc": "Main/Auxiliary Angle Signal Level Constant High"},
+  {"dtc": "C1BA500", "l_dsc": "ECU Operation Error"},
+  {"dtc": "C1BA600", "l_dsc": "ECU Overtemperature"},
+  {"dtc": "C1BA700", "l_dsc": "ECU Fails to ROM and Check"},
+  {"dtc": "C1BA900", "l_dsc": "Supply Voltage of Torque Sensor Abnormal"},
+  {"dtc": "C1BAA00", "l_dsc": "Motor Drive Circuit Failure"},
+  {"dtc": "C1BAB21", "l_dsc": "Output Voltage of Temperature Detection Circuit Too Low"},
+  {"dtc": "C1BAB22", "l_dsc": "Output Voltage of Temperature Detection Circuit Too High"},
+  {"dtc": "C1BAE00", "l_dsc": "ECU Not Executing Angle Calibration Order"},
+  {"dtc": "C1BB200", "l_dsc": "ESP Speed Data Error"},
+  {"dtc": "C2A1700", "l_dsc": "Brake Hydraulic Circuit L1 Overcompensation (air Present)"},
+  {"dtc": "P056200", "l_dsc": "System Voltage Too Low"},
+  {"dtc": "P056300", "l_dsc": "System Voltage Too High"},
+  {"dtc": "P060400", "l_dsc": "ECU Internal Control Module Fault(RAM)"},
+  {"dtc": "P060500", "l_dsc": "ECU Internal Control Module Fault(ROM)"},
+  {"dtc": "P060600", "l_dsc": "ECM/PCM processor fault"},
+  {"dtc": "P060700", "l_dsc": "ECU Hardware Failure"},
+  {"dtc": "P060B00", "l_dsc": "ECU Hardware Fault(A/D processor)"},
+  {"dtc": "P060C00", "l_dsc": "ECU Internal Control Module Fault(program running)"},
+  {"dtc": "P06B800", "l_dsc": "ECU Internal Control Module Fault(NVRAM memory)"},
+  {"dtc": "P151100", "l_dsc": "AC High-voltage Interlock Fault"},
+  {"dtc": "P151500", "l_dsc": "Water Temperature Sensor Fault"},
+  {"dtc": "P157016", "l_dsc": "Low Voltage at AC Side"},
+  {"dtc": "P157017", "l_dsc": "High Voltage at AC Side"},
+  {"dtc": "P157216", "l_dsc": "Low Voltage at DC Side"},
+  {"dtc": "P157217", "l_dsc": "High Voltage at DC Side"},
+  {"dtc": "P157219", "l_dsc": "DC Side Overcurrent"},
+  {"dtc": "P157400", "l_dsc": "Power Supply Device Fault"},
+  {"dtc": "P157897", "l_dsc": "CC Signal Abnormal"},
+  {"dtc": "P15794B", "l_dsc": "Temperature Sampling 1 High"},
+  {"dtc": "P157A36", "l_dsc": "Low Frequency of Charging Grid"},
+  {"dtc": "P157A37", "l_dsc": "High Frequency of Charging Grid"},
+  {"dtc": "P157B00", "l_dsc": "AC Side Overcurrent"},
+  {"dtc": "P157C00", "l_dsc": "Hardware Protection"},
+  {"dtc": "P157E11", "l_dsc": "Outer of Charging Connection Signal Short to Ground"},
+  {"dtc": "P157E12", "l_dsc": "Outer of Charging Connection Signal Short to Power"},
+  {"dtc": "P157F11", "l_dsc": "AC Output Short-circuited"},
+  {"dtc": "P15834B", "l_dsc": "Temperature Sampling 2 High"},
+  {"dtc": "P158798", "l_dsc": "Phase Temperature of Charging Port Too High"},
+  {"dtc": "P158900", "l_dsc": "Phase Temperature Sampling at Charging Port Abnormal"},
+  {"dtc": "P158A00", "l_dsc": "Electric Lock Abnormal"},
+  {"dtc": "P15FD00", "l_dsc": "High Temperature of Cooling Water"},
+  {"dtc": "P15FF00", "l_dsc": "Internal Temperature Sensor Fault"},
+  {"dtc": "P1A0000", "l_dsc": "Serious Electric Leakage Fault"},
+  {"dtc": "P1A0100", "l_dsc": "Common Electric Leakage Fault"},
+  {"dtc": "P1A0200", "l_dsc": "BIC1 Working Abnormal"},
+  {"dtc": "P1A0300", "l_dsc": "BIC2 Working Abnormal"},
+  {"dtc": "P1A0400", "l_dsc": "BIC3 Working Abnormal"},
+  {"dtc": "P1A0500", "l_dsc": "BIC4 Working Abnormal"},
+  {"dtc": "P1A0600", "l_dsc": "BIC5 Working Abnormal"},
+  {"dtc": "P1A0700", "l_dsc": "BIC6 Working Abnormal"},
+  {"dtc": "P1A0800", "l_dsc": "BIC7 Working Abnormal"},
+  {"dtc": "P1A0900", "l_dsc": "BIC8 Working Abnormal"},
+  {"dtc": "P1A0C00", "l_dsc": "BIC1 Voltage Sampling Abnormal"},
+  {"dtc": "P1A0D00", "l_dsc": "BIC2 Voltage Sampling Abnormal"},
+  {"dtc": "P1A0E00", "l_dsc": "BIC3 Voltage Sampling Abnormal"},
+  {"dtc": "P1A0F00", "l_dsc": "BIC4 Voltage Sampling Abnormal"},
+  {"dtc": "P1A1000", "l_dsc": "BIC5 Voltage Sampling Abnormal"},
+  {"dtc": "P1A1100", "l_dsc": "BIC6 Voltage Sampling Abnormal"},
+  {"dtc": "P1A1200", "l_dsc": "BIC7 Voltage Sampling Abnormal"},
+  {"dtc": "P1A1300", "l_dsc": "BIC8 Voltage Sampling Abnormal"},
+  {"dtc": "P1A2000", "l_dsc": "BIC1 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2100", "l_dsc": "BIC2 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2200", "l_dsc": "BIC3 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2300", "l_dsc": "BIC4 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2400", "l_dsc": "BIC5 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2500", "l_dsc": "BIC6 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2600", "l_dsc": "BIC7 Temperature Sampling Abnormal"},
+  {"dtc": "P1A2700", "l_dsc": "BIC8 Temperature Sampling Abnormal"},
+  {"dtc": "P1A3522", "l_dsc": "Severely high voltage of power battery cell"},
+  {"dtc": "P1A3622", "l_dsc": "Power Battery Cell Voltage Generally High"},
+  {"dtc": "P1A3721", "l_dsc": "Severely low voltage of power battery cell"},
+  {"dtc": "P1A3922", "l_dsc": "Power Battery Cell Temperature Seriously High"},
+  {"dtc": "P1A3B21", "l_dsc": "Power battery's single-cell temperature seriously low"},
+  {"dtc": "P1A3D00", "l_dsc": "Negative Contactor Loop Check Fault"},
+  {"dtc": "P1A3E00", "l_dsc": "Main Contactor Loop Check Fault"},
+  {"dtc": "P1A3F00", "l_dsc": "Pre-charging Contactor Loop Check Fault"},
+  {"dtc": "P1A4100", "l_dsc": "Main Contactor Sintering Fault"},
+  {"dtc": "P1A4200", "l_dsc": "Negative Contactor Sintering"},
+  {"dtc": "P1A5600", "l_dsc": "12V Supply Input of Battery Management System Too Low"},
+  {"dtc": "P1A5B00", "l_dsc": "Contactor Disconnected Due to Dual-circuit Power Supply Fault"},
+  {"dtc": "P1A6000", "l_dsc": "High Voltage Interlock 1 Fault"},
+  {"dtc": "P1AC000", "l_dsc": "Collision Alarm of Airbag ECU"},
+  {"dtc": "P1AC400", "l_dsc": "Serious Imbalance at Battery"},
+  {"dtc": "P1AC900", "l_dsc": "DC Charging Inductive Signal Circuit Broken"},
+  {"dtc": "P1ACB07", "l_dsc": "DC Charging Anode Contactor Sintering"},
+  {"dtc": "P1ACC07", "l_dsc": "DC Charging Cathode Contactor Sintering"},
+  {"dtc": "P1AD44B", "l_dsc": "Temperature of Charging Port 1 Generally High"},
+  {"dtc": "P1AD54B", "l_dsc": "Temperature of Charging Port 2 Generally High"},
+  {"dtc": "P1AD698", "l_dsc": "Temperature of Charging Port 3 Generally High"},
+  {"dtc": "P1AD900", "l_dsc": "Temperature Sampling Point of Charging Port Abnormal"},
+  {"dtc": "P1ADE00", "l_dsc": "Battery Cooling Failure Due to Air Conditioner System Fault"},
+  {"dtc": "P1ADF00", "l_dsc": "Inner Cycle Failure at Battery Due to Air Conditioner System Fault"},
+  {"dtc": "P1AE000", "l_dsc": "Battery Heating Failure Due to Air Conditioner System Fault"},
+  {"dtc": "P1AE400", "l_dsc": "High Voltage Process Ended Due to Abnormal Low-voltage Supply"},
+  {"dtc": "P1AE800", "l_dsc": "DC Charging Anode Contactor Loop Check Fault"},
+  {"dtc": "P1AE900", "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"},
+  {"dtc": "P1AF200", "l_dsc": "Voltage Output at DC Charger Abnormal"},
+  {"dtc": "P1AF300", "l_dsc": "DC Charging Cabinet Stops Charging Actively"},
+  {"dtc": "P1AF400", "l_dsc": "Insufficient Capacity of DC Charging Cabinet"},
+  {"dtc": "P1AF800", "l_dsc": "Battery data not updated"},
+  {"dtc": "P1AFB00", "l_dsc": "A/C System High Voltage Interlock Fault"},
+  {"dtc": "P1AFC00", "l_dsc": "On-board Charger High Voltage Interlock Fault"},
+  {"dtc": "P1AFD00", "l_dsc": "DC-DC High Voltage Interlock Fault"},
+  {"dtc": "P1B1F00", "l_dsc": "Fail to Anti-theft Authentication"},
+  {"dtc": "P1B2516", "l_dsc": "Supply Voltage at Low Voltage Side Too Low"},
+  {"dtc": "P1B2517", "l_dsc": "Supply Voltage at Low Voltage Side Too High"},
+  {"dtc": "P1BA000", "l_dsc": "Cruise Configuration Unwritten In"},
+  {"dtc": "P1BAC00", "l_dsc": "IGBT Core Common Overtemperature Warning for Front Drive Motor Control Module"},
+  {"dtc": "P1BAC19", "l_dsc": "IGBT Core Serious Overtemperature Warning for Front Drive Motor Control Module (chopper OFF)"},
+  {"dtc": "P1BB000", "l_dsc": "Front Drive Motor Overcurrent"},
+  {"dtc": "P1BB100", "l_dsc": "IPM Fault at Front Drive Motor Control Module"},
+  {"dtc": "P1BB200", "l_dsc": "Common Overtemperature Warning for Front Drive Motor"},
+  {"dtc": "P1BB298", "l_dsc": "Serious Overtemperature Warning for Front Drive Motor"},
+  {"dtc": "P1BB300", "l_dsc": "IGBT-NTC Common Overtemperature Warning for Front Drive Motor Control Module"},
+  {"dtc": "P1BB319", "l_dsc": "IGBT-NTC Serious Overtemperature Warning for Front Drive Motor Control Module(chopper OFF)"},
+  {"dtc": "P1BB500", "l_dsc": "High Voltage Side of Front Drive Motor Control Module Undervoltage"},
+  {"dtc": "P1BB600", "l_dsc": "High Voltage Side of Front Drive Motor Control Module Overvoltage"},
+  {"dtc": "P1BB700", "l_dsc": "Voltage Sampling Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BB800", "l_dsc": "Collision Signal Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BB900", "l_dsc": "Cap Opening Protection of Front Drive Motor Control Module"},
+  {"dtc": "P1BBA00", "l_dsc": "EEPROM Error of Front Drive Motor Control Module"},
+  {"dtc": "P1BBC00", "l_dsc": "DSP Reset Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BBD00", "l_dsc": "Active Release Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BBF00", "l_dsc": "Front Drive Motor Rotary Transformer Fault -Signal Lost"},
+  {"dtc": "P1BC000", "l_dsc": "Front Drive Motor Rotary Transformer Fault -Angle Abnormal"},
+  {"dtc": "P1BC100", "l_dsc": "Front Drive Motor Rotary Transformer Fault-Signal Amplitude Decreasing"},
+  {"dtc": "P1BC200", "l_dsc": "Phase A of Front Drive Motor Lost"},
+  {"dtc": "P1BC300", "l_dsc": "Phase B of Front Drive Motor Lost"},
+  {"dtc": "P1BC400", "l_dsc": "Phase C of Front Drive Motor Lost"},
+  {"dtc": "P1BC500", "l_dsc": "Hall Current Sensor B Fault at Front Drive Motor Control Module"},
+  {"dtc": "P1BC600", "l_dsc": "Hall Current Sensor C Fault at Front Drive Motor Control Module"},
+  {"dtc": "P1BC700", "l_dsc": "IPM Radiator of Front Drive Motor Control Module Overtemperature"},
+  {"dtc": "P1BC800", "l_dsc": "IGBT Three-phase Temperature Calibration Fault Alarm for Front Drive Motor Control Module"},
+  {"dtc": "P1BC900", "l_dsc": "Hall Current Sensor A Fault at Front Drive Motor Control Module"},
+  {"dtc": "P1BCF00", "l_dsc": "Temperature Sensor Fault of Front Drive Motor-Torque Limitation"},
+  {"dtc": "P1BD000", "l_dsc": "Drive DSP1 Crash Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BD117", "l_dsc": "Drive CPLD Overvoltage of Front Drive Motor Control Module"},
+  {"dtc": "P1BD119", "l_dsc": "Drive CPLD Overcurrent of Front Drive Motor Control Module"},
+  {"dtc": "P1BD200", "l_dsc": "Drive CPLD Detecting IGBT On-axle Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BD300", "l_dsc": "Drive CPLD Detecting IGBT Off-axle Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BD400", "l_dsc": "Drive CPLD Running Fault of Front Drive Motor Control Module"},
+  {"dtc": "P1BF100", "l_dsc": "IPM Temperature Sampling of Front Drive Motor Control Module Abnormal"},
+  {"dtc": "P1BF200", "l_dsc": "Winding Temperature Sensor Sampling at Front Drive Motor Abnormal"},
+  {"dtc": "P1D6144", "l_dsc": "EEPROM Error at VCU"},
+  {"dtc": "P1D6200", "l_dsc": "Cruise Switch Signal Fault"},
+  {"dtc": "P1D6600", "l_dsc": "Accelerator Signal Fault-Check Fault"},
+  {"dtc": "P1D6A00", "l_dsc": "Stepless Fan Motor Open-circuited"},
+  {"dtc": "P1D6D00", "l_dsc": "DSP Reset Fault of VCU"},
+  {"dtc": "P1D7902", "l_dsc": "Collision Alarm"},
+  {"dtc": "P1D7B00", "l_dsc": "Throttle Signal Fault-1 Signal Fault"},
+  {"dtc": "P1D7C00", "l_dsc": "Throttle Signal Fault-2 Signal Fault"},
+  {"dtc": "P1D8300", "l_dsc": "Limited Power of Vehicle"},
+  {"dtc": "P1D8400", "l_dsc": "Water temperature fault (OBC)"},
+  {"dtc": "P1D8D00", "l_dsc": "Stepless Fan Motor Stalling, Short-circuited Etc"},
+  {"dtc": "P1D8E00", "l_dsc": "Stepless Fan Overtemperature Protection, Electronic Error, Etc"},
+  {"dtc": "P1D8F00", "l_dsc": "Stepless Fan Power Supply Overvoltage or Undervoltage"},
+  {"dtc": "P1D9016", "l_dsc": "Voltage of Power Battery Cell Too Low"},
+  {"dtc": "P1D9017", "l_dsc": "Voltage of Power Battery Cell Too High"},
+  {"dtc": "P1D9100", "l_dsc": "Total Voltage of Power Battery Too High"},
+  {"dtc": "P1D9117", "l_dsc": "Total Voltage of Power Battery Seriously High"},
+  {"dtc": "P1D9200", "l_dsc": "Total Voltage of Power Battery Too Low"},
+  {"dtc": "P1D9216", "l_dsc": "Total Voltage of Power Battery Seriously Low"},
+  {"dtc": "P1D9308", "l_dsc": "Life Frame of Power Battery Abnormal"},
+  {"dtc": "P1D9400", "l_dsc": "Low Voltage Output Line Broken"},
+  {"dtc": "P1D9516", "l_dsc": "Supply Voltage at Low Voltage Side Too Low"},
+  {"dtc": "P1D9600", "l_dsc": "Life Frame of Power Battery Abnormal -Counter Out of Order"},
+  {"dtc": "P1D9700", "l_dsc": "Life Frame of Power Battery Abnormal -Check Value Abnormal"},
+  {"dtc": "P1D9B00", "l_dsc": "Water Temperature Sensor Fault"},
+  {"dtc": "P1D9C00", "l_dsc": "Water Temperature Overtemperature"},
+  {"dtc": "P1EC000", "l_dsc": "Voltage Too High at High Voltage Side during Step-down"},
+  {"dtc": "P1EC100", "l_dsc": "Voltage Too Low at High Voltage Side during Step-down"},
+  {"dtc": "P1EC200", "l_dsc": "Voltage Too High at Low Voltage Side during Step-down"},
+  {"dtc": "P1EC300", "l_dsc": "Voltage Too Low at Low Voltage Side during Step-down"},
+  {"dtc": "P1EC400", "l_dsc": "Current Too High at Low Voltage Side during Step-down"},
+  {"dtc": "P1EC600", "l_dsc": "Current Too High at High Voltage Side during Step-down"},
+  {"dtc": "P1EC700", "l_dsc": "Hardware Fault during Step-down"},
+  {"dtc": "P1ED316", "l_dsc": "Supply Voltage at Low Voltage Side Too High"},
+  {"dtc": "P1ED317", "l_dsc": "Supply Voltage at Low Voltage Side Too Low"},
+  {"dtc": "P1ED400", "l_dsc": "DC Output Positive Line Broken"},
+  {"dtc": "P1ED500", "l_dsc": "AC Electric Leakage"},
+  {"dtc": "P1EE000", "l_dsc": "DC Overtemperature"},
+  {"dtc": "P229900", "l_dsc": "Master Cylinder Position Sensor Signal Calibration Error"},
+  {"dtc": "P25C600", "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too Low"},
+  {"dtc": "P25C700", "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too High"},
+  {"dtc": "P26804B", "l_dsc": "Temperature of Charging Port 1 Generally High"},
+  {"dtc": "P26814B", "l_dsc": "Temperature of Charging Port 2 Generally High"},
+  {"dtc": "P26824B", "l_dsc": "Temperature Rise of Charging Port 3 Seriously High"},
+  {"dtc": "P26834B", "l_dsc": "Temperature Rise of Charging Port Generally High"},
+  {"dtc": "P26844B", "l_dsc": "Temperature Rise of Charging Port Seriously High"},
+  {"dtc": "P268600", "l_dsc": "High-voltage Interlock Fault"},
+  {"dtc": "P268700", "l_dsc": "Power Supply Relay Loop Check Fault"},
+  {"dtc": "P268873", "l_dsc": "DC Charging Anode Contactor Sintering"},
+  {"dtc": "P268973", "l_dsc": "DC Charging Cathode Contactor Sintering"},
+  {"dtc": "P268A00", "l_dsc": "DC Charging Anode Contactor Loop Check Fault"},
+  {"dtc": "P268B00", "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"},
+  {"dtc": "P268C00", "l_dsc": "Voltage of DC Charging Port Abnormal"},
+  {"dtc": "P268D00", "l_dsc": "Connection Signal of AC Charging Gun Inconsistent"},
+  {"dtc": "P268E00", "l_dsc": "Voltage Output at DC Charger Abnormal"},
+  {"dtc": "P2B7000", "l_dsc": "General Fault of Voltage Sampling Wire Broken"},
+  {"dtc": "P2B7100", "l_dsc": "Serious Fault of Voltage Sampling Wire Broken"},
+  {"dtc": "P2B7200", "l_dsc": "General Fault of Temperature Sampling Wire Broken"},
+  {"dtc": "P2B7300", "l_dsc": "Serious Fault of Temperature Sampling Wire Broken"},
+  {"dtc": "P2B7400", "l_dsc": "Power battery overcharged"},
+  {"dtc": "P2B7516", "l_dsc": "Power Battery Pack Undervoltage"},
+  {"dtc": "P2B7517", "l_dsc": "Power Battery Pack Overvoltage"},
+  {"dtc": "P2B7900", "l_dsc": "Battery pack charging overcurrent alarm"},
+  {"dtc": "P2B7B00", "l_dsc": "Shunt Temperature Generally High"},
+  {"dtc": "P2B7C00", "l_dsc": "Shunt Temperature Seriously High"},
+  {"dtc": "P2B7D00", "l_dsc": "Temperature Sampling Fault of Shunt"},
+  {"dtc": "P2B7E00", "l_dsc": "Large Deviation at Current Sampling of Shunt"},
+  {"dtc": "P2B8000", "l_dsc": "HVSU_PACK+ Voltage Sampling Fault"},
+  {"dtc": "P2B8100", "l_dsc": "HVSU_LINK+ Voltage Sampling Fault"},
+  {"dtc": "P2B8200", "l_dsc": "HVSU_LINK-Voltage Sampling Fault"},
+  {"dtc": "P2B8500", "l_dsc": "Power Supply of HVSU Abnormal"},
+  {"dtc": "P2B8A00", "l_dsc": "BIC Configuration Inconsistent with Module State"},
+  {"dtc": "P2B8E00", "l_dsc": "High Side Drive Undervoltage UV"},
+  {"dtc": "P2B8F12", "l_dsc": "High Side Drive Overvoltage OV"},
+  {"dtc": "P2B9000", "l_dsc": "High Side Drive Overcurrent (Contactor Channel)"},
+  {"dtc": "P2B9100", "l_dsc": "Abnormal DC charging port voltage"},
+  {"dtc": "P2B9200", "l_dsc": "Abnormal battery temperature difference"},
+  {"dtc": "P2B9211", "l_dsc": "High Side Short to Ground SC (Contactor Channel)"},
+  {"dtc": "P2B9212", "l_dsc": "High Side Short to Power OS (Contactor Channel)"},
+  {"dtc": "P2B9213", "l_dsc": "High Side Drive Open-circuited"},
+  {"dtc": "P2B9219", "l_dsc": "High Side Drive Overcurrent (HVSU Channel)"},
+  {"dtc": "P2B9298", "l_dsc": "High Side Drive Overtemperature"},
+  {"dtc": "P2B9400", "l_dsc": "Power Battery Overdischarge"},
+  {"dtc": "U0073", "l_dsc": "Control Module Communication Bus \"A\" Off (generic SAE)"},
+  {"dtc": "U011000", "l_dsc": "Communication with Motor Control Unit Failed"},
+  {"dtc": "U011100", "l_dsc": "Communication with BMC Failed"},
+  {"dtc": "U011181", "l_dsc": "Message Data of BMC Abnormal"},
+  {"dtc": "U011182", "l_dsc": "Cycle Counter of BMC Abnormal"},
+  {"dtc": "U011187", "l_dsc": "Communication with Battery Management System (BMS) Failed"},
+  {"dtc": "U012187", "l_dsc": "Communication with ABS Failed"},
+  {"dtc": "U014081", "l_dsc": "Message Data of BCM Abnormal"},
+  {"dtc": "U014087", "l_dsc": "Communication with BCM Failed"},
+  {"dtc": "U014187", "l_dsc": "Communication fault with the complete bus controller"},
+  {"dtc": "U0146", "l_dsc": "Communication between Instrument and Gateway Interrupted"},
+  {"dtc": "U014B87", "l_dsc": "Communication with DC Charging Cabinet Failed"},
+  {"dtc": "U014E87", "l_dsc": "Communication with Security Gateway Module Failed"},
+  {"dtc": "U015129", "l_dsc": "Motor Control Module Receiving SRS ,CAN Signal Abnormal"},
+  {"dtc": "U015229", "l_dsc": "Motor Control Module Receiving SRS Hardwire Signal Abnormal"},
+  {"dtc": "U015500", "l_dsc": "Communication Timeout at Combination Instrument"},
+  {"dtc": "U015587", "l_dsc": "Communication with Combination Instrument Failed"},
+  {"dtc": "U015887", "l_dsc": "Communication with ESP Lost -TRW"},
+  {"dtc": "U015987", "l_dsc": "Communication with VTOG Lost -TRW"},
+  {"dtc": "U015A38", "l_dsc": "Main/Auxiliary/Torque Signal Period Abnormal"},
+  {"dtc": "U015B02", "l_dsc": "Duty Cycle of Main/Auxiliary Angle Signal Abnormal"},
+  {"dtc": "U015D86", "l_dsc": "Angle signal not available"},
+  {"dtc": "U015E31", "l_dsc": "Motor Rotor Position Signal Fault"},
+  {"dtc": "U015F86", "l_dsc": "Received ESP Signal Not Available"},
+  {"dtc": "U016002", "l_dsc": "Duty Cycle of Main/Auxiliary/Main+Auxiliary Torque Signal Abnormal"},
+  {"dtc": "U0164", "l_dsc": "Communication with Air Conditioning System Lost"},
+  {"dtc": "U016400", "l_dsc": "Communication with Air Conditioner Failed"},
+  {"dtc": "U016487", "l_dsc": "Communication with Air Conditioner Failed"},
+  {"dtc": "U018087", "l_dsc": "Communication with High-side Drive Lost"},
+  {"dtc": "U019780", "l_dsc": "Communication with Intelligent Power Brake Control Module Failed"},
+  {"dtc": "U01A500", "l_dsc": "Communication with Front Motor Motor Control Unit (FMCU) Failed"},
+  {"dtc": "U0245", "l_dsc": "Communication between Instrument Panel and Multimedia Interrupted"},
+  {"dtc": "U024500", "l_dsc": "Communication Timeout at Multimedia"},
+  {"dtc": "U024582", "l_dsc": "Message Data of Multimedia Abnormal"},
+  {"dtc": "U024C87", "l_dsc": "Communication with I-KEY Failed"},
+  {"dtc": "U024E87", "l_dsc": "Communication with ESC Failed"},
+  {"dtc": "U025387", "l_dsc": "Communication with compressor lost"},
+  {"dtc": "U027E01", "l_dsc": "BIC1 Cascade Communication Failed"},
+  {"dtc": "U027E02", "l_dsc": "BIC2 Cascade Communication Failed"},
+  {"dtc": "U027E03", "l_dsc": "BIC3 Cascade Communication Fault"},
+  {"dtc": "U027E04", "l_dsc": "BIC4 Cascade Communication Fault"},
+  {"dtc": "U027E05", "l_dsc": "BIC5 Cascade Communication Fault"},
+  {"dtc": "U027E06", "l_dsc": "BIC6 Cascade Communication Fault"},
+  {"dtc": "U027E07", "l_dsc": "BIC7 Cascade Communication Fault"},
+  {"dtc": "U027E08", "l_dsc": "BIC8 Cascade Communication Failed"},
+  {"dtc": "U029187", "l_dsc": "Communication with Gear Control Module Failed"},
+  {"dtc": "U029787", "l_dsc": "Communication with On-board Charger Failed"},
+  {"dtc": "U029800", "l_dsc": "Communication between Battery Manager System and DC Failed"},
+  {"dtc": "U029887", "l_dsc": "Communication with DC Failed"},
+  {"dtc": "U029F87", "l_dsc": "Communication with OBC Failed"},
+  {"dtc": "U02A200", "l_dsc": "Communication with Active Release Module Failed"},
+  {"dtc": "U02B087", "l_dsc": "Lost Communication with Humidity Sensor"},
+  {"dtc": "U030000", "l_dsc": "ECU Internal Control Module Software Fault"},
+  {"dtc": "U043204", "l_dsc": "Communication Timeout at Yaw Rate Sensor"},
+  {"dtc": "U1101", "l_dsc": "Communication between Instrument and Combination Switch Interrupted"},
+  {"dtc": "U110287", "l_dsc": "Communication with BCM Failed"},
+  {"dtc": "U1103", "l_dsc": "Communication between Instrument and SRS Interrupted"},
+  {"dtc": "U110387", "l_dsc": "Communication with Airbag ECU Failed"},
+  {"dtc": "U20B000", "l_dsc": "BIC1 CAN Communication Timeout"},
+  {"dtc": "U20B100", "l_dsc": "BIC2 CAN Communication Timeout"},
+  {"dtc": "U20B200", "l_dsc": "BIC3 CAN Communication Timeout"},
+  {"dtc": "U20B300", "l_dsc": "BIC4 CAN Communication Timeout"},
+  {"dtc": "U20B400", "l_dsc": "BIC5 CAN Communication Timeout"},
+  {"dtc": "U20B500", "l_dsc": "BIC6 CAN Communication Timeout"},
+  {"dtc": "U20B600", "l_dsc": "BIC7 CAN Communication Timeout"},
+  {"dtc": "U20B700", "l_dsc": "BIC8 CAN Communication Timeout"},
+  {"dtc": "U20B800", "l_dsc": "BIC9 CAN Communication Timeout Fault"},
+  {"dtc": "U300000", "l_dsc": "Microprocessor Error in ECU"},
+  {"dtc": "U300316", "l_dsc": "Battery Soft Undervoltage Fault(independent)"},
+  {"dtc": "U300317", "l_dsc": "Battery Soft Overvoltage Fault(independent)"}
 ]

--- a/web_data/dtc/byd_atto3_dtc.json
+++ b/web_data/dtc/byd_atto3_dtc.json
@@ -1,0 +1,3926 @@
+[
+  {
+    "code": null,
+    "dtc": "B110811",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Short-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B110913",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B110A02",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester CAN Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B110B07",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Air Pump Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B110C09",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Laser Diode Failure"
+  },
+  {
+    "code": null,
+    "dtc": "B110D09",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Photoelectric Receiving Module Failure"
+  },
+  {
+    "code": null,
+    "dtc": "B110E09",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Temperature and Humidity Module Failure"
+  },
+  {
+    "code": null,
+    "dtc": "B110F09",
+    "s_dsc": null,
+    "l_dsc": "PM2.5 Quick Tester Solenoid Valve Failure"
+  },
+  {
+    "code": null,
+    "dtc": "B111009",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B116212",
+    "s_dsc": null,
+    "l_dsc": "Water Temperature Sensor Short-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B116214",
+    "s_dsc": null,
+    "l_dsc": "Water Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B11BD11",
+    "s_dsc": null,
+    "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B11BD12",
+    "s_dsc": null,
+    "l_dsc": "LIN1 Ambient Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B11BD13",
+    "s_dsc": null,
+    "l_dsc": "LIN1 Ambient Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B11BD19",
+    "s_dsc": null,
+    "l_dsc": "LIN1 ambient light drive overload"
+  },
+  {
+    "code": null,
+    "dtc": "B11BE11",
+    "s_dsc": null,
+    "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B11BE12",
+    "s_dsc": null,
+    "l_dsc": "LIN2 Ambient Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B11BE13",
+    "s_dsc": null,
+    "l_dsc": "LIN2 Ambient Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B11BE19",
+    "s_dsc": null,
+    "l_dsc": "LIN2 ambient light drive overload"
+  },
+  {
+    "code": null,
+    "dtc": "B133413",
+    "s_dsc": null,
+    "l_dsc": "Refrigerant Temperature Sensor 2 Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B133511",
+    "s_dsc": null,
+    "l_dsc": "Refrigerant temperature sensor 2 is short to ground"
+  },
+  {
+    "code": null,
+    "dtc": "B133613",
+    "s_dsc": null,
+    "l_dsc": "Open circuit of refrigerant temperature sensor 3"
+  },
+  {
+    "code": null,
+    "dtc": "B133711",
+    "s_dsc": null,
+    "l_dsc": "Refrigerant Temperature Sensor 3 Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B133800",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 1 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133900",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 2 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133A00",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 3 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133B00",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 4 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133C00",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 5 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133D00",
+    "s_dsc": null,
+    "l_dsc": "Solenoid Valve 6 Status Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133E00",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage PTC Relay 1 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B133F00",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage PTC Relay 2 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B134000",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage PTC Relay 3 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B134111",
+    "s_dsc": null,
+    "l_dsc": "Three-way Valve Motor Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B134211",
+    "s_dsc": null,
+    "l_dsc": "Three-way Valve Motor Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B134392",
+    "s_dsc": null,
+    "l_dsc": "Three-way Valve Motor Not Rotating in Place"
+  },
+  {
+    "code": null,
+    "dtc": "B134611",
+    "s_dsc": null,
+    "l_dsc": "Refrigerant Temperature Sensor 1 Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B134613",
+    "s_dsc": null,
+    "l_dsc": "Refrigerant Temperature Sensor 1 Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B134711",
+    "s_dsc": null,
+    "l_dsc": "Air conditioner pressure sensor is short to power"
+  },
+  {
+    "code": null,
+    "dtc": "B134713",
+    "s_dsc": null,
+    "l_dsc": "Air conditioner pressure sensor P1 broken circuit"
+  },
+  {
+    "code": null,
+    "dtc": "B16001B",
+    "s_dsc": null,
+    "l_dsc": "Driver Frontal Airbag Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B160111",
+    "s_dsc": null,
+    "l_dsc": "Driver Frontal Airbag Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B160212",
+    "s_dsc": null,
+    "l_dsc": "Driver Frontal Airbag Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B160A1A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Driver Frontal Airbag Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B16101B",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Frontal Airbag Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B161111",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Frontal Airbag Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B161212",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Frontal Airbag Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B161A1A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Front Passenger Frontal Airbag Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B16201B",
+    "s_dsc": null,
+    "l_dsc": "Driver Side Airbag Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B162111",
+    "s_dsc": null,
+    "l_dsc": "Driver Side Airbag Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B162212",
+    "s_dsc": null,
+    "l_dsc": "Driver Side Airbag Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B162A1A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Driver Side Airbag Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B16301B",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Side Airbag Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B163111",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Side Airbag Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B163212",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Side Airbag Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B163B1B",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Front Passenger Side Airbag Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B16401B",
+    "s_dsc": null,
+    "l_dsc": "Driver Seat Belt Pretensioner Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B164111",
+    "s_dsc": null,
+    "l_dsc": "Driver Seat Belt Pretensioner Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B164212",
+    "s_dsc": null,
+    "l_dsc": "Driver Seat Belt Pretensioner Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B16451A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Driver Seat Belt Pretensioner Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B164A1B",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Seat Belt Pretensioner Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B164B11",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B164C12",
+    "s_dsc": null,
+    "l_dsc": "Front Passenger Seat Belt Pretensioner Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B164F1A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Front Passenger Seat Belt Pretensioner Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B165400",
+    "s_dsc": null,
+    "l_dsc": "Left front impact sensor not connected"
+  },
+  {
+    "code": null,
+    "dtc": "B165511",
+    "s_dsc": null,
+    "l_dsc": "Left Front Frontal Impact Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B165D00",
+    "s_dsc": null,
+    "l_dsc": "Right Front Impact Sensor Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B165E11",
+    "s_dsc": null,
+    "l_dsc": "Right Front Frontal Impact Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B166600",
+    "s_dsc": null,
+    "l_dsc": "Left Side Impact Sensor Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B166711",
+    "s_dsc": null,
+    "l_dsc": "Left Side Impact Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B166F00",
+    "s_dsc": null,
+    "l_dsc": "Right Side Impact Sensor Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B167011",
+    "s_dsc": null,
+    "l_dsc": "Right Side Impact Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B169416",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169517",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169700",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169800",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169C00",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169D00",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B169F00",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B16A100",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B16AE00",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B16B000",
+    "s_dsc": null,
+    "l_dsc": "SRS_ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B17041B",
+    "s_dsc": null,
+    "l_dsc": "Left Air Curtain Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B170511",
+    "s_dsc": null,
+    "l_dsc": "Left Air Curtain Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B170612",
+    "s_dsc": null,
+    "l_dsc": "Left Air Curtain is Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B17081A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Left Air Curtain Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B170D1B",
+    "s_dsc": null,
+    "l_dsc": "Right Air Curtain Not Connected"
+  },
+  {
+    "code": null,
+    "dtc": "B170E11",
+    "s_dsc": null,
+    "l_dsc": "Right Air Curtain Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B170F12",
+    "s_dsc": null,
+    "l_dsc": "Right Air Curtain Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B17121A",
+    "s_dsc": null,
+    "l_dsc": "Resistance of Right Air Curtain Equaling to 0"
+  },
+  {
+    "code": null,
+    "dtc": "B17A300",
+    "s_dsc": null,
+    "l_dsc": "SRS CAN Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B17A400",
+    "s_dsc": null,
+    "l_dsc": "SRS Hardwire Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4800",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Corner Sensor Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4812",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Power or No Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4814",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Angle Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4A00",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Right Rear Corner Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4B00",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Center Sensor Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4B12",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Center Sensor Signal Wire Short to Power or Not Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4B14",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Center Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4D00",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Right Rear Center Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4E00",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Center Sensor Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4E12",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Center Sensor Signal Wire Short to Power or Not Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B4E14",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Center Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5000",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Left Rear Center Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5100",
+    "s_dsc": null,
+    "l_dsc": "Internal Fault at Left Rear Corner Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5112",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Angle Sensor Signal Wire Short to Power Supply or No Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5114",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Corner Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5300",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Left Rear Corner Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5400",
+    "s_dsc": null,
+    "l_dsc": "Right Front Corner Sensor Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5412",
+    "s_dsc": null,
+    "l_dsc": "Right Front Corner Sensor Signal Wire Short to Power or Not Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5414",
+    "s_dsc": null,
+    "l_dsc": "Right Front Corner Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5600",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5700",
+    "s_dsc": null,
+    "l_dsc": "Left Front Corner Sensor Internal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5712",
+    "s_dsc": null,
+    "l_dsc": "Left Front Corner Sensor Signal Wire Short to Power or Not Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5714",
+    "s_dsc": null,
+    "l_dsc": "Left Front Corner Sensor Signal Wire Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1B5900",
+    "s_dsc": null,
+    "l_dsc": "Afterwave Time Fault of Right Front Corner Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "B1BE801",
+    "s_dsc": null,
+    "l_dsc": "Detection Signal of Front Wiper High-speed Switch Hard Wire Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1BF400",
+    "s_dsc": null,
+    "l_dsc": "Front Wiper Reset Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1C0800",
+    "s_dsc": null,
+    "l_dsc": "Rear Wiper Reset Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1C0D12",
+    "s_dsc": null,
+    "l_dsc": "Washing Motor Short-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1C0D13",
+    "s_dsc": null,
+    "l_dsc": "Washing Motor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1C0D71",
+    "s_dsc": null,
+    "l_dsc": "Washing Motor Stalling"
+  },
+  {
+    "code": null,
+    "dtc": "B1C5E11",
+    "s_dsc": null,
+    "l_dsc": "Right Charging Port Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1C5E12",
+    "s_dsc": null,
+    "l_dsc": "Right Charging Port Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1C5E13",
+    "s_dsc": null,
+    "l_dsc": "Right Charging Port Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1C5E19",
+    "s_dsc": null,
+    "l_dsc": "Right charging port light drive overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CAF00",
+    "s_dsc": null,
+    "l_dsc": "Humidity Sensor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDA11",
+    "s_dsc": null,
+    "l_dsc": "Trunk Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDA12",
+    "s_dsc": null,
+    "l_dsc": "Trunk Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDA13",
+    "s_dsc": null,
+    "l_dsc": "Trunk Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDA19",
+    "s_dsc": null,
+    "l_dsc": "Trunk light drive circuit overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDB11",
+    "s_dsc": null,
+    "l_dsc": "Left Front Door Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDB12",
+    "s_dsc": null,
+    "l_dsc": "Left Front Door Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDB13",
+    "s_dsc": null,
+    "l_dsc": "Left Front Door Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDB19",
+    "s_dsc": null,
+    "l_dsc": "Left Front Door Drive Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDD11",
+    "s_dsc": null,
+    "l_dsc": "Right Front Door Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDD12",
+    "s_dsc": null,
+    "l_dsc": "Right Front Door Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDD13",
+    "s_dsc": null,
+    "l_dsc": "Right Front Door Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDD19",
+    "s_dsc": null,
+    "l_dsc": "Right Front Door Drive Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDF11",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDF12",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDF13",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CDF19",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive of Left Exterior Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE011",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE012",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE013",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE019",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive of Left Exterior Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE111",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE112",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE113",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Left Exterior Rearview Mirror Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE119",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive of Left Exterior Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE211",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE212",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE213",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE219",
+    "s_dsc": null,
+    "l_dsc": "Left&Right Commutator Motor Drive of Exterior Right Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE311",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE312",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE313",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive Circuit of Exterior Right Rearview Mirror Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE319",
+    "s_dsc": null,
+    "l_dsc": "Up&Down Commutator Motor Drive of Exterior Right Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE411",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE412",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE413",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive Circuit of Exterior Right Rearview Mirror Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE419",
+    "s_dsc": null,
+    "l_dsc": "Folding Motor Drive of Exterior Right Rearview Mirror Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE911",
+    "s_dsc": null,
+    "l_dsc": "Left Footwell Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE912",
+    "s_dsc": null,
+    "l_dsc": "Left footwell light drive circuit short to power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE913",
+    "s_dsc": null,
+    "l_dsc": "Left footwell light drive circuit is broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CE919",
+    "s_dsc": null,
+    "l_dsc": "Left footwell light drive is overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1CEB11",
+    "s_dsc": null,
+    "l_dsc": "Right Footwell Light Drive Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B1CEB12",
+    "s_dsc": null,
+    "l_dsc": "Right Footwell Light Drive Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B1CEB13",
+    "s_dsc": null,
+    "l_dsc": "Right Footwell Light Drive Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "B1CEB19",
+    "s_dsc": null,
+    "l_dsc": "Right Footwell Light Drive Overload"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0007",
+    "s_dsc": null,
+    "l_dsc": "Volume \"+\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0107",
+    "s_dsc": null,
+    "l_dsc": "Channel \"+\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0207",
+    "s_dsc": null,
+    "l_dsc": "Bluetooth Telephone Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0407",
+    "s_dsc": null,
+    "l_dsc": "\"Mode\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0507",
+    "s_dsc": null,
+    "l_dsc": "\"Voice\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0607",
+    "s_dsc": null,
+    "l_dsc": "Panoramic Image Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0707",
+    "s_dsc": null,
+    "l_dsc": "Volume \"-\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E0807",
+    "s_dsc": null,
+    "l_dsc": "Channel \"-\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E1007",
+    "s_dsc": null,
+    "l_dsc": "EPPROM Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1E1907",
+    "s_dsc": null,
+    "l_dsc": "\"Mute\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E1A07",
+    "s_dsc": null,
+    "l_dsc": "Custom Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E1C07",
+    "s_dsc": null,
+    "l_dsc": "Instrument Menu Return Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E2000",
+    "s_dsc": null,
+    "l_dsc": "Steering Wheel Built-in Vibration Motor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B1E2D07",
+    "s_dsc": null,
+    "l_dsc": "\"Cruise\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E2E07",
+    "s_dsc": null,
+    "l_dsc": "\"Cancel\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E2F07",
+    "s_dsc": null,
+    "l_dsc": "Speed + Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3007",
+    "s_dsc": null,
+    "l_dsc": "Speed -Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3107",
+    "s_dsc": null,
+    "l_dsc": "\"Setting\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3207",
+    "s_dsc": null,
+    "l_dsc": "\"Reset\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3307",
+    "s_dsc": null,
+    "l_dsc": "Time Interval \"-\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3407",
+    "s_dsc": null,
+    "l_dsc": "Time Interval \"+\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B1E3507",
+    "s_dsc": null,
+    "l_dsc": "\"Lane Offset\" Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B222400",
+    "s_dsc": null,
+    "l_dsc": "Sunroof Hall Sensor Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B222401",
+    "s_dsc": null,
+    "l_dsc": "Blinder Motor Hall Sensor Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B225300",
+    "s_dsc": null,
+    "l_dsc": "Sunroof Initialization Lost"
+  },
+  {
+    "code": null,
+    "dtc": "B225407",
+    "s_dsc": null,
+    "l_dsc": "Sunroof Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B225511",
+    "s_dsc": null,
+    "l_dsc": "Sunroof Motor Short (to Ground)"
+  },
+  {
+    "code": null,
+    "dtc": "B225513",
+    "s_dsc": null,
+    "l_dsc": "Sunroof Motor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B225600",
+    "s_dsc": null,
+    "l_dsc": "Sun shade initialization lost"
+  },
+  {
+    "code": null,
+    "dtc": "B225707",
+    "s_dsc": null,
+    "l_dsc": "Blinder Switch Stuck"
+  },
+  {
+    "code": null,
+    "dtc": "B225811",
+    "s_dsc": null,
+    "l_dsc": "Blinder Motor Short (to Ground)"
+  },
+  {
+    "code": null,
+    "dtc": "B225813",
+    "s_dsc": null,
+    "l_dsc": "Blinder Motor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B227C13",
+    "s_dsc": null,
+    "l_dsc": "Interior Front Detection Antenna Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B227D13",
+    "s_dsc": null,
+    "l_dsc": "Interior Middle Detection Antenna Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B227E13",
+    "s_dsc": null,
+    "l_dsc": "Interior Rear Detection Antenna Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B229D16",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of High Frequency Receiver Module Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "B229D17",
+    "s_dsc": null,
+    "l_dsc": "Power Supply of High Frequency Receiver Module Too High"
+  },
+  {
+    "code": null,
+    "dtc": "B22A613",
+    "s_dsc": null,
+    "l_dsc": "Open circuit of the exterior right front detection antenna"
+  },
+  {
+    "code": null,
+    "dtc": "B22A813",
+    "s_dsc": null,
+    "l_dsc": "Exterior Trunk Detection Antenna Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2342",
+    "s_dsc": null,
+    "l_dsc": "Internal Fault of Instrument"
+  },
+  {
+    "code": null,
+    "dtc": "B2343",
+    "s_dsc": null,
+    "l_dsc": "Clock Running Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B234A",
+    "s_dsc": null,
+    "l_dsc": "CAN Bus Receives Incorrect Coolant Temperature Signal"
+  },
+  {
+    "code": null,
+    "dtc": "B234C",
+    "s_dsc": null,
+    "l_dsc": "CAN Bus Does Not Detect Motor Speed Signal"
+  },
+  {
+    "code": null,
+    "dtc": "B234D",
+    "s_dsc": null,
+    "l_dsc": "Information Switching Key Input Device Short-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B236009",
+    "s_dsc": null,
+    "l_dsc": "Display Fault (Backlight Fault) or Display Chip Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B24AB00",
+    "s_dsc": null,
+    "l_dsc": "Light Handle Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B24AC00",
+    "s_dsc": null,
+    "l_dsc": "Wiper Handle Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B24D700",
+    "s_dsc": null,
+    "l_dsc": "Handle Input Power Overvoltage"
+  },
+  {
+    "code": null,
+    "dtc": "B24D800",
+    "s_dsc": null,
+    "l_dsc": "Handle Input Power Undervoltage"
+  },
+  {
+    "code": null,
+    "dtc": "B2A0801",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2A0803",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Outlet Refrigerant Pressure Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A0811",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B2A0813",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Outlet Refrigerant Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2013",
+    "s_dsc": null,
+    "l_dsc": "Interior temperature sensor open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2111",
+    "s_dsc": null,
+    "l_dsc": "Interior Temperature Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2213",
+    "s_dsc": null,
+    "l_dsc": "Exterior Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2311",
+    "s_dsc": null,
+    "l_dsc": "Exterior Temperature Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2413",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2511",
+    "s_dsc": null,
+    "l_dsc": "Evaporator Temperature Sensor Circuit Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2712",
+    "s_dsc": null,
+    "l_dsc": "Sunlight Sensor Circuit Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2A12",
+    "s_dsc": null,
+    "l_dsc": "Mode Motor Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2A14",
+    "s_dsc": null,
+    "l_dsc": "Mode Motor Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2A92",
+    "s_dsc": null,
+    "l_dsc": "Mode Motor Not Rotating in Place"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2B12",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Air Mix Motor Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2B14",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Air Mix Motor Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2B92",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Air Mix Motor Not Rotating in Place"
+  },
+  {
+    "code": null,
+    "dtc": "B2A2F09",
+    "s_dsc": null,
+    "l_dsc": "A/C Pipes in High Pressure State or Low Pressure State"
+  },
+  {
+    "code": null,
+    "dtc": "B2A3214",
+    "s_dsc": null,
+    "l_dsc": "Front Blower Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A3314",
+    "s_dsc": null,
+    "l_dsc": "Front Blower Adjustment Signal Harness Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A4B12",
+    "s_dsc": null,
+    "l_dsc": "Circulation Motor Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2A4B14",
+    "s_dsc": null,
+    "l_dsc": "Circulation Motor Short to Ground or Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A4B92",
+    "s_dsc": null,
+    "l_dsc": "Circulation Motor Not Rotating in Place"
+  },
+  {
+    "code": null,
+    "dtc": "B2A5811",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "B2A5813",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Face Outlet Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2A5913",
+    "s_dsc": null,
+    "l_dsc": "Driver's Side Floor Outlet Temperature Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB049",
+    "s_dsc": null,
+    "l_dsc": "Current Sampling Circuit Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB149",
+    "s_dsc": null,
+    "l_dsc": "Motor Phase Lost"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB249",
+    "s_dsc": null,
+    "l_dsc": "IPM IGBT Fault"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB349",
+    "s_dsc": null,
+    "l_dsc": "Internal temperature sensor fault"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB41D",
+    "s_dsc": null,
+    "l_dsc": "Internal Current Excessive"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB573",
+    "s_dsc": null,
+    "l_dsc": "Fail to Start Up"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB64B",
+    "s_dsc": null,
+    "l_dsc": "Internal Temperature Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB774",
+    "s_dsc": null,
+    "l_dsc": "Speed Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB81C",
+    "s_dsc": null,
+    "l_dsc": "Phase Voltage Too High"
+  },
+  {
+    "code": null,
+    "dtc": "B2AB997",
+    "s_dsc": null,
+    "l_dsc": "Overload fault"
+  },
+  {
+    "code": null,
+    "dtc": "B2ABA1C",
+    "s_dsc": null,
+    "l_dsc": "Fault at Internal Low-voltage Power"
+  },
+  {
+    "code": null,
+    "dtc": "B2ABB17",
+    "s_dsc": null,
+    "l_dsc": "Voltage of High Voltage Side Overvoltage"
+  },
+  {
+    "code": null,
+    "dtc": "B2ABC16",
+    "s_dsc": null,
+    "l_dsc": "Voltage of High Voltage Side Low"
+  },
+  {
+    "code": null,
+    "dtc": "B2AD616",
+    "s_dsc": null,
+    "l_dsc": "12V Power Supply Undervoltage (Lower Than 9V)"
+  },
+  {
+    "code": null,
+    "dtc": "B2AD617",
+    "s_dsc": null,
+    "l_dsc": "12V Power Supply Overvoltage"
+  },
+  {
+    "code": null,
+    "dtc": "B2FD016",
+    "s_dsc": null,
+    "l_dsc": "Power Supply Voltage Low Alarm"
+  },
+  {
+    "code": null,
+    "dtc": "B2FD017",
+    "s_dsc": null,
+    "l_dsc": "Power Supply Voltage High Alarm"
+  },
+  {
+    "code": null,
+    "dtc": "B2FD14B",
+    "s_dsc": null,
+    "l_dsc": "Wireless Charging Overtemperature Alarm"
+  },
+  {
+    "code": null,
+    "dtc": "C000100",
+    "s_dsc": null,
+    "l_dsc": "CSV Valve 1 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C000200",
+    "s_dsc": null,
+    "l_dsc": "PSV Valve 1 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C000300",
+    "s_dsc": null,
+    "l_dsc": "CSV Valve 2 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C000400",
+    "s_dsc": null,
+    "l_dsc": "PSV Valve 2 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001000",
+    "s_dsc": null,
+    "l_dsc": "Left Front Inlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001100",
+    "s_dsc": null,
+    "l_dsc": "Left Front Outlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001400",
+    "s_dsc": null,
+    "l_dsc": "Right Front Inlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001500",
+    "s_dsc": null,
+    "l_dsc": "Right Front Outlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001800",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Inlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001900",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Outlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001C00",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Inlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C001D00",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Outlet Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C002192",
+    "s_dsc": null,
+    "l_dsc": "Brake Booster Module Pipeline Hydraulic Pressure Below Normal Value"
+  },
+  {
+    "code": null,
+    "dtc": "C002400",
+    "s_dsc": null,
+    "l_dsc": "SSV Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C003100",
+    "s_dsc": null,
+    "l_dsc": "Left Front Wheel Speed Sensor Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C003200",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of Left Front Wheel Speed Sensor Low"
+  },
+  {
+    "code": null,
+    "dtc": "C003400",
+    "s_dsc": null,
+    "l_dsc": "Right Front Wheel Speed Sensor Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C003500",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of Right Front Wheel Speed Sensor Low"
+  },
+  {
+    "code": null,
+    "dtc": "C003700",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Wheel Speed Sensor Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C003800",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of Left Rear Wheel Speed Sensor Low"
+  },
+  {
+    "code": null,
+    "dtc": "C003A00",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Wheel Speed Sensor Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C003B00",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of Right Rear Wheel Speed Sensor Low"
+  },
+  {
+    "code": null,
+    "dtc": "C004900",
+    "s_dsc": null,
+    "l_dsc": "Brake Fluid Level Under Normal Value"
+  },
+  {
+    "code": null,
+    "dtc": "C006A01",
+    "s_dsc": null,
+    "l_dsc": "Yaw Rate Sensor Parameter Wrongly Configured"
+  },
+  {
+    "code": null,
+    "dtc": "C006A02",
+    "s_dsc": null,
+    "l_dsc": "Yaw Rate Sensor Signal Error"
+  },
+  {
+    "code": null,
+    "dtc": "C007500",
+    "s_dsc": null,
+    "l_dsc": "Master Cylinder Position Sensor A Fault/Short Circuit"
+  },
+  {
+    "code": null,
+    "dtc": "C050000",
+    "s_dsc": null,
+    "l_dsc": "Left Front Wheel Speed Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "C050200",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Ground Line"
+  },
+  {
+    "code": null,
+    "dtc": "C050300",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Left Front Wheel Speed Sensor Signal Line and Power Supply Line"
+  },
+  {
+    "code": null,
+    "dtc": "C050400",
+    "s_dsc": null,
+    "l_dsc": "Left Front Wheel Speed Sensor Air Gap Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C050576",
+    "s_dsc": null,
+    "l_dsc": "Incorrect Installation Direction of Left Front Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C050600",
+    "s_dsc": null,
+    "l_dsc": "Right Front Wheel Speed Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "C050800",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Front Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C050900",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Right Front Wheel Speed Sensor Signal Line and Power Supply Line"
+  },
+  {
+    "code": null,
+    "dtc": "C050A00",
+    "s_dsc": null,
+    "l_dsc": "Right Front Wheel Speed Sensor Air Gap Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C050B76",
+    "s_dsc": null,
+    "l_dsc": "Incorrect Installation Direction of Right Front Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C050C00",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Wheel Speed Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "C050E00",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Left Rear Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C050F00",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Left Rear Wheel Speed Sensor Signal Line and Power Supply Line"
+  },
+  {
+    "code": null,
+    "dtc": "C051000",
+    "s_dsc": null,
+    "l_dsc": "Left Rear Wheel Speed Sensor Air Gap Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C051176",
+    "s_dsc": null,
+    "l_dsc": "Incorrect Installation Direction of Left Rear Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C051200",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Wheel Speed Sensor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "C051400",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Signal Wire and Ground Wire of Right Rear Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C051500",
+    "s_dsc": null,
+    "l_dsc": "Short Circuit between Right Rear Wheel Speed Sensor Signal Line and Power Supply Line"
+  },
+  {
+    "code": null,
+    "dtc": "C051600",
+    "s_dsc": null,
+    "l_dsc": "Right Rear Wheel Speed Sensor Air Gap Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C051776",
+    "s_dsc": null,
+    "l_dsc": "Incorrect Installation Direction of Right Rear Wheel Speed Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "C051D01",
+    "s_dsc": null,
+    "l_dsc": "Yaw Rate Sensor Wrongly Calibrated"
+  },
+  {
+    "code": null,
+    "dtc": "C052901",
+    "s_dsc": null,
+    "l_dsc": "Steering Angle Sensor Module Lost"
+  },
+  {
+    "code": null,
+    "dtc": "C053D00",
+    "s_dsc": null,
+    "l_dsc": "Pressure Sensor B Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C053E00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Pressure Sensor A Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C053F00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Pressure Sensor A Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C054100",
+    "s_dsc": null,
+    "l_dsc": "Pressure Sensor B Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C054200",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Pressure Sensor B Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C054300",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Pressure Sensor B Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C055000",
+    "s_dsc": null,
+    "l_dsc": "ECU Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C055E00",
+    "s_dsc": null,
+    "l_dsc": "Brake Hydraulic Circuit A Leaky"
+  },
+  {
+    "code": null,
+    "dtc": "C055F92",
+    "s_dsc": null,
+    "l_dsc": "Hydraulic Unit Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C056B00",
+    "s_dsc": null,
+    "l_dsc": "Brake Booster Module Pressure Sensor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C057900",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C057A00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor B Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C057F00",
+    "s_dsc": null,
+    "l_dsc": "Brake Booster Motor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "C058200",
+    "s_dsc": null,
+    "l_dsc": "Circuit Signal of Brake Booster Motor Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C058800",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C058900",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C058A00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Motor Position Sensor A Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C059000",
+    "s_dsc": null,
+    "l_dsc": "Supply Current of Brake Booster Motoris Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C059100",
+    "s_dsc": null,
+    "l_dsc": "Supply Current of Brake Booster Motor Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C059400",
+    "s_dsc": null,
+    "l_dsc": "Brake Booster Motor Load Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C05B001",
+    "s_dsc": null,
+    "l_dsc": "Brake Hydraulic Circuit L1 Leaky"
+  },
+  {
+    "code": null,
+    "dtc": "C05C200",
+    "s_dsc": null,
+    "l_dsc": "Brake Booster Motor A Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "C05C24B",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Brake Booster Motor Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C05CA00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too high"
+  },
+  {
+    "code": null,
+    "dtc": "C05CB00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor A Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C05CC00",
+    "s_dsc": null,
+    "l_dsc": "Master cylinder position sensor A abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C05CD00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C05CE00",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Master Cylinder Position Sensor B Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C05D000",
+    "s_dsc": null,
+    "l_dsc": "Master Cylinder Position Sensor Signal Value Incorrect"
+  },
+  {
+    "code": null,
+    "dtc": "C05D200",
+    "s_dsc": null,
+    "l_dsc": "Master Cylinder Stroke Exceed Expected Value"
+  },
+  {
+    "code": null,
+    "dtc": "C05D500",
+    "s_dsc": null,
+    "l_dsc": "TSV Valve Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C106600",
+    "s_dsc": null,
+    "l_dsc": "Angle Sensor Not Calibrated"
+  },
+  {
+    "code": null,
+    "dtc": "C110009",
+    "s_dsc": null,
+    "l_dsc": "Control Module Main Chip Fault(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "C117009",
+    "s_dsc": null,
+    "l_dsc": "EPB Switch Fault(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "C11A006",
+    "s_dsc": null,
+    "l_dsc": "Actuator Overload(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "C11B013",
+    "s_dsc": null,
+    "l_dsc": "Left Motor or Line Fault(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "C11B113",
+    "s_dsc": null,
+    "l_dsc": "Right Motor or Line Fault(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "C120700",
+    "s_dsc": null,
+    "l_dsc": "Pump Not Returnable"
+  },
+  {
+    "code": null,
+    "dtc": "C12F909",
+    "s_dsc": null,
+    "l_dsc": "Brake Hydraulic Circuit Blocked"
+  },
+  {
+    "code": null,
+    "dtc": "C1A3800",
+    "s_dsc": null,
+    "l_dsc": "System Not Fully Initialized"
+  },
+  {
+    "code": null,
+    "dtc": "C1B6044",
+    "s_dsc": null,
+    "l_dsc": "ECU RAM Fault"
+  },
+  {
+    "code": null,
+    "dtc": "C1B9000",
+    "s_dsc": null,
+    "l_dsc": "Loss of Power Supply"
+  },
+  {
+    "code": null,
+    "dtc": "C1B9C23",
+    "s_dsc": null,
+    "l_dsc": "Main/Auxiliary/Torque Signal Keeping at Low Level"
+  },
+  {
+    "code": null,
+    "dtc": "C1B9C24",
+    "s_dsc": null,
+    "l_dsc": "Main/Auxiliary/Torque Signal Keeping at High Level"
+  },
+  {
+    "code": null,
+    "dtc": "C1B9D21",
+    "s_dsc": null,
+    "l_dsc": "Voltage of Power Supply Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C1B9D22",
+    "s_dsc": null,
+    "l_dsc": "Voltage of Power Supply Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA023",
+    "s_dsc": null,
+    "l_dsc": "Main/Auxiliary Angle Signal Level Constant Low"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA024",
+    "s_dsc": null,
+    "l_dsc": "Main/Auxiliary Angle Signal Level Constant High"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA500",
+    "s_dsc": null,
+    "l_dsc": "ECU Operation Error"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA600",
+    "s_dsc": null,
+    "l_dsc": "ECU Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA700",
+    "s_dsc": null,
+    "l_dsc": "ECU Fails to ROM and Check"
+  },
+  {
+    "code": null,
+    "dtc": "C1BA900",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage of Torque Sensor Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "C1BAA00",
+    "s_dsc": null,
+    "l_dsc": "Motor Drive Circuit Failure"
+  },
+  {
+    "code": null,
+    "dtc": "C1BAB21",
+    "s_dsc": null,
+    "l_dsc": "Output Voltage of Temperature Detection Circuit Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "C1BAB22",
+    "s_dsc": null,
+    "l_dsc": "Output Voltage of Temperature Detection Circuit Too High"
+  },
+  {
+    "code": null,
+    "dtc": "C1BAE00",
+    "s_dsc": null,
+    "l_dsc": "ECU Not Executing Angle Calibration Order"
+  },
+  {
+    "code": null,
+    "dtc": "C1BB200",
+    "s_dsc": null,
+    "l_dsc": "ESP Speed Data Error"
+  },
+  {
+    "code": null,
+    "dtc": "C2A1700",
+    "s_dsc": null,
+    "l_dsc": "Brake Hydraulic Circuit L1 Overcompensation (air Present)"
+  },
+  {
+    "code": null,
+    "dtc": "P056200",
+    "s_dsc": null,
+    "l_dsc": "System Voltage Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P056300",
+    "s_dsc": null,
+    "l_dsc": "System Voltage Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P060400",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Control Module Fault(RAM)"
+  },
+  {
+    "code": null,
+    "dtc": "P060500",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Control Module Fault(ROM)"
+  },
+  {
+    "code": null,
+    "dtc": "P060600",
+    "s_dsc": null,
+    "l_dsc": "ECM/PCM processor fault"
+  },
+  {
+    "code": null,
+    "dtc": "P060700",
+    "s_dsc": null,
+    "l_dsc": "ECU Hardware Failure"
+  },
+  {
+    "code": null,
+    "dtc": "P060B00",
+    "s_dsc": null,
+    "l_dsc": "ECU Hardware Fault(A/D processor)"
+  },
+  {
+    "code": null,
+    "dtc": "P060C00",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Control Module Fault(program running)"
+  },
+  {
+    "code": null,
+    "dtc": "P06B800",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Control Module Fault(NVRAM memory)"
+  },
+  {
+    "code": null,
+    "dtc": "P151100",
+    "s_dsc": null,
+    "l_dsc": "AC High-voltage Interlock Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P151500",
+    "s_dsc": null,
+    "l_dsc": "Water Temperature Sensor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P157016",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage at AC Side"
+  },
+  {
+    "code": null,
+    "dtc": "P157017",
+    "s_dsc": null,
+    "l_dsc": "High Voltage at AC Side"
+  },
+  {
+    "code": null,
+    "dtc": "P157216",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage at DC Side"
+  },
+  {
+    "code": null,
+    "dtc": "P157217",
+    "s_dsc": null,
+    "l_dsc": "High Voltage at DC Side"
+  },
+  {
+    "code": null,
+    "dtc": "P157219",
+    "s_dsc": null,
+    "l_dsc": "DC Side Overcurrent"
+  },
+  {
+    "code": null,
+    "dtc": "P157400",
+    "s_dsc": null,
+    "l_dsc": "Power Supply Device Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P157897",
+    "s_dsc": null,
+    "l_dsc": "CC Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P15794B",
+    "s_dsc": null,
+    "l_dsc": "Temperature Sampling 1 High"
+  },
+  {
+    "code": null,
+    "dtc": "P157A36",
+    "s_dsc": null,
+    "l_dsc": "Low Frequency of Charging Grid"
+  },
+  {
+    "code": null,
+    "dtc": "P157A37",
+    "s_dsc": null,
+    "l_dsc": "High Frequency of Charging Grid"
+  },
+  {
+    "code": null,
+    "dtc": "P157B00",
+    "s_dsc": null,
+    "l_dsc": "AC Side Overcurrent"
+  },
+  {
+    "code": null,
+    "dtc": "P157C00",
+    "s_dsc": null,
+    "l_dsc": "Hardware Protection"
+  },
+  {
+    "code": null,
+    "dtc": "P157E11",
+    "s_dsc": null,
+    "l_dsc": "Outer of Charging Connection Signal Short to Ground"
+  },
+  {
+    "code": null,
+    "dtc": "P157E12",
+    "s_dsc": null,
+    "l_dsc": "Outer of Charging Connection Signal Short to Power"
+  },
+  {
+    "code": null,
+    "dtc": "P157F11",
+    "s_dsc": null,
+    "l_dsc": "AC Output Short-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "P15834B",
+    "s_dsc": null,
+    "l_dsc": "Temperature Sampling 2 High"
+  },
+  {
+    "code": null,
+    "dtc": "P158798",
+    "s_dsc": null,
+    "l_dsc": "Phase Temperature of Charging Port Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P158900",
+    "s_dsc": null,
+    "l_dsc": "Phase Temperature Sampling at Charging Port Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P158A00",
+    "s_dsc": null,
+    "l_dsc": "Electric Lock Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P15FD00",
+    "s_dsc": null,
+    "l_dsc": "High Temperature of Cooling Water"
+  },
+  {
+    "code": null,
+    "dtc": "P15FF00",
+    "s_dsc": null,
+    "l_dsc": "Internal Temperature Sensor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0000",
+    "s_dsc": null,
+    "l_dsc": "Serious Electric Leakage Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0100",
+    "s_dsc": null,
+    "l_dsc": "Common Electric Leakage Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0200",
+    "s_dsc": null,
+    "l_dsc": "BIC1 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0300",
+    "s_dsc": null,
+    "l_dsc": "BIC2 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0400",
+    "s_dsc": null,
+    "l_dsc": "BIC3 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0500",
+    "s_dsc": null,
+    "l_dsc": "BIC4 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0600",
+    "s_dsc": null,
+    "l_dsc": "BIC5 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0700",
+    "s_dsc": null,
+    "l_dsc": "BIC6 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0800",
+    "s_dsc": null,
+    "l_dsc": "BIC7 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0900",
+    "s_dsc": null,
+    "l_dsc": "BIC8 Working Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0C00",
+    "s_dsc": null,
+    "l_dsc": "BIC1 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0D00",
+    "s_dsc": null,
+    "l_dsc": "BIC2 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0E00",
+    "s_dsc": null,
+    "l_dsc": "BIC3 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A0F00",
+    "s_dsc": null,
+    "l_dsc": "BIC4 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A1000",
+    "s_dsc": null,
+    "l_dsc": "BIC5 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A1100",
+    "s_dsc": null,
+    "l_dsc": "BIC6 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A1200",
+    "s_dsc": null,
+    "l_dsc": "BIC7 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A1300",
+    "s_dsc": null,
+    "l_dsc": "BIC8 Voltage Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2000",
+    "s_dsc": null,
+    "l_dsc": "BIC1 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2100",
+    "s_dsc": null,
+    "l_dsc": "BIC2 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2200",
+    "s_dsc": null,
+    "l_dsc": "BIC3 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2300",
+    "s_dsc": null,
+    "l_dsc": "BIC4 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2400",
+    "s_dsc": null,
+    "l_dsc": "BIC5 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2500",
+    "s_dsc": null,
+    "l_dsc": "BIC6 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2600",
+    "s_dsc": null,
+    "l_dsc": "BIC7 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A2700",
+    "s_dsc": null,
+    "l_dsc": "BIC8 Temperature Sampling Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3522",
+    "s_dsc": null,
+    "l_dsc": "Severely high voltage of power battery cell"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3622",
+    "s_dsc": null,
+    "l_dsc": "Power Battery Cell Voltage Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3721",
+    "s_dsc": null,
+    "l_dsc": "Severely low voltage of power battery cell"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3922",
+    "s_dsc": null,
+    "l_dsc": "Power Battery Cell Temperature Seriously High"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3B21",
+    "s_dsc": null,
+    "l_dsc": "Power battery's single-cell temperature seriously low"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3D00",
+    "s_dsc": null,
+    "l_dsc": "Negative Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3E00",
+    "s_dsc": null,
+    "l_dsc": "Main Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A3F00",
+    "s_dsc": null,
+    "l_dsc": "Pre-charging Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A4100",
+    "s_dsc": null,
+    "l_dsc": "Main Contactor Sintering Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A4200",
+    "s_dsc": null,
+    "l_dsc": "Negative Contactor Sintering"
+  },
+  {
+    "code": null,
+    "dtc": "P1A5600",
+    "s_dsc": null,
+    "l_dsc": "12V Supply Input of Battery Management System Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1A5B00",
+    "s_dsc": null,
+    "l_dsc": "Contactor Disconnected Due to Dual-circuit Power Supply Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1A6000",
+    "s_dsc": null,
+    "l_dsc": "High Voltage Interlock 1 Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AC000",
+    "s_dsc": null,
+    "l_dsc": "Collision Alarm of Airbag ECU"
+  },
+  {
+    "code": null,
+    "dtc": "P1AC400",
+    "s_dsc": null,
+    "l_dsc": "Serious Imbalance at Battery"
+  },
+  {
+    "code": null,
+    "dtc": "P1AC900",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Inductive Signal Circuit Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P1ACB07",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Anode Contactor Sintering"
+  },
+  {
+    "code": null,
+    "dtc": "P1ACC07",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Cathode Contactor Sintering"
+  },
+  {
+    "code": null,
+    "dtc": "P1AD44B",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Charging Port 1 Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P1AD54B",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Charging Port 2 Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P1AD698",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Charging Port 3 Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P1AD900",
+    "s_dsc": null,
+    "l_dsc": "Temperature Sampling Point of Charging Port Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1ADE00",
+    "s_dsc": null,
+    "l_dsc": "Battery Cooling Failure Due to Air Conditioner System Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1ADF00",
+    "s_dsc": null,
+    "l_dsc": "Inner Cycle Failure at Battery Due to Air Conditioner System Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AE000",
+    "s_dsc": null,
+    "l_dsc": "Battery Heating Failure Due to Air Conditioner System Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AE400",
+    "s_dsc": null,
+    "l_dsc": "High Voltage Process Ended Due to Abnormal Low-voltage Supply"
+  },
+  {
+    "code": null,
+    "dtc": "P1AE800",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Anode Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AE900",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AF200",
+    "s_dsc": null,
+    "l_dsc": "Voltage Output at DC Charger Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1AF300",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Cabinet Stops Charging Actively"
+  },
+  {
+    "code": null,
+    "dtc": "P1AF400",
+    "s_dsc": null,
+    "l_dsc": "Insufficient Capacity of DC Charging Cabinet"
+  },
+  {
+    "code": null,
+    "dtc": "P1AF800",
+    "s_dsc": null,
+    "l_dsc": "Battery data not updated"
+  },
+  {
+    "code": null,
+    "dtc": "P1AFB00",
+    "s_dsc": null,
+    "l_dsc": "A/C System High Voltage Interlock Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AFC00",
+    "s_dsc": null,
+    "l_dsc": "On-board Charger High Voltage Interlock Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1AFD00",
+    "s_dsc": null,
+    "l_dsc": "DC-DC High Voltage Interlock Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1B1F00",
+    "s_dsc": null,
+    "l_dsc": "Fail to Anti-theft Authentication"
+  },
+  {
+    "code": null,
+    "dtc": "P1B2516",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1B2517",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage at Low Voltage Side Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P1BA000",
+    "s_dsc": null,
+    "l_dsc": "Cruise Configuration Unwritten In"
+  },
+  {
+    "code": null,
+    "dtc": "P1BAC00",
+    "s_dsc": null,
+    "l_dsc": "IGBT Core Common Overtemperature Warning for Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BAC19",
+    "s_dsc": null,
+    "l_dsc": "IGBT Core Serious Overtemperature Warning for Front Drive Motor Control Module (chopper OFF)"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB000",
+    "s_dsc": null,
+    "l_dsc": "Front Drive Motor Overcurrent"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB100",
+    "s_dsc": null,
+    "l_dsc": "IPM Fault at Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB200",
+    "s_dsc": null,
+    "l_dsc": "Common Overtemperature Warning for Front Drive Motor"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB298",
+    "s_dsc": null,
+    "l_dsc": "Serious Overtemperature Warning for Front Drive Motor"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB300",
+    "s_dsc": null,
+    "l_dsc": "IGBT-NTC Common Overtemperature Warning for Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB319",
+    "s_dsc": null,
+    "l_dsc": "IGBT-NTC Serious Overtemperature Warning for Front Drive Motor Control Module(chopper OFF)"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB500",
+    "s_dsc": null,
+    "l_dsc": "High Voltage Side of Front Drive Motor Control Module Undervoltage"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB600",
+    "s_dsc": null,
+    "l_dsc": "High Voltage Side of Front Drive Motor Control Module Overvoltage"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB700",
+    "s_dsc": null,
+    "l_dsc": "Voltage Sampling Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB800",
+    "s_dsc": null,
+    "l_dsc": "Collision Signal Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BB900",
+    "s_dsc": null,
+    "l_dsc": "Cap Opening Protection of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BBA00",
+    "s_dsc": null,
+    "l_dsc": "EEPROM Error of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BBC00",
+    "s_dsc": null,
+    "l_dsc": "DSP Reset Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BBD00",
+    "s_dsc": null,
+    "l_dsc": "Active Release Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BBF00",
+    "s_dsc": null,
+    "l_dsc": "Front Drive Motor Rotary Transformer Fault -Signal Lost"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC000",
+    "s_dsc": null,
+    "l_dsc": "Front Drive Motor Rotary Transformer Fault -Angle Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC100",
+    "s_dsc": null,
+    "l_dsc": "Front Drive Motor Rotary Transformer Fault-Signal Amplitude Decreasing"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC200",
+    "s_dsc": null,
+    "l_dsc": "Phase A of Front Drive Motor Lost"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC300",
+    "s_dsc": null,
+    "l_dsc": "Phase B of Front Drive Motor Lost"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC400",
+    "s_dsc": null,
+    "l_dsc": "Phase C of Front Drive Motor Lost"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC500",
+    "s_dsc": null,
+    "l_dsc": "Hall Current Sensor B Fault at Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC600",
+    "s_dsc": null,
+    "l_dsc": "Hall Current Sensor C Fault at Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC700",
+    "s_dsc": null,
+    "l_dsc": "IPM Radiator of Front Drive Motor Control Module Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC800",
+    "s_dsc": null,
+    "l_dsc": "IGBT Three-phase Temperature Calibration Fault Alarm for Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BC900",
+    "s_dsc": null,
+    "l_dsc": "Hall Current Sensor A Fault at Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BCF00",
+    "s_dsc": null,
+    "l_dsc": "Temperature Sensor Fault of Front Drive Motor-Torque Limitation"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD000",
+    "s_dsc": null,
+    "l_dsc": "Drive DSP1 Crash Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD117",
+    "s_dsc": null,
+    "l_dsc": "Drive CPLD Overvoltage of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD119",
+    "s_dsc": null,
+    "l_dsc": "Drive CPLD Overcurrent of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD200",
+    "s_dsc": null,
+    "l_dsc": "Drive CPLD Detecting IGBT On-axle Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD300",
+    "s_dsc": null,
+    "l_dsc": "Drive CPLD Detecting IGBT Off-axle Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BD400",
+    "s_dsc": null,
+    "l_dsc": "Drive CPLD Running Fault of Front Drive Motor Control Module"
+  },
+  {
+    "code": null,
+    "dtc": "P1BF100",
+    "s_dsc": null,
+    "l_dsc": "IPM Temperature Sampling of Front Drive Motor Control Module Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1BF200",
+    "s_dsc": null,
+    "l_dsc": "Winding Temperature Sensor Sampling at Front Drive Motor Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1D6144",
+    "s_dsc": null,
+    "l_dsc": "EEPROM Error at VCU"
+  },
+  {
+    "code": null,
+    "dtc": "P1D6200",
+    "s_dsc": null,
+    "l_dsc": "Cruise Switch Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1D6600",
+    "s_dsc": null,
+    "l_dsc": "Accelerator Signal Fault-Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1D6A00",
+    "s_dsc": null,
+    "l_dsc": "Stepless Fan Motor Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "P1D6D00",
+    "s_dsc": null,
+    "l_dsc": "DSP Reset Fault of VCU"
+  },
+  {
+    "code": null,
+    "dtc": "P1D7902",
+    "s_dsc": null,
+    "l_dsc": "Collision Alarm"
+  },
+  {
+    "code": null,
+    "dtc": "P1D7B00",
+    "s_dsc": null,
+    "l_dsc": "Throttle Signal Fault-1 Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1D7C00",
+    "s_dsc": null,
+    "l_dsc": "Throttle Signal Fault-2 Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1D8300",
+    "s_dsc": null,
+    "l_dsc": "Limited Power of Vehicle"
+  },
+  {
+    "code": null,
+    "dtc": "P1D8400",
+    "s_dsc": null,
+    "l_dsc": "Water temperature fault (OBC)"
+  },
+  {
+    "code": null,
+    "dtc": "P1D8D00",
+    "s_dsc": null,
+    "l_dsc": "Stepless Fan Motor Stalling, Short-circuited Etc"
+  },
+  {
+    "code": null,
+    "dtc": "P1D8E00",
+    "s_dsc": null,
+    "l_dsc": "Stepless Fan Overtemperature Protection, Electronic Error, Etc"
+  },
+  {
+    "code": null,
+    "dtc": "P1D8F00",
+    "s_dsc": null,
+    "l_dsc": "Stepless Fan Power Supply Overvoltage or Undervoltage"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9016",
+    "s_dsc": null,
+    "l_dsc": "Voltage of Power Battery Cell Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9017",
+    "s_dsc": null,
+    "l_dsc": "Voltage of Power Battery Cell Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9100",
+    "s_dsc": null,
+    "l_dsc": "Total Voltage of Power Battery Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9117",
+    "s_dsc": null,
+    "l_dsc": "Total Voltage of Power Battery Seriously High"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9200",
+    "s_dsc": null,
+    "l_dsc": "Total Voltage of Power Battery Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9216",
+    "s_dsc": null,
+    "l_dsc": "Total Voltage of Power Battery Seriously Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9308",
+    "s_dsc": null,
+    "l_dsc": "Life Frame of Power Battery Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9400",
+    "s_dsc": null,
+    "l_dsc": "Low Voltage Output Line Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9516",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9600",
+    "s_dsc": null,
+    "l_dsc": "Life Frame of Power Battery Abnormal -Counter Out of Order"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9700",
+    "s_dsc": null,
+    "l_dsc": "Life Frame of Power Battery Abnormal -Check Value Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9B00",
+    "s_dsc": null,
+    "l_dsc": "Water Temperature Sensor Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P1D9C00",
+    "s_dsc": null,
+    "l_dsc": "Water Temperature Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC000",
+    "s_dsc": null,
+    "l_dsc": "Voltage Too High at High Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC100",
+    "s_dsc": null,
+    "l_dsc": "Voltage Too Low at High Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC200",
+    "s_dsc": null,
+    "l_dsc": "Voltage Too High at Low Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC300",
+    "s_dsc": null,
+    "l_dsc": "Voltage Too Low at Low Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC400",
+    "s_dsc": null,
+    "l_dsc": "Current Too High at Low Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC600",
+    "s_dsc": null,
+    "l_dsc": "Current Too High at High Voltage Side during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1EC700",
+    "s_dsc": null,
+    "l_dsc": "Hardware Fault during Step-down"
+  },
+  {
+    "code": null,
+    "dtc": "P1ED316",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage at Low Voltage Side Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P1ED317",
+    "s_dsc": null,
+    "l_dsc": "Supply Voltage at Low Voltage Side Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P1ED400",
+    "s_dsc": null,
+    "l_dsc": "DC Output Positive Line Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P1ED500",
+    "s_dsc": null,
+    "l_dsc": "AC Electric Leakage"
+  },
+  {
+    "code": null,
+    "dtc": "P1EE000",
+    "s_dsc": null,
+    "l_dsc": "DC Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "P229900",
+    "s_dsc": null,
+    "l_dsc": "Master Cylinder Position Sensor Signal Calibration Error"
+  },
+  {
+    "code": null,
+    "dtc": "P25C600",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too Low"
+  },
+  {
+    "code": null,
+    "dtc": "P25C700",
+    "s_dsc": null,
+    "l_dsc": "Circuit Voltage of Brake Booster Temperature Sensor A Too High"
+  },
+  {
+    "code": null,
+    "dtc": "P26804B",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Charging Port 1 Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P26814B",
+    "s_dsc": null,
+    "l_dsc": "Temperature of Charging Port 2 Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P26824B",
+    "s_dsc": null,
+    "l_dsc": "Temperature Rise of Charging Port 3 Seriously High"
+  },
+  {
+    "code": null,
+    "dtc": "P26834B",
+    "s_dsc": null,
+    "l_dsc": "Temperature Rise of Charging Port Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P26844B",
+    "s_dsc": null,
+    "l_dsc": "Temperature Rise of Charging Port Seriously High"
+  },
+  {
+    "code": null,
+    "dtc": "P268600",
+    "s_dsc": null,
+    "l_dsc": "High-voltage Interlock Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P268700",
+    "s_dsc": null,
+    "l_dsc": "Power Supply Relay Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P268873",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Anode Contactor Sintering"
+  },
+  {
+    "code": null,
+    "dtc": "P268973",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Cathode Contactor Sintering"
+  },
+  {
+    "code": null,
+    "dtc": "P268A00",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Anode Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P268B00",
+    "s_dsc": null,
+    "l_dsc": "DC Charging Cathode Contactor Loop Check Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P268C00",
+    "s_dsc": null,
+    "l_dsc": "Voltage of DC Charging Port Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P268D00",
+    "s_dsc": null,
+    "l_dsc": "Connection Signal of AC Charging Gun Inconsistent"
+  },
+  {
+    "code": null,
+    "dtc": "P268E00",
+    "s_dsc": null,
+    "l_dsc": "Voltage Output at DC Charger Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7000",
+    "s_dsc": null,
+    "l_dsc": "General Fault of Voltage Sampling Wire Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7100",
+    "s_dsc": null,
+    "l_dsc": "Serious Fault of Voltage Sampling Wire Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7200",
+    "s_dsc": null,
+    "l_dsc": "General Fault of Temperature Sampling Wire Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7300",
+    "s_dsc": null,
+    "l_dsc": "Serious Fault of Temperature Sampling Wire Broken"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7400",
+    "s_dsc": null,
+    "l_dsc": "Power battery overcharged"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7516",
+    "s_dsc": null,
+    "l_dsc": "Power Battery Pack Undervoltage"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7517",
+    "s_dsc": null,
+    "l_dsc": "Power Battery Pack Overvoltage"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7900",
+    "s_dsc": null,
+    "l_dsc": "Battery pack charging overcurrent alarm"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7B00",
+    "s_dsc": null,
+    "l_dsc": "Shunt Temperature Generally High"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7C00",
+    "s_dsc": null,
+    "l_dsc": "Shunt Temperature Seriously High"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7D00",
+    "s_dsc": null,
+    "l_dsc": "Temperature Sampling Fault of Shunt"
+  },
+  {
+    "code": null,
+    "dtc": "P2B7E00",
+    "s_dsc": null,
+    "l_dsc": "Large Deviation at Current Sampling of Shunt"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8000",
+    "s_dsc": null,
+    "l_dsc": "HVSU_PACK+ Voltage Sampling Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8100",
+    "s_dsc": null,
+    "l_dsc": "HVSU_LINK+ Voltage Sampling Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8200",
+    "s_dsc": null,
+    "l_dsc": "HVSU_LINK-Voltage Sampling Fault"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8500",
+    "s_dsc": null,
+    "l_dsc": "Power Supply of HVSU Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8A00",
+    "s_dsc": null,
+    "l_dsc": "BIC Configuration Inconsistent with Module State"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8E00",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Undervoltage UV"
+  },
+  {
+    "code": null,
+    "dtc": "P2B8F12",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Overvoltage OV"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9000",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Overcurrent (Contactor Channel)"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9100",
+    "s_dsc": null,
+    "l_dsc": "Abnormal DC charging port voltage"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9200",
+    "s_dsc": null,
+    "l_dsc": "Abnormal battery temperature difference"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9211",
+    "s_dsc": null,
+    "l_dsc": "High Side Short to Ground SC (Contactor Channel)"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9212",
+    "s_dsc": null,
+    "l_dsc": "High Side Short to Power OS (Contactor Channel)"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9213",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Open-circuited"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9219",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Overcurrent (HVSU Channel)"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9298",
+    "s_dsc": null,
+    "l_dsc": "High Side Drive Overtemperature"
+  },
+  {
+    "code": null,
+    "dtc": "P2B9400",
+    "s_dsc": null,
+    "l_dsc": "Power Battery Overdischarge"
+  },
+  {
+    "code": null,
+    "dtc": "U011000",
+    "s_dsc": null,
+    "l_dsc": "Communication with Motor Control Unit Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U011100",
+    "s_dsc": null,
+    "l_dsc": "Communication with BMC Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U011181",
+    "s_dsc": null,
+    "l_dsc": "Message Data of BMC Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U011182",
+    "s_dsc": null,
+    "l_dsc": "Cycle Counter of BMC Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U011187",
+    "s_dsc": null,
+    "l_dsc": "Communication with Battery Management System (BMS) Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U012187",
+    "s_dsc": null,
+    "l_dsc": "Communication with ABS Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U014081",
+    "s_dsc": null,
+    "l_dsc": "Message Data of BCM Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U014087",
+    "s_dsc": null,
+    "l_dsc": "Communication with BCM Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U014187",
+    "s_dsc": null,
+    "l_dsc": "Communication fault with the complete bus controller"
+  },
+  {
+    "code": null,
+    "dtc": "U0146",
+    "s_dsc": null,
+    "l_dsc": "Communication between Instrument and Gateway Interrupted"
+  },
+  {
+    "code": null,
+    "dtc": "U014B87",
+    "s_dsc": null,
+    "l_dsc": "Communication with DC Charging Cabinet Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U014E87",
+    "s_dsc": null,
+    "l_dsc": "Communication with Security Gateway Module Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U015129",
+    "s_dsc": null,
+    "l_dsc": "Motor Control Module Receiving SRS ,CAN Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U015229",
+    "s_dsc": null,
+    "l_dsc": "Motor Control Module Receiving SRS Hardwire Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U015500",
+    "s_dsc": null,
+    "l_dsc": "Communication Timeout at Combination Instrument"
+  },
+  {
+    "code": null,
+    "dtc": "U015587",
+    "s_dsc": null,
+    "l_dsc": "Communication with Combination Instrument Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U015887",
+    "s_dsc": null,
+    "l_dsc": "Communication with ESP Lost -TRW"
+  },
+  {
+    "code": null,
+    "dtc": "U015987",
+    "s_dsc": null,
+    "l_dsc": "Communication with VTOG Lost -TRW"
+  },
+  {
+    "code": null,
+    "dtc": "U015A38",
+    "s_dsc": null,
+    "l_dsc": "Main/Auxiliary/Torque Signal Period Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U015B02",
+    "s_dsc": null,
+    "l_dsc": "Duty Cycle of Main/Auxiliary Angle Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U015D86",
+    "s_dsc": null,
+    "l_dsc": "Angle signal not available"
+  },
+  {
+    "code": null,
+    "dtc": "U015E31",
+    "s_dsc": null,
+    "l_dsc": "Motor Rotor Position Signal Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U015F86",
+    "s_dsc": null,
+    "l_dsc": "Received ESP Signal Not Available"
+  },
+  {
+    "code": null,
+    "dtc": "U016002",
+    "s_dsc": null,
+    "l_dsc": "Duty Cycle of Main/Auxiliary/Main+Auxiliary Torque Signal Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U0164",
+    "s_dsc": null,
+    "l_dsc": "Communication with Air Conditioning System Lost"
+  },
+  {
+    "code": null,
+    "dtc": "U016400",
+    "s_dsc": null,
+    "l_dsc": "Communication with Air Conditioner Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U016487",
+    "s_dsc": null,
+    "l_dsc": "Communication with Air Conditioner Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U018087",
+    "s_dsc": null,
+    "l_dsc": "Communication with High-side Drive Lost"
+  },
+  {
+    "code": null,
+    "dtc": "U019780",
+    "s_dsc": null,
+    "l_dsc": "Communication with Intelligent Power Brake Control Module Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U01A500",
+    "s_dsc": null,
+    "l_dsc": "Communication with Front Motor Motor Control Unit (FMCU) Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U0245",
+    "s_dsc": null,
+    "l_dsc": "Communication between Instrument Panel and Multimedia Interrupted"
+  },
+  {
+    "code": null,
+    "dtc": "U024500",
+    "s_dsc": null,
+    "l_dsc": "Communication Timeout at Multimedia"
+  },
+  {
+    "code": null,
+    "dtc": "U024582",
+    "s_dsc": null,
+    "l_dsc": "Message Data of Multimedia Abnormal"
+  },
+  {
+    "code": null,
+    "dtc": "U024C87",
+    "s_dsc": null,
+    "l_dsc": "Communication with I-KEY Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U024E87",
+    "s_dsc": null,
+    "l_dsc": "Communication with ESC Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U025387",
+    "s_dsc": null,
+    "l_dsc": "Communication with compressor lost"
+  },
+  {
+    "code": null,
+    "dtc": "U027E01",
+    "s_dsc": null,
+    "l_dsc": "BIC1 Cascade Communication Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U027E02",
+    "s_dsc": null,
+    "l_dsc": "BIC2 Cascade Communication Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U027E03",
+    "s_dsc": null,
+    "l_dsc": "BIC3 Cascade Communication Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U027E04",
+    "s_dsc": null,
+    "l_dsc": "BIC4 Cascade Communication Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U027E05",
+    "s_dsc": null,
+    "l_dsc": "BIC5 Cascade Communication Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U027E06",
+    "s_dsc": null,
+    "l_dsc": "BIC6 Cascade Communication Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U027E07",
+    "s_dsc": null,
+    "l_dsc": "BIC7 Cascade Communication Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U027E08",
+    "s_dsc": null,
+    "l_dsc": "BIC8 Cascade Communication Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U029187",
+    "s_dsc": null,
+    "l_dsc": "Communication with Gear Control Module Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U029787",
+    "s_dsc": null,
+    "l_dsc": "Communication with On-board Charger Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U029800",
+    "s_dsc": null,
+    "l_dsc": "Communication between Battery Manager System and DC Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U029887",
+    "s_dsc": null,
+    "l_dsc": "Communication with DC Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U029F87",
+    "s_dsc": null,
+    "l_dsc": "Communication with OBC Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U02A200",
+    "s_dsc": null,
+    "l_dsc": "Communication with Active Release Module Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U02B087",
+    "s_dsc": null,
+    "l_dsc": "Lost Communication with Humidity Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "U030000",
+    "s_dsc": null,
+    "l_dsc": "ECU Internal Control Module Software Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U043204",
+    "s_dsc": null,
+    "l_dsc": "Communication Timeout at Yaw Rate Sensor"
+  },
+  {
+    "code": null,
+    "dtc": "U1101",
+    "s_dsc": null,
+    "l_dsc": "Communication between Instrument and Combination Switch Interrupted"
+  },
+  {
+    "code": null,
+    "dtc": "U110287",
+    "s_dsc": null,
+    "l_dsc": "Communication with BCM Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U1103",
+    "s_dsc": null,
+    "l_dsc": "Communication between Instrument and SRS Interrupted"
+  },
+  {
+    "code": null,
+    "dtc": "U110387",
+    "s_dsc": null,
+    "l_dsc": "Communication with Airbag ECU Failed"
+  },
+  {
+    "code": null,
+    "dtc": "U20B000",
+    "s_dsc": null,
+    "l_dsc": "BIC1 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B100",
+    "s_dsc": null,
+    "l_dsc": "BIC2 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B200",
+    "s_dsc": null,
+    "l_dsc": "BIC3 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B300",
+    "s_dsc": null,
+    "l_dsc": "BIC4 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B400",
+    "s_dsc": null,
+    "l_dsc": "BIC5 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B500",
+    "s_dsc": null,
+    "l_dsc": "BIC6 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B600",
+    "s_dsc": null,
+    "l_dsc": "BIC7 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B700",
+    "s_dsc": null,
+    "l_dsc": "BIC8 CAN Communication Timeout"
+  },
+  {
+    "code": null,
+    "dtc": "U20B800",
+    "s_dsc": null,
+    "l_dsc": "BIC9 CAN Communication Timeout Fault"
+  },
+  {
+    "code": null,
+    "dtc": "U300000",
+    "s_dsc": null,
+    "l_dsc": "Microprocessor Error in ECU"
+  },
+  {
+    "code": null,
+    "dtc": "U300316",
+    "s_dsc": null,
+    "l_dsc": "Battery Soft Undervoltage Fault(independent)"
+  },
+  {
+    "code": null,
+    "dtc": "U300317",
+    "s_dsc": null,
+    "l_dsc": "Battery Soft Overvoltage Fault(independent)"
+  }
+]


### PR DESCRIPTION
### What
A DTC list of codes for BYD Atto 3

### Why
Offer future decoding of DTC's as per other vehicles

### How
Adds byd_atto3_dtc.json into repo location as per other manufacturers.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
