### PR TITLE
Safety: add 20 mV hysteresis to per-cell overvoltage charge cut

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -16,6 +16,7 @@ static bool battery_empty_event_fired = false;
 #define LOWEST_ALLOWED_CELLVOLTAGE_RECOVERY_CHARGE_MV 2000  //If cells are below this, recovery charge not allowed
 #define MAX_CHARGEPOWER_RECOVERY_CHARGE_DA 50
 #define HYSTERESIS_OFFSET_DV 20
+#define CELL_HYSTERESIS_MV 20  // Re-allow charge only once max cell drops this far below limit (avoids chatter at knee)
 
 //battery pause status begin
 bool emulator_pause_request_ON = false;
@@ -114,8 +115,15 @@ void update_machineryprotection() {
     }
 
     // Cell overvoltage, further charging not possible. Battery might be imbalanced.
+    static bool cell_overvoltage_charge_blocked = false;
     if (datalayer.battery.status.cell_max_voltage_mV >= datalayer.battery.info.max_cell_voltage_mV) {
       set_event(EVENT_CELL_OVER_VOLTAGE, 0);
+      cell_overvoltage_charge_blocked = true;  // Latch at the ceiling
+    } else if (datalayer.battery.status.cell_max_voltage_mV <
+               (datalayer.battery.info.max_cell_voltage_mV - CELL_HYSTERESIS_MV)) {
+      cell_overvoltage_charge_blocked = false;  // Release only once well below the ceiling
+    }
+    if (cell_overvoltage_charge_blocked) {
       datalayer.battery.status.max_charge_power_W = 0;
     }
     // Cell CRITICAL overvoltage, critical latching error without automatic reset. Requires user action to inspect battery.


### PR DESCRIPTION
### What
Add 20 mV hysteresis to the per-cell overvoltage charge cut in safety.cpp.

### Why
The cut zeroed charge power the instant cell_max ≥ max_cell_voltage and re-allowed it the moment it dipped below — so when a pack is held at the cell ceiling, charge toggles on/off every cycle (start/stop chatter). The pack-voltage limit right below it already uses hysteresis; the per-cell cut didn't. Applies to every battery, not just one chemistry.

### How
Latch a cell_overvoltage_charge_blocked flag when the cell hits the limit, and only release it once the max cell drops a full 20 mV below the limit — mirroring the existing HYSTERESIS_OFFSET_DV pattern for the user-set pack limit. While latched, charge power is held at 0. The CRITICAL latching event and the warning event itself are unchanged.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
