### PR TITLE
EOTA: pause battery before restarting

### DIFF
--- a/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
+++ b/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
@@ -1,5 +1,7 @@
 #include "ElegantOTA.h"
 
+#include "../../../devboard/safety/safety.h"
+
 ElegantOTAClass::ElegantOTAClass(){}
 
 void ElegantOTAClass::begin(ELEGANTOTA_WEBSERVER *server){
@@ -57,6 +59,8 @@ void ElegantOTAClass::begin(ELEGANTOTA_WEBSERVER *server){
         request->send(response);
         // Set reboot flag
         if (!Update.hasError()) {
+            // Stop current flow as the reboot will open contactors
+            setBatteryPause(true, false, false, false);
             _reboot_request_millis = millis();
             _reboot = true;
         }


### PR DESCRIPTION
### What
It seems that the automatic reboot after an OTA upgrade doesn't pause the inverter, so can open contactors under load if you don't manually pause first.

(Unless I've misunderstood how it works).

Now pauses before the 2 second delay until it reboots.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
