### PR TITLE
Testing: Stark 2xFD + 3rd battery

### DIFF
--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -57,17 +57,10 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_35; }
   virtual uint32_t MCP2517_FREQ() { return 40000000; }
 
-  // CAN_ADDON
-  // SCK input of MCP2515
-  virtual gpio_num_t MCP2515_SCK() { return GPIO_NUM_14; }
-  // SDI input of MCP2515
-  virtual gpio_num_t MCP2515_MOSI() { return GPIO_NUM_12; }
-  // SDO output of MCP2515
-  virtual gpio_num_t MCP2515_MISO() { return GPIO_NUM_34; }
-  // CS input of MCP2515
-  virtual gpio_num_t MCP2515_CS() { return GPIO_NUM_15; }
-  // INT output of MCP2515
-  virtual gpio_num_t MCP2515_INT() { return GPIO_NUM_13; }
+  // MCP2518FD add-on via the GPIO pins
+  // SPI Bus is shared with the 1st interface, only INT and CS pins are needed
+  virtual gpio_num_t MCP2517_CS2() { return GPIO_NUM_12; }
+  virtual gpio_num_t MCP2517_INT2() { return GPIO_NUM_14; }
 
   // Contactor handling
   virtual gpio_num_t POSITIVE_CONTACTOR_PIN() { return GPIO_NUM_32; }
@@ -79,7 +72,7 @@ class StarkHal : public Esp32Hal {
     return GPIO_NUM_25;
   }
   virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_19; }
-  virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_NC; }
+  virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_15; }
   virtual gpio_num_t BMS_POWER() {
     if (user_selected_gpioopt5 == GPIOOPT5::BMS_POWER_25) {
       return GPIO_NUM_25;
@@ -117,9 +110,11 @@ class StarkHal : public Esp32Hal {
       case comm_interface::CanFdNative:
         return "CAN FD 2 (Native)";
       case comm_interface::CanAddonMcp2515:
-        return "MCP2515 (GPIO add-on)";
+        return "";
       case comm_interface::CanFdAddonMcp2518:
         return "";
+      case comm_interface::CanFdAddonMcp2518_2:
+        return "MCP2518FD (GPIO add-on)";
       case comm_interface::Modbus:
         return "Modbus";
       case comm_interface::RS485:

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -999,15 +999,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       %GPIOOPT1%
     </select>
   )rawliteral"
-#define CANFD2ASCAN_SETTING \
-  R"rawliteral(
-    <label>Use CanFD2 as classic CAN: </label>
-    <input type='checkbox' name='CANFD2ASCAN' value='on' %CANFD2ASCAN% 
-    title="When enabled, CAN-FD channel will operate as normal 500kbps CAN" />
-  )rawliteral"
 #else
 #define GPIOOPT1_SETTING ""
-#define CANFD2ASCAN_SETTING ""
 #endif
 
 #ifdef HW_LILYGO
@@ -1068,6 +1061,17 @@ const char* getCANInterfaceName(CAN_Interface interface) {
   )rawliteral"
 #else
 #define GPIOOPT6_SETTING ""
+#endif
+
+#if defined(HW_LILYGO2CAN) || defined(HW_STARK)
+#define CANFD2ASCAN_SETTING \
+  R"rawliteral(
+    <label>Use CanFD2 as classic CAN: </label>
+    <input type='checkbox' name='CANFD2ASCAN' value='on' %CANFD2ASCAN% 
+    title="When enabled, CAN-FD channel will operate as normal 500kbps CAN" />
+  )rawliteral"
+#else
+#define CANFD2ASCAN_SETTING ""
 #endif
 
 #define SETTINGS_HTML_SCRIPTS \


### PR DESCRIPTION
### What
This builds on the 2CAN-FD PR and adds the option for a second FD interface on Stark over GPIO. It also allocates a third-battery-contactor GPIO.

Pins:
SCK: 17
SDI/MOSI: 5
SDO/MISO: 34
CS: 12
INT: 14
3rd-battery: 15

This will need tidying/rebasing once the 2CAN-FD PR is merged.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
