### PR TITLE
Safety :warning:  Don't engage contactors before battery communication established

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -207,8 +207,8 @@ void handle_contactors() {
 
     currentTime = millis();
 
-    if (currentTime < INTERVAL_10_S) {
-      // Skip running the state machine before system has started up.
+    if ((currentTime < INTERVAL_10_S) || !battery_detected) {
+      // Skip running the state machine before system has started up. Conditions are 10sec post boot, and battery comms established
       // Gives the system some time to detect any faults from battery before blindly just engaging the contactors
       return;
     }

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -16,6 +16,8 @@ extern battery_pause_status emulator_pause_status;
 extern bool allowed_to_send_CAN;
 //battery pause status end
 
+extern bool battery_detected;
+
 extern void store_settings_equipment_stop();
 
 void update_machineryprotection();


### PR DESCRIPTION
### What
This PR makes the contactor control wait until battery communications has been established

### Why
Previous integration had a safety oversight. If you boot the system without CAN to battery, the contactors will incorrectly engage after 10 seconds, and dis-engage after 1 minute has passed and the system notices CAN is down towards batterty

### How
Instead we now wait until we have confirmation that battery communication is UP, before we start the contactor statemachine

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
