### PR TITLE
BMW SBOX: Speed up CAN sending from 20 to 10ms

### DIFF
--- a/Software/src/battery/BMW-SBOX.cpp
+++ b/Software/src/battery/BMW-SBOX.cpp
@@ -76,9 +76,10 @@ void BmwSbox::transmit_can(unsigned long currentMillis) {
   } else {
     datalayer.shunt.available = true;
   }
-  // Send 20ms CAN Message
-  if (currentMillis - LastMsgTime >= INTERVAL_20_MS) {
-    LastMsgTime = currentMillis;
+
+  // Send 10ms CAN Message
+  if (currentMillis - previousMillis10 >= INTERVAL_10_MS) {
+    previousMillis10 = currentMillis;
     // First check if we have any active errors, incase we do, turn off the battery
     if (datalayer.system.status.system_status == FAULT) {
       timeSpentInFaultedMode++;

--- a/Software/src/battery/BMW-SBOX.h
+++ b/Software/src/battery/BMW-SBOX.h
@@ -31,7 +31,7 @@ class BmwSbox : public CanShunt {
       5000;  // Precharge time before precharge resistor is bypassed by positive contactor
   static const int CONTACTOR_CONTROL_T3 = 2000;  // Precharge relay lead time after positive contactor has been engaged
 
-  static const int MAX_ALLOWED_FAULT_TICKS = 1000;
+  static const int MAX_ALLOWED_FAULT_TICKS = 2000;
 
   enum SboxState { DISCONNECTED, PRECHARGE, NEGATIVE, POSITIVE, PRECHARGE_OFF, COMPLETED, SHUTDOWN_REQUESTED };
   SboxState contactorStatus = DISCONNECTED;
@@ -40,8 +40,8 @@ class BmwSbox : public CanShunt {
   unsigned long negativeStartTime = 0;
   unsigned long positiveStartTime = 0;
   unsigned long timeSpentInFaultedMode = 0;
-  unsigned long LastMsgTime = 0;  // will store last time a 20ms CAN Message was send
-  unsigned long LastAvgTime = 0;  // Last current storage time
+  unsigned long previousMillis10 = 0;  // will store last time a 10ms CAN Message was send
+  unsigned long LastAvgTime = 0;       // Last current storage time
   unsigned long ShuntLastSeen = 0;
 
   uint32_t avg_mA_array[10];


### PR DESCRIPTION
### What
This PR implements ...

### Why
Why does it do it?

### How
ZombieVerter sends sbox control every 10ms, we now do the same

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
