### PR TITLE
Add SMA contactor input for Waveshare

### DIFF
--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -40,11 +40,14 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
 
   // Battery wake up pins
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_8; }
-  virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_9; }
+  virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_9; }  //Collides with SMA contactor input
 
   // Automatic precharging
   virtual gpio_num_t HIA4V1_PIN() { return GPIO_NUM_5; }
   virtual gpio_num_t INVERTER_DISCONNECT_CONTACTOR_PIN() { return GPIO_NUM_3; }
+
+  // SMA CAN contactor pins (collides with WUP2)
+  virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_PIN() { return GPIO_NUM_9; }
 
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {


### PR DESCRIPTION
### What
This PR implements HAL definition for SMA contactor input when using Waveshare S3 board

### Why
Fixes #2445

### How
Defined to GPIO 9

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
