### PR TITLE
Nissan LEAF: Skip reading temperatures until both min&max is available on AZE0

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -49,10 +49,13 @@ void NissanLeafBattery::
     datalayer_battery->status.temperature_max_dC = (battery_AverageTemperature * 10);  //Increase range from C to C+1
   } else if (LEAF_battery_Type == AZE0_BATTERY) {
     //Use the value sent constantly via CAN in 5C0 (only available on AZE0)
-    datalayer_battery->status.temperature_min_dC =
-        (battery_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
-    datalayer_battery->status.temperature_max_dC =
-        (battery_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
+    //Only update when both values have been read from the muxed message
+    if ((battery_HistData_Temperature_MIN != 86) && (battery_HistData_Temperature_MAX != 86)) {
+      datalayer_battery->status.temperature_min_dC =
+          (battery_HistData_Temperature_MIN * 10);  //Increase range from C to C+1
+      datalayer_battery->status.temperature_max_dC =
+          (battery_HistData_Temperature_MAX * 10);  //Increase range from C to C+1
+    }
   } else {  // ZE1 (TODO: Once the muxed value in 5C0 becomes known, switch to using that instead of this complicated polled value)
     if (battery_temp_raw_min != 0)  //We have a polled value available
     {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -160,15 +160,15 @@ class NissanLeafBattery : public CanBattery {
   uint16_t battery_Wh_Remaining = 0;           //Amount of energy in battery, in Wh
   uint16_t battery_GIDS = 273;                 //Startup in 24kWh mode
   uint16_t battery_MAX = 0;
-  uint16_t battery_Max_GIDS = 273;               //Startup in 24kWh mode
-  uint16_t battery_StateOfHealth = 99;           //State of health %
-  uint16_t battery_Total_Voltage2 = 740;         //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
-  int16_t battery_Current2 = 0;                  //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
-  int16_t battery_HistData_Temperature_MAX = 6;  //-40 to 86*C
-  int16_t battery_HistData_Temperature_MIN = 5;  //-40 to 86*C
-  int16_t battery_AverageTemperature = 6;        //Only available on ZE0, in celcius, -40 to +55
-  uint8_t battery_Relay_Cut_Request = 0;         //battery_FAIL
-  uint8_t battery_Failsafe_Status = 0;           //battery_STATUS
+  uint16_t battery_Max_GIDS = 273;                //Startup in 24kWh mode
+  uint16_t battery_StateOfHealth = 99;            //State of health %
+  uint16_t battery_Total_Voltage2 = 740;          //Battery voltage (0-450V) [0.5V/bit, so actual range 0-800]
+  int16_t battery_Current2 = 0;                   //Battery current (-400-200A) [0.5A/bit, so actual range -800-400]
+  int16_t battery_HistData_Temperature_MAX = 86;  //-40 to 86*C
+  int16_t battery_HistData_Temperature_MIN = 86;  //-40 to 86*C
+  int16_t battery_AverageTemperature = 6;         //Only available on ZE0, in celcius, -40 to +55
+  uint8_t battery_Relay_Cut_Request = 0;          //battery_FAIL
+  uint8_t battery_Failsafe_Status = 0;            //battery_STATUS
   bool battery_Interlock =
       true;  //Contains info on if HV leads are seated (Note, to use this both HV connectors need to be inserted)
   bool battery_Full_CHARGE_flag = false;  //battery_FCHGEND , Goes to 1 if battery is fully charged


### PR DESCRIPTION
### What
This PR skips reading temperatures until both min&max is available on AZE0 LEAF

### Why
On AZE0 the value is fetched from 0x5C0 message that is multiplexed, so it can take a long time to  get both min&max.
When ambient temperatures are close to 30*C, the default startup value can make the software incorrectly flag a BATTERY_TEMP_DEVIATION_HIGH event on poweron

### How
We wait until both values are available until we take them into use

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
