### PR TITLE
Feature/bmw i3 protocol improvement.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ compile.bat
 
 # Ignore secret file
 USER_SECRETS.h
+
+# Ignore generated ESP-IDF component manifest
+Software/idf_component.yml

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -362,28 +362,28 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
 
   // Run balancing shutdown sequence (0x12F byte3 transition)
   if (balancing_mode_active && !can_communication_stopped) {
-    unsigned long elapsed = currentMillis - balancing_start_time;
+    unsigned long elapsed_time = currentMillis - balancing_start_time;
 
     // Update 0x12F byte3 based on elapsed time
     BMW_12F.data.u8[3] = BMW_12F_BYTE3_ACTIVE;  // Start value (DD)
     for (int i = BALANCING_12F_STEPS - 1; i >= 0; i--) {
-      if (elapsed >= balancing_12F_times[i]) {
+      if (elapsed_time >= balancing_12F_times[i]) {
         BMW_12F.data.u8[3] = balancing_12F_values[i];
         break;
       }
     }
 
     // Transition states based on elapsed time
-    if (UserRequestBalancing == REQUESTED && elapsed >= 20000) {
+    if (UserRequestBalancing == REQUESTED && elapsed_time >= 20000) {
       UserRequestBalancing = STARTING;
     }
-    if (UserRequestBalancing == STARTING && elapsed >= 30000) {
+    if (UserRequestBalancing == STARTING && elapsed_time >= INTERVAL_30_S) {
       UserRequestBalancing = EXECUTING;
       set_event(EVENT_BALANCING_START, 0);
     }
 
     // Stop all CAN communication after ~96s (battery sleeps), ~42s after contactors open
-    if (elapsed >= BALANCING_CAN_STOP_DELAY_MS) {
+    if (elapsed_time >= BALANCING_CAN_STOP_DELAY_MS) {
       can_communication_stopped = true;
       battery_awake = false;  // Battery is sleeping, must re-detect on wakeup via 0x112
     }

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -5,6 +5,7 @@
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/common_functions.h"  //For CRC table
 #include "../devboard/utils/events.h"
+#include "../devboard/utils/logging.h"
 
 /* Do not change code below unless you are sure what you are doing */
 
@@ -32,6 +33,9 @@ void BmwI3Battery::initiate_balancing() {
 void BmwI3Battery::end_balancing() {
   UserRequestBalancing = NONE;
   UserRequestBalancingMillis = 0;
+  balancing_mode_active = false;
+  can_communication_stopped = false;
+  BMW_12F.data.u8[3] = BMW_12F_BYTE3_ACTIVE;  // Restore active state
   cmdState = SOC;
   battery_info_available = false;
   set_event(EVENT_BALANCING_END, 0);
@@ -49,6 +53,9 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
   // so the safety check (EVENT_CAN_BATTERY_MISSING) does not trigger
   if (UserRequestBalancing == EXECUTING) {
     datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+    datalayer.system.status.system_status = STANDBY;
+    // During balancing sleep, report contactors as open so an old engaged state is not latched.
+    datalayer.system.status.contactors_engaged = 0;
   }
 
   // Map internal balancing state to datalayer balancing_status
@@ -117,6 +124,23 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
     set_event(EVENT_CONTACTOR_WELDED, 0);
   } else {
     clear_event(EVENT_CONTACTOR_WELDED);
+  }
+
+  // Map BMW I3 DC switch status to system datalayer
+  // battery_status_disconnecting_switch: 0=open, 1=precharge ongoing, 2=contactors engaged, 3=invalid
+  switch (battery_status_disconnecting_switch) {
+    case 0:  // Contactors open
+      datalayer.system.status.contactors_engaged = 0;
+      break;
+    case 1:  // Precharge ongoing
+      datalayer.system.status.contactors_engaged = 3;
+      break;
+    case 2:  // Contactors engaged
+      datalayer.system.status.contactors_engaged = 1;
+      break;
+    default:  // Invalid signal - treat as open
+      datalayer.system.status.contactors_engaged = 0;
+      break;
   }
 }
 
@@ -235,6 +259,19 @@ void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_status_service_disconnection_plug = (rx_frame.data.u8[0] & 0x0F);
       battery_status_measurement_isolation = (rx_frame.data.u8[0] & 0x0C) >> 2;
       battery_request_abort_charging = (rx_frame.data.u8[0] & 0x30) >> 4;
+      // Log the moment the battery reports charge-finished (RQ_ABRT_CHGNG becomes 1 = "Request to
+      // interrupt charging"). This is the signal that ends auto-/manual calibration and drives SOC to
+      // 100%. Only value 1 is a real request - 2 (cooling) and 3 (invalid) are ignored to avoid
+      // spurious stops on transient/invalid frames.
+      if (battery_request_abort_charging == 1 && previous_request_abort_charging != 1) {
+        logging.print("BMW i3: Battery reports charge-finished (abort charging = ");
+        logging.print(battery_request_abort_charging);
+        logging.print("). Reported SOC = ");
+        logging.print(battery_display_SOC *
+                      0.5);  // display SOC * 0.5 = display/reported SOC in percent (display SOC * 50 = 0.01% units)
+        logging.println(" %");
+      }
+      previous_request_abort_charging = battery_request_abort_charging;
       battery_prediction_duration_charging_minutes = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);
       battery_prediction_time_end_of_charging_minutes = rx_frame.data.u8[4];
       battery_energy_content_maximum_Wh = (((rx_frame.data.u8[6] & 0x0F) << 8) | rx_frame.data.u8[5]) * 20;
@@ -321,12 +358,72 @@ void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
 void BmwI3Battery::transmit_can(unsigned long currentMillis) {
 
-  if (battery_awake) {
-    //Send 20ms message
+  // Handle balancing mode request - simulates real car shutdown sequence from discharge log
+  // (timed from balancing start = 0x3E9 byte2 -> 0x41, the charge-finished signal):
+  // t=0s:   0x12F byte3 begins sequence DD->6D->5D->5C->4C->3C->2C->1C->1A (~5s)
+  // t=54s:  0x10B contactor opens (byte1 high nibble 1->0)
+  // t=96s:  All CAN communication stops (battery goes to sleep)
+  if (UserRequestBalancing != NONE && !balancing_mode_active) {
+    balancing_mode_active = true;
+    balancing_start_time = currentMillis;
+    can_communication_stopped = false;
+    cmdState = OFF;
+  } else if (UserRequestBalancing == NONE && balancing_mode_active) {
+    // Resume: already handled in end_balancing(), just ensure flags are consistent
+    balancing_mode_active = false;
+    can_communication_stopped = false;
+  }
+
+  // Run balancing shutdown sequence (0x12F byte3 transition)
+  if (balancing_mode_active && !can_communication_stopped) {
+    unsigned long elapsed = currentMillis - balancing_start_time;
+
+    // Update 0x12F byte3 based on elapsed time
+    BMW_12F.data.u8[3] = BMW_12F_BYTE3_ACTIVE;  // Start value (DD)
+    for (int i = BALANCING_12F_STEPS - 1; i >= 0; i--) {
+      if (elapsed >= balancing_12F_times[i]) {
+        BMW_12F.data.u8[3] = balancing_12F_values[i];
+        break;
+      }
+    }
+
+    // Transition states based on elapsed time
+    if (UserRequestBalancing == REQUESTED && elapsed >= 20000) {
+      UserRequestBalancing = STARTING;
+    }
+    if (UserRequestBalancing == STARTING && elapsed >= 30000) {
+      UserRequestBalancing = EXECUTING;
+      set_event(EVENT_BALANCING_START, 0);
+    }
+
+    // Stop all CAN communication after ~96s (battery sleeps), ~42s after contactors open
+    if (elapsed >= BALANCING_CAN_STOP_DELAY_MS) {
+      can_communication_stopped = true;
+      battery_awake = false;  // Battery is sleeping, must re-detect on wakeup via 0x112
+    }
+  }
+
+  // Don't send any CAN when communication is stopped (battery sleeping)
+  if (can_communication_stopped) {
+    return;
+  }
+
+  // Keep transmitting during the whole balancing shutdown sequence even after
+  // battery_awake flips false at EXECUTING - the real car keeps sending 0x10B
+  // (with contactors open) and all keepalive frames until CAN stops at ~96s.
+  if (battery_awake || balancing_mode_active) {
+    // Send 20ms message
     if (currentMillis - previousMillis20 >= INTERVAL_20_MS) {
       previousMillis20 = currentMillis;
 
-      if (datalayer.system.status.system_status == FAULT) {
+      // Contactor control: open ~54 seconds after balancing start (charge-finished signal)
+      // Until then, contactors stay closed (matches real car discharge log)
+      bool contactors_should_open =
+          balancing_mode_active && (currentMillis - balancing_start_time >= BALANCING_CONTACTOR_DELAY_MS);
+
+      if (contactors_should_open) {
+        BMW_10B.data.u8[1] = 0x00;  // Open contactors - balancing shutdown sequence
+      } else if (datalayer.system.status.system_status == FAULT) {
         BMW_10B.data.u8[1] = 0x00;  // Keep contactors open - fault condition
       } else if (startup_counter_contactor < 160) {
         startup_counter_contactor++;
@@ -348,7 +445,7 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
       BMW_13E.data.u8[4] = BMW_13E_counter;
 
       if (allows_contactor_closing) {
-        *allows_contactor_closing = true;
+        *allows_contactor_closing = !contactors_should_open;
       }
       transmit_can_frame(&BMW_10B);  // Always send 10B - content (0x00/0x10) controlled by logic above
     }
@@ -357,11 +454,15 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
     if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
       previousMillis100 = currentMillis;
 
+      // Always operate the BMW i3 in Charge/Calibration mode (0x35).
+      BMW_12F.data.u8[5] = 0x35;  // Charge/Calibration mode
+
       BMW_12F.data.u8[1] = ((BMW_12F.data.u8[1] & 0xF0) + alive_counter_100ms);
       BMW_12F.data.u8[0] = calculateCRC(BMW_12F, 8, 0x60);
 
       alive_counter_100ms = increment_alive_counter(alive_counter_100ms);
 
+      transmit_can_frame(&BMW_108);  // Actual Charging Electronics Data
       transmit_can_frame(&BMW_12F);
     }
     // Send 200ms CAN Message
@@ -373,39 +474,46 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
 
       alive_counter_200ms = increment_alive_counter(alive_counter_200ms);
 
-      transmit_can_frame(&BMW_19B);
-
-      if (UserRequestBalancing != NONE && battery_info_available) {
-        switch (detectedBattery) {
-          case BATTERY_60AH:
-            transmit_can_frame(&BMW_3E9);
-            break;
-          case BATTERY_94AH:
-            BMW_3E9.data.u8[0] = 0x0B;
-            BMW_3E9.data.u8[1] = 0x81;
-            transmit_can_frame(&BMW_3E9);
-            break;
-          case BATTERY_120AH:
-            BMW_3E9.data.u8[0] = 0xD8;
-            BMW_3E9.data.u8[1] = 0xA4;
-            transmit_can_frame(&BMW_3E9);
-            break;
-        }
-
-        cmdState = OFF;
-        if (UserRequestBalancing == REQUESTED && currentMillis - UserRequestBalancingMillis > 20000) {
-          UserRequestBalancing = STARTING;
-        }
-        if (UserRequestBalancing == STARTING && currentMillis - UserRequestBalancingMillis > 30000) {
-          battery_awake = false;
-          UserRequestBalancing = EXECUTING;
-          set_event(EVENT_BALANCING_START, 0);
-        }
-        if (UserRequestBalancing == EXECUTING && battery_awake) {
-          set_event(EVENT_BALANCING_START, 1);
-          battery_awake = false;
-        }
+      // Set BMW_3E9 byte0/byte1 based on battery type, byte2 based on balancing state
+      switch (detectedBattery) {
+        case BATTERY_94AH:
+          BMW_3E9.data.u8[0] = 0x0B;
+          BMW_3E9.data.u8[1] = 0x81;
+          break;
+        case BATTERY_120AH:
+          BMW_3E9.data.u8[0] = 0xD8;
+          BMW_3E9.data.u8[1] = 0xA4;
+          break;
+        default:  // BATTERY_60AH
+          BMW_3E9.data.u8[0] = 0x08;
+          BMW_3E9.data.u8[1] = 0x52;
+          break;
       }
+      // byte2 = Chg_Status_Info (high nibble) | Charge_Req (low nibble), per DBC AEMsg3E9:
+      // byte3/byte4 carry Chg_Readiness (byte3 bit0-1) and Charging_Pwr (byte3 bit4-7 + byte4, *25 W).
+      if (balancing_mode_active) {
+        BMW_3E9.data.u8[2] = 0x41;  // Charge_complete + PlugCharge (we start the shutdown/balancing)
+        BMW_3E9.data.u8[3] = 0x00;
+        BMW_3E9.data.u8[4] = 0x00;
+      } else {
+        BMW_3E9.data.u8[2] = 0x21;  // Charge_active + PlugCharge (always in charging / calibration mode)
+        // Charging_Pwr = the battery's own measured charging power (active_power_W, positive = charging),
+        // a 12-bit field at 25 W/bit spread over byte3 bit4-7 (low nibble) + byte4 (high 8 bits).
+        // byte3 bit0-1 keeps Chg_Readiness=Ready (0x1).
+        int32_t charge_power_W = datalayer_battery ? datalayer_battery->status.active_power_W : 0;
+        if (charge_power_W < 0) {
+          charge_power_W = 0;  // Only report charging power; clamp discharge/idle to zero
+        }
+        uint16_t charge_pwr_raw = charge_power_W / 25;  // 25 W per bit
+        if (charge_pwr_raw > 0x0FFF) {
+          charge_pwr_raw = 0x0FFF;  // Saturate to the 12-bit field
+        }
+        BMW_3E9.data.u8[3] = 0x01 | ((charge_pwr_raw & 0x0F) << 4);  // Chg_Readiness=Ready + Charging_Pwr low nibble
+        BMW_3E9.data.u8[4] = (charge_pwr_raw >> 4) & 0xFF;           // Charging_Pwr high bits
+      }
+
+      transmit_can_frame(&BMW_3E9);  // Load Status
+      transmit_can_frame(&BMW_19B);
     }
     // Send 500ms CAN Message
     if (currentMillis - previousMillis500 >= INTERVAL_500_MS) {
@@ -416,6 +524,7 @@ void BmwI3Battery::transmit_can(unsigned long currentMillis) {
 
       alive_counter_500ms = increment_alive_counter(alive_counter_500ms);
 
+      transmit_can_frame(&BMW_19E);  // Subsystems Control
       transmit_can_frame(&BMW_30B);
     }
     // Send 640ms CAN Message

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -5,7 +5,6 @@
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/common_functions.h"  //For CRC table
 #include "../devboard/utils/events.h"
-#include "../devboard/utils/logging.h"
 
 /* Do not change code below unless you are sure what you are doing */
 
@@ -259,19 +258,6 @@ void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_status_service_disconnection_plug = (rx_frame.data.u8[0] & 0x0F);
       battery_status_measurement_isolation = (rx_frame.data.u8[0] & 0x0C) >> 2;
       battery_request_abort_charging = (rx_frame.data.u8[0] & 0x30) >> 4;
-      // Log the moment the battery reports charge-finished (RQ_ABRT_CHGNG becomes 1 = "Request to
-      // interrupt charging"). This is the signal that ends auto-/manual calibration and drives SOC to
-      // 100%. Only value 1 is a real request - 2 (cooling) and 3 (invalid) are ignored to avoid
-      // spurious stops on transient/invalid frames.
-      if (battery_request_abort_charging == 1 && previous_request_abort_charging != 1) {
-        logging.print("BMW i3: Battery reports charge-finished (abort charging = ");
-        logging.print(battery_request_abort_charging);
-        logging.print("). Reported SOC = ");
-        logging.print(battery_display_SOC *
-                      0.5);  // display SOC * 0.5 = display/reported SOC in percent (display SOC * 50 = 0.01% units)
-        logging.println(" %");
-      }
-      previous_request_abort_charging = battery_request_abort_charging;
       battery_prediction_duration_charging_minutes = (rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);
       battery_prediction_time_end_of_charging_minutes = rx_frame.data.u8[4];
       battery_energy_content_maximum_Wh = (((rx_frame.data.u8[6] & 0x0F) << 8) | rx_frame.data.u8[5]) * 20;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -1,6 +1,7 @@
 #ifndef BMW_I3_BATTERY_H
 #define BMW_I3_BATTERY_H
 
+#include <Arduino.h>
 #include "../datalayer/datalayer.h"
 #include "../devboard/hal/hal.h"
 #include "BMW-I3-HTML.h"
@@ -85,6 +86,19 @@ class BmwI3Battery : public CanBattery {
   uint8_t ST_cold_shutoff_valve() { return battery_status_cold_shutoff_valve; }
   // Status balancing
   uint8_t ST_balancing_status() { return UserRequestBalancing; }
+  // Charge-abort request from the battery via 0x431 RQ_ABRT_CHGNG
+  const char* get_abort_charging_string() {
+    switch (battery_request_abort_charging) {
+      case 0:
+        return "None";
+      case 1:
+        return "Abort requested (charge finished)";
+      case 2:
+        return "Reserved";
+      default:
+        return "Signal invalid";
+    }
+  }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
@@ -96,6 +110,7 @@ class BmwI3Battery : public CanBattery {
   enum BalancingState { NONE, REQUESTED, STARTING, EXECUTING };
   BalancingState UserRequestBalancing = NONE;
   unsigned long UserRequestBalancingMillis = 0;
+  bool currently_in_charge_mode = false;  // Tracks last mode sent in 0x12F (Drive vs Charge/Calibration)
 
   const int MAX_CELL_VOLTAGE_60AH = 4110;   // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_60AH = 2700;   // Battery is put into emergency stop if one cell goes below this value
@@ -143,8 +158,8 @@ class BmwI3Battery : public CanBattery {
   CmdState cmdState = SOC;
 
   /* CAN messages from PT-CAN2 not needed to operate the battery
-     0AA 105 13D 0BB 0AD 0A5 150 100 1A1 10E 153 197 429 1AA 12F 59A 2E3 2BE 211 2b3 3FD 2E8 2B7 108 29D 29C 29B 2C0 330
-     3E9 32F 19E 326 55E 515 509 50A 51A 2F5 3A4 432 3C9 
+     0AA 105 13D 0BB 0AD 0A5 150 100 1A1 10E 153 197 429 1AA 12F 59A 2E3 2BE 211 2b3 3FD 2E8 2B7 29D 29C 29B 2C0 330
+     32F 326 55E 515 509 50A 51A 2F5 3A4 432 3C9
      */
 
   CAN_frame BMW_10B = {.FD = false,
@@ -152,6 +167,12 @@ class BmwI3Battery : public CanBattery {
                        .DLC = 3,
                        .ID = 0x10B,
                        .data = {0xCD, 0x00, 0xFC}};  // Contactor closing command
+  static constexpr CAN_frame BMW_108 = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x108,
+      .data = {0x00, 0x7D, 0xFF, 0xFF, 0x07, 0xF1, 0xFF, 0xFF}};  // Actual Charging Electronics Data
   CAN_frame BMW_12F = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
@@ -172,6 +193,12 @@ class BmwI3Battery : public CanBattery {
                        .DLC = 8,
                        .ID = 0x19B,
                        .data = {0x20, 0x40, 0x40, 0x55, 0xFD, 0xFF, 0xFF, 0xFF}};
+  static constexpr CAN_frame BMW_19E = {
+      .FD = false,
+      .ext_ID = false,
+      .DLC = 8,
+      .ID = 0x19E,
+      .data = {0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF}};  // Subsystems Control
   CAN_frame BMW_1D0 = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
@@ -331,6 +358,20 @@ class BmwI3Battery : public CanBattery {
 
   //The above CAN messages need to be sent towards the battery to keep it alive
 
+  // Balancing shutdown sequence constants (mirrors real car discharge log).
+  // Timing is measured from the moment 0x3E9 byte2 -> 0x41 (charge-finished signal),
+  // which coincides with balancing_start_time.
+  static const uint8_t BMW_12F_BYTE3_ACTIVE = 0xDD;       // Normal operation value for byte3
+  static const int BALANCING_CONTACTOR_DELAY_MS = 54000;  // Open contactors ~54s after charge-finished
+  static const int BALANCING_CAN_STOP_DELAY_MS = 96000;   // Stop all CAN ~96s after charge-finished (battery sleeps)
+  static const int BALANCING_12F_STEPS = 9;
+  const unsigned long balancing_12F_times[BALANCING_12F_STEPS] = {0, 625, 1250, 1875, 2500, 3125, 3750, 4375, 5000};
+  const uint8_t balancing_12F_values[BALANCING_12F_STEPS] = {0xDD, 0x6D, 0x5D, 0x5C, 0x4C, 0x3C, 0x2C, 0x1C, 0x1A};
+
+  bool balancing_mode_active = false;
+  bool can_communication_stopped = false;
+  unsigned long balancing_start_time = 0;
+
   uint8_t startup_counter_contactor = 0;
   uint8_t alive_counter_20ms = 0;
   uint8_t alive_counter_100ms = 0;
@@ -409,6 +450,7 @@ class BmwI3Battery : public CanBattery {
   uint8_t battery_status_service_disconnection_plug = 0;
   uint8_t battery_status_measurement_isolation = 0;
   uint8_t battery_request_abort_charging = 0;
+  uint8_t previous_request_abort_charging = 0;  //Edge detection for logging when battery reports charge-finished
   uint8_t battery_prediction_time_end_of_charging_minutes = 0;
   uint8_t battery_request_operating_mode = 0;
   uint8_t battery_request_charging_condition_minimum = 0;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -449,7 +449,6 @@ class BmwI3Battery : public CanBattery {
   uint8_t battery_status_service_disconnection_plug = 0;
   uint8_t battery_status_measurement_isolation = 0;
   uint8_t battery_request_abort_charging = 0;
-  uint8_t previous_request_abort_charging = 0;  //Edge detection for logging when battery reports charge-finished
   uint8_t battery_prediction_time_end_of_charging_minutes = 0;
   uint8_t battery_request_operating_mode = 0;
   uint8_t battery_request_charging_condition_minimum = 0;

--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -110,7 +110,6 @@ class BmwI3Battery : public CanBattery {
   enum BalancingState { NONE, REQUESTED, STARTING, EXECUTING };
   BalancingState UserRequestBalancing = NONE;
   unsigned long UserRequestBalancingMillis = 0;
-  bool currently_in_charge_mode = false;  // Tracks last mode sent in 0x12F (Drive vs Charge/Calibration)
 
   const int MAX_CELL_VOLTAGE_60AH = 4110;   // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_60AH = 2700;   // Battery is put into emergency stop if one cell goes below this value

--- a/Software/src/battery/BMW-I3-HTML.cpp
+++ b/Software/src/battery/BMW-I3-HTML.cpp
@@ -111,6 +111,7 @@ String BmwI3HtmlRenderer::get_status_html() {
                                           "15"};
   content +=
       "<h4>Balancing status: " + String(safeArrayAccess(balancingText, 16, batt.ST_balancing_status())) + "</h4>";
+  content += "<h4>Charge abort request: " + String(batt.get_abort_charging_string()) + "</h4>";
 
   return content;
 }


### PR DESCRIPTION
What
This PR improves the BMW i3 battery protocol implementation with more accurate charge behaviour, a realistic balancing shutdown sequence, contactor status reporting, and better diagnostics.

Main changes:

- Charge/Calibration mode by default — the battery is now always operated in Charge/Calibration mode (0x12F byte5 = 0x35,     0x3E9 byte2 = 0x21 Charge_active + PlugCharge). The 0x3E9 Charging_Pwr field is now populated from the battery's own measured charging power (active_power_W, 25 W/bit, 12-bit, clamped to charging only).

- Realistic balancing shutdown sequence — when balancing is requested, the code now reproduces the real car's shutdown    sequence captured from a discharge log, timed from the charge-finished signal (0x3E9 byte2 → 0x41):
  t=0s: 0x12F byte3 steps DD → 6D → 5D → 5C → 4C → 3C → 2C → 1C → 1A over ~5s
  t=54s: contactors open (0x10B)
  t=96s: all CAN transmission stops (battery goes to sleep)

- Contactor / DC switch status mapping — battery_status_disconnecting_switch is now mapped to datalayer.system.status.contactors_engaged (open / precharge / engaged / invalid), and allows_contactor_closing follows the balancing shutdown state.
- Standby reporting during balancing sleep — system status is set to STANDBY and contactors reported as open so a stale engaged state is not latched.
- Charge-finished logging — edge-detected logging when the battery reports RQ_ABRT_CHGNG = 1 (charge finished), including reported SOC. Values 2 (cooling) and 3 (invalid) are ignored to avoid spurious stops.
- Additional keepalive frames — now transmitting 0x108 (Actual Charging Electronics Data) and 0x19E (Subsystems Control).
- Web UI — added a "Charge abort request" line to the BMW i3 status page.

Why
The previous implementation did not fully reproduce the BMW i3's charging/calibration behaviour, and the balancing routine did not match the real vehicle's shutdown sequence. Reporting the proper charging power, contactor status, and a faithful shutdown sequence makes the emulated battery behave closer to the real pack, which improves balancing/calibration reliability and gives clearer diagnostics about when and why the battery reports charge-finished.

How

- Added timing constants and step tables (balancing_12F_times / balancing_12F_values, contactor and CAN-stop delays) derived from a real discharge log, driven from balancing_start_time in transmit_can().
- Reworked the 0x3E9 build logic to set byte0/byte1 per detected battery type and byte2–byte4 per balancing/charging state, encoding Charging_Pwr from active_power_W.
- Mapped the BMW DC switch status into the system datalayer in update_values().
- Added edge-detection (previous_request_abort_charging) and logging for the charge-finished signal, plus a get_abort_charging_string() helper surfaced in the HTML renderer.
- Enabled the 0x108 and 0x19E frames in the periodic transmit schedule.