### PR TITLE
MQTT: Add `state_class` assignment for `balancing_active_cells` autodiscovery sensor

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -344,6 +344,7 @@ static bool publish_common_info(void) {
       // records long-term statistics for it. (strncmp also covers the "_2" double-battery variant.)
       if (strncmp(config.default_entity_id, "balancing_active_cells", strlen("balancing_active_cells")) == 0) {
         doc["state_class"] = "measurement";
+        doc["icon"] = "mdi:fuel-cell";
       }
       set_common_discovery_attributes(doc);
       serializeJson(doc, mqtt_msg);

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -339,6 +339,12 @@ static bool publish_common_info(void) {
         doc["device_class"] = config.device_class;
         doc["state_class"] = "measurement";
       }
+      // "balancing_active_cells" is a numeric count with no device_class, so it misses the
+      // state_class assignment above. Mark it as a measurement explicitly so Home Assistant
+      // records long-term statistics for it. (strncmp also covers the "_2" double-battery variant.)
+      if (strncmp(config.default_entity_id, "balancing_active_cells", strlen("balancing_active_cells")) == 0) {
+        doc["state_class"] = "measurement";
+      }
       set_common_discovery_attributes(doc);
       serializeJson(doc, mqtt_msg);
       if (mqtt_publish(generateCommonInfoAutoConfigTopic(config.default_entity_id).c_str(), mqtt_msg, true)) {


### PR DESCRIPTION
Explicitly mark 'balancing_active_cells' as a measurement state class sensor for Home Assistant.

### What
The balancing_active_cells sensor exposed via MQTT discovery shows up in Home Assistant without state_class: measurement. As a result HA treats it as a plain stateful sensor instead of a measurement, so it isn't recorded in long-term statistics and can't be used in the statistics graph card / statistics helpers like the other numeric battery sensors.

### Why
This is how the sensor histroy appears in Home Assistant:
<img width="532" height="60" alt="kép" src="https://github.com/user-attachments/assets/d82943d7-b1f5-4f01-b203-89b54b3bd837" />
This is incorrect. It should be a time-dependent graph. 
The sensor autodiscovered by HA is missing `state_class`, which needs to be set to `measurement`. Since it's got no measurement unit (it's just the count of cells actively balancing), this needs to be explicitly set in HA to display correctly, and for HA to start recording the statistics for it.

### How
Root cause
In publish_common_info() (Software/src/devboard/mqtt/mqtt.cpp), state_class is only emitted inside the device_class branch:
```
cppif (config.device_class != nullptr && strlen(config.device_class) > 0) {
  doc["device_class"] = config.device_class;
  doc["state_class"] = "measurement";
}
```
balancing_active_cells is defined in the sensor template with an empty device_class (there is no appropriate HA device_class for "a count of cells"):
`cpp{"balancing_active_cells", "Balancing Active Cells", "", "", "", always},`
So it never reaches the line that sets state_class, even though it's a perfectly valid numeric measurement. state_class does not require a device_class in Home Assistant, so the coupling is what drops it.

Fix
Add a targeted assignment right after the existing device_class block so balancing_active_cells gets state_class: measurement without inventing a misleading device_class.

Scope
Only balancing_active_cells is affected. Text-state entities (balancing_status, bms_status, pause_status, event_level, emulator_status) are untouched and correctly remain without a state_class.
No device_class is added (none is semantically correct for a count); state_class: measurement stands on its own.
The strncmp prefix match also covers the balancing_active_cells_2 entity created in double-battery setups.
No struct/template changes, no new includes (strncmp/strlen are already used in this file).

Existing installs won't retroactively gain statistics for past data. The updated state_class takes effect once the retained discovery config is re-published, which happens automatically on the next MQTT connect after flashing this build. Statistics will be gathered from then on.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
