### PR TITLE
`SET_LIMITS` discharge limit compared against wrong (charge) setpoint

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -217,7 +217,7 @@ void update_calculated_values(unsigned long currentMillis) {
 
   /* Apply remote restrictions if set*/
   if (datalayer.battery.settings.remote_settings_limit_discharge) {
-    if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_remote_set_charge_dA) {
+    if (datalayer.battery.status.max_discharge_current_dA > datalayer.battery.settings.max_remote_set_discharge_dA) {
       datalayer.battery.status.max_discharge_current_dA = datalayer.battery.settings.max_remote_set_discharge_dA;
     }
   } else {


### PR DESCRIPTION
### What
The discharge branch has a copy-paste error in the condition.

### Why
The threshold compares against `max_remote_set_charge_dA` (charge) while the clamp assigns `max_remote_set_discharge_dA` (discharge). The charge branch (lines 205–206) is correct. In the common case where you set both, or set only discharge (leaving charge at 0), it usually still clamps — but if you send a high `max_charge` and a low `max_discharge`, the discharge clamp may not trigger when it should. The condition should read > `max_remote_set_discharge_dA`.

### How
The SET_LIMITS discharge branch compared max_discharge_current_dA
against max_remote_set_charge_dA instead of max_remote_set_discharge_dA,
so a high max_charge with a low max_discharge could skip the discharge
clamp. Use the discharge setpoint, matching the charge branch.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
