### PR TITLE
MQTT: Set suggested display precision to 3 and proper icon for cell voltages in HA discovery

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -234,6 +234,7 @@ void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, co
   doc["state_class"] = "measurement";
   doc["state_topic"] = state_topic;
   doc["unit_of_measurement"] = "V";
+  doc["suggested_display_precision"] = 3;
   doc["value_template"] = "{{ value_json.cell_voltages[" + String(i) + "] }}";
 }
 
@@ -338,6 +339,13 @@ static bool publish_common_info(void) {
       if (config.device_class != nullptr && strlen(config.device_class) > 0) {
         doc["device_class"] = config.device_class;
         doc["state_class"] = "measurement";
+      }
+      // Cell min/max voltages are reported in volts; show 3 decimals in HA so they don't
+      // round all to the same integer on display. Intentionally not applied to battery_voltage. (strncmp also
+      // covers the "_2" double-battery variants.)
+      if (strncmp(config.default_entity_id, "cell_max_voltage", strlen("cell_max_voltage")) == 0 ||
+          strncmp(config.default_entity_id, "cell_min_voltage", strlen("cell_min_voltage")) == 0) {
+        doc["suggested_display_precision"] = 3;
       }
       set_common_discovery_attributes(doc);
       serializeJson(doc, mqtt_msg);

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -235,6 +235,7 @@ void set_battery_voltage_attributes(JsonDocument& doc, int i, int cellNumber, co
   doc["state_topic"] = state_topic;
   doc["unit_of_measurement"] = "V";
   doc["suggested_display_precision"] = 3;
+  doc["icon"] = "mdi:current-dc";
   doc["value_template"] = "{{ value_json.cell_voltages[" + String(i) + "] }}";
 }
 
@@ -346,6 +347,7 @@ static bool publish_common_info(void) {
       if (strncmp(config.default_entity_id, "cell_max_voltage", strlen("cell_max_voltage")) == 0 ||
           strncmp(config.default_entity_id, "cell_min_voltage", strlen("cell_min_voltage")) == 0) {
         doc["suggested_display_precision"] = 3;
+        doc["icon"] = "mdi:current-dc";
       }
       set_common_discovery_attributes(doc);
       serializeJson(doc, mqtt_msg);


### PR DESCRIPTION
### What
With "Send all cellvoltages via MQTT" enabled, each cell is auto-discovered as a voltage sensor in volts (e.g. 3.779). Home Assistant's default display precision for these entities shows no decimals, so every cell reads as 4 V, making the values useless at a glance. Same situation with `cell_max_voltage` and `cell_min_voltage`.
Additionally, the entities errorneously show a sine wave icon because for voltage, if unspecified, that's the default in Home Assistant.

### Why
At cell-voltage transmission with HA auto-discovery; `homeassistant/sensor/<topic>/cell_voltageN/config` now contains `"suggested_display_precision": 3` and cells display as e.g. 3.779 V in HA on fresh discovery. Adding icon = "mdi:current-dc" for proper display.

### How
Add `suggested_display_precision: 3` and `mdi:current-dc` icon to the cell-voltage discovery payload in `set_battery_voltage_attributes()`. 
Match only `cell_max_voltage` and `cell_min_voltage` (and their _2 double-battery variants, since those entity IDs are built by appending _2). No SensorConfig struct change, so no need to touch the other ~25 template rows — keeps the diff to this one block and avoids accidental scope creep.
strncmp/strlen need no new includes; already used throughout the file.

Before:
<img width="315" height="117" alt="image" src="https://github.com/user-attachments/assets/06926268-2e79-4825-9511-10dec6360493" />

After:
<img width="319" height="119" alt="image" src="https://github.com/user-attachments/assets/a4ee73bc-00f3-4f7d-8a33-c9ba2f438039" />

### Note
One thing to note: suggested_display_precision only sets the default display rounding for new entities. For cells that already exist in HA, the retained discovery config gets re-published on the next MQTT connect, but HA won't retroactively change an entity whose display precision a user has already touched. For untouched existing entities the new default applies once the updated config is processed; if any look stuck, deleting the device/entities and letting them re-discover forces a clean pickup.
Icons similarly because these entities have device_class: voltage, Home Assistant normally picks the icon from the device class. A custom icon in the discovery config does override that default, but only for entities that don't already have a user-set icon — and as with precision, it applies cleanly on fresh discovery; existing entities pick it up when the retained config is re-published unless a user has customized the icon.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
