### PR TITLE
Feature: BYD live DTC read & erase

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -281,6 +281,25 @@ void BydAttoBattery::
       stateMachineCalibrateSOC = STARTED;
       datalayer_bydatto->UserRequestCalibrateSOC = false;
     }
+
+    if (datalayer_bydatto->UserRequestDTCreadout && stateMachineReadDTC == NOT_RUNNING) {
+      stateMachineReadDTC = STARTED;
+      datalayer_bydatto->dtc_read_in_progress = true;
+      datalayer_bydatto->dtc_read_failed = false;
+      dtc_request_millis = millis();
+      datalayer_bydatto->UserRequestDTCreadout = false;
+    }
+
+    if (datalayer_bydatto->UserRequestDTCreset && stateMachineEraseDTC == NOT_RUNNING) {
+      stateMachineEraseDTC = STARTED;
+      datalayer_bydatto->UserRequestDTCreset = false;
+    }
+    // Fail the read if the BMS never answers
+    if (datalayer_bydatto->dtc_read_in_progress && (millis() - dtc_request_millis > 2000)) {
+      datalayer_bydatto->dtc_read_in_progress = false;
+      datalayer_bydatto->dtc_read_failed = true;
+      dtc_rx_active = false;
+    }
   }
 }
 
@@ -468,6 +487,30 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x7EF:  //OBD2 PID reply from battery
+      // DTC reply (0x19 0x02 -> 0x59 0x02) is multi-frame. Reassemble it, ACK the first frame with
+      // our own flow control, and parse once complete. Done before the single-frame PID parsing so
+      // the consecutive frames aren't mistaken for PIDs.
+      if (rx_frame.data.u8[0] == 0x10 && rx_frame.data.u8[2] == 0x59 && rx_frame.data.u8[3] == 0x02) {
+        dtc_rx_expected = ((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
+        dtc_rx_len = 0;
+        for (uint8_t i = 2; i < 8 && dtc_rx_len < sizeof(dtc_buffer); i++) {
+          dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
+        }
+        dtc_rx_active = true;
+        transmit_can_frame(&ATTO_3_7E7_DTC_FC);
+        break;
+      }
+      if (dtc_rx_active && (rx_frame.data.u8[0] & 0xF0) == 0x20) {
+        for (uint8_t i = 1; i < 8 && dtc_rx_len < sizeof(dtc_buffer); i++) {
+          dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
+        }
+        if (dtc_rx_len >= dtc_rx_expected) {
+          dtc_rx_len = dtc_rx_expected;  // Drop ISO-TP padding so it isn't parsed as a DTC
+          parseDTCResponse();
+          dtc_rx_active = false;
+        }
+        break;
+      }
       if ((rx_frame.data.u8[0] == 0x04) && (rx_frame.data.u8[1] == 0x67) && (rx_frame.data.u8[2] == 0x01)) {
         seed = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
         solvedKey = byd_generate_key(seed, 0x63);  //For now key can be either 0xbd or 0x63, 50/50 of guessing right
@@ -561,6 +604,53 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     default:
       break;
   }
+}
+
+// Parse a reassembled UDS ReadDTCInformation (0x59 0x02) reply: 3 header bytes (59 02 mask) then
+// 4 bytes per DTC (3-byte code + status). Stores raw codes; HTML decodes them to strings.
+void BydAttoBattery::parseDTCResponse() {
+  if (dtc_buffer[0] != 0x59 || dtc_buffer[1] != 0x02) {
+    datalayer_bydatto->dtc_read_failed = true;
+    datalayer_bydatto->dtc_read_in_progress = false;
+    return;
+  }
+  uint8_t count = 0;
+  for (uint16_t off = 3; (off + 4 <= dtc_rx_len) && (count < MAX_DTC_COUNT); off += 4) {
+    uint32_t code =
+        ((uint32_t)dtc_buffer[off] << 16) | ((uint32_t)dtc_buffer[off + 1] << 8) | (uint32_t)dtc_buffer[off + 2];
+    uint8_t status = dtc_buffer[off + 3];
+    if (code == 0 || status == 0) {  // Empty slot or cleared DTC
+      continue;
+    }
+    datalayer_bydatto->dtc_codes[count] = code;
+    datalayer_bydatto->dtc_status[count] = status;
+    count++;
+  }
+  // Display order: active (status bit0) first, then ascending code.
+  uint32_t* codes = datalayer_bydatto->dtc_codes;
+  uint8_t* sts = datalayer_bydatto->dtc_status;
+  for (uint8_t a = 1; a < count; a++) {
+    uint32_t c = codes[a];
+    uint8_t s = sts[a];
+    int b = a - 1;
+    while (b >= 0) {
+      bool keyActive = (s & 0x01);
+      bool bActive = (sts[b] & 0x01);
+      bool keyFirst = (keyActive != bActive) ? keyActive : (c < codes[b]);
+      if (!keyFirst) {
+        break;
+      }
+      codes[b + 1] = codes[b];
+      sts[b + 1] = sts[b];
+      b--;
+    }
+    codes[b + 1] = c;
+    sts[b + 1] = s;
+  }
+  datalayer_bydatto->dtc_count = count;
+  datalayer_bydatto->dtc_last_read_millis = millis();
+  datalayer_bydatto->dtc_read_failed = false;
+  datalayer_bydatto->dtc_read_in_progress = false;
 }
 
 // Software contactor state machine. Steps the transmitted 0x12D frame between the vehicle's
@@ -805,6 +895,31 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       default:
         break;
     }
+    switch (stateMachineReadDTC) {
+      case STARTED:
+        transmit_can_frame(&ATTO_3_7E7_READ_DTC);
+        stateMachineReadDTC = NOT_RUNNING;
+        break;
+      default:
+        break;
+    }
+    switch (stateMachineEraseDTC) {
+      case STARTED:
+        // DiagnosticSessionControl, default session
+        ATTO_3_7E7_CLEAR_CRASH.data = {0x02, 0x10, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
+        transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
+        stateMachineEraseDTC = RUNNING_STEP_1;
+        break;
+      case RUNNING_STEP_1:
+        // ClearDiagnosticInformation, all groups
+        ATTO_3_7E7_CLEAR_CRASH.data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00};
+        transmit_can_frame(&ATTO_3_7E7_CLEAR_CRASH);
+        stateMachineEraseDTC = NOT_RUNNING;
+        datalayer_bydatto->UserRequestDTCreadout = true;  // Re-read so the table reflects the cleared state
+        break;
+      default:
+        break;
+    }
     switch (stateMachineCalibrateSOC) {
       case STARTED:
         // DiagnosticSesssionControl enter extendedDiagnosticSession
@@ -972,8 +1087,9 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
         break;
     }
 
-    if ((stateMachineClearCrash == NOT_RUNNING) &&
-        (stateMachineCalibrateSOC == NOT_RUNNING)) {  //Don't poll battery for data if any diag ongoing
+    if ((stateMachineClearCrash == NOT_RUNNING) && (stateMachineCalibrateSOC == NOT_RUNNING) &&
+        (stateMachineReadDTC == NOT_RUNNING) && (stateMachineEraseDTC == NOT_RUNNING) &&
+        !dtc_rx_active) {  //Don't poll battery for data if any diag ongoing
       transmit_can_frame(&ATTO_3_7E7_POLL);
     }
   }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -39,6 +39,10 @@ class BydAttoBattery : public CanBattery {
   bool supports_contactor_close() { return true; }
   void request_open_contactors() { requestContactorOpen = true; }
   void request_close_contactors() { requestContactorClose = true; }
+  bool supports_read_DTC() { return true; }
+  void read_DTC() { datalayer_bydatto->UserRequestDTCreadout = true; }
+  bool supports_reset_DTC() { return true; }
+  void reset_DTC() { datalayer_bydatto->UserRequestDTCreset = true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
@@ -194,6 +198,17 @@ class BydAttoBattery : public CanBattery {
   uint8_t stateMachineClearCrash = NOT_RUNNING;
   uint8_t stateMachineCalibrateSOC = NOT_RUNNING;
 
+  // DTC readout: request 0x19 02 09, reassemble the 0x59 02 ISO-TP reply, parse 4 bytes per DTC.
+  static const int MAX_DTC_COUNT = 30;
+  uint8_t stateMachineReadDTC = NOT_RUNNING;
+  uint8_t stateMachineEraseDTC = NOT_RUNNING;
+  unsigned long dtc_request_millis = 0;
+  uint8_t dtc_buffer[140] = {0};
+  uint16_t dtc_rx_expected = 0;
+  uint16_t dtc_rx_len = 0;
+  bool dtc_rx_active = false;
+  void parseDTCResponse();
+
   /* Software contactor control: step the transmitted 0x12D frame through the same payload
   states the real VCU uses (taken from CAN logs of two cars). Byte 6 is a rolling counter,
   byte 7 the 0x441-style checksum over bytes 0-6.
@@ -319,6 +334,16 @@ class BydAttoBattery : public CanBattery {
                                     .DLC = 8,
                                     .ID = 0x7E7,  //This sets SOC to 100.00% (0x27 10) , and AH to 150.00 (0x3A 98)
                                     .data = {0x07, 0x2E, 0x1F, 0xFC, 0x10, 0x27, 0x98, 0x3A}};
+  CAN_frame ATTO_3_7E7_READ_DTC = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 8,
+                                   .ID = 0x7E7,  //ReadDTCInformation, reportDTCByStatusMask, mask 0x09
+                                   .data = {0x03, 0x19, 0x02, 0x09, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame ATTO_3_7E7_DTC_FC = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x7E7,  //Flow control for the DTC reply, BS 0 (send all), STmin 5ms
+                                 .data = {0x30, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
   void handle_auto_soc_calibration(bool crit_taper, uint32_t dt_ms, uint32_t now_ms);
 };

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -1,6 +1,7 @@
 #ifndef _BYD_ATTO_3_HTML_H
 #define _BYD_ATTO_3_HTML_H
 
+#include <Arduino.h>
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/webserver/BatteryHtmlRenderer.h"
@@ -341,6 +342,54 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "  xhr.send();";
     content += "}";
     content += "</script>";
+
+    // Diagnostic Trouble Codes, populated on demand by the 'Read DTC' button (Advanced page).
+    content +=
+        "<h4 style='margin-top:20px;color:#27b06c;border-bottom:2px solid #27b06c;padding-bottom:5px;'>&#128295; "
+        "Diagnostic Trouble Codes</h4>";
+    if (byd_datalayer->dtc_last_read_millis == 0) {
+      content += "<p style='color:#bbb;'>Not read yet &mdash; use the Read DTC button below to scan.</p>";
+    } else if (byd_datalayer->dtc_read_failed) {
+      content += "<p style='color:#ff8a80;'>&#9888; Last DTC read failed or timed out.</p>";
+    } else if (byd_datalayer->dtc_count == 0) {
+      content += "<p style='color:#69f0ae;'>&#10003; No DTCs present.</p>";
+    } else {
+      unsigned long age_s = (millis() - byd_datalayer->dtc_last_read_millis) / 1000;
+      content += "<p style='color:#bbb;'>" + String(byd_datalayer->dtc_count) + " codes &mdash; read " + String(age_s) +
+                 "s ago</p>";
+      content += "<div style='overflow-x:auto;margin-bottom:12px;'>";
+      content +=
+          "<table style='margin:0 auto;text-align:left;border-collapse:separate;border-spacing:0;"
+          "border:1px solid #4a5a64;border-radius:8px;overflow:hidden;'>";
+      content +=
+          "<thead><tr style='background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#fff;'>"
+          "<th style='padding:10px 18px;text-align:left;'>DTC</th>"
+          "<th style='padding:10px 18px;text-align:left;'>Status</th>"
+          "<th style='padding:10px 18px;text-align:left;'>Description</th></tr></thead><tbody>";
+      // Decode the raw 3-byte code to the string our JSON is keyed by: top 2 bits of byte0 -> P/C/B/U.
+      const char SYS[5] = "PCBU";
+      for (int i = 0; i < byd_datalayer->dtc_count; i++) {
+        uint32_t code = byd_datalayer->dtc_codes[i];
+        uint8_t status = byd_datalayer->dtc_status[i];
+        char dtcStr[8];
+        snprintf(dtcStr, sizeof(dtcStr), "%c%02lX%02lX%02lX", SYS[(code >> 22) & 0x03],
+                 (unsigned long)((code >> 16) & 0x3F), (unsigned long)((code >> 8) & 0xFF),
+                 (unsigned long)(code & 0xFF));
+        bool active = status & 0x01;
+        String statusStr = active ? "Active" : "Stored";
+        String statusColor = active ? "#ff5252" : "#9e9e9e";
+        content +=
+            "<tr><td style='padding:8px 18px;border-top:1px solid #3a4750;font-family:monospace;"
+            "font-weight:600;'>" +
+            String(dtcStr) + "</td>";
+        content += "<td style='padding:8px 18px;border-top:1px solid #3a4750;color:" + statusColor +
+                   ";font-weight:600;'>" + statusStr + "</td>";
+        content += "<td data-dtc-code='" + String(dtcStr) +
+                   "' style='padding:8px 18px;border-top:1px solid #3a4750;'>Unknown</td></tr>";
+      }
+      content += "</tbody></table></div>";
+      content += get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, "byd_atto3_dtc.json");
+    }
 
     return content;
   }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -196,6 +196,16 @@ struct DATALAYER_INFO_BYDATTO3 {
   bool autocal_crit_drift = false;
   bool autocal_crit_cooldown_ready = false;
   bool autocal_crit_contactors = false;
+
+  // DTC readout (UDS 0x19 0x02). Codes packed as raw 3 bytes in a uint32, rendered to string in HTML.
+  uint32_t dtc_codes[32] = {0};
+  uint8_t dtc_status[32] = {0};
+  uint8_t dtc_count = 0;
+  unsigned long dtc_last_read_millis = 0;
+  bool dtc_read_in_progress = false;
+  bool dtc_read_failed = false;
+  bool UserRequestDTCreadout = false;  // User requesting DTC readout via WebUI
+  bool UserRequestDTCreset = false;    // User requesting DTC erase via WebUI
 };
 
 struct DATALAYER_INFO_CELLPOWER {

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -28,7 +28,7 @@ std::vector<BatteryCommand> battery_commands = {
     {"resetContactor", "Perform contactor reset", "reset contactors?",
      [](Battery* b) { return b && b->supports_contactor_reset(); }, [](Battery* b) { b->reset_contactor(); }},
     {"resetDTC", "Erase DTC", "erase DTCs?", [](Battery* b) { return b && b->supports_reset_DTC(); },
-     [](Battery* b) { b->reset_DTC(); }},
+     [](Battery* b) { b->reset_DTC(); }, true},
     {"startBalancing", "Balancing",
      "continue? Please charge battery fully for this to work. After a couple of minutes, battery will sleep and do "
      "balancing. It often takes many hours. There will be no progress indication.",
@@ -44,7 +44,7 @@ std::vector<BatteryCommand> battery_commands = {
     {"isolationTest", "Isolation Test", "start an isolation test?",
      [](Battery* b) { return b && b->supports_isolation_test(); }, [](Battery* b) { b->request_isolation_test(); }},
     {"readDTC", "Read DTC", nullptr, [](Battery* b) { return b && b->supports_read_DTC(); },
-     [](Battery* b) { b->read_DTC(); }},
+     [](Battery* b) { b->read_DTC(); }, true},
     {"resetBECM", "Restart BECM module", "restart BECM??", [](Battery* b) { return b && b->supports_reset_BECM(); },
      [](Battery* b) { b->reset_BECM(); }},
     {"contactorClose", "Close Contactors", "a contactor close request?",
@@ -100,6 +100,9 @@ String advanced_battery_processor(const String& var) {
           content += "function " + String(cmd.identifier) + "(batteryNum) {";
           content += "  var xhr = new XMLHttpRequest();";
           content += "  xhr.open('PUT', '/" + String(cmd.identifier) + "', true);";
+          if (cmd.reload_after) {
+            content += "  xhr.onload = function(){ setTimeout(function(){ location.reload(); }, 1500); };";
+          }
           // Send index of the battery as PUT content
           content += "  xhr.send(batteryNum);";
           content += "}";

--- a/Software/src/devboard/webserver/advanced_battery_html.h
+++ b/Software/src/devboard/webserver/advanced_battery_html.h
@@ -33,6 +33,9 @@ struct BatteryCommand {
 
   // Function that executes the command for the given battery.
   std::function<void(Battery*)> action;
+
+  // Reload page after running (for read commands).
+  bool reload_after = false;
 };
 
 extern std::vector<BatteryCommand> battery_commands;


### PR DESCRIPTION
### What
Adds live DTC read & erase for the BYD Atto 3/Seal/Dolphin in the web UI. Reads the fault codes off the BMS, shows them with descriptions, and lets you clear them.

### Why
So you can actually see (and clear) what your pack is complaining about straight from the web UI, same as the BMW packs already do. Pairs up with the DTC list added in #2485.

### How
* "Read DTC" button asks the BMS for stored codes (UDS 19 02), reassembles the multi-frame reply and decodes each one back to its P/C/B/U string.
* Shows them in a table (active first, then stored, sorted by code) and pulls the descriptions from byd_atto3_dtc.json — same loader the BMW pages use.
* "Erase DTC" button clears them on the BMS (UDS 14 FF FF FF) then auto re-reads so the table updates itself.
* Both buttons are the existing generic battery commands — just flipped on supports_read_DTC / supports_reset_DTC for BYD, no new web routes.
* Added a small reload_after flag to the generic command buttons so the page refreshes itself after a read/erase (BMW's Read DTC picks this up too).

Heads up: the BYD erase uses the same 14 FF FF FF clear that the "Unlock crashed BMS" button already sends, so it'll also clear a crash code — they overlap on purpose, not worth a separate clear.  Can look to remove this at a later stage if required.

<img width="814" height="572" alt="image" src="https://github.com/user-attachments/assets/c053b217-6a95-4f3e-a9f5-c98f241100c5" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
