### PR TITLE
Actions improvement: rename firmware.bin inside ZIP with PR# and short SHA for clarity

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -57,12 +57,17 @@ jobs:
     - name: Build image for ${{ matrix.board_name }}
       run: pio run -e ${{ matrix.pio_env }}
 
-    #rename firmware.bin to be like firmware-63dd8b.bin for easier location after saved
-    - name: Rename firmware.bin with short SHA
+    #rename firmware.bin to contain pr number and commit short sha for easier location after saved on disk
+    - name: Rename firmware.bin with PR number and commit short SHA
       run: |
-        SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-6)
-        cp .pio/build/${{ matrix.pio_env }}/firmware.bin \
-           .pio/build/${{ matrix.pio_env }}/firmware-${SHORT_SHA}.bin
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-6)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_PART="pr${{ github.event.pull_request.number }}-"
+          else
+            PR_PART=""
+          fi
+          cp .pio/build/${{ matrix.pio_env }}/firmware.bin \
+             .pio/build/${{ matrix.pio_env }}/firmware-${PR_PART}${SHORT_SHA}.bin
 
     - name: Upload artifact for ${{ matrix.board_name }}
       uses: actions/upload-artifact@v7

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -57,8 +57,15 @@ jobs:
     - name: Build image for ${{ matrix.board_name }}
       run: pio run -e ${{ matrix.pio_env }}
 
+    #rename firmware.bin to be like firmware-63dd8b.bin for easier location after saved
+    - name: Rename firmware.bin with short SHA
+      run: |
+        SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-6)
+        cp .pio/build/${{ matrix.pio_env }}/firmware.bin \
+           .pio/build/${{ matrix.pio_env }}/firmware-${SHORT_SHA}.bin
+
     - name: Upload artifact for ${{ matrix.board_name }}
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.artifact_name }}.bin
-        path: .pio/build/${{ matrix.pio_env }}/firmware.bin
+        path: .pio/build/${{ matrix.pio_env }}/firmware-*.bin


### PR DESCRIPTION
### What
Added a step to rename firmware.bin to include a short SHA for easier identification after unzipping.
On a PR build → "firmware-pr2523-63dd8b.bin". On a push straight to main (no PR) → fall back to just "firmware-63dd8b.bin".

### Why
One may test multiple binaries from adjacent commits, can save them all at the location with files named accordingly. Zips can be all extracted to the same directory on the user's machine and they don't overwrite each other. The user can easily find the file corresponds to which PR, and which commit was generated from within that PR. Makes life easier when comparing functionality in "before" and "after" tests.

### How
`$GITHUB_SHA` is set automatically by GitHub Actions and is the full 40-char commit SHA of the triggering commit — ${GITHUB_SHA::6} takes the first 6 chars via bash substring expansion. For pull_request events, GITHUB_SHA is the auto-generated merge commit, not the head commit of the PR branch. We specifically want the PR's head commit short SHA si we also use ${{ github.event.pull_request.head.sha }} when the event is a PR, falling back to github.sha otherwise.
Used a glob (firmware-*.bin) in the path: field so no need to duplicate the SHA logic in two places — upload-artifact will just pick up the single renamed file. Since this step runs per matrix entry, each board's zip will independently contain firmware-<sha>.bin — exactly like for example "battery-emulator-waveshareRS485CAN.bin.zip", just with the renamed file inside.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
