### PR TITLE
Volkswagen MEB: Avoid high temperature diff on reboot

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -242,11 +242,12 @@ void MebBattery::
   datalayer_battery->status.active_power_W =
       ((datalayer_battery->status.voltage_dV * datalayer_battery->status.current_dA) / 100);
 
-  // datalayer.battery.status.temperature_min_dC = actual_temperature_lowest_C*5 -400;  // We use the value below, because it has better accuracy
-  datalayer_battery->status.temperature_min_dC = (battery_min_temp * 10) / 64;
-
-  // datalayer.battery.status.temperature_max_dC = actual_temperature_highest_C*5 -400;  // We use the value below, because it has better accuracy
-  datalayer_battery->status.temperature_max_dC = (battery_max_temp * 10) / 64;
+  if ((battery_min_temp != 600) && (battery_max_temp != 600)) {  //Only update when both values have been read
+    // datalayer.battery.status.temperature_min_dC = actual_temperature_lowest_C*5 -400;  // We use the value below, because it has better accuracy
+    datalayer_battery->status.temperature_min_dC = (battery_min_temp * 10) / 64;
+    // datalayer.battery.status.temperature_max_dC = actual_temperature_highest_C*5 -400;  // We use the value below, because it has better accuracy
+    datalayer_battery->status.temperature_max_dC = (battery_max_temp * 10) / 64;
+  }
 
   //Map all cell voltages to the global array
   memcpy(datalayer_battery->status.cell_voltages_mV, cellvoltages_polled, 108 * sizeof(uint16_t));


### PR DESCRIPTION
### What
This PR avoids high temperature diff on MEB on reboot

### Why
Fixes #2527 , if battery temp strays +-25*C from the initial 9,3*C value, you can get an incorrect high battery temp deviation before both min/max have been read.

### How
Only update when both values available to avoid incorrect event firing

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
