### PR TITLE
fix(security): don't expose passwords in web log and settings page

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1867,16 +1867,14 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         <label>Access point name: </label>
         <input type='text' name='APNAME' value="%APNAME%" 
-        pattern="[ -~]{1,63}" 
-        title="Max 63 characters, printable ASCII only"
-        required />
+        pattern="([ -~]{1,63})?"
+        title="Max 63 characters, printable ASCII only" />
 
         <label>Access point password: </label>
         <input type='password' name='APPASSWORD' value="%APPASSWORD%" 
-        pattern="[ -~]{8,63}" 
+        pattern="([ -~]{8,63})?"
         title="Password must be 8-63 characters long, printable ASCII only"
-        placeholder='Leave blank to keep unchanged'
-        required />
+        placeholder='Leave blank to keep unchanged' />
 
         <label>Wifi channel 0-14: </label>
         <input type='number' name='WIFICHANNEL' value="%WIFICHANNEL%" 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -370,7 +370,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "PASSWORD") {
-    return settings.getString("PASSWORD");
+    return String("");  // never expose the stored password in the served HTML
   }
 
   if (var == "WEBAUTH") {
@@ -382,7 +382,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "HTTPPASS") {
-    return settings.getString("HTTPPASS");
+    return String("");
   }
 
   if (var == "SAVEDCLASS") {
@@ -522,7 +522,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "APPASSWORD") {
-    return settings.getString("APPASSWORD", "123456789");
+    return String("");
   }
 
   if (var == "APNAME") {
@@ -642,7 +642,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "MQTTPASSWORD") {
-    return settings.getString("MQTTPASSWORD");
+    return String("");
   }
 
   if (var == "MQTTTOPICS") {
@@ -1460,7 +1460,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         <label>Password: </label><input type='password' name='PASSWORD' value="%PASSWORD%" 
         pattern="[ -~]{8,63}" 
-        title="Password must be 8-63 characters long, printable ASCII only" />
+        title="Password must be 8-63 characters long, printable ASCII only" placeholder='Leave blank to keep unchanged' />
         </div>
         </div>
 
@@ -1480,12 +1480,12 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label>Web interface password: </label>
         <input type='password' name='HTTPPASS' value="%HTTPPASS%"
         pattern="[ -~]{0,63}"
-        title="Set a password before enabling password protection. Printable ASCII only" />
+        title="Set a password before enabling password protection. Printable ASCII only" placeholder='Leave blank to keep unchanged' />
 
         <label>Repeat web interface password: </label>
         <input type='password' name='HTTPPASSCONFIRM' value="%HTTPPASS%"
         pattern="[ -~]{0,63}"
-        title="Repeat the web interface password" />
+        title="Repeat the web interface password" placeholder='Leave blank to keep unchanged' />
 
         <label>Show web interface password: </label>
         <input type='checkbox' onchange='toggleWebPasswordVisibility(this.checked)' />
@@ -1881,6 +1881,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='password' name='APPASSWORD' value="%APPASSWORD%" 
         pattern="[ -~]{8,63}" 
         title="Password must be 8-63 characters long, printable ASCII only"
+        placeholder='Leave blank to keep unchanged'
         required />
 
         <label>Wifi channel 0-14: </label>
@@ -1943,7 +1944,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         title="MQTT username can only contain printable ASCII" />
         <label>MQTT password: </label><input type='password' name='MQTTPASSWORD' value="%MQTTPASSWORD%" 
         pattern="[ -~]+"
-        title="MQTT password can only contain printable ASCII" />
+        title="MQTT password can only contain printable ASCII" placeholder='Leave blank to keep unchanged' />
         <label>MQTT timeout ms: </label>
         <input name='MQTTTIMEOUT' type='number' value="%MQTTTIMEOUT%" 
         min="1" max="60000" step="1"

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1426,12 +1426,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       return false;
     }
 
-    if (webAuth.checked && (!user.value || !pass.value)) {
-      alert('Set a username and password before enabling web interface password protection.');
-      (!user.value ? user : pass).focus();
-      return false;
-    }
-
     return true;
   }
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -453,9 +453,13 @@ void init_webserver() {
               String requestedHttpUser =
                   httpUserParam != nullptr ? httpUserParam->value() : settings.getString("HTTPUSER", "admin");
               String requestedHttpPass =
-                  httpPassParam != nullptr ? httpPassParam->value() : settings.getString("HTTPPASS");
+                  (httpPassParam != nullptr && !httpPassParam->value().isEmpty()) ? httpPassParam->value()
+                                                                                  : settings.getString("HTTPPASS");
+
               String requestedHttpPassConfirm =
-                  httpPassConfirmParam != nullptr ? httpPassConfirmParam->value() : requestedHttpPass;
+                  (httpPassConfirmParam != nullptr && !httpPassConfirmParam->value().isEmpty())
+                      ? httpPassConfirmParam->value()
+                      : requestedHttpPass;
 
               if (requestedHttpPass != requestedHttpPassConfirm) {
                 request->send(400, "text/plain", "Web interface passwords do not match.");
@@ -523,7 +527,9 @@ void init_webserver() {
                   settings.saveString("SSID", p->value().c_str());
                   ssid = settings.getString("SSID", "").c_str();
                 } else if (p->name() == "PASSWORD") {
-                  settings.saveString("PASSWORD", p->value().c_str());
+                  if (!p->value().isEmpty()) {  // blank = keep existing (field is rendered empty)
+                    settings.saveString("PASSWORD", p->value().c_str());
+                  }
                   password = settings.getString("PASSWORD", "").c_str();
                 } else if (p->name() == "MQTTPUBLISHMS") {
                   auto interval = atoi(p->value().c_str()) * 1000;  // Convert seconds to milliseconds
@@ -539,6 +545,13 @@ void init_webserver() {
 
                 for (auto& stringSetting : stringSettingNames) {
                   if (p->name() == stringSetting) {
+                    // Password fields are rendered blank; an empty value means "keep unchanged".
+                    const bool isPasswordField = (std::string(stringSetting) == "APPASSWORD" ||
+                                                  std::string(stringSetting) == "MQTTPASSWORD" ||
+                                                  std::string(stringSetting) == "HTTPPASS");
+                    if (isPasswordField && p->value().isEmpty()) {
+                      continue;  // keep existing stored password
+                    }
                     if (settings.getString(stringSetting) != p->value()) {
                       settings.saveString(stringSetting, p->value().c_str());
                     }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -452,9 +452,9 @@ void init_webserver() {
               bool requestedWebAuth = webAuthParam != nullptr && webAuthParam->value() == "on";
               String requestedHttpUser =
                   httpUserParam != nullptr ? httpUserParam->value() : settings.getString("HTTPUSER", "admin");
-              String requestedHttpPass =
-                  (httpPassParam != nullptr && !httpPassParam->value().isEmpty()) ? httpPassParam->value()
-                                                                                  : settings.getString("HTTPPASS");
+              String requestedHttpPass = (httpPassParam != nullptr && !httpPassParam->value().isEmpty())
+                                             ? httpPassParam->value()
+                                             : settings.getString("HTTPPASS");
 
               String requestedHttpPassConfirm =
                   (httpPassConfirmParam != nullptr && !httpPassConfirmParam->value().isEmpty())
@@ -546,9 +546,9 @@ void init_webserver() {
                 for (auto& stringSetting : stringSettingNames) {
                   if (p->name() == stringSetting) {
                     // Password fields are rendered blank; an empty value means "keep unchanged".
-                    const bool isPasswordField = (std::string(stringSetting) == "APPASSWORD" ||
-                                                  std::string(stringSetting) == "MQTTPASSWORD" ||
-                                                  std::string(stringSetting) == "HTTPPASS");
+                    const bool isPasswordField =
+                        (std::string(stringSetting) == "APPASSWORD" || std::string(stringSetting) == "MQTTPASSWORD" ||
+                         std::string(stringSetting) == "HTTPPASS");
                     if (isPasswordField && p->value().isEmpty()) {
                       continue;  // keep existing stored password
                     }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -57,8 +57,7 @@ static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
 
 void init_WiFi() {
-  DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s, password=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str(),
-               password.c_str());
+  DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
 
   // Register event handlers BEFORE WiFi.mode() creates the arduino_events task.
   // WiFi events can fire immediately once the task exists, and vector reallocation
@@ -181,8 +180,7 @@ void connectToWiFi() {
     if (wifi_channel > 14) {
       wifi_channel = 0;
     }  //prevent users going out of bounds
-    DEBUG_PRINTF("Connecting to Wi-Fi SSID: %s, password: %s, Channel: %d\n", ssid.c_str(), password.c_str(),
-                 wifi_channel);
+    DEBUG_PRINTF("Connecting to Wi-Fi SSID: %s, Channel: %d\n", ssid.c_str(), wifi_channel);
     WiFi.begin(ssid.c_str(), password.c_str(), wifi_channel);
   } else {
     logging.println("Wi-Fi already connected.");
@@ -249,7 +247,7 @@ void init_mDNS() {
 void init_WiFi_AP() {
 
   DEBUG_PRINTF("Creating Access Point: %s\n", ssidAP.c_str());
-  DEBUG_PRINTF("With password: %s\n", passwordAP.c_str());
+  DEBUG_PRINTF("Access Point password is set (%u characters)\n", (unsigned)passwordAP.length());
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
   IPAddress IP = WiFi.softAPIP();


### PR DESCRIPTION
### What
Wi-Fi/AP passwords were printed in cleartext to the web log via DEBUG_PRINTF, and the Wi-Fi/AP/MQTT/HTTP-auth password fields rendered the stored value into their HTML value attribute (visible in page source despite type=password).

### Why
Many users leave the AP mode enabled too, even when connected to their home (iot) network. They also don't change the AP default password and nothing enforces them to do so. Since this information is publicly available, this generates a serious attack vector for the malicious actors, who can simply connect to BE's AP using the publicly known password, and easily read out the home network wifi password out, by either looking at the log, or just opening the settings page and looking at the page source in the browser. Since Battery Emulator likely sits on a network intended to be protected, operating mission critical equipment, it's even more important to prevent such mistakes from happening.

### How
Remove the password values from the wifi.cpp log lines (keeping SSID and channel), render all four password fields blank, and treat a blank submission as "keep existing" in the save handler (with a stored-value fallback for the web-auth precondition and a relaxed client validator).

A password can no longer be cleared to empty via a blank field, this is intended also as a security measure, to prevent users setting blank passwords.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
