### PR TITLE
Double/Triple battery: Add hysteresis to out of sync voltage event

### DIFF
--- a/Software/src/devboard/safety/parallel_safety.cpp
+++ b/Software/src/devboard/safety/parallel_safety.cpp
@@ -22,12 +22,14 @@ void check_parallel_battery_safety(uint8_t batteryNumber) {
         datalayer.system.status.battery2_allowed_contactor_closing = true;
       }
     } else {  //Voltage between the two packs is too large
-      set_event(EVENT_VOLTAGE_DIFFERENCE_BAT2, (uint8_t)(voltage_diff_battery2_towards_main / 10));
-
       //If we start to drift out of sync between the two packs for more than 10 seconds, open contactors
+      //We alert user if we have been out of sync for more than 3 seconds, but we allow 10 seconds before we disengage the second battery
       if (secondsOutOfVoltageSyncBattery2 < 10) {
         secondsOutOfVoltageSyncBattery2++;
-      } else {
+        if (secondsOutOfVoltageSyncBattery2 > 3) {
+          set_event(EVENT_VOLTAGE_DIFFERENCE_BAT2, (uint8_t)(voltage_diff_battery2_towards_main / 10));
+        }
+      } else {  //10 seconds out of sync, disengage the second battery
         datalayer.system.status.battery2_allowed_contactor_closing = false;
       }
     }
@@ -51,12 +53,14 @@ void check_parallel_battery_safety(uint8_t batteryNumber) {
         datalayer.system.status.battery3_allowed_contactor_closing = true;
       }
     } else {  //Voltage between the two packs is too large
-      set_event(EVENT_VOLTAGE_DIFFERENCE_BAT3, (uint8_t)(voltage_diff_battery3_towards_main / 10));
-
       //If we start to drift out of sync between the two packs for more than 10 seconds, open contactors
+      //We alert user if we have been out of sync for more than 3 seconds, but we allow 10 seconds before we disengage the second battery
       if (secondsOutOfVoltageSyncBattery3 < 10) {
         secondsOutOfVoltageSyncBattery3++;
-      } else {
+        if (secondsOutOfVoltageSyncBattery3 > 3) {
+          set_event(EVENT_VOLTAGE_DIFFERENCE_BAT3, (uint8_t)(voltage_diff_battery3_towards_main / 10));
+        }
+      } else {  //10 seconds out of sync, disengage the second battery
         datalayer.system.status.battery3_allowed_contactor_closing = false;
       }
     }


### PR DESCRIPTION
### What
This PR implements hysteresis to out of sync voltage event

### Why
User report on Discord, spamming of this event occasionally;
```
 591.001 Event: Too large voltage diff between the batteries. Third battery cannot join the DC-link
 624.001 Event: Too large voltage diff between the batteries. Second battery cannot join the DC-link
 644.003 Event: Too large voltage diff between the batteries. Second battery cannot join the DC-link
 900.003 Event: Too large voltage diff between the batteries. Third battery cannot join the DC-link
 902.003 Event: Too large voltage diff between the batteries. Third battery cannot join the DC-link
 909.003 Event: Too large voltage diff between the batteries. Third battery cannot join the DC-link
```

### How
Instead of raising the event if we are 1.5V out of sync for over 1s, we now need to be out of sync for 3seconds before it fires. This should remove any spam.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
