### PR TITLE
Security enhancement(wifi): option to disable the access point after connecting to the local network

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -195,6 +195,7 @@ void init_stored_settings() {
 
   // WIFI AP is enabled by default unless disabled in the settings
   wifiap_enabled = settings.getBool("WIFIAPENABLED", true);
+  wifi_ap_disable_after_connect = settings.getBool("APOFFONCONN", true);
   wifi_channel = settings.getUInt("WIFICHANNEL", 0);
   ssidAP = settings.getString("APNAME", "BatteryEmulator").c_str();
   passwordAP = settings.getString("APPASSWORD", "123456789").c_str();

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -521,6 +521,10 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("WIFIAPENABLED", wifiap_enabled) ? "checked" : "";
   }
 
+  if (var == "APOFFONCONN") {
+    return settings.getBool("APOFFONCONN", true) ? "checked" : "";  // default: checked
+  }
+  
   if (var == "APPASSWORD") {
     return String("");
   }
@@ -1880,6 +1884,9 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='number' name='WIFICHANNEL' value="%WIFICHANNEL%" 
         min="0" max="14" step="1"
         title="Force specific channel. Set to 0 for autodetect" required />
+
+        <label>Disable access point after connecting to local network: </label>
+        <input type='checkbox' name='APOFFONCONN' value='on' %APOFFONCONN% />
 
         <label>Custom Wifi hostname: </label>
         <input type='text' name='HOSTNAME' value="%HOSTNAME%" 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -524,7 +524,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "APOFFONCONN") {
     return settings.getBool("APOFFONCONN", true) ? "checked" : "";  // default: checked
   }
-  
+
   if (var == "APPASSWORD") {
     return String("");
   }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -423,7 +423,7 @@ void init_webserver() {
       "CANLOGSD",      "WIFIAPENABLED", "MQTTENABLED", "NOINVDISC",    "HADISC",        "MQTTTOPICS",   "MQTTCELLV",
       "GTWRHD",        "DIGITALHVIL",   "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET",  "PYLONORDER",
       "DEYEBYD",       "NCCONTACTOR",   "TRIBTR",      "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",   "CTINVERT",
-      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",
+      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",  "APOFFONCONN",
   };
 
   const char* uintSettingNames[] = {

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -8,7 +8,7 @@
 bool wifi_enabled = true;
 bool wifiap_enabled = true;
 bool wifi_ap_disable_after_connect = true;  // If AP broadcast is on, turn it off once STA has an IP
-bool mdns_enabled = true;    //If true, allows battery monitor te be found by .local address
+bool mdns_enabled = true;                   //If true, allows battery monitor te be found by .local address
 bool espnow_enabled = true;  //If true, allows battery emulator to send battery status by using ESPNow messages
 uint16_t wifi_channel = 0;
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -47,6 +47,10 @@ static const uint16_t STEP_WIFI_FULL_RECONNECT_INTERVAL =
 static const uint16_t MAX_RECONNECT_ATTEMPTS =
     3;  // Maximum number of reconnect attempts before forcing a full connection
 
+// Fixed channel for the soft-AP when no STA channel is forced, so the AP stays put
+// instead of being dragged around by STA scans. Used only as the AP's own channel.
+static const uint8_t DEFAULT_AP_CHANNEL = 1;
+
 // State variables
 static unsigned long lastReconnectAttempt = 0;
 static unsigned long lastWiFiCheck = 0;
@@ -147,9 +151,12 @@ void wifi_monitor() {
         // If no previous connection, force a full connection attempt
         if (currentMillis - lastReconnectAttempt > current_full_reconnect_interval) {
           logging.println("No previous OK connection, force a full connection attempt...");
-          wifiap_enabled = true;
-          WiFi.mode(WIFI_AP_STA);
-          init_WiFi_AP();
+          // Ensure the AP is up while we still can't connect, but don't re-create it
+          // or re-assert the mode if it's already running (that dropped AP clients).
+          if (wifiap_enabled && !ap_active) {
+            WiFi.mode(WIFI_AP_STA);
+            init_WiFi_AP();
+          }
 
           FullReconnectToWiFi();
         }
@@ -256,11 +263,20 @@ void init_mDNS() {
 }
 
 void init_WiFi_AP() {
+  // If the AP is already running, don't re-create it — re-calling softAP()/mode()
+  // forces associated clients to re-associate, which is what caused client drops
+  // while the STA kept failing to connect.
+  if (ap_active) {
+    return;
+  }
 
   DEBUG_PRINTF("Creating Access Point: %s\n", ssidAP.c_str());
   DEBUG_PRINTF("Access Point password is set (%u characters)\n", (unsigned)passwordAP.length());
 
-  WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
+  // Pin the AP to the forced Wi-Fi channel if one is set, otherwise a fixed default,
+  // so STA channel changes disturb the AP as little as possible.
+  uint8_t ap_channel = (wifi_channel >= 1 && wifi_channel <= 14) ? (uint8_t)wifi_channel : DEFAULT_AP_CHANNEL;
+  WiFi.softAP(ssidAP.c_str(), passwordAP.c_str(), ap_channel);
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -7,6 +7,7 @@
 
 bool wifi_enabled = true;
 bool wifiap_enabled = true;
+bool wifi_ap_disable_after_connect = true;  // If AP broadcast is on, turn it off once STA has an IP
 bool mdns_enabled = true;    //If true, allows battery monitor te be found by .local address
 bool espnow_enabled = true;  //If true, allows battery emulator to send battery status by using ESPNow messages
 uint16_t wifi_channel = 0;
@@ -55,6 +56,7 @@ static uint16_t reconnectAttempts = 0;  // Counter for reconnect attempts
 static uint16_t current_full_reconnect_interval = INIT_WIFI_FULL_RECONNECT_INTERVAL;
 static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
+static bool ap_active = false;  // true while the soft-AP is running
 
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
@@ -208,6 +210,15 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
   logging.print("Wi-Fi Got IP. ");
   logging.print("IP address: ");
   logging.println(WiFi.localIP().toString());
+
+  // If AP broadcast is enabled and the user opted to drop the AP after connecting,
+  // shut the soft-AP down now that we have a working local-network connection.
+  if (wifiap_enabled && wifi_ap_disable_after_connect && ap_active) {
+    logging.println("Connected to local network, disabling Wi-Fi access point.");
+    WiFi.softAPdisconnect(true);  // stop the AP and free its resources
+    WiFi.mode(WIFI_STA);          // keep station-only mode
+    ap_active = false;
+  }
 }
 
 // Event handler for Wi-Fi disconnection
@@ -250,7 +261,8 @@ void init_WiFi_AP() {
   DEBUG_PRINTF("Access Point password is set (%u characters)\n", (unsigned)passwordAP.length());
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
+  ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 
-  DEBUG_PRINTF("Access Point created.\nIP address: %s\n", IP.toString().c_str());
+  DEBUG_PRINTF("Access Point created. IP address: %s\n", IP.toString().c_str());
 }

--- a/Software/src/devboard/wifi/wifi.h
+++ b/Software/src/devboard/wifi/wifi.h
@@ -36,6 +36,7 @@ void init_mDNS();
 
 extern bool wifi_enabled;
 extern bool wifiap_enabled;
+extern bool wifi_ap_disable_after_connect;
 extern bool mdns_enabled;
 extern bool espnow_enabled;
 extern bool static_IP_enabled;


### PR DESCRIPTION
### What
Add a settings-page checkbox "Disable access point after connecting to local network" (checked by default, persisted as NVS key APOFFONCONN). When AP broadcast is enabled and this option is on, the soft-AP stays up while the device cannot join the configured STA network, and is shut down (station-only mode) once STA obtains an IP.

### Why
Increase security at the sites where BE is deployed, by offering the option to disable AP after connection the local network. It is by default enabled, to increase user awareness.

This gives a captive-AP-style bootstrap experience: the AP stays available while the device can't reach the network (so you can configure it), and disappears once it's on the LAN.
Original behavior (keep both STA and AP modes) can be restored by clearing the checkbox and saving the settings+reboot.

Additional benefit is freeing the runtime resources of the seldomly used AP.

Fixes #799

### How
When "Broadcast Wifi access point" is enabled and this option is on, the device keeps its soft-AP running after boot for as long as it cannot join the configured station (STA) network. As soon as it successfully connects and obtains an IP, the AP is shut down and the device drops to station-only mode. While the device has not yet connected since boot, the AP stays available. Once STA obtains an IP the AP is shut down. 

- Boot, with AP broadcast option enabled: AP starts and stays up.
- While STA can't connect: no GOT_IP fires, so the AP remains available; the existing full-reconnect path also re-asserts the AP while the device has never connected.
- On first successful IP: onWifiGotIP runs once and, if enabled, tears the AP down and switches to station-only. ap_active prevents repeated toggling.
- Option unchecked: previous always-on-AP behavior is preserved.
- Option disabled / AP broadcast disabled: no change from current behavior.
- The unlikely event that the configured local networ SSID never comes back (eg. someone steals the AP or reconfigures the network to a different SSID) manual intervention is needed anyway, thus a BE reboot will restore access through the AP.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
