### PR TITLE
feat(wifi): long-press board BOOT button to start AP or factory reset

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -240,6 +240,20 @@ void init_stored_settings() {
   datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN2", true);
 }
 
+void clear_wifi_sta_settings() {
+  BatteryEmulatorSettingsStore settings;
+  static const char* sta_keys[] = {
+      "SSID",     "PASSWORD",
+      "WIFICHANNEL", "STATICIP",
+      "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
+      "GATEWAY1", "GATEWAY2", "GATEWAY3", "GATEWAY4",
+      "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
+  };
+  for (auto key : sta_keys) {
+    settings.removeKey(key);
+  }
+}
+
 void store_settings_equipment_stop() {
   BatteryEmulatorSettingsStore settings(false);
   settings.saveBool("EQUIPMENT_STOP", datalayer.system.info.equipment_stop_active);

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -246,7 +246,10 @@ void clear_wifi_sta_settings() {
   settings.saveString("PASSWORD", "");
   settings.saveUInt("WIFICHANNEL", 0);
   settings.saveBool("STATICIP", false);
-  // Static-IP octets -> 0 (STATICIP=false already disables their use)
+  // Force the AP on so the device is reachable after the STA settings are cleared,
+  // overriding a user preference that may have disabled it:
+  settings.saveBool("WIFIAPENABLED", true);
+  // Static-IP octets -> 0 (STATICIP=false already disables their use):
   const char* ip_keys[] = {
       "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4", "GATEWAY1", "GATEWAY2",
       "GATEWAY3", "GATEWAY4", "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -243,11 +243,8 @@ void init_stored_settings() {
 void clear_wifi_sta_settings() {
   BatteryEmulatorSettingsStore settings;
   static const char* sta_keys[] = {
-      "SSID",     "PASSWORD",
-      "WIFICHANNEL", "STATICIP",
-      "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
-      "GATEWAY1", "GATEWAY2", "GATEWAY3", "GATEWAY4",
-      "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
+      "SSID",     "PASSWORD", "WIFICHANNEL", "STATICIP", "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
+      "GATEWAY1", "GATEWAY2", "GATEWAY3",    "GATEWAY4", "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
   };
   for (auto key : sta_keys) {
     settings.removeKey(key);

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -242,12 +242,18 @@ void init_stored_settings() {
 
 void clear_wifi_sta_settings() {
   BatteryEmulatorSettingsStore settings;
-  static const char* sta_keys[] = {
-      "SSID",     "PASSWORD", "WIFICHANNEL", "STATICIP", "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
-      "GATEWAY1", "GATEWAY2", "GATEWAY3",    "GATEWAY4", "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
+  settings.saveString("SSID", "");
+  settings.saveString("PASSWORD", "");
+  settings.saveUInt("WIFICHANNEL", 0);
+  settings.saveBool("STATICIP", false);
+  // Static-IP octets -> 0 (STATICIP=false already disables their use)
+  const char* ip_keys[] = {
+      "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
+      "GATEWAY1", "GATEWAY2", "GATEWAY3", "GATEWAY4",
+      "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
   };
-  for (auto key : sta_keys) {
-    settings.removeKey(key);
+  for (auto key : ip_keys) {
+    settings.saveUInt(key, 0);
   }
 }
 

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -248,9 +248,8 @@ void clear_wifi_sta_settings() {
   settings.saveBool("STATICIP", false);
   // Static-IP octets -> 0 (STATICIP=false already disables their use)
   const char* ip_keys[] = {
-      "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4",
-      "GATEWAY1", "GATEWAY2", "GATEWAY3", "GATEWAY4",
-      "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
+      "LOCALIP1", "LOCALIP2", "LOCALIP3", "LOCALIP4", "GATEWAY1", "GATEWAY2",
+      "GATEWAY3", "GATEWAY4", "SUBNET1",  "SUBNET2",  "SUBNET3",  "SUBNET4",
   };
   for (auto key : ip_keys) {
     settings.saveUInt(key, 0);

--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -36,6 +36,8 @@ void store_settings_equipment_stop();
  */
 void store_settings();
 
+void clear_wifi_sta_settings();
+
 // Wraps the Preferences object begin/end calls, so that the scope of this object
 // runs them automatically (via constructor/destructor).
 class BatteryEmulatorSettingsStore {
@@ -51,6 +53,13 @@ class BatteryEmulatorSettingsStore {
   void clearAll() {
     settings.clear();
     settingsUpdated = true;
+  }
+
+  void removeKey(const char* name) {
+    if (settings.isKey(name)) {
+      settings.remove(name);
+      settingsUpdated = true;
+    }
   }
 
   int32_t getInt(const char* name, int32_t defaultValue) {

--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -55,13 +55,6 @@ class BatteryEmulatorSettingsStore {
     settingsUpdated = true;
   }
 
-  void removeKey(const char* name) {
-    if (settings.isKey(name)) {
-      settings.remove(name);
-      settingsUpdated = true;
-    }
-  }
-
   int32_t getInt(const char* name, int32_t defaultValue) {
     return settings.isKey(name) ? settings.getInt(name, defaultValue) : defaultValue;
   }

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -205,6 +205,9 @@ class Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_NC; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_NC; }
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP. Usually the BOOT button on GPIO0.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_NC; }
+
   // Returns the available comm interfaces on this HW
   virtual std::vector<comm_interface> available_interfaces() = 0;
 

--- a/Software/src/devboard/hal/hw_becom.h
+++ b/Software/src/devboard/hal/hw_becom.h
@@ -63,6 +63,9 @@ class BEComHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_2; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_41; }
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanFdAddonMcp2518,
             comm_interface::CanFdAddonMcp2518_2};

--- a/Software/src/devboard/hal/hw_devkit.h
+++ b/Software/src/devboard/hal/hw_devkit.h
@@ -67,6 +67,9 @@ class DevKitHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_25; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   std::vector<comm_interface> available_interfaces() {
     return {
         comm_interface::Modbus,

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -109,6 +109,9 @@ class LilyGoHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_25; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {
     if (user_selected_gpioopt4 == GPIOOPT4::I2C_DISPLAY_SSD1306) {

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -143,6 +143,9 @@ class LilyGo2CANHal : public Esp32Hal {
     return GPIO_NUM_14;
   }
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
             comm_interface::CanFdAddonMcp2518};

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -98,6 +98,9 @@ class StarkHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_25; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_32; }
 
+  // the FLA momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP if not running
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,
             comm_interface::CanFdNative};

--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -43,6 +43,9 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
   virtual gpio_num_t WUP_PIN1() { return GPIO_NUM_8; }
   virtual gpio_num_t WUP_PIN2() { return GPIO_NUM_9; }  //Collides with SMA contactor input
 
+  // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
+
   // Automatic precharging
   virtual gpio_num_t HIA4V1_PIN() { return GPIO_NUM_5; }
   virtual gpio_num_t INVERTER_DISCONNECT_CONTACTOR_PIN() { return GPIO_NUM_3; }

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -19,6 +19,19 @@
 
 static LED* led = nullptr;
 
+static bool led_override_active = false;
+static uint32_t led_override_color = 0;
+static uint16_t led_override_period_ms = 0;
+
+void set_led_override(bool active, uint32_t color, uint16_t period_ms) {
+  if (led == nullptr) {
+    return;  // no LED (GPIO unset or used for an OLED) — nothing to drive
+  }
+  led_override_active = active;
+  led_override_color = color;
+  led_override_period_ms = period_ms;
+}
+
 uint16_t map_int(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
@@ -49,6 +62,14 @@ void led_exe(void) {
 }
 
 void LED::exe(void) {
+  // Button-hold feedback: square-wave blink at full brightness, ahead of normal state.
+  if (led_override_active && led_override_period_ms > 0) {
+    const bool on = (millis() / (led_override_period_ms / 2)) % 2;
+    pixels.setPixelColor(on ? led_override_color : 0);
+    pixels.show();
+    return;
+  }
+  
   // Update brightness
   switch (datalayer.battery.status.led_mode) {
     case led_mode_enum::FLOW:

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -69,7 +69,7 @@ void LED::exe(void) {
     pixels.show();
     return;
   }
-  
+
   // Update brightness
   switch (datalayer.battery.status.led_mode) {
     case led_mode_enum::FLOW:

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -4,6 +4,8 @@
 #include "../../devboard/utils/types.h"
 #include "../../lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h"
 
+static const uint32_t LED_COLOR_WHITE = 0xFFFFFF;  // R=G=B=255
+
 class LED {
  public:
   LED(gpio_num_t pin, uint8_t maxBrightness)
@@ -30,5 +32,10 @@ class LED {
 
 bool led_init(void);
 void led_exe(void);
+
+// Temporarily override the LED for button-hold feedback: blinks `color` on/off at
+// `period_ms`. Pass active=false to release and resume normal battery-state behavior.
+// No-op when no LED is present (GPIO unset, or configured as an OLED instead).
+void set_led_override(bool active, uint32_t color, uint16_t period_ms);
 
 #endif  // LED_H_

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1036,9 +1036,10 @@ String processor(const String& var) {
     }
 
     if (ap_active) {
-      content += "<h4>Wi-Fi access point active &mdash; SSID: " + html_escape(ssidAP.c_str()) + " (" + WiFi.softAPIP().toString() + ")</h4>";
+      content += "<h4>Wi-Fi access point active &mdash; SSID: " + html_escape(ssidAP.c_str()) + " (" +
+                 WiFi.softAPIP().toString() + ")</h4>";
     }
-    
+
     // Close the block
     content += "</div>";
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1034,6 +1034,11 @@ String processor(const String& var) {
     } else {
       content += "<h4>Wifi state: " + getConnectResultString(status) + "</h4>";
     }
+
+    if (ap_active) {
+      content += "<h4>Wi-Fi access point active &mdash; SSID: " + html_escape(ssidAP.c_str()) + " (" + WiFi.softAPIP().toString() + ")</h4>";
+    }
+    
     // Close the block
     content += "</div>";
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -56,6 +56,11 @@ static uint16_t current_full_reconnect_interval = INIT_WIFI_FULL_RECONNECT_INTER
 static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
 
+static bool ap_button_inited = false;
+static bool ap_button_was_pressed = false;
+static unsigned long ap_button_press_start = 0;
+static const unsigned long AP_BUTTON_HOLD_MS = 5000;  // 5-second long-press to start AP
+
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
 
@@ -100,6 +105,8 @@ void init_WiFi() {
 
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
+  check_ap_button();
+
   if (ssid.empty() || password.empty()) {
     return;
   }
@@ -253,4 +260,36 @@ void init_WiFi_AP() {
   IPAddress IP = WiFi.softAPIP();
 
   DEBUG_PRINTF("Access Point created.\nIP address: %s\n", IP.toString().c_str());
+}
+
+// Long-press the board button (usually BOOT/GPIO0) for 5 s to start the AP if it's off.
+static void check_ap_button() {
+  const gpio_num_t pin = esp32hal->AP_BUTTON_PIN();
+  if (pin == GPIO_NUM_NC) {
+    return;  // board has no AP button
+  }
+
+  if (!ap_button_inited) {
+    // Configure lazily, after boot, so we never disturb GPIO0's strapping at reset.
+    pinMode(pin, INPUT_PULLUP);
+    ap_button_inited = true;
+    return;  // let the pull-up settle before the first read
+  }
+
+  const bool pressed = (digitalRead(pin) == LOW);  // active-low (button to GND)
+  const unsigned long now = millis();
+
+  if (pressed && !ap_button_was_pressed) {
+    ap_button_press_start = now;  // press started
+  } else if (pressed && ap_button_was_pressed) {
+    if (now - ap_button_press_start >= AP_BUTTON_HOLD_MS) {
+      if (!ap_active) {
+        logging.println("AP button long-press: starting Wi-Fi access point.");
+        WiFi.mode(WIFI_AP_STA);
+        init_WiFi_AP();  // idempotent; sets ap_active
+      }
+      ap_button_press_start = now;  // re-arm; won't retrigger until released/re-held
+    }
+  }
+  ap_button_was_pressed = pressed;
 }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,8 +1,8 @@
 #include "wifi.h"
+#include "../../communication/nvm/comm_nvm.h"
 #include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
 #include "../utils/events.h"
 #include "../utils/logging.h"
-#include "../../communication/nvm/comm_nvm.h"
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif
@@ -62,8 +62,8 @@ bool ap_active = false;
 static bool ap_button_inited = false;
 static bool ap_button_was_pressed = false;
 static unsigned long ap_button_press_start = 0;
-static const unsigned long AP_BUTTON_AP_MS = 5000;             // >=5 s: start AP
-static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000; // >=30 s: factory reset
+static const unsigned long AP_BUTTON_AP_MS = 5000;              // >=5 s: start AP
+static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000;  // >=30 s: factory reset
 
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,6 +1,7 @@
 #include "wifi.h"
 #include "../../communication/nvm/comm_nvm.h"
 #include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
+#include "../utils/led_handler.h"
 #include "../utils/events.h"
 #include "../utils/logging.h"
 #ifndef SMALL_FLASH_DEVICE
@@ -129,8 +130,21 @@ static void check_ap_button() {
 
   if (pressed && !ap_button_was_pressed) {
     ap_button_press_start = now;  // press started
+  } else if (pressed && ap_button_was_pressed) {
+    // Still held: white blink, rate steps up as each tier is reached.
+    const unsigned long held = now - ap_button_press_start;
+    if (held >= AP_BUTTON_FACTORY_RESET_MS) {
+      set_led_override(true, LED_COLOR_WHITE, 100);  // >=30 s
+    } else if (held >= AP_BUTTON_STA_WIPE_MS) {
+      set_led_override(true, LED_COLOR_WHITE, 200);  // >=15 s
+    } else if (held >= AP_BUTTON_AP_MS) {
+      set_led_override(true, LED_COLOR_WHITE, 400);  // >=5 s
+    } else {
+      set_led_override(false, 0, 0);  // <5 s: no feedback yet
+    }
   } else if (!pressed && ap_button_was_pressed) {
     // Released: act based on how long it was held.
+    set_led_override(false, 0, 0);  // released: stop blink feedback
     const unsigned long held = now - ap_button_press_start;
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       logging.println("Button held >=30 s: performing factory reset and rebooting.");

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -156,7 +156,7 @@ static void check_ap_button() {
 
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
-  ();
+  check_ap_button();
 
   if (ssid.empty() || password.empty()) {
     return;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,8 +1,8 @@
 #include "wifi.h"
 #include "../../communication/nvm/comm_nvm.h"
 #include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
-#include "../utils/led_handler.h"
 #include "../utils/events.h"
+#include "../utils/led_handler.h"
 #include "../utils/logging.h"
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,10 +1,10 @@
 #include "wifi.h"
 #include "../../communication/nvm/comm_nvm.h"
 #include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
+#include "../safety/safety.h"
 #include "../utils/events.h"
 #include "../utils/led_handler.h"
 #include "../utils/logging.h"
-#include "../safety/safety.h"
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -4,6 +4,7 @@
 #include "../utils/events.h"
 #include "../utils/led_handler.h"
 #include "../utils/logging.h"
+#include "../safety/safety.h"
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif
@@ -147,7 +148,6 @@ static void check_ap_button() {
     set_led_override(false, 0, 0);  // released: stop blink feedback
     const unsigned long held = now - ap_button_press_start;
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
-      logging.println("Button held >=30 s: performing factory reset and rebooting.");
       // Stop current flow without persisting the equipment state before factory reset as reboot will open contactors
       // Max Charge/Discharge = 0; CAN = stop; contactors = open
       setBatteryPause(true, true, true, false);
@@ -156,7 +156,6 @@ static void check_ap_button() {
       delay(1000);
       ESP.restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
-      logging.println("Button held >=15 s: clearing Wi-Fi station settings and rebooting.");
       // Stop current flow as the reboot will open contactors
       setBatteryPause(true, false, false, false);
       clear_wifi_sta_settings();
@@ -164,7 +163,6 @@ static void check_ap_button() {
       ESP.restart();
     } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {
-        logging.println("Button held >=5 s: starting Wi-Fi access point.");
         WiFi.mode(WIFI_AP_STA);
         init_WiFi_AP();  // sets ap_active
       }
@@ -324,11 +322,11 @@ void init_mDNS() {
 void init_WiFi_AP() {
 
   DEBUG_PRINTF("Creating Access Point: %s\n", ssidAP.c_str());
-  DEBUG_PRINTF("Access Point password is set (%u characters)\n", (unsigned)passwordAP.length());
+  DEBUG_PRINTF("Access Point password set (%u characters)\n", (unsigned)passwordAP.length());
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 
-  DEBUG_PRINTF("Access Point created. IP address: %s\n", IP.toString().c_str());
+  DEBUG_PRINTF("Access Point created, IP address: %s\n", IP.toString().c_str());
 }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -2,6 +2,7 @@
 #include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
 #include "../utils/events.h"
 #include "../utils/logging.h"
+#include "../../communication/nvm/comm_nvm.h"
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif
@@ -61,7 +62,8 @@ bool ap_active = false;
 static bool ap_button_inited = false;
 static bool ap_button_was_pressed = false;
 static unsigned long ap_button_press_start = 0;
-static const unsigned long AP_BUTTON_HOLD_MS = 5000;  // 5-second long-press to start AP
+static const unsigned long AP_BUTTON_AP_MS = 5000;             // >=5 s: start AP
+static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000; // >=30 s: factory reset
 
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
@@ -105,7 +107,9 @@ void init_WiFi() {
   DEBUG_PRINTF("init_Wifi complete\n");
 }
 
-// Long-press the board button (usually BOOT/GPIO0) for 5 s to start the AP if it's off.
+// Board button (usually BOOT/GPIO0):
+//   held >= 30 s then released -> factory reset (clear settings) + reboot
+//   held >=  5 s then released -> start the Wi-Fi AP if it isn't running
 static void check_ap_button() {
   const gpio_num_t pin = esp32hal->AP_BUTTON_PIN();
   if (pin == GPIO_NUM_NC) {
@@ -124,14 +128,21 @@ static void check_ap_button() {
 
   if (pressed && !ap_button_was_pressed) {
     ap_button_press_start = now;  // press started
-  } else if (pressed && ap_button_was_pressed) {
-    if (now - ap_button_press_start >= AP_BUTTON_HOLD_MS) {
+  } else if (!pressed && ap_button_was_pressed) {
+    // Released: act based on how long it was held.
+    const unsigned long held = now - ap_button_press_start;
+    if (held >= AP_BUTTON_FACTORY_RESET_MS) {
+      logging.println("Button held >=30 s: performing factory reset and rebooting.");
+      BatteryEmulatorSettingsStore settings;
+      settings.clearAll();
+      delay(100);
+      ESP.restart();
+    } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {
-        logging.println("AP button long-press: starting Wi-Fi access point.");
+        logging.println("Button held >=5 s: starting Wi-Fi access point.");
         WiFi.mode(WIFI_AP_STA);
         init_WiFi_AP();  // sets ap_active
       }
-      ap_button_press_start = now;  // re-arm; won't retrigger until released/re-held
     }
   }
   ap_button_was_pressed = pressed;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,6 +1,7 @@
 #include "wifi.h"
 #include "../utils/events.h"
 #include "../utils/logging.h"
+#include "../hal/hal.h"        // esp32hal / AP_BUTTON_PIN()
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif
@@ -56,6 +57,7 @@ static uint16_t current_full_reconnect_interval = INIT_WIFI_FULL_RECONNECT_INTER
 static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
 
+static bool ap_active = false;
 static bool ap_button_inited = false;
 static bool ap_button_was_pressed = false;
 static unsigned long ap_button_press_start = 0;
@@ -101,6 +103,38 @@ void init_WiFi() {
   connectToWiFi();
 
   DEBUG_PRINTF("init_Wifi complete\n");
+}
+
+// Long-press the board button (usually BOOT/GPIO0) for 5 s to start the AP if it's off.
+static void check_ap_button() {
+  const gpio_num_t pin = esp32hal->AP_BUTTON_PIN();
+  if (pin == GPIO_NUM_NC) {
+    return;  // board has no AP button
+  }
+
+  if (!ap_button_inited) {
+    // Configure lazily, after boot, so we never disturb GPIO0 strapping at reset.
+    pinMode(pin, INPUT_PULLUP);
+    ap_button_inited = true;
+    return;  // let the pull-up settle before the first read
+  }
+
+  const bool pressed = (digitalRead(pin) == LOW);  // active-low (button to GND)
+  const unsigned long now = millis();
+
+  if (pressed && !ap_button_was_pressed) {
+    ap_button_press_start = now;  // press started
+  } else if (pressed && ap_button_was_pressed) {
+    if (now - ap_button_press_start >= AP_BUTTON_HOLD_MS) {
+      if (!ap_active) {
+        logging.println("AP button long-press: starting Wi-Fi access point.");
+        WiFi.mode(WIFI_AP_STA);
+        init_WiFi_AP();  // sets ap_active
+      }
+      ap_button_press_start = now;  // re-arm; won't retrigger until released/re-held
+    }
+  }
+  ap_button_was_pressed = pressed;
 }
 
 // Task to monitor Wi-Fi status and handle reconnections
@@ -257,39 +291,9 @@ void init_WiFi_AP() {
   DEBUG_PRINTF("Access Point password is set (%u characters)\n", (unsigned)passwordAP.length());
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
+  ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 
   DEBUG_PRINTF("Access Point created.\nIP address: %s\n", IP.toString().c_str());
 }
 
-// Long-press the board button (usually BOOT/GPIO0) for 5 s to start the AP if it's off.
-static void check_ap_button() {
-  const gpio_num_t pin = esp32hal->AP_BUTTON_PIN();
-  if (pin == GPIO_NUM_NC) {
-    return;  // board has no AP button
-  }
-
-  if (!ap_button_inited) {
-    // Configure lazily, after boot, so we never disturb GPIO0's strapping at reset.
-    pinMode(pin, INPUT_PULLUP);
-    ap_button_inited = true;
-    return;  // let the pull-up settle before the first read
-  }
-
-  const bool pressed = (digitalRead(pin) == LOW);  // active-low (button to GND)
-  const unsigned long now = millis();
-
-  if (pressed && !ap_button_was_pressed) {
-    ap_button_press_start = now;  // press started
-  } else if (pressed && ap_button_was_pressed) {
-    if (now - ap_button_press_start >= AP_BUTTON_HOLD_MS) {
-      if (!ap_active) {
-        logging.println("AP button long-press: starting Wi-Fi access point.");
-        WiFi.mode(WIFI_AP_STA);
-        init_WiFi_AP();  // idempotent; sets ap_active
-      }
-      ap_button_press_start = now;  // re-arm; won't retrigger until released/re-held
-    }
-  }
-  ap_button_was_pressed = pressed;
-}

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -148,14 +148,19 @@ static void check_ap_button() {
     const unsigned long held = now - ap_button_press_start;
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       logging.println("Button held >=30 s: performing factory reset and rebooting.");
+      // Stop current flow without persisting the equipment state before factory reset as reboot will open contactors
+      // Max Charge/Discharge = 0; CAN = stop; contactors = open
+      setBatteryPause(true, true, true, false);
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
-      delay(100);
+      delay(1000);
       ESP.restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
       logging.println("Button held >=15 s: clearing Wi-Fi station settings and rebooting.");
+      // Stop current flow as the reboot will open contactors
+      setBatteryPause(true, false, false, false);
       clear_wifi_sta_settings();
-      delay(100);
+      delay(1000);
       ESP.restart();
     } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -1,7 +1,7 @@
 #include "wifi.h"
+#include "../hal/hal.h"  // esp32hal / AP_BUTTON_PIN()
 #include "../utils/events.h"
 #include "../utils/logging.h"
-#include "../hal/hal.h"        // esp32hal / AP_BUTTON_PIN()
 #ifndef SMALL_FLASH_DEVICE
 #include <ESPmDNS.h>
 #endif
@@ -296,4 +296,3 @@ void init_WiFi_AP() {
 
   DEBUG_PRINTF("Access Point created.\nIP address: %s\n", IP.toString().c_str());
 }
-

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -294,5 +294,5 @@ void init_WiFi_AP() {
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 
-  DEBUG_PRINTF("Access Point created.\nIP address: %s\n", IP.toString().c_str());
+  DEBUG_PRINTF("Access Point created. IP address: %s\n", IP.toString().c_str());
 }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -57,7 +57,7 @@ static uint16_t current_full_reconnect_interval = INIT_WIFI_FULL_RECONNECT_INTER
 static uint16_t current_check_interval = WIFI_CHECK_INTERVAL;
 static bool connected_once = false;
 
-static bool ap_active = false;
+bool ap_active = false;
 static bool ap_button_inited = false;
 static bool ap_button_was_pressed = false;
 static unsigned long ap_button_press_start = 0;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -63,6 +63,7 @@ static bool ap_button_inited = false;
 static bool ap_button_was_pressed = false;
 static unsigned long ap_button_press_start = 0;
 static const unsigned long AP_BUTTON_AP_MS = 5000;              // >=5 s: start AP
+static const unsigned long AP_BUTTON_STA_WIPE_MS = 15000;       // >=15 s: wipe STA settings + reboot
 static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000;  // >=30 s: factory reset
 
 void init_WiFi() {
@@ -137,6 +138,11 @@ static void check_ap_button() {
       settings.clearAll();
       delay(100);
       ESP.restart();
+    } else if (held >= AP_BUTTON_STA_WIPE_MS) {
+      logging.println("Button held >=15 s: clearing Wi-Fi station settings and rebooting.");
+      clear_wifi_sta_settings();
+      delay(100);
+      ESP.restart();
     } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {
         logging.println("Button held >=5 s: starting Wi-Fi access point.");
@@ -150,7 +156,7 @@ static void check_ap_button() {
 
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
-  check_ap_button();
+  ();
 
   if (ssid.empty() || password.empty()) {
     return;

--- a/Software/src/devboard/wifi/wifi.h
+++ b/Software/src/devboard/wifi/wifi.h
@@ -36,6 +36,7 @@ void init_mDNS();
 
 extern bool wifi_enabled;
 extern bool wifiap_enabled;
+extern bool ap_active;
 extern bool mdns_enabled;
 extern bool espnow_enabled;
 extern bool static_IP_enabled;


### PR DESCRIPTION
### What
Three runtime actions triggered by long-pressing the board button (typically the BOOT button on GPIO0, opt-in per board via the HAL). All actions are decided on button release, based on how long it was held, and the thresholds are checked highest-first so the tiers never overlap or double-fire. The color led blinks white at various speeeds to confirm the selected stage.

| Hold duration | Action | Visual feedback (white) |
| --------------|--------|-----------------|
| n≥ 5 s (and < 15 s) | Start the Wi-Fi access point | Slow blink (400ms) |
| ≥ 15 s (and < 30 s) | Wipe Wi-Fi client settings and reboot with AP on | Mid blink (200ms) |
| ≥ 30 s | Full factory reset and reboot | Fast blink (100ms) |

### Why
GPIO0/BOOT button has no other use at runtime. There are use cases which could benefit from having a way to physically interact with BE:

- The AP is the device's out-of-band access path: if the configured client network is unreachable or the user doesn't know the device's LAN address, a physical way to bring the AP up on demand lets them reach the web interface to reconfigure — without needing serial access or a reflash. This would also encourage people to turn the AP mode off for everyday use and only bring it up when they need it, easily.
- A full factory reset is too blunt when the only problem is wrong network credentials — a mistyped SSID/password or a static IP that doesn't fit the new network. This  is a targeted recovery: fix just the STA connection data and keep everything else (battery/inverter config, AP setup, MQTT, hostname, etc.) intact. After the wipe the device sits with no SSID, so the STA side goes idle cleanly (the connect/monitor code early-returns on an empty SSID — no reconnect churn), and the user reconfigures via the AP.
- Provides a physical, UI-independent recovery of last resort — usable when the device is misconfigured even to the point of being unreachable through the web interface.

### How
- Opt-in per board. GPIO0 is a strapping pin and only usually a button, so the pin is declared per board via AP_BUTTON_PIN(); boards that don't override it get none of these features.
- Fire-on-release + highest-threshold-first. This is what makes the three tiers safe and mutually exclusive, and prevents accidental destructive actions from a held/stuck pin.
- No hold feedback. Consistent with a single silent button, there's no on-device countdown; users can't see the 5/15/30 s boundaries. The two destructive tiers are 15 s apart to reduce mis-triggering.
- Reachability after a wipe/reset. Both reboot into a state reachable via the AP — at boot if AP broadcast is enabled, otherwise via the 5 s long-press.

### Which boards
These boards have the button for GPIO0 soldered from factory, thus this feature is activated:
- Waveshare ESP32‐S3‐RS485‐CAN
- LilyGo T-2CAN (and FD)
- LilyGo T-CAN485
- ESP32 Devkit V1
- Stark CMR
- BECom

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
