### PR TITLE
CMFA platform: Add support for triple battery operation

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -361,6 +361,9 @@ void setup_battery() {
       case BatteryType::NissanLeaf:
         battery3 = new NissanLeafBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
         break;
+      case BatteryType::CmfaEv:
+        battery3 = new CmfaEvBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
+        break;
       case BatteryType::RelionBattery:
         battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,
                                      &datalayer.system.status.battery3_allowed_contactor_closing);


### PR DESCRIPTION
### What
This PR implements support for triple battery operation for CMFA platform batteries

### Why
User requested feature, fixes #2503

### How
We allow constructor to build battery3
> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
