### PR TITLE
VCU: Always assume inverter is alive to avoid fault mode

### DIFF
--- a/Software/src/inverter/VCU-CAN.cpp
+++ b/Software/src/inverter/VCU-CAN.cpp
@@ -19,6 +19,9 @@ static uint8_t calculate_CRC_Nissan(CAN_frame* frame) {
 
 void VCUInverter::update_values() {  //Called every 1s
 
+  //Fake that we have inverter alive, to avoid fault event
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+
   LEAF_1DC.data.u8[0] = ((datalayer.battery.status.max_discharge_power_W / 4) << 2);
   LEAF_1DC.data.u8[1] = ((datalayer.battery.status.max_discharge_power_W / 4) << 6);
   LEAF_1DC.data.u8[1] = (LEAF_1DC.data.u8[1] || (((datalayer.battery.status.max_charge_power_W / 4) >> 4) & 0x3F));
@@ -42,16 +45,12 @@ void VCUInverter::update_values() {  //Called every 1s
 void VCUInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1F2:
-      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x1D4:
-      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x50B:
-      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x50C:
-      datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
       break;
     default:
       break;


### PR DESCRIPTION
### What
This PR implements always assuming inverter is alive to avoid fault mode

### Why
Fixes #2545

### How
We always force CAN inverter alive

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
