### PR TITLE
Update short SHA length in firmware rename step

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -60,7 +60,7 @@ jobs:
     #rename firmware.bin to contain pr number and commit short sha for easier location after saved on disk
     - name: Rename firmware.bin with PR number and commit short SHA
       run: |
-          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-6)
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-7)
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_PART="pr${{ github.event.pull_request.number }}-"
           else


### PR DESCRIPTION
### What
Increase the length of the short SHA from mistakenly set 6 to the correct value of 7 characters in the rename step.

### Why
I miscounted the chars

### How
Only change `cut -c1-6` → `cut -c1-7`. 

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
