### PR TITLE
Improvement: Skip BMS reset incase equipment stop is active

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -299,6 +299,11 @@ void bms_power_on() {
 }
 
 void handle_BMSpower() {
+  //Skip running the BMS reset state machine if equipment stop is active, as we don't want to powercycle the BMS during that time
+  if (datalayer.system.info.equipment_stop_active) {
+    return;
+  }
+
   if (periodic_bms_reset || remote_bms_reset) {
     currentTime = millis();
 


### PR DESCRIPTION
### What
This PR skips BMS reset incase equipment stop is active

### Why
Fixes #2491

There is a risk that the periodic BMS reset will unpause a battery!

### How
We skip running the BMS reset statemachine incase equipment stop is active (This is the signal used both by the pause function & physical equipment stop button)

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
