### PR TITLE
Do a graceful restart for reboot/MQTT/OTA, keeping CAN active

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -511,6 +511,8 @@ void core_loop(void*) {
         inverter->update_values();
       }
 
+      update_restart_progress();  // Check if we need to restart the ESP32
+
       if (datalayer.system.info.performance_measurement_active) {
         END_TIME_MEASUREMENT_MAX(values, datalayer.system.status.time_values_us);
       }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -705,9 +705,7 @@ void mqtt_message_received(char* topic_raw, int topic_len, char* data, int data_
   }
 
   if (strcmp(topic, generateButtonTopic("RESTART").c_str()) == 0) {
-    setBatteryPause(true, true, EquipmentStop::STOP, false);
-    delay(1000);
-    ESP.restart();
+    graceful_restart();
   }
 
   if (strcmp(topic, generateButtonTopic("STOP").c_str()) == 0) {

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -25,6 +25,7 @@ static bool battery_empty_event_fired = false;
 bool emulator_pause_request_ON = false;
 bool emulator_pause_CAN_send_ON = false;
 bool allowed_to_send_CAN = true;
+static uint32_t emulator_restart_request_millis = 0;
 
 //component detection
 bool battery_detected = false;
@@ -606,6 +607,32 @@ void setBatteryPause(bool pause_battery, bool pause_CAN, EquipmentStop equipment
 
   //immediate check if we can send CAN messages
   update_pause_state();
+}
+
+void graceful_restart() {
+  // Pause charge/discharge, and then restart the ESP32 within 5s (as soon as the power stops).
+
+  set_event(EVENT_RESTARTING, 0);
+
+  // Stop charge/discharge so we don't damage the contactors
+  setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
+
+  uint32_t now = millis();
+  emulator_restart_request_millis = now > 0 ? now : 1;
+}
+
+void update_restart_progress() {
+  // If is a restart has been requested, check the time and restart if the
+  // conditions are met.
+
+  if (emulator_restart_request_millis > 0) {
+    uint32_t now = millis();
+    uint32_t elapsed = now - emulator_restart_request_millis;
+    // Restart after 2s if the emulator has paused. Always restart after 5s.
+    if ((elapsed > INTERVAL_2_S && emulator_pause_status == PAUSED) || elapsed > INTERVAL_5_S) {
+      ESP.restart();
+    }
+  }
 }
 
 /// @brief handle emulator pause status and CAN sending allowed

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -628,7 +628,7 @@ void update_restart_progress() {
   if (emulator_restart_request_millis > 0) {
     uint32_t now = millis();
     uint32_t elapsed = now - emulator_restart_request_millis;
-    // Restart after 2s if the emulator has paused. Always restart after 5s.
+    // Restart after 5s if the emulator has paused. Always restart after 10s.
     if ((elapsed > INTERVAL_5_S && emulator_pause_status == PAUSED) || elapsed > INTERVAL_10_S) {
       ESP.restart();
     }

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -629,7 +629,7 @@ void update_restart_progress() {
     uint32_t now = millis();
     uint32_t elapsed = now - emulator_restart_request_millis;
     // Restart after 2s if the emulator has paused. Always restart after 5s.
-    if ((elapsed > INTERVAL_2_S && emulator_pause_status == PAUSED) || elapsed > INTERVAL_5_S) {
+    if ((elapsed > INTERVAL_5_S && emulator_pause_status == PAUSED) || elapsed > INTERVAL_10_S) {
       ESP.restart();
     }
   }

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -22,6 +22,8 @@ extern bool battery_detected;
 extern void store_settings_equipment_stop();
 
 void update_machineryprotection();
+void graceful_restart();
+void update_restart_progress();
 
 typedef enum : uint8_t { UNCHANGED = 0, STOP = 1, RESUME = 2 } EquipmentStop;
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -107,6 +107,7 @@ void init_events(void) {
   events.entries[EVENT_UNKNOWN_EVENT_SET].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_OTA_UPDATE].level = EVENT_LEVEL_UPDATE;
   events.entries[EVENT_OTA_UPDATE_TIMEOUT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_RESTARTING].level = EVENT_LEVEL_UPDATE;  // Stops Fronius erroring out during restarts
   events.entries[EVENT_DUMMY_INFO].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DUMMY_DEBUG].level = EVENT_LEVEL_DEBUG;
   events.entries[EVENT_DUMMY_WARNING].level = EVENT_LEVEL_WARNING;
@@ -406,6 +407,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "The board was reset due to a detected power glitch";
     case EVENT_RESET_CPU_LOCKUP:
       return "The board was reset due to CPU lockup. Inform developers!";
+    case EVENT_RESTARTING:
+      return "The emulator is restarting.";
     case EVENT_RJXZS_LOG:
       return "Error code active in RJXZS BMS. Clear via their smartphone app!";
     case EVENT_PAUSE_BEGIN:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -87,6 +87,7 @@
   XX(EVENT_UNKNOWN_EVENT_SET)           \
   XX(EVENT_OTA_UPDATE)                  \
   XX(EVENT_OTA_UPDATE_TIMEOUT)          \
+  XX(EVENT_RESTARTING)                  \
   XX(EVENT_DUMMY_INFO)                  \
   XX(EVENT_DUMMY_DEBUG)                 \
   XX(EVENT_DUMMY_WARNING)               \

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -842,12 +842,7 @@ void init_webserver() {
   // Route to handle reboot command
   def_route_with_auth("/reboot", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     request->send(200, "text/plain", "Rebooting server...");
-
-    //Equipment STOP without persisting the equipment state before restart
-    // Max Charge/Discharge = 0; CAN = stop; contactors = open
-    setBatteryPause(true, true, EquipmentStop::STOP, false);
-    delay(1000);
-    ESP.restart();
+    graceful_restart();
   });
 
   // Initialize ElegantOTA
@@ -881,9 +876,6 @@ String getConnectResultString(wl_status_t status) {
 }
 
 void ota_monitor() {
-
-  ElegantOTA.loop();
-
   if (ota_active && ota_timeout_timer.elapsed()) {
     // OTA timeout, try to restore can and clear the update event
     set_event(EVENT_OTA_UPDATE_TIMEOUT, 0);
@@ -1708,7 +1700,7 @@ String processor(const String& var) {
 
 void onOTAStart() {
   //try to Pause the battery
-  setBatteryPause(true, true);
+  setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
 
   // Log when OTA has started
   set_event(EVENT_OTA_UPDATE, 0);
@@ -1737,15 +1729,12 @@ void onOTAEnd(bool success) {
 
   // Log when OTA has finished
   if (success) {
-    //Equipment STOP without persisting the equipment state before restart
-    // Max Charge/Discharge = 0; CAN = stop; contactors = open
-    setBatteryPause(true, true, EquipmentStop::STOP, false);
-    // a reboot will be done by the OTA library. no need to do anything here
     logging.println("OTA update finished successfully!");
+    graceful_restart();
   } else {
     logging.println("There was an error during OTA update!");
-    //try to Resume the battery pause and CAN communication
-    setBatteryPause(false, false);
+    // Unpause battery (preserving equipment stop if set)
+    setBatteryPause(false, false, EquipmentStop::UNCHANGED, false);
   }
 }
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -148,19 +148,12 @@ static void check_ap_button() {
     set_led_override(false, 0, 0);  // released: stop blink feedback
     const unsigned long held = now - ap_button_press_start;
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
-      // Stop current flow without persisting the equipment state before factory reset as reboot will open contactors
-      // Max Charge/Discharge = 0; CAN = stop; contactors = open
-      setBatteryPause(true, true, EquipmentStop::STOP, false);
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
-      delay(1000);
-      ESP.restart();
+      graceful_restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
-      // Stop current flow as the reboot will open contactors
-      setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
       clear_wifi_sta_settings();
-      delay(1000);
-      ESP.restart();
+      graceful_restart();
     } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {
         WiFi.mode(WIFI_AP_STA);

--- a/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
+++ b/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
@@ -57,13 +57,6 @@ void ElegantOTAClass::begin(ELEGANTOTA_WEBSERVER *server){
         response->addHeader("Connection", "close");
         response->addHeader("Access-Control-Allow-Origin", "*");
         request->send(response);
-        // Set reboot flag
-        if (!Update.hasError()) {
-            // Stop current flow as the reboot will open contactors
-            setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
-            _reboot_request_millis = millis();
-            _reboot = true;
-        }
     }, [&](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
         //Upload handler chunks in data
         if (!index) {
@@ -94,14 +87,6 @@ void ElegantOTAClass::begin(ELEGANTOTA_WEBSERVER *server){
         }
     });
 
-}
-
-void ElegantOTAClass::loop() {
-  // Check if 2 seconds have passed since _reboot_request_millis was set
-  if (_reboot && millis() - _reboot_request_millis > 2000) {
-    ESP.restart();
-    _reboot = false;
-  }
 }
 
 void ElegantOTAClass::onStart(std::function<void()> callable){

--- a/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h
+++ b/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.h
@@ -38,16 +38,12 @@ class ElegantOTAClass{
 
     void begin(ELEGANTOTA_WEBSERVER *server);
 
-    void loop();
-
     void onStart(std::function<void()> callable);
     void onProgress(std::function<void(size_t current, size_t final)> callable);
     void onEnd(std::function<void(bool success)> callable);
     
   private:
     ELEGANTOTA_WEBSERVER *_server;
-    bool _reboot = false;
-    unsigned long _reboot_request_millis = 0;
 
     String _update_error_str = "";
     unsigned long _current_progress_size;

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -150,6 +150,7 @@ class ESPClass {
   }
 
   uint64_t getEfuseMac() { return 0xAABBCCDDEEFFULL; }
+  void restart() {}
 };
 
 extern ESPClass ESP;


### PR DESCRIPTION
### What
Currently, reboots via OTA, WiFi and mqtt send pause_CAN=true, which can result in the inverter being paused before the power=0W restriction is sent.

Add a new `graceful_restart()` function which stops charge/discharge (but leaves CAN operating, equipment stop unasserted, and is not persistent).

Add a tick function to the main loop which will then restart the ESP after 2s once PAUSED (so the current has fallen), or after 5s regardless.

Note: the pause_CAN argument is no longer used anywhere - should it be, or can it be removed?

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
