### PR TITLE
Add battery3 current to pause/reset checks

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -319,12 +319,13 @@ void handle_BMSpower() {
 
       int16_t battery_current_dA = datalayer.battery.status.current_dA;
       int16_t battery2_current_dA = datalayer.battery2.status.current_dA;  // Should be 0 if no battery2
+      int16_t battery3_current_dA = datalayer.battery3.status.current_dA;  // Should be 0 if no battery3
 
       if (
           // No current, safe to cut power
-          (battery_current_dA == 0 && battery2_current_dA == 0)
+          (battery_current_dA == 0 && battery2_current_dA == 0 && battery3_current_dA == 0)
           // or reasonably low current and 5 seconds has passed
-          || (abs(battery_current_dA) < 10 && abs(battery2_current_dA) < 10 &&
+          || (abs(battery_current_dA) < 10 && abs(battery2_current_dA) < 10 && abs(battery3_current_dA) < 10 &&
               currentTime - lastPowerRemovalTime >= 5000)) {
 
         bms_power_off();

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -586,9 +586,14 @@ void update_pause_state() {
     allowed_to_send_CAN = true;
   }
 
+  int16_t battery_current_dA = datalayer.battery.status.current_dA;
+  int16_t battery2_current_dA = datalayer.battery2.status.current_dA;  // Should be 0 if no battery2
+  int16_t battery3_current_dA = datalayer.battery3.status.current_dA;  // Should be 0 if no battery3
+  static const int16_t CURRENT_THRESHOLD_dA = 18;                      // 1.8A in deciAmps
+
   // in some inverters this values are not accurate, so we need to check if we are consider 1.8 amps as the limit
-  if (emulator_pause_request_ON && emulator_pause_status == PAUSING && datalayer.battery.status.current_dA < 18 &&
-      datalayer.battery.status.current_dA > -18) {
+  if (emulator_pause_request_ON && emulator_pause_status == PAUSING && abs(battery_current_dA) < CURRENT_THRESHOLD_dA &&
+      abs(battery2_current_dA) < CURRENT_THRESHOLD_dA && abs(battery3_current_dA) < CURRENT_THRESHOLD_dA) {
     emulator_pause_status = PAUSED;
   }
 


### PR DESCRIPTION
### What
A couple of places check for battery current falling below thresholds, include battery3 in those checks.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
