### PR TITLE
Make equipment stop STOP/RESUME explicit

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -350,7 +350,7 @@ void handle_BMSpower() {
       // Wait for BMS to start up before unpausing
       if (currentTime - bmsPowerOnTime >= bmsWarmupDuration) {
         // Unpause the battery
-        setBatteryPause(false, false, false, false);
+        setBatteryPause(false, false, EquipmentStop::UNCHANGED, false);
 
         // Reset is complete
 
@@ -369,7 +369,7 @@ void start_bms_reset() {
       lastPowerRemovalTime = millis();
 
       // Issue a pause, which should stop charge/discharge whilst the reset is ongoing
-      setBatteryPause(true, false, false, false);
+      setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
 
       if (contactor_control_enabled) {
         // We power the contactors directly, so we can avoid closing/opening them

--- a/Software/src/communication/equipmentstopbutton/comm_equipmentstopbutton.cpp
+++ b/Software/src/communication/equipmentstopbutton/comm_equipmentstopbutton.cpp
@@ -45,20 +45,20 @@ void monitor_equipment_stop_button() {
   if (equipment_stop_behavior == STOP_BUTTON_BEHAVIOR::LATCHING_SWITCH) {
     if (changed_state == PRESSED) {
       // Changed to ON – initiating equipment stop.
-      setBatteryPause(true, false, true);
+      setBatteryPause(true, false, EquipmentStop::STOP);
     } else if (changed_state == RELEASED) {
       // Changed to OFF – ending equipment stop.
-      setBatteryPause(false, false, false);
+      setBatteryPause(false, false, EquipmentStop::RESUME);
     }
   } else if (equipment_stop_behavior == STOP_BUTTON_BEHAVIOR::MOMENTARY_SWITCH) {
     if (changed_state == RELEASED) {  // button is released
 
       if (timeSincePress < equipment_button_long_press_duration) {
         // Short press detected, trigger equipment stop
-        setBatteryPause(true, false, true);
+        setBatteryPause(true, false, EquipmentStop::STOP);
       } else {
         // Long press detected, reset equipment stop state
-        setBatteryPause(false, false, false);
+        setBatteryPause(false, false, EquipmentStop::RESUME);
       }
     }
   }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -701,17 +701,17 @@ void mqtt_message_received(char* topic_raw, int topic_len, char* data, int data_
   }
 
   if (strcmp(topic, generateButtonTopic("RESUME").c_str()) == 0) {
-    setBatteryPause(false, false, false);
+    setBatteryPause(false, false, EquipmentStop::RESUME);
   }
 
   if (strcmp(topic, generateButtonTopic("RESTART").c_str()) == 0) {
-    setBatteryPause(true, true, true, false);
+    setBatteryPause(true, true, EquipmentStop::STOP, false);
     delay(1000);
     ESP.restart();
   }
 
   if (strcmp(topic, generateButtonTopic("STOP").c_str()) == 0) {
-    setBatteryPause(true, false, true);
+    setBatteryPause(true, false, EquipmentStop::STOP);
   }
 
   if (strcmp(topic, generateButtonTopic("SET_LIMITS").c_str()) == 0) {

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -528,18 +528,18 @@ void update_machineryprotection() {
 }
 
 //battery pause status begin
-void setBatteryPause(bool pause_battery, bool pause_CAN, bool equipment_stop, bool store_settings) {
+void setBatteryPause(bool pause_battery, bool pause_CAN, EquipmentStop equipment_stop, bool store_settings) {
   DEBUG_PRINTF("Battery pause begin %d %d %d %d\n", pause_battery, pause_CAN, equipment_stop, store_settings);
 
   // First handle equipment stop / resume
-  if (equipment_stop && !datalayer.system.info.equipment_stop_active) {
+  if (equipment_stop == STOP && !datalayer.system.info.equipment_stop_active) {
     datalayer.system.info.equipment_stop_active = true;
     if (store_settings) {
       store_settings_equipment_stop();
     }
 
     set_event(EVENT_EQUIPMENT_STOP, 1);
-  } else if (!equipment_stop && datalayer.system.info.equipment_stop_active) {
+  } else if (equipment_stop == RESUME && datalayer.system.info.equipment_stop_active) {
     datalayer.system.info.equipment_stop_active = false;
     if (store_settings) {
       store_settings_equipment_stop();

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -1,5 +1,6 @@
 #ifndef SAFETY_H
 #define SAFETY_H
+#include <stdint.h>
 #include <string>
 
 #define MAX_CAN_FAILURES 50
@@ -22,8 +23,11 @@ extern void store_settings_equipment_stop();
 
 void update_machineryprotection();
 
+typedef enum : uint8_t { UNCHANGED = 0, STOP = 1, RESUME = 2 } EquipmentStop;
+
 //battery pause status begin
-void setBatteryPause(bool pause_battery, bool pause_CAN, bool equipment_stop = false, bool store_settings = true);
+void setBatteryPause(bool pause_battery, bool pause_CAN, EquipmentStop equipment_stop = UNCHANGED,
+                     bool store_settings = true);
 void update_pause_state();
 std::string get_emulator_pause_status();
 //battery pause status end

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -630,9 +630,10 @@ void init_webserver() {
   // Route for equipment stop/resume
   update_string("/equipmentStop", [](String value) {
     if (value == "true" || value == "1") {
-      setBatteryPause(true, false, true);  //Pause battery, do not pause CAN, equipment stop on (store to flash)
+      setBatteryPause(true, false,
+                      EquipmentStop::STOP);  //Pause battery, do not pause CAN, equipment stop on (store to flash)
     } else {
-      setBatteryPause(false, false, false);
+      setBatteryPause(false, false, EquipmentStop::RESUME);
     }
   });
 
@@ -844,7 +845,7 @@ void init_webserver() {
 
     //Equipment STOP without persisting the equipment state before restart
     // Max Charge/Discharge = 0; CAN = stop; contactors = open
-    setBatteryPause(true, true, true, false);
+    setBatteryPause(true, true, EquipmentStop::STOP, false);
     delay(1000);
     ESP.restart();
   });
@@ -1738,7 +1739,7 @@ void onOTAEnd(bool success) {
   if (success) {
     //Equipment STOP without persisting the equipment state before restart
     // Max Charge/Discharge = 0; CAN = stop; contactors = open
-    setBatteryPause(true, true, true, false);
+    setBatteryPause(true, true, EquipmentStop::STOP, false);
     // a reboot will be done by the OTA library. no need to do anything here
     logging.println("OTA update finished successfully!");
   } else {

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -150,14 +150,14 @@ static void check_ap_button() {
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       // Stop current flow without persisting the equipment state before factory reset as reboot will open contactors
       // Max Charge/Discharge = 0; CAN = stop; contactors = open
-      setBatteryPause(true, true, true, false);
+      setBatteryPause(true, true, EquipmentStop::STOP, false);
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
       delay(1000);
       ESP.restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
       // Stop current flow as the reboot will open contactors
-      setBatteryPause(true, false, false, false);
+      setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
       clear_wifi_sta_settings();
       delay(1000);
       ESP.restart();

--- a/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
+++ b/Software/src/lib/ayushsharma82-ElegantOTA/src/ElegantOTA.cpp
@@ -60,7 +60,7 @@ void ElegantOTAClass::begin(ELEGANTOTA_WEBSERVER *server){
         // Set reboot flag
         if (!Update.hasError()) {
             // Stop current flow as the reboot will open contactors
-            setBatteryPause(true, false, false, false);
+            setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
             _reboot_request_millis = millis();
             _reboot = true;
         }


### PR DESCRIPTION
### What
Currently the third argument to setBatteryPause is a bool, which sets equipment stop if `true`, and unsets if `false`.

This can lead to scenarios where other pauses inadvertently unset an equipment stop.

Make it tri-state, so that the default is UNCHANGED (which leaves it as it was), with explicit STOP/RESUME options.

### Why
Reduce the likelihood of equipment being un-stopped without consent.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
