### PR TITLE
feature: Add general logging to a syslog server

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -187,10 +187,12 @@ void init_stored_settings() {
   datalayer.system.info.web_logging_active = settings.getBool("WEBENABLED", false);
   datalayer.system.info.CAN_SD_logging_active = settings.getBool("CANLOGSD", false);
   datalayer.system.info.SD_logging_active = settings.getBool("SDLOGENABLED", false);
+#ifndef SMALL_FLASH_DEVICE
   datalayer.system.info.syslog_logging_active = settings.getBool("SYSLOGEN", false);
   syslog_ip = settings.getString("SYSLOGIP").c_str();
   syslog_port = settings.getUInt("SYSLOGPORT", 514);
   syslog_facility = settings.getUInt("SYSLOGFAC", 1);
+#endif
   datalayer.battery.status.led_mode = (led_mode_enum)settings.getUInt("LEDMODE", false);
 
   //Some early integrations need manually set allowed charge/discharge power

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -188,8 +188,8 @@ void init_stored_settings() {
   datalayer.system.info.CAN_SD_logging_active = settings.getBool("CANLOGSD", false);
   datalayer.system.info.SD_logging_active = settings.getBool("SDLOGENABLED", false);
   datalayer.system.info.syslog_logging_active = settings.getBool("SYSLOGEN", false);
-  syslog_ip       = settings.getString("SYSLOGIP").c_str();
-  syslog_port     = settings.getUInt("SYSLOGPORT", 514);
+  syslog_ip = settings.getString("SYSLOGIP").c_str();
+  syslog_port = settings.getUInt("SYSLOGPORT", 514);
   syslog_facility = settings.getUInt("SYSLOGFAC", 1);
   datalayer.battery.status.led_mode = (led_mode_enum)settings.getUInt("LEDMODE", false);
 

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -187,6 +187,10 @@ void init_stored_settings() {
   datalayer.system.info.web_logging_active = settings.getBool("WEBENABLED", false);
   datalayer.system.info.CAN_SD_logging_active = settings.getBool("CANLOGSD", false);
   datalayer.system.info.SD_logging_active = settings.getBool("SDLOGENABLED", false);
+  datalayer.system.info.syslog_logging_active = settings.getBool("SYSLOGEN", false);
+  syslog_ip       = settings.getString("SYSLOGIP").c_str();
+  syslog_port     = settings.getUInt("SYSLOGPORT", 514);
+  syslog_facility = settings.getUInt("SYSLOGFAC", 1);
   datalayer.battery.status.led_mode = (led_mode_enum)settings.getUInt("LEDMODE", false);
 
   //Some early integrations need manually set allowed charge/discharge power

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -290,6 +290,8 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
   bool web_logging_active = false;
   /** bool, determines if general logging to SD card should be active */
   bool SD_logging_active = false;
+  /** bool, determines if general logging to a remote syslog server is active */
+  bool syslog_logging_active = false;
   /** bool, determines if CAN replay should loop or not */
   bool loop_playback = false;
   /** bool, Native CAN failed to send flag */

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -511,7 +511,7 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched) {
       (events.entries[event].state != EVENT_STATE_ACTIVE_LATCHED)) {
     events.entries[event].MQTTpublished = false;
 
-    logging.set_next_severity(event_level_to_syslog(events.entries[event].level));
+    LOG_SET_NEXT_SEVERITY(event_level_to_syslog(events.entries[event].level));
     DEBUG_PRINTF("Event: %s\n", get_event_message_string(event).c_str());
   }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -20,6 +20,24 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched);
 static void update_event_level(void);
 static void update_bms_status(void);
 
+// Map a Battery-Emulator event level to an RFC 5424 syslog severity.
+static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
+  switch (lvl) {
+    case EVENT_LEVEL_ERROR:
+      return 3;  // err
+    case EVENT_LEVEL_WARNING:
+      return 4;  // warning
+    case EVENT_LEVEL_UPDATE:
+      return 5;  // notice
+    case EVENT_LEVEL_INFO:
+      return 6;  // info
+    case EVENT_LEVEL_DEBUG:
+      return 7;  // debug
+    default:
+      return 6;
+  }
+}
+
 /* Initialization function */
 void init_events(void) {
   for (uint16_t i = 0; i < EVENT_NOF_EVENTS; i++) {
@@ -493,6 +511,7 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched) {
       (events.entries[event].state != EVENT_STATE_ACTIVE_LATCHED)) {
     events.entries[event].MQTTpublished = false;
 
+    logging.set_next_severity(event_level_to_syslog(events.entries[event].level));
     DEBUG_PRINTF("Event: %s\n", get_event_message_string(event).c_str());
   }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -20,6 +20,7 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched);
 static void update_event_level(void);
 static void update_bms_status(void);
 
+#ifndef SMALL_FLASH_DEVICE
 // Map a Battery-Emulator event level to an RFC 5424 syslog severity.
 static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
   switch (lvl) {
@@ -37,6 +38,7 @@ static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
       return 6;
   }
 }
+#endif
 
 /* Initialization function */
 void init_events(void) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -1,8 +1,8 @@
 #include "logging.h"
-#include "../../datalayer/datalayer.h"
-#include "../sdcard/sdcard.h"
 #include <WiFi.h>
 #include <WiFiUdp.h>
+#include "../../datalayer/datalayer.h"
+#include "../sdcard/sdcard.h"
 #include "../wifi/wifi.h"  // custom_hostname
 
 #define MAX_LINE_LENGTH_PRINTF 128
@@ -12,14 +12,14 @@ bool previous_message_was_newline = true;
 
 // ---- Remote syslog sink ----
 std::string syslog_ip;
-uint16_t    syslog_port     = 514;
-uint8_t     syslog_facility = 1;  // 1 = user-level
+uint16_t syslog_port = 514;
+uint8_t syslog_facility = 1;  // 1 = user-level
 
 static const uint8_t SYSLOG_DEFAULT_SEVERITY = 7;  // debug — for messages without an event level
-static int     syslog_next_severity = -1;          // -1 = use default; set per-line by set_next_severity()
+static int syslog_next_severity = -1;              // -1 = use default; set per-line by set_next_severity()
 static WiFiUDP syslogUdp;
 #define SYSLOG_LINE_MAX 240
-static char   syslogLine[SYSLOG_LINE_MAX];
+static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
 
 void Logging::set_next_severity(uint8_t sev) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -54,7 +54,8 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
   if (!datalayer.system.info.syslog_logging_active) {
     return;
   }
-  if (WiFi.status() != WL_CONNECTED) {
+  // Send when joined to a network (STA) OR when a client is on our SoftAP.
+  if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
     return;
   }
   for (size_t i = 0; i < size; i++) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -1,11 +1,77 @@
 #include "logging.h"
 #include "../../datalayer/datalayer.h"
 #include "../sdcard/sdcard.h"
+#include <WiFi.h>
+#include <WiFiUdp.h>
+#include "../wifi/wifi.h"  // custom_hostname
 
 #define MAX_LINE_LENGTH_PRINTF 128
 #define MAX_LENGTH_TIME_STR 14
 
 bool previous_message_was_newline = true;
+
+// ---- Remote syslog sink ----
+std::string syslog_ip;
+uint16_t    syslog_port     = 514;
+uint8_t     syslog_facility = 1;  // 1 = user-level
+
+static const uint8_t SYSLOG_DEFAULT_SEVERITY = 7;  // debug — for messages without an event level
+static int     syslog_next_severity = -1;          // -1 = use default; set per-line by set_next_severity()
+static WiFiUDP syslogUdp;
+#define SYSLOG_LINE_MAX 240
+static char   syslogLine[SYSLOG_LINE_MAX];
+static size_t syslogLineLen = 0;
+
+void Logging::set_next_severity(uint8_t sev) {
+  syslog_next_severity = (int)sev;
+}
+
+static void syslog_flush_line(void) {
+  int sev_override = syslog_next_severity;
+  syslog_next_severity = -1;  // consume regardless of outcome
+  size_t len = syslogLineLen;
+  syslogLineLen = 0;
+  if (len == 0) {
+    return;
+  }
+  syslogLine[len] = '\0';
+  IPAddress dst;
+  if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
+    return;
+  }
+  uint8_t sev = (sev_override >= 0) ? (uint8_t)sev_override : SYSLOG_DEFAULT_SEVERITY;
+  uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
+  const char* host = custom_hostname.empty() ? "batteryemulator" : custom_hostname.c_str();
+  if (syslogUdp.beginPacket(dst, syslog_port)) {
+    // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
+    // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
+    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, host, syslogLine);
+    syslogUdp.endPacket();
+  }
+}
+
+static void syslog_emit(const uint8_t* buffer, size_t size) {
+  if (!datalayer.system.info.syslog_logging_active) {
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    return;
+  }
+  for (size_t i = 0; i < size; i++) {
+    char c = (char)buffer[i];
+    if (c == '\r') {
+      continue;
+    }
+    if (c == '\n') {
+      syslog_flush_line();
+    } else {
+      syslogLine[syslogLineLen++] = c;
+      if (syslogLineLen >= SYSLOG_LINE_MAX - 1) {
+        syslog_flush_line();
+      }
+    }
+  }
+}
 
 void Logging::add_timestamp(size_t size) {
 
@@ -50,7 +116,7 @@ void Logging::add_timestamp(size_t size) {
 size_t Logging::write(const uint8_t* buffer, size_t size) {
   // Check if any logging is enabled at runtime
   if (!datalayer.system.info.web_logging_active && !datalayer.system.info.usb_logging_active &&
-      !datalayer.system.info.SD_logging_active) {
+      !datalayer.system.info.SD_logging_active && !datalayer.system.info.syslog_logging_active) {
     return 0;
   }
 
@@ -70,6 +136,8 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
   if (datalayer.system.info.usb_logging_active) {
     Serial.write(buffer, size);
   }
+
+  syslog_emit(buffer, size);
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     char* message_string = datalayer.system.info.logged_can_messages;
@@ -91,7 +159,7 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
 void Logging::printf(const char* fmt, ...) {
   // Check if any logging is enabled at runtime
   if (!datalayer.system.info.web_logging_active && !datalayer.system.info.usb_logging_active &&
-      !datalayer.system.info.SD_logging_active) {
+      !datalayer.system.info.SD_logging_active && !datalayer.system.info.syslog_logging_active) {
     return;
   }
 
@@ -134,6 +202,8 @@ void Logging::printf(const char* fmt, ...) {
   if (datalayer.system.info.usb_logging_active) {
     Serial.write(message_buffer, size);
   }
+
+  syslog_emit((const uint8_t*)message_buffer, size);
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     // Data was already added to buffer, just move offset

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -1,15 +1,19 @@
 #include "logging.h"
-#include <WiFi.h>
-#include <WiFiUdp.h>
 #include "../../datalayer/datalayer.h"
 #include "../sdcard/sdcard.h"
+
+#ifndef SMALL_FLASH_DEVICE
+#include <WiFi.h>
+#include <WiFiUdp.h>
 #include "../wifi/wifi.h"  // custom_hostname
+#endif
 
 #define MAX_LINE_LENGTH_PRINTF 128
 #define MAX_LENGTH_TIME_STR 14
 
 bool previous_message_was_newline = true;
 
+#ifndef SMALL_FLASH_DEVICE
 // ---- Remote syslog sink ----
 std::string syslog_ip;
 uint16_t syslog_port = 514;
@@ -73,6 +77,7 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
     }
   }
 }
+#endif
 
 void Logging::add_timestamp(size_t size) {
 
@@ -138,7 +143,9 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
     Serial.write(buffer, size);
   }
 
+#ifndef SMALL_FLASH_DEVICE
   syslog_emit(buffer, size);
+#endif
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     char* message_string = datalayer.system.info.logged_can_messages;
@@ -204,7 +211,9 @@ void Logging::printf(const char* fmt, ...) {
     Serial.write(message_buffer, size);
   }
 
+#ifndef SMALL_FLASH_DEVICE
   syslog_emit((const uint8_t*)message_buffer, size);
+#endif
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     // Data was already added to buffer, just move offset

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -5,6 +5,7 @@
 #include "../../datalayer/datalayer.h"
 #include "Print.h"
 #include "types.h"
+#include <string>
 
 #ifndef UNIT_TEST
 // Real implementation for production
@@ -16,20 +17,23 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
+  void set_next_severity(uint8_t sev);  // syslog severity for the next assembled line
   Logging() {}
 };
 
 // Production macros
 #define DEBUG_PRINTF(fmt, ...)                                                                  \
   do {                                                                                          \
-    if (datalayer.system.info.web_logging_active || datalayer.system.info.usb_logging_active) { \
+    if (datalayer.system.info.web_logging_active || datalayer.system.info.usb_logging_active || \
+        datalayer.system.info.syslog_logging_active) {                                          \
       logging.printf(fmt, ##__VA_ARGS__);                                                       \
     }                                                                                           \
   } while (0)
 
 #define DEBUG_PRINTLN(str)                                                                      \
   do {                                                                                          \
-    if (datalayer.system.info.web_logging_active || datalayer.system.info.usb_logging_active) { \
+    if (datalayer.system.info.web_logging_active || datalayer.system.info.usb_logging_active || \
+        datalayer.system.info.syslog_logging_active) {                                          \
       logging.println(str);                                                                     \
     }                                                                                           \
   } while (0)
@@ -103,6 +107,7 @@ class Logging {
   static void println(double num) { (void)num; }
   static void println(bool b) { (void)b; }
   static void println() {}  // Empty println
+  void set_next_severity(uint8_t s) { (void)s; }  // no-op for tests
 
   Logging() {}
 };
@@ -115,5 +120,10 @@ class Logging {
 #endif
 
 extern Logging logging;
+
+// Remote syslog config (loaded from NVS in comm_nvm.cpp, consumed in logging.cpp)
+extern std::string syslog_ip;
+extern uint16_t    syslog_port;
+extern uint8_t     syslog_facility;  // 0..23
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -2,10 +2,10 @@
 #define __LOGGING_H__
 
 #include <inttypes.h>
+#include <string>
 #include "../../datalayer/datalayer.h"
 #include "Print.h"
 #include "types.h"
-#include <string>
 
 #ifndef UNIT_TEST
 // Real implementation for production
@@ -106,7 +106,7 @@ class Logging {
   static void println(float num) { (void)num; }
   static void println(double num) { (void)num; }
   static void println(bool b) { (void)b; }
-  static void println() {}  // Empty println
+  static void println() {}                        // Empty println
   void set_next_severity(uint8_t s) { (void)s; }  // no-op for tests
 
   Logging() {}
@@ -123,7 +123,7 @@ extern Logging logging;
 
 // Remote syslog config (loaded from NVS in comm_nvm.cpp, consumed in logging.cpp)
 extern std::string syslog_ip;
-extern uint16_t    syslog_port;
-extern uint8_t     syslog_facility;  // 0..23
+extern uint16_t syslog_port;
+extern uint8_t syslog_facility;  // 0..23
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -8,9 +8,9 @@
 #include "types.h"
 
 #ifndef UNIT_TEST
-    // Real implementation for production
+// Real implementation for production
 
-    class Logging : public Print {
+class Logging : public Print {
   void add_timestamp(size_t size);
 
  public:
@@ -50,7 +50,7 @@
 #include <cstdarg>
 #include <cstdio>
 
-    class Logging {
+class Logging {
  public:
   // Mock methods that do nothing
   size_t write(const uint8_t* buffer, size_t size) { return size; }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -1,4 +1,4 @@
-f #ifndef __LOGGING_H__
+#ifndef __LOGGING_H__
 #define __LOGGING_H__
 
 #include <inttypes.h>

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -107,7 +107,7 @@ class Logging {
   static void println(float num) { (void)num; }
   static void println(double num) { (void)num; }
   static void println(bool b) { (void)b; }
-  static void println() {}                        // Empty println
+  static void println() {}  // Empty println
 
   Logging() {}
 };

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -1,4 +1,4 @@
-#ifndef __LOGGING_H__
+f#ifndef __LOGGING_H__
 #define __LOGGING_H__
 
 #include <inttypes.h>
@@ -17,7 +17,9 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
+#ifndef SMALL_FLASH_DEVICE
   void set_next_severity(uint8_t sev);  // syslog severity for the next assembled line
+#endif
   Logging() {}
 };
 
@@ -37,7 +39,11 @@ class Logging : public Print {
       logging.println(str);                                                                     \
     }                                                                                           \
   } while (0)
+#ifndef SMALL_FLASH_DEVICE
 #define LOG_SET_NEXT_SEVERITY(sev) logging.set_next_severity(sev)
+#else
+#define LOG_SET_NEXT_SEVERITY(sev) ((void)0)
+#endif
 
 #else
 // Mock implementation for tests
@@ -122,9 +128,11 @@ class Logging {
 
 extern Logging logging;
 
+#ifndef SMALL_FLASH_DEVICE
 // Remote syslog config (loaded from NVS in comm_nvm.cpp, consumed in logging.cpp)
 extern std::string syslog_ip;
 extern uint16_t syslog_port;
 extern uint8_t syslog_facility;  // 0..23
+#endif
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -1,4 +1,4 @@
-f#ifndef __LOGGING_H__
+f #ifndef __LOGGING_H__
 #define __LOGGING_H__
 
 #include <inttypes.h>
@@ -8,9 +8,9 @@ f#ifndef __LOGGING_H__
 #include "types.h"
 
 #ifndef UNIT_TEST
-// Real implementation for production
+    // Real implementation for production
 
-class Logging : public Print {
+    class Logging : public Print {
   void add_timestamp(size_t size);
 
  public:
@@ -50,7 +50,7 @@ class Logging : public Print {
 #include <cstdarg>
 #include <cstdio>
 
-class Logging {
+    class Logging {
  public:
   // Mock methods that do nothing
   size_t write(const uint8_t* buffer, size_t size) { return size; }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -37,6 +37,7 @@ class Logging : public Print {
       logging.println(str);                                                                     \
     }                                                                                           \
   } while (0)
+#define LOG_SET_NEXT_SEVERITY(sev) logging.set_next_severity(sev)
 
 #else
 // Mock implementation for tests
@@ -107,7 +108,6 @@ class Logging {
   static void println(double num) { (void)num; }
   static void println(bool b) { (void)b; }
   static void println() {}                        // Empty println
-  void set_next_severity(uint8_t s) { (void)s; }  // no-op for tests
 
   Logging() {}
 };
@@ -116,6 +116,7 @@ class Logging {
 #define DEBUG_PRINT(fmt, ...) ((void)0)
 #define DEBUG_PRINTF(fmt, ...) ((void)0)
 #define DEBUG_PRINTLN(str) ((void)0)
+#define LOG_SET_NEXT_SEVERITY(sev) ((void)0)
 
 #endif
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -621,6 +621,19 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("SDLOGENABLED") ? "checked" : "";
   }
 
+  if (var == "SYSLOGEN") {
+    return settings.getBool("SYSLOGEN") ? "checked" : "";
+  }
+  if (var == "SYSLOGIP") {
+    return settings.getString("SYSLOGIP");
+  }
+  if (var == "SYSLOGPORT") {
+    return String(settings.getUInt("SYSLOGPORT", 514));
+  }
+  if (var == "SYSLOGFAC") {
+    return String(settings.getUInt("SYSLOGFAC", 1));
+  }
+
   if (var == "ESPNOWENABLED") {
     return settings.getBool("ESPNOWENABLED") ? "checked" : "";
   }
@@ -1400,6 +1413,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    form .if-syslogen { display: none; }
+    form[data-syslogen="true"] .if-syslogen {
+      display: contents;
+    }
+
     form .if-topics { display: none; }
     form[data-mqtttopics="true"] .if-topics {
       display: contents;
@@ -2013,6 +2031,24 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <label>Enable general logging via SD card: </label>
         <input type='checkbox' name='SDLOGENABLED' value='on' %SDLOGENABLED% 
         title="Enable this if you want general logging to be stored to an SD card. Only works on select hardware with SD-card slot" />
+
+        <label>Enable general logging to syslog server: </label>
+        <input type='checkbox' name='SYSLOGEN' value='on' %SYSLOGEN%
+              title="Send general logging as UDP syslog datagrams (RFC 5424) to a remote server. Events use their own severity; other lines are sent as debug." />
+
+        <div class='if-syslogen'>
+        <label>Syslog server IP: </label>
+        <input type='text' name='SYSLOGIP' value="%SYSLOGIP%"
+              pattern="((25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(25[0-5]|2[0-4]\d|1?\d?\d)"
+              title="IPv4 address of the syslog server" />
+        <label>Syslog UDP port: </label>
+        <input type='number' name='SYSLOGPORT' value="%SYSLOGPORT%"
+              min="1" max="65535" step="1" title="UDP port (default 514)" />
+        <label>Syslog facility: </label>
+        <input type='number' name='SYSLOGFAC' value="%SYSLOGFAC%"
+              min="0" max="23" step="1"
+              title="0=kern, 1=user, 3=daemon, 16-23=local0-7 (default 1)" />
+        </div>
 
         </div>
          </div>

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -620,7 +620,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SDLOGENABLED") {
     return settings.getBool("SDLOGENABLED") ? "checked" : "";
   }
-
+#ifndef SMALL_FLASH_DEVICE
   if (var == "SYSLOGEN") {
     return settings.getBool("SYSLOGEN") ? "checked" : "";
   }
@@ -633,7 +633,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SYSLOGFAC") {
     return String(settings.getUInt("SYSLOGFAC", 1));
   }
-
+#endif
   if (var == "ESPNOWENABLED") {
     return settings.getBool("ESPNOWENABLED") ? "checked" : "";
   }
@@ -1089,6 +1089,31 @@ const char* getCANInterfaceName(CAN_Interface interface) {
   )rawliteral"
 #else
 #define CANFD2ASCAN_SETTING ""
+#endif
+
+#ifndef SMALL_FLASH_DEVICE
+#define SYSLOG_SETTING_HTML \
+  R"rawliteral(
+        <label>Enable general logging to syslog server: </label>
+        <input type='checkbox' name='SYSLOGEN' value='on' %SYSLOGEN%
+              title="Send general logging as UDP syslog datagrams (RFC 5424) to a remote server. Events use their own severity; other lines are sent as debug." />
+
+        <div class='if-syslogen'>
+        <label>Syslog server IP: </label>
+        <input type='text' name='SYSLOGIP' value="%SYSLOGIP%"
+              pattern="((25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(25[0-5]|2[0-4]\d|1?\d?\d)"
+              title="IPv4 address of the syslog server" />
+        <label>Syslog UDP port: </label>
+        <input type='number' name='SYSLOGPORT' value="%SYSLOGPORT%"
+              min="1" max="65535" step="1" title="UDP port (default 514)" />
+        <label>Syslog facility: </label>
+        <input type='number' name='SYSLOGFAC' value="%SYSLOGFAC%"
+              min="0" max="23" step="1"
+              title="0=kern, 1=user, 3=daemon, 16-23=local0-7 (default 1)" />
+        </div>
+  )rawliteral"
+#else
+#define SYSLOG_SETTING_HTML ""
 #endif
 
 #define SETTINGS_HTML_SCRIPTS \
@@ -2036,19 +2061,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='checkbox' name='SYSLOGEN' value='on' %SYSLOGEN%
               title="Send general logging as UDP syslog datagrams (RFC 5424) to a remote server. Events use their own severity; other lines are sent as debug." />
 
-        <div class='if-syslogen'>
-        <label>Syslog server IP: </label>
-        <input type='text' name='SYSLOGIP' value="%SYSLOGIP%"
-              pattern="((25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(25[0-5]|2[0-4]\d|1?\d?\d)"
-              title="IPv4 address of the syslog server" />
-        <label>Syslog UDP port: </label>
-        <input type='number' name='SYSLOGPORT' value="%SYSLOGPORT%"
-              min="1" max="65535" step="1" title="UDP port (default 514)" />
-        <label>Syslog facility: </label>
-        <input type='number' name='SYSLOGFAC' value="%SYSLOGFAC%"
-              min="0" max="23" step="1"
-              title="0=kern, 1=user, 3=daemon, 16-23=local0-7 (default 1)" />
-        </div>
+        )rawliteral" SYSLOG_SETTING_HTML R"rawliteral(
 
         </div>
          </div>

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -2057,10 +2057,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='checkbox' name='SDLOGENABLED' value='on' %SDLOGENABLED% 
         title="Enable this if you want general logging to be stored to an SD card. Only works on select hardware with SD-card slot" />
 
-        <label>Enable general logging to syslog server: </label>
-        <input type='checkbox' name='SYSLOGEN' value='on' %SYSLOGEN%
-              title="Send general logging as UDP syslog datagrams (RFC 5424) to a remote server. Events use their own severity; other lines are sent as debug." />
-
         )rawliteral" SYSLOG_SETTING_HTML R"rawliteral(
 
         </div>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -437,10 +437,9 @@ void init_webserver() {
       "SYSLOGPORT", "SYSLOGFAC",
   };
 
-  const char* stringSettingNames[] = {"APNAME",         "APPASSWORD",   "HOSTNAME",  "MQTTSERVER",
-                                      "MQTTUSER",       "MQTTPASSWORD", "MQTTTOPIC", "MQTTOBJIDPREFIX",
-                                      "MQTTDEVICENAME", "HADEVICEID",   "HTTPUSER",  "HTTPPASS",
-                                      "SYSLOGIP"};
+  const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",
+                                      "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID",
+                                      "HTTPUSER",     "HTTPPASS",   "SYSLOGIP"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -423,7 +423,7 @@ void init_webserver() {
       "CANLOGSD",      "WIFIAPENABLED", "MQTTENABLED", "NOINVDISC",    "HADISC",        "MQTTTOPICS",   "MQTTCELLV",
       "GTWRHD",        "DIGITALHVIL",   "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET",  "PYLONORDER",
       "DEYEBYD",       "NCCONTACTOR",   "TRIBTR",      "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",   "CTINVERT",
-      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",
+      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",  "SYSLOGEN",
   };
 
   const char* uintSettingNames[] = {
@@ -434,11 +434,13 @@ void init_webserver() {
       "GTWCOUNTRY", "GTWMAPREG",   "GTWCHASSIS", "GTWPACK",     "LEDMODE",     "GPIOOPT1",  "GPIOOPT2",   "GPIOOPT3",
       "INVSUNTYPE", "GPIOOPT4",    "CTVNOM",     "CTANOM",      "CTATTEN",     "PYLONBAUD", "PYLONBRAND", "DALYPWRPCT",
       "DALYPWRDV",  "DALYDVSTART", "DALYPWRDEG", "DALYPWR0C",   "RAMPDOWNSOC", "GPIOOPT5",  "GPIOOPT6",   "INVICNT",
+      "SYSLOGPORT", "SYSLOGFAC",
   };
 
   const char* stringSettingNames[] = {"APNAME",         "APPASSWORD",   "HOSTNAME",  "MQTTSERVER",
                                       "MQTTUSER",       "MQTTPASSWORD", "MQTTTOPIC", "MQTTOBJIDPREFIX",
-                                      "MQTTDEVICENAME", "HADEVICEID",   "HTTPUSER",  "HTTPPASS"};
+                                      "MQTTDEVICENAME", "HADEVICEID",   "HTTPUSER",  "HTTPPASS",
+                                      "SYSLOGIP"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -423,7 +423,10 @@ void init_webserver() {
       "CANLOGSD",      "WIFIAPENABLED", "MQTTENABLED", "NOINVDISC",    "HADISC",        "MQTTTOPICS",   "MQTTCELLV",
       "GTWRHD",        "DIGITALHVIL",   "PERFPROFILE", "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET",  "PYLONORDER",
       "DEYEBYD",       "NCCONTACTOR",   "TRIBTR",      "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",   "CTINVERT",
-      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",  "SYSLOGEN",
+      "LOWPASSFILTER", "WEBAUTH",       "SLOWCANINV",
+#ifndef SMALL_FLASH_DEVICE
+      "SYSLOGEN",
+#endif
   };
 
   const char* uintSettingNames[] = {
@@ -434,12 +437,18 @@ void init_webserver() {
       "GTWCOUNTRY", "GTWMAPREG",   "GTWCHASSIS", "GTWPACK",     "LEDMODE",     "GPIOOPT1",  "GPIOOPT2",   "GPIOOPT3",
       "INVSUNTYPE", "GPIOOPT4",    "CTVNOM",     "CTANOM",      "CTATTEN",     "PYLONBAUD", "PYLONBRAND", "DALYPWRPCT",
       "DALYPWRDV",  "DALYDVSTART", "DALYPWRDEG", "DALYPWR0C",   "RAMPDOWNSOC", "GPIOOPT5",  "GPIOOPT6",   "INVICNT",
+#ifndef SMALL_FLASH_DEVICE
       "SYSLOGPORT", "SYSLOGFAC",
+#endif
   };
 
   const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",
                                       "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID",
-                                      "HTTPUSER",     "HTTPPASS",   "SYSLOGIP"};
+                                      "HTTPUSER",     "HTTPPASS",
+#ifndef SMALL_FLASH_DEVICE
+                                      "SYSLOGIP"
+#endif
+};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -442,13 +442,13 @@ void init_webserver() {
 #endif
   };
 
-  const char* stringSettingNames[] = {"APNAME",       "APPASSWORD", "HOSTNAME",        "MQTTSERVER",     "MQTTUSER",
-                                      "MQTTPASSWORD", "MQTTTOPIC",  "MQTTOBJIDPREFIX", "MQTTDEVICENAME", "HADEVICEID",
-                                      "HTTPUSER",     "HTTPPASS",
+  const char* stringSettingNames[] = {"APNAME",         "APPASSWORD",   "HOSTNAME",  "MQTTSERVER",
+                                      "MQTTUSER",       "MQTTPASSWORD", "MQTTTOPIC", "MQTTOBJIDPREFIX",
+                                      "MQTTDEVICENAME", "HADEVICEID",   "HTTPUSER",  "HTTPPASS",
 #ifndef SMALL_FLASH_DEVICE
                                       "SYSLOGIP"
 #endif
-};
+  };
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,


### PR DESCRIPTION
### What

Adds optional **remote syslog logging** as a new output sink for the existing general log stream. You can use your NAS as a syslog server, if you have one supporting such packages.

Under **Settings → Debug options** there's a new checkbox, *"Enable general logging to syslog server"*, which reveals three fields: the syslog **server IP**, **UDP port** (default 514), and **facility** (default 1/user). When enabled, every log line the firmware already produces is also sent to that server as an RFC 5424 UDP datagram.

Event messages are sent at their own severity (error → `err`, warning → `warning`, update → `notice`, info → `info`, debug → `debug`); all other log lines are sent as `debug`. Settings are persisted in NVS and survive reboot.

Since there's no wall-clock and no RTC in Battery Emulator, messages are sent with NILVALUE timestamp, which will make the syslog server stamp the messages on receipt with its own time.

### Why

Today the general log is only reachable in three ways, none of which suit a headless, always-on installation:

- **USB serial** — needs a physical cable and an attached terminal.
- **Web log** — a volatile in-RAM ring buffer that only fills while the debug page is open and is capped in size, so history is lost.
- **SD card** — only available on select hardware, and still requires pulling the card to read it (+SD flash wear?).

There's no way to centrally aggregate, retain, or monitor logs from a running unit. Syslog is the standard, lightweight answer: point the emulator at an existing rsyslog / syslog-ng / Graylog collector and get durable, searchable, filterable logs — and, because events map to real syslog severities, server-side alerting on warnings/errors becomes trivial. Good home NAS brands have free syslog server packages available which can be used for this task.

The implementation was kept deliberately minimal to add as little flash as possible.

### How

- **Reuses the existing sink pattern.** The central `Logging` class already fans out to USB / web / SD, each behind a runtime flag. This adds a fourth sink in the same place (`Logging::write()` and `Logging::printf()`), gated by a new `syslog_logging_active` flag — no changes to the ~626 existing log call sites.
- **No new library.** Sending is raw `WiFiUDP` over the lwIP stack that's already linked by WiFi and the async webserver, so the flash cost is negligible (a few hundred bytes plus one small static line buffer).
- **Line-framed, self-contained.** Output is buffered per line and one datagram is emitted per line, formatted as RFC 5424 with a NILVALUE (`-`) timestamp so the syslog server stamps on receipt — avoiding any NTP dependency. Sends are guarded on `WL_CONNECTED`.
- **Per-event severity.** `set_event()` passes the event's level to the logger via a lightweight `set_next_severity()` hint just before it prints; the syslog flush consumes it for that one line and otherwise falls back to the `debug(7)` default.
- **Settings & UI reuse existing plumbing.** The new keys hook into the generic NVS persistence arrays in `webserver.cpp`; the UI uses the existing template-placeholder and `data-*` conditional-display patterns (no new JavaScript).
- **Guard updates.** The `DEBUG_PRINTF/DEBUG_PRINTLN` macro guards and the internal early-return checks were extended with the syslog flag so logging works even when syslog is the *only* enabled sink.

**Flash impact:** negligible — reuses lwIP, no new dependencies.

**Testing:** verified datagrams are received and correctly severity-tagged against rsyslog (`imudp`); confirmed the checkbox reveals/hides the fields, that settings persist across reboot, and that disabling syslog leaves USB/web/SD behavior unchanged. Mock `Logging` used by the unit-test build gets a no-op `set_next_severity()` so the test target still compiles.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
