### PR TITLE
Improvement: Remove unreliable ESP32 CPU temperature code :thermometer: 

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -147,16 +147,6 @@ void logging_loop(void*) {
 }
 
 void update_calculated_values(unsigned long currentMillis) {
-  /* Update CPU temperature*/
-  union {
-    float temp;
-    uint32_t hex;
-  } temp = {.temp = temperatureRead()};
-  if (temp.hex != 0x42555555) {
-    // Ignoring erroneous temperature value that ESP32 sometimes returns
-    datalayer.system.info.CPU_temperature = temp.temp;
-  }
-
   /*Update free heap*/
   datalayer.system.info.CPU_free_heap = ESP.getFreeHeap();
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -270,8 +270,6 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
   char inverter_brand[8] = {0};
 
   size_t logged_can_messages_offset = 0;
-  /** ESP32 main CPU temperature, for displaying on webserver and for safeties */
-  float CPU_temperature = 0;
   /** ESP32 free heap amount, for displaying on webserver and for safeties */
   uint32_t CPU_free_heap = 0;
 

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -434,7 +434,6 @@ static bool publish_common_info(void) {
 
     doc["event_level"] = get_event_level_string(get_event_level());
     doc["emulator_status"] = get_emulator_status_string(get_emulator_status());
-    doc["cpu_temp"] = (int)(datalayer.system.info.CPU_temperature + 0.5);
     doc["emulator_uptime"] = millis64() / 1000;
 
     serializeJson(doc, mqtt_msg);

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -976,21 +976,20 @@ String processor(const String& var) {
 
 // Show hardware used:
 #ifdef HW_LILYGO
-    content += " Hardware: LilyGo T-CAN485";
+    content += " Hardware: LilyGo T-CAN485</h4>";
 #endif  // HW_LILYGO
 #ifdef HW_LILYGO2CAN
-    content += " Hardware: LilyGo T_2CAN";
+    content += " Hardware: LilyGo T_2CAN</h4>";
 #endif  // HW_LILYGO2CAN
 #ifdef HW_BECOM
-    content += " Hardware: BECom";
+    content += " Hardware: BECom</h4>";
 #endif  // HW_BECOM
 #ifdef HW_STARK
-    content += " Hardware: Stark CMR Module";
+    content += " Hardware: Stark CMR Module</h4>";
 #endif  // HW_STARK
 #ifdef HW_WAVESHARE
-    content += " Hardware: Waveshare ESP32-S3-RS485-CAN";
+    content += " Hardware: Waveshare ESP32-S3-RS485-CAN</h4>";
 #endif  // HW_WAVESHARE
-    content += " @ " + String(datalayer.system.info.CPU_temperature, 1) + " &deg;C</h4>";
     content += "<h4>Uptime: " + get_uptime() + "</h4>";
     if (datalayer.system.info.performance_measurement_active) {
       content +=


### PR DESCRIPTION
### What
This PR removes any trace of CPU temperature (Webserver, MQTT)

### Why
ESP32 temperature sensors are not calibrated from factory, and can swing 50 degrees from board to board. This is causing unnecessary stress and support load, so we remove it from the code. We previously removed the warning Events, but this PR removes it all.

### How
CPU temperature removed from both Webserver & MQTT.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
