### PR TITLE
Github: Make compile action use more caches for faster builds

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -40,12 +40,27 @@ jobs:
     - uses: actions/checkout@v7
       name: Checkout code
 
+    - name: Get platformio.ini hash
+      id: platformio_ini_hash
+      run: |
+        PLATFORMIO_INI_HASH=$(md5sum platformio.ini | awk '{ print $1 }')
+        echo "platformio_ini_hash=$PLATFORMIO_INI_HASH" >> $GITHUB_OUTPUT
+
+    # Broader cache (just the download files)
     - uses: actions/cache@v6
       with:
         path: |
           ~/.cache/pip
           ~/.platformio/.cache
         key: ${{ runner.os }}-pio
+
+    # Tighter cache (of platformio itself)
+    - uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.platformio
+        key: ${{ runner.os }}-pio-${{ steps.platformio_ini_hash.outputs.platformio_ini_hash }}
 
     - uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
### What
Adds a second layer of caching (as used in the measure-size action), to cache the PlatformIO installation itself as well as just the downloaded files.

Cache key is based on a hash of the platformio.ini file, so if that changes it'll regenerate.

### Why
Should significantly speed up compiles, and reduce the amount of GitHub Action worker CPU time we're burning through...

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
