### PR TITLE
Guard display against SMALL_FLASH_DEVICE

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -93,7 +93,9 @@ void connectivity_loop(void*) {
     init_mDNS();
   }
 
+#ifndef SMALL_FLASH_DEVICE
   init_display();
+#endif
 
   if (espnow_enabled) {
     init_espnow();
@@ -103,7 +105,9 @@ void connectivity_loop(void*) {
     START_TIME_MEASUREMENT(wifi);
     wifi_monitor();
 
+#ifndef SMALL_FLASH_DEVICE
     update_display();
+#endif
 
     if (espnow_enabled) {
       update_espnow();

--- a/Software/src/devboard/display/display.cpp
+++ b/Software/src/devboard/display/display.cpp
@@ -1,6 +1,8 @@
 // A realtime display of battery status and events, using a I2C-connected 128x64
 // OLED display based on the SSD1306 driver.
 
+#ifndef SMALL_FLASH_DEVICE
+
 #include "../../battery/BATTERIES.h"
 #include "../../datalayer/datalayer.h"
 #include "../hal/hal.h"
@@ -470,3 +472,5 @@ void update_display() {
   }
   lastUpdateMillis = currentMillis;
 }
+
+#endif  // SMALL_FLASH_DEVICE

--- a/Software/src/devboard/display/display.h
+++ b/Software/src/devboard/display/display.h
@@ -1,7 +1,9 @@
 #ifndef _DISPLAY_H_
 #define _DISPLAY_H_
 
+#ifndef SMALL_FLASH_DEVICE
 void init_display();
 void update_display();
+#endif  // SMALL_FLASH_DEVICE
 
 #endif  // _DISPLAY_H_

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -194,9 +194,11 @@ class Esp32Hal {
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_NC; }
   virtual uint8_t LED_MAX_BRIGHTNESS() { return 40; }
 
+#ifndef SMALL_FLASH_DEVICE
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t DISPLAY_SCL_PIN() { return GPIO_NUM_NC; }
+#endif  // SMALL_FLASH_DEVICE
 
   // Equipment stop pin
   virtual gpio_num_t EQUIPMENT_STOP_PIN() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -112,6 +112,7 @@ class LilyGoHal : public Esp32Hal {
   // Momentary push-button that can be long-pressed at runtime to start the Wi-Fi AP.
   virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_0; }
 
+#ifndef SMALL_FLASH_DEVICE
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {
     if (user_selected_gpioopt4 == GPIOOPT4::I2C_DISPLAY_SSD1306) {
@@ -125,6 +126,7 @@ class LilyGoHal : public Esp32Hal {
     }
     return GPIO_NUM_NC;
   }
+#endif  // SMALL_FLASH_DEVICE
 
   std::vector<comm_interface> available_interfaces() {
     return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative, comm_interface::CanAddonMcp2515,

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -105,6 +105,7 @@ class LilyGo2CANHal : public Esp32Hal {
   virtual gpio_num_t CHADEMO_LOCK() { return GPIO_NUM_40; }
   virtual gpio_num_t CHADEMO_CT_PIN() { return GPIO_NUM_5; }  // ADC1_CH4
 
+#ifndef SMALL_FLASH_DEVICE
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {
     if (user_selected_gpioopt1 == GPIOOPT1::I2C_DISPLAY_SSD1306) {
@@ -118,6 +119,7 @@ class LilyGo2CANHal : public Esp32Hal {
     }
     return GPIO_NUM_NC;
   }
+#endif  // SMALL_FLASH_DEVICE
 
   // Equipment stop pin
   virtual gpio_num_t EQUIPMENT_STOP_PIN() {

--- a/Software/src/devboard/hal/hw_waveshare.h
+++ b/Software/src/devboard/hal/hw_waveshare.h
@@ -53,6 +53,7 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
   // SMA CAN contactor pins (collides with WUP2)
   virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_PIN() { return GPIO_NUM_9; }
 
+#ifndef SMALL_FLASH_DEVICE
   // i2c display
   virtual gpio_num_t DISPLAY_SDA_PIN() {
     if (user_selected_gpioopt6 == GPIOOPT6::I2C_DISPLAY_SSD1306) {
@@ -66,6 +67,7 @@ class WaveshareS3Rs485CanHal : public Esp32Hal {
     }
     return GPIO_NUM_NC;
   }
+#endif  // SMALL_FLASH_DEVICE
 
   // CANFD add-on defines for MCP2517
   virtual gpio_num_t MCP2517_SCK() { return GPIO_NUM_10; }

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -179,7 +179,7 @@ const char* name_for_gpioopt3(GPIOOPT3 option) {
 const char* name_for_gpioopt4(GPIOOPT4 option) {
   switch (option) {
     case GPIOOPT4::DEFAULT_SD_CARD:
-      return "uSD Card";
+      return "µSD Card";
 #ifndef SMALL_FLASH_DEVICE
     case GPIOOPT4::I2C_DISPLAY_SSD1306:
       return "I2C Display (SSD1306)";
@@ -1040,7 +1040,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 #ifdef HW_LILYGO
 #define GPIOOPT4_SETTING \
   R"rawliteral(
-    <label for="GPIOOPT4">uSD Slot:</label>
+    <label for="GPIOOPT4">µSD Slot:</label>
     <select id="GPIOOPT4" name="GPIOOPT4">
       %GPIOOPT4%
     </select>

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -144,8 +144,10 @@ const char* name_for_gpioopt1(GPIOOPT1 option) {
   switch (option) {
     case GPIOOPT1::DEFAULT_OPT:
       return "WUP1 / WUP2";
+#ifndef SMALL_FLASH_DEVICE
     case GPIOOPT1::I2C_DISPLAY_SSD1306:
       return "I2C Display (SSD1306)";
+#endif  // SMALL_FLASH_DEVICE
     case GPIOOPT1::ESTOP_BMS_POWER:
       return "E-Stop / BMS Power";
     default:
@@ -178,8 +180,10 @@ const char* name_for_gpioopt4(GPIOOPT4 option) {
   switch (option) {
     case GPIOOPT4::DEFAULT_SD_CARD:
       return "uSD Card";
+#ifndef SMALL_FLASH_DEVICE
     case GPIOOPT4::I2C_DISPLAY_SSD1306:
       return "I2C Display (SSD1306)";
+#endif  // SMALL_FLASH_DEVICE
     default:
       return nullptr;
   }
@@ -202,8 +206,10 @@ const char* name_for_gpioopt6(GPIOOPT6 option) {
   switch (option) {
     case GPIOOPT6::DEFAULT_STATUS_LED:
       return "Status LED (GPIO2)";
+#ifndef SMALL_FLASH_DEVICE
     case GPIOOPT6::I2C_DISPLAY_SSD1306:
       return "I2C Display SSD1306 (GPIO1=SDA, GPIO2=SCL)";
+#endif  // SMALL_FLASH_DEVICE
     default:
       return nullptr;
   }


### PR DESCRIPTION
### What
This PR encloses all functionality related to the I2C SSD1306 display between #ifndef SMALL_FLASH_DEVICE / #endif guards, including its web UI settings options.

### Why
To be able to free up flash space on memory-constrained targets (LilyGo T-CAN485, devkit builds with SMALL_FLASH_DEVICE).

It's just too much. ESPNow costs a fraction of that (https://github.com/dalathegreat/Battery-Emulator/pull/2557), doesn't need GPIO, and displays through it are a magnitude more useful than the tiny monochrome oleds which burn in after about 1 year.

### How
Follows the existing SMALL_FLASH_DEVICE pattern already used in comm_rs485.cpp, wifi.cpp, and battery files. No #else branches or stubs needed — call sites are guarded directly. Two things are intentionally not guarded:

- The I2C_DISPLAY_SSD1306 enumerator values in types.h: the T-CAN485 SD-card pin functions in hw_lilygo.h compare against them to resolve the GPIO 14/15 pin-sharing conflict, and bare enum values cost no flash.
- Those pin-conflict checks themselves: if a device's NVS still holds GPIOOPT4 = 1 from a previously flashed full build, the SD card correctly stays disabled instead of driving pins wired to a display. The display simply won't run.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
