### PR TITLE
security: Provisioning window for AP with default pass

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -197,7 +197,7 @@ void init_stored_settings() {
   wifiap_enabled = settings.getBool("WIFIAPENABLED", true);
   wifi_channel = settings.getUInt("WIFICHANNEL", 0);
   ssidAP = settings.getString("APNAME", "BatteryEmulator").c_str();
-  passwordAP = settings.getString("APPASSWORD", "123456789").c_str();
+  passwordAP = settings.getString("APPASSWORD", DEFAULT_AP_PASSWORD).c_str();
   espnow_enabled = settings.getBool("ESPNOWENABLED", false);
   mqtt_enabled = settings.getBool("MQTTENABLED", false);
   mqtt_timeout_ms = settings.getUInt("MQTTTIMEOUT", 2000);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -411,8 +411,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_WIFI_DISCONNECT:
       return "Wifi disconnected.";
     case EVENT_WIFI_AP_PROVISION_TIMEOUT:
-      return "Wifi access point disabled: the provisioning window expired. Change password or "
-             "hold the BOOT button >=5 seconds or reboot to re-enable it.";
+      return "Wifi AP disabled: the provisioning window expired. Change password or "
+             "hold BOOT button 5 to 15 secs or reboot to re-enable.";
     case EVENT_MQTT_CONNECT:
       return "MQTT connected.";
     case EVENT_MQTT_DISCONNECT:

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -411,8 +411,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_WIFI_DISCONNECT:
       return "Wifi disconnected.";
     case EVENT_WIFI_AP_PROVISION_TIMEOUT:
-      return "Wifi AP disabled: the provisioning window expired. Change password or "
-             "hold BOOT button 5 to 15 secs or reboot to re-enable.";
+      return "Wifi AP disabled due to cybersecurity concern. Change default password to keep AP "
+             "constantly on! Reboot/Hold BOOT button 5-15 seconds to re-enable AP temporarily.";
     case EVENT_MQTT_CONNECT:
       return "MQTT connected.";
     case EVENT_MQTT_DISCONNECT:

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -411,9 +411,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_WIFI_DISCONNECT:
       return "Wifi disconnected.";
     case EVENT_WIFI_AP_PROVISION_TIMEOUT:
-      return "Wifi access point disabled: the provisioning window expired while the factory-default AP password was "
-             "still in use. Reboot or hold the BOOT button >=5 seconds to re-enable it, or set a custom AP password "
-             "to keep the access point permanently enabled.";
+      return "Wifi access point disabled: the provisioning window expired. Change password or "
+             "hold the BOOT button >=5 seconds or reboot to re-enable it.";
     case EVENT_MQTT_CONNECT:
       return "MQTT connected.";
     case EVENT_MQTT_DISCONNECT:

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -136,6 +136,7 @@ void init_events(void) {
   events.entries[EVENT_PID_FAILED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_CONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_DISCONNECT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_WIFI_AP_PROVISION_TIMEOUT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MQTT_CONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MQTT_DISCONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_EQUIPMENT_STOP].level = EVENT_LEVEL_ERROR;
@@ -409,6 +410,10 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Wifi connected.";
     case EVENT_WIFI_DISCONNECT:
       return "Wifi disconnected.";
+    case EVENT_WIFI_AP_PROVISION_TIMEOUT:
+      return "Wifi access point disabled: the provisioning window expired while the factory-default AP password was "
+             "still in use. Reboot or hold the BOOT button >=5 seconds to re-enable it, or set a custom AP password "
+             "to keep the access point permanently enabled.";
     case EVENT_MQTT_CONNECT:
       return "MQTT connected.";
     case EVENT_MQTT_DISCONNECT:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -118,6 +118,7 @@
   XX(EVENT_PID_FAILED)                  \
   XX(EVENT_WIFI_CONNECT)                \
   XX(EVENT_WIFI_DISCONNECT)             \
+  XX(EVENT_WIFI_AP_PROVISION_TIMEOUT)   \
   XX(EVENT_MQTT_CONNECT)                \
   XX(EVENT_MQTT_DISCONNECT)             \
   XX(EVENT_EQUIPMENT_STOP)              \

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -90,7 +90,6 @@ static void check_ap_provisioning_window() {
   if (millis() - ap_started_at < AP_PROVISIONING_WINDOW_MS) {
     return;
   }
-  logging.println("AP provisioning window expired (factory-default AP password), disabling access point.");
   WiFi.softAPdisconnect(true);  // stop the AP and drop the AP bit from the WiFi mode; STA stays up
   ap_active = false;
   ap_provisioning_expired = true;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -90,6 +90,9 @@ static void check_ap_provisioning_window() {
   if (millis() - ap_started_at < AP_PROVISIONING_WINDOW_MS) {
     return;
   }
+  if (WiFi.softAPgetStationNum() > 0) {
+    return;  // a client is connected: don't cut off an active provisioning session
+  }
   WiFi.softAPdisconnect(true);  // stop the AP and drop the AP bit from the WiFi mode; STA stays up
   ap_active = false;
   ap_provisioning_expired = true;
@@ -365,6 +368,7 @@ void init_WiFi_AP() {
   }
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
+  esp_wifi_set_inactive_time(WIFI_IF_AP, 180);  // deauth silent stations (who walked away without disconnecting) after 180 s (IDF default: 300 s)
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -368,7 +368,9 @@ void init_WiFi_AP() {
   }
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
-  esp_wifi_set_inactive_time(WIFI_IF_AP, 180);  // deauth silent stations (who walked away without disconnecting) after 180 s (IDF default: 300 s)
+  esp_wifi_set_inactive_time(
+      WIFI_IF_AP,
+      180);  // deauth silent stations (who walked away without disconnecting) after 180 s (IDF default: 300 s)
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -72,7 +72,7 @@ static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000;  // >=30 s: facto
 // Provisioning window: while the AP runs with the factory-default password it is
 // only kept up for a limited time, then shut down. Rebooting or long-pressing the
 // BOOT button (>=5 s) opens a new window. Setting a custom AP password lifts the
-// restriction entirely (AP stays up indefinitely, as before).
+// restriction entirely (AP stays up indefinitely).
 static const unsigned long AP_PROVISIONING_WINDOW_MS = 5UL * 60UL * 1000UL;  // 5 minutes
 static unsigned long ap_started_at = 0;                                      // millis() when the AP was (re)started
 static bool ap_provisioning_expired = false;  // blocks automatic AP re-enable until reboot/button

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -20,6 +20,7 @@ std::string ssid;
 std::string password;
 std::string ssidAP;
 std::string passwordAP;
+const char* DEFAULT_AP_PASSWORD = "123456789";
 
 // Set your Static IP address. Only used incase Static address option is set
 bool static_IP_enabled = false;
@@ -67,6 +68,34 @@ static unsigned long ap_button_press_start = 0;
 static const unsigned long AP_BUTTON_AP_MS = 5000;              // >=5 s: start AP
 static const unsigned long AP_BUTTON_STA_WIPE_MS = 15000;       // >=15 s: wipe STA settings + reboot
 static const unsigned long AP_BUTTON_FACTORY_RESET_MS = 30000;  // >=30 s: factory reset
+
+// Provisioning window: while the AP runs with the factory-default password it is
+// only kept up for a limited time, then shut down. Rebooting or long-pressing the
+// BOOT button (>=5 s) opens a new window. Setting a custom AP password lifts the
+// restriction entirely (AP stays up indefinitely, as before).
+static const unsigned long AP_PROVISIONING_WINDOW_MS = 5UL * 60UL * 1000UL;  // 5 minutes
+static unsigned long ap_started_at = 0;                                      // millis() when the AP was (re)started
+static bool ap_provisioning_expired = false;  // blocks automatic AP re-enable until reboot/button
+
+static bool ap_password_is_default() {
+  return passwordAP == DEFAULT_AP_PASSWORD;
+}
+
+// Shut the AP down once it has been running with the factory-default password
+// for longer than the provisioning window.
+static void check_ap_provisioning_window() {
+  if (!ap_active || !ap_password_is_default()) {
+    return;
+  }
+  if (millis() - ap_started_at < AP_PROVISIONING_WINDOW_MS) {
+    return;
+  }
+  logging.println("AP provisioning window expired (factory-default AP password), disabling access point.");
+  WiFi.softAPdisconnect(true);  // stop the AP and drop the AP bit from the WiFi mode; STA stays up
+  ap_active = false;
+  ap_provisioning_expired = true;
+  set_event(EVENT_WIFI_AP_PROVISION_TIMEOUT, 0);
+}
 
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
@@ -163,8 +192,9 @@ static void check_ap_button() {
       ESP.restart();
     } else if (held >= AP_BUTTON_AP_MS) {
       if (!ap_active) {
+        ap_provisioning_expired = false;  // manual start opens a fresh provisioning window
         WiFi.mode(WIFI_AP_STA);
-        init_WiFi_AP();  // sets ap_active
+        init_WiFi_AP();  // sets ap_active, restarts the provisioning window timer
       }
     }
   }
@@ -174,6 +204,7 @@ static void check_ap_button() {
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
   check_ap_button();
+  check_ap_provisioning_window();
 
   if (ssid.empty() || password.empty()) {
     return;
@@ -220,9 +251,13 @@ void wifi_monitor() {
         // If no previous connection, force a full connection attempt
         if (currentMillis - lastReconnectAttempt > current_full_reconnect_interval) {
           logging.println("No previous OK connection, force a full connection attempt...");
-          wifiap_enabled = true;
-          WiFi.mode(WIFI_AP_STA);
-          init_WiFi_AP();
+          // Don't resurrect the rescue AP if its provisioning window already
+          // expired with the factory-default password still in place.
+          if (!ap_provisioning_expired) {
+            wifiap_enabled = true;
+            WiFi.mode(WIFI_AP_STA);
+            init_WiFi_AP();
+          }
 
           FullReconnectToWiFi();
         }
@@ -323,6 +358,12 @@ void init_WiFi_AP() {
 
   DEBUG_PRINTF("Creating Access Point: %s\n", ssidAP.c_str());
   DEBUG_PRINTF("Access Point password set (%u characters)\n", (unsigned)passwordAP.length());
+
+  if (!ap_active) {
+    // (Re)start the provisioning window timer only on an off->on transition, so
+    // repeated re-inits from the STA reconnect fallback don't keep extending it.
+    ap_started_at = millis();
+  }
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
   ap_active = true;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -368,9 +368,6 @@ void init_WiFi_AP() {
   }
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
-  esp_wifi_set_inactive_time(
-      WIFI_IF_AP,
-      180);  // deauth silent stations (who walked away without disconnecting) after 180 s (IDF default: 300 s)
   ap_active = true;
   IPAddress IP = WiFi.softAPIP();
 

--- a/Software/src/devboard/wifi/wifi.h
+++ b/Software/src/devboard/wifi/wifi.h
@@ -9,6 +9,9 @@ extern std::string password;
 extern uint16_t wifi_channel;
 extern std::string ssidAP;
 extern std::string passwordAP;
+// Factory-default AP password. While the AP runs with this password, it is only
+// kept enabled for a limited provisioning window (see wifi.cpp).
+extern const char* DEFAULT_AP_PASSWORD;
 extern std::string custom_hostname;
 
 void init_WiFi();


### PR DESCRIPTION
## What

This PR adds a provisioning window for the Wi-Fi Access Point: when the AP is running with the factory-default password (`123456789`), and no client connects to it, it is automatically disabled after 5 minutes. If a custom AP password has been set, behavior is unchanged and the AP stays enabled indefinitely.

After the window expires, the AP can be re-enabled by:
- rebooting the device, or
- long-pressing the BOOT button for ≥5 s (existing behavior)

A new info event `EVENT_WIFI_AP_PROVISION_TIMEOUT` is raised when the window expires, with a message explaining how to re-enable the AP or make it permanent.

### Why

The AP ships with a well-known default password, and remains enabled by default. Leaving it permanently enabled means anyone within radio range can join the emulator's network and reach the webserver/settings of a device controlling a high-voltage battery. Limiting the default-password AP to a short provisioning window closes this exposure while keeping first-time setup and recovery access fully functional:

- New users still get 5 minutes at every boot to connect and start configuring the device
- Once connected, the AP doesn't shutdown until the user disconnects (or walks away + 5 minutes)
- Recovery access remains available at any time via the BOOT button long-press
- Users who set their own AP password keep today's always-on behavior

### How

- `wifi.cpp`: new `check_ap_provisioning_window()` called from `wifi_monitor()` (before the `ssid.empty()` early-return, so it also works on devices with no STA credentials configured). On expiry it calls `WiFi.softAPdisconnect(true)` — dropping only the AP bit from the Wi-Fi mode, STA/ESP-NOW stay up — clears `ap_active`, and latches `ap_provisioning_expired`.
- `init_WiFi_AP()` records the window start time **only on an off→on transition**, so the repeated re-inits from the STA reconnect fallback don't keep extending the window.
- The "no previous OK connection" rescue-AP fallback in `wifi_monitor()` is gated on `!ap_provisioning_expired`, so it can't resurrect the AP right after the window closed.
- The BOOT button ≥5 s handler clears the expired latch before starting the AP, opening a fresh window.
- `wifi.h` / `comm_nvm.cpp`: the `"123456789"` literal is promoted to a shared `DEFAULT_AP_PASSWORD` constant (single source of truth).
- `events.h` / `events.cpp`: new `EVENT_WIFI_AP_PROVISION_TIMEOUT` (level `INFO`) with a user-facing message.
- Timer math uses unsigned `millis()` subtraction (rollover-safe).

### Note
Changing the AP password via the web UI takes effect after reboot (as with other settings), so a password changed mid-window still results in AP shutdown at the 5-minute mark or after the user disconnects — the AP is still broadcasting the default password until reboot, so this is the safe choice.

Wiki needs to be updated after this is merged.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
