### PR TITLE
GitHub: Fix PR measure action to use correct base commit

### DIFF
--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -10,8 +10,16 @@ jobs:
     - name: Checkout PR base
       uses: actions/checkout@v7
       with:
-        ref: ${{ github.event.pull_request.base.ref }}
-        fetch-depth: 100
+        fetch-depth: 200
+
+    - name: Find true base Commit
+      id: get_base
+      run: |
+        # Find the common ancestor between the two parents of the merge commit
+        TRUE_BASE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+        echo "PR base commit is: $TRUE_BASE_SHA"
+        git checkout $TRUE_BASE_SHA
+        echo "base_sha=$TRUE_BASE_SHA" >> $GITHUB_OUTPUT
 
     - name: Get platformio.ini hash
       id: platformio_ini_hash
@@ -52,9 +60,8 @@ jobs:
 
     - name: Checkout PR head
       run: |
-        git remote add fork https://github.com/${{ github.event.pull_request.head.repo.full_name }}
-        git fetch fork ${{ github.event.pull_request.head.ref }}
-        git checkout FETCH_HEAD
+        git fetch origin refs/pull/${{ github.event.number }}/head
+        git checkout ${{ github.event.pull_request.head.sha }}
     
     - name: Build image for lilygo_330
       run: pio run -e lilygo_330
@@ -67,7 +74,7 @@ jobs:
     - name: Compare firmware sizes
       shell: python -u {0}
       env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BASE_SHA: ${{ steps.get_base.outputs.base_sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         import os


### PR DESCRIPTION
### What
The new PR-measurement GitHub action has a subtle bug, where it used the latest main as the comparison base rather than the actual commit the PR is based off.

Was causing other recent commits to get inadvertently included in the displayed totals (causing, so far, small errors).

Have tested thoroughly and this seems to fix it.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
