### PR TITLE
Combine BYD/MEB DTC renderers together

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -285,7 +285,7 @@ void BydAttoBattery::
     if (datalayer_bydatto->UserRequestDTCreadout && stateMachineReadDTC == NOT_RUNNING) {
       stateMachineReadDTC = STARTED;
       datalayer_bydatto->dtc_read_in_progress = true;
-      datalayer_bydatto->dtc_read_failed = false;
+      datalayer_battery->dtc.dtc_read_failed = false;
       dtc_request_millis = millis();
       datalayer_bydatto->UserRequestDTCreadout = false;
     }
@@ -297,7 +297,7 @@ void BydAttoBattery::
     // Fail the read if the BMS never answers
     if (datalayer_bydatto->dtc_read_in_progress && (millis() - dtc_request_millis > 2000)) {
       datalayer_bydatto->dtc_read_in_progress = false;
-      datalayer_bydatto->dtc_read_failed = true;
+      datalayer_battery->dtc.dtc_read_failed = true;
       dtc_rx_active = false;
     }
   }
@@ -610,7 +610,7 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 // 4 bytes per DTC (3-byte code + status). Stores raw codes; HTML decodes them to strings.
 void BydAttoBattery::parseDTCResponse() {
   if (dtc_buffer[0] != 0x59 || dtc_buffer[1] != 0x02) {
-    datalayer_bydatto->dtc_read_failed = true;
+    datalayer_battery->dtc.dtc_read_failed = true;
     datalayer_bydatto->dtc_read_in_progress = false;
     return;
   }
@@ -622,13 +622,13 @@ void BydAttoBattery::parseDTCResponse() {
     if (code == 0 || status == 0) {  // Empty slot or cleared DTC
       continue;
     }
-    datalayer_bydatto->dtc_codes[count] = code;
-    datalayer_bydatto->dtc_status[count] = status;
+    datalayer_battery->dtc.dtc_codes[count] = code;
+    datalayer_battery->dtc.dtc_status[count] = status;
     count++;
   }
   // Display order: active (status bit0) first, then ascending code.
-  uint32_t* codes = datalayer_bydatto->dtc_codes;
-  uint8_t* sts = datalayer_bydatto->dtc_status;
+  uint32_t* codes = datalayer_battery->dtc.dtc_codes;
+  uint8_t* sts = datalayer_battery->dtc.dtc_status;
   for (uint8_t a = 1; a < count; a++) {
     uint32_t c = codes[a];
     uint8_t s = sts[a];
@@ -647,9 +647,9 @@ void BydAttoBattery::parseDTCResponse() {
     codes[b + 1] = c;
     sts[b + 1] = s;
   }
-  datalayer_bydatto->dtc_count = count;
-  datalayer_bydatto->dtc_last_read_millis = millis();
-  datalayer_bydatto->dtc_read_failed = false;
+  datalayer_battery->dtc.dtc_count = count;
+  datalayer_battery->dtc.dtc_last_read_millis = millis();
+  datalayer_battery->dtc.dtc_read_failed = false;
   datalayer_bydatto->dtc_read_in_progress = false;
 }
 

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -343,53 +343,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "}";
     content += "</script>";
 
-    // Diagnostic Trouble Codes, populated on demand by the 'Read DTC' button (Advanced page).
-    content +=
-        "<h4 style='margin-top:20px;color:#27b06c;border-bottom:2px solid #27b06c;padding-bottom:5px;'>&#128295; "
-        "Diagnostic Trouble Codes</h4>";
-    if (byd_datalayer->dtc_last_read_millis == 0) {
-      content += "<p style='color:#bbb;'>Not read yet &mdash; use the Read DTC button below to scan.</p>";
-    } else if (byd_datalayer->dtc_read_failed) {
-      content += "<p style='color:#ff8a80;'>&#9888; Last DTC read failed or timed out.</p>";
-    } else if (byd_datalayer->dtc_count == 0) {
-      content += "<p style='color:#69f0ae;'>&#10003; No DTCs present.</p>";
-    } else {
-      unsigned long age_s = (millis() - byd_datalayer->dtc_last_read_millis) / 1000;
-      content += "<p style='color:#bbb;'>" + String(byd_datalayer->dtc_count) + " codes &mdash; read " + String(age_s) +
-                 "s ago</p>";
-      content += "<div style='overflow-x:auto;margin-bottom:12px;'>";
-      content +=
-          "<table style='margin:0 auto;text-align:left;border-collapse:separate;border-spacing:0;"
-          "border:1px solid #4a5a64;border-radius:8px;overflow:hidden;'>";
-      content +=
-          "<thead><tr style='background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#fff;'>"
-          "<th style='padding:10px 18px;text-align:left;'>DTC</th>"
-          "<th style='padding:10px 18px;text-align:left;'>Status</th>"
-          "<th style='padding:10px 18px;text-align:left;'>Description</th></tr></thead><tbody>";
-      // Decode the raw 3-byte code to the string our JSON is keyed by: top 2 bits of byte0 -> P/C/B/U.
-      const char SYS[5] = "PCBU";
-      for (int i = 0; i < byd_datalayer->dtc_count; i++) {
-        uint32_t code = byd_datalayer->dtc_codes[i];
-        uint8_t status = byd_datalayer->dtc_status[i];
-        char dtcStr[8];
-        snprintf(dtcStr, sizeof(dtcStr), "%c%02lX%02lX%02lX", SYS[(code >> 22) & 0x03],
-                 (unsigned long)((code >> 16) & 0x3F), (unsigned long)((code >> 8) & 0xFF),
-                 (unsigned long)(code & 0xFF));
-        bool active = status & 0x01;
-        String statusStr = active ? "Active" : "Stored";
-        String statusColor = active ? "#ff5252" : "#9e9e9e";
-        content +=
-            "<tr><td style='padding:8px 18px;border-top:1px solid #3a4750;font-family:monospace;"
-            "font-weight:600;'>" +
-            String(dtcStr) + "</td>";
-        content += "<td style='padding:8px 18px;border-top:1px solid #3a4750;color:" + statusColor +
-                   ";font-weight:600;'>" + statusStr + "</td>";
-        content += "<td data-dtc-code='" + String(dtcStr) +
-                   "' style='padding:8px 18px;border-top:1px solid #3a4750;'>Unknown</td></tr>";
-      }
-      content += "</tbody></table></div>";
-      content += get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, "byd_atto3_dtc.json");
-    }
+    auto& dtc = s.length() ? datalayer.battery2.dtc : datalayer.battery.dtc;
+    content += BatteryHtmlRenderer::render_dtc_section_html(dtc, "byd_atto3_dtc.json", true);
 
     return content;
   }

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -797,7 +797,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     uds_request_timestamp = currentMillis;
     datalayer_extended.meb.UserRequestDTCreadout = false;  // consume the request
     datalayer_extended.meb.dtc_read_in_progress = true;
-    datalayer_extended.meb.dtc_read_failed = false;
+    datalayer_battery->dtc.dtc_read_failed = false;
   }
 
   // DTC clear requested via WebUI: OBD service 0x04 (ClearDiagnosticInformation) sent to the
@@ -808,7 +808,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     uds_request_timestamp = currentMillis;
     datalayer_extended.meb.UserRequestDTCreset = false;  // consume the request
     datalayer_extended.meb.dtc_read_in_progress = true;
-    datalayer_extended.meb.dtc_read_failed = false;
+    datalayer_battery->dtc.dtc_read_failed = false;
   }
 
   if (currentMillis - last_can_msg_timestamp > 500) {
@@ -1338,17 +1338,17 @@ void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype 
       break;
     case (0x04 + kPositiveResponseOffset):  // clear DTCs (OBD service 0x04) positive response
       uds_request_pending = false;
-      datalayer_extended.meb.dtc_read_failed = false;
-      datalayer_extended.meb.dtc_count = 0;  // Clear any existing DTCs after a successful erase
-      datalayer_extended.meb.dtc_last_read_millis = 0;
+      datalayer_battery->dtc.dtc_read_failed = false;
+      datalayer_battery->dtc.dtc_count = 0;  // Clear any existing DTCs after a successful erase
+      datalayer_battery->dtc.dtc_last_read_millis = 0;
       datalayer_extended.meb.dtc_read_in_progress = false;
       break;
     case (UDS_RESPONSE_SID_OF(ReadDTCInformation)):  // DTC read positive response (0x59)
       if (data[1] != 0x02) {
         // Unexpected report type — treat as a failed readout.
-        datalayer_extended.meb.dtc_read_failed = true;
+        datalayer_battery->dtc.dtc_read_failed = true;
       } else {
-        datalayer_extended.meb.dtc_read_failed = false;
+        datalayer_battery->dtc.dtc_read_failed = false;
         int dtcStartIndex = 3;  // Skip 59 02 <statusAvailabilityMask>
         int availableBytes = len - dtcStartIndex;
         int maxDtcCount = availableBytes / 4;
@@ -1369,14 +1369,14 @@ void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype 
           uint32_t dtcCode =
               ((uint32_t)data[offset] << 16) | ((uint32_t)data[offset + 1] << 8) | (uint32_t)data[offset + 2];
           uint8_t dtcStatus = data[offset + 3];
-          datalayer_extended.meb.dtc_codes[i] = dtcCode;
-          datalayer_extended.meb.dtc_status[i] = dtcStatus;
+          datalayer_battery->dtc.dtc_codes[i] = dtcCode;
+          datalayer_battery->dtc.dtc_status[i] = dtcStatus;
         }
-        datalayer_extended.meb.dtc_count = maxDtcCount;
+        datalayer_battery->dtc.dtc_count = maxDtcCount;
       }
       uds_request_pending = false;
+      datalayer_battery->dtc.dtc_last_read_millis = millis();
       datalayer_extended.meb.dtc_read_in_progress = false;
-      datalayer_extended.meb.dtc_last_read_millis = millis();
       break;
     case (ServiceNotSupportedInActiveSession):  // Negative response (0x7F)
       // data[1] = original request service id, data[2] = NRC
@@ -1388,7 +1388,7 @@ void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype 
         // DTC read was rejected — the transaction is complete, allow the next request.
         uds_request_pending = false;
         datalayer_extended.meb.dtc_read_in_progress = false;
-        datalayer_extended.meb.dtc_read_failed = true;
+        datalayer_battery->dtc.dtc_read_failed = true;
       } else {
         // Any other NRC: the transaction is complete (rejected), allow the next request.
         uds_request_pending = false;

--- a/Software/src/battery/MEB-HTML.h
+++ b/Software/src/battery/MEB-HTML.h
@@ -286,74 +286,7 @@ class MebHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Total discharged: " + String(datalayer.battery.status.total_discharged_battery_Wh / 1000.0, 1) +
                " kWh</h4>";
 
-    // Diagnostic Trouble Codes section. Populated by the "Read DTC" button (UDS 0x19 0x02) and
-    // cleared by "Erase DTC" (OBD service 0x04). Descriptions are fetched at runtime by the
-    // shared get_dtc_json_loader_html() JavaScript from the JSON on GitHub.
-    content +=
-        "<h3 style='color:#27b06c;border-bottom:2px solid #27b06c;padding-bottom:5px;'>🔧 Diagnostic Trouble "
-        "Codes</h3>";
-    content += "<div style='margin-left:15px;margin-right:15px;'>";
-
-    if (datalayer_extended.meb.dtc_last_read_millis == 0) {
-      content +=
-          "<p style='color:#ff9800;'>ℹ DTCs have not been read yet. Click 'Read DTC' to scan for fault codes.</p>";
-    } else if (datalayer_extended.meb.dtc_read_failed) {
-      content += "<p style='color:#d32f2f;'>⚠ Last DTC read failed or not supported</p>";
-    } else if (datalayer_extended.meb.dtc_count == 0) {
-      content += "<p style='color:#4CAF50;'>✓ No DTCs present</p>";
-    } else {
-      content += "<p><strong>DTC Count:</strong> " + String(datalayer_extended.meb.dtc_count) + "</p>";
-
-      // Shared cell styles defined once, then referenced by class on every row.
-      content +=
-          "<style>.dh,.dc{padding:12px 15px}.dh{text-align:left;font-weight:600}"
-          ".dc{border-top:1px solid #e0e0e0}.dm{font-family:monospace;font-size:1.1em;font-weight:600}"
-          ".dd{font-size:.95em;color:#ddd}.dse{font-weight:500}</style>";
-      content += "<div style='overflow-x:auto;margin-top:10px;margin-bottom:15px;'>";
-      content +=
-          "<table style='width:auto;margin:0 auto;border-collapse:separate;border-spacing:0;border:1px solid "
-          "#ddd;border-radius:8px;overflow:hidden;'>";
-      content += "<thead>";
-      content += "<tr style='background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:white;'>";
-      content += "<th class='dh'>DTC Code</th>";
-      content += "<th class='dh'>Status</th>";
-      content += "<th class='dh'>Description</th>";
-      content += "</tr>";
-      content += "</thead>";
-      content += "<tbody>";
-
-      for (int i = 0; i < datalayer_extended.meb.dtc_count; i++) {
-        uint32_t code = datalayer_extended.meb.dtc_codes[i];
-        uint8_t status = datalayer_extended.meb.dtc_status[i];
-
-        char dtcStr[12];
-        sprintf(dtcStr, "%06lX", (unsigned long)code);
-
-        String statusStr = "Stored";
-        String statusColor = "#757575";
-        if (status & 0x08) {
-          statusStr = "Confirmed";
-          statusColor = "#ff6f00";
-        }
-        if (status & 0x01) {
-          statusStr = "Active";
-          statusColor = "#d32f2f";
-        }
-
-        content += "<tr>";
-        content += "<td class='dc dm'>" + String(dtcStr) + "</td>";
-        content += "<td class='dc dse' style='color:" + statusColor + "'>" + statusStr + "</td>";
-        content += "<td class='dc dd' data-dtc-code='" + String(code) + "'>Unknown</td>";
-        content += "</tr>";
-      }
-
-      content += "</tbody>";
-      content += "</table>";
-      content += "</div>";
-
-      content += get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, "vag_meb_dtc.json");
-    }
-    content += "</div>";
+    content += BatteryHtmlRenderer::render_dtc_section_html(datalayer.battery.dtc, "vag_meb_dtc.json", false);
 
     return content;
   }

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -6,6 +6,22 @@
 
 /*Note when editing this file. Order of datatypes matter heavily to keep padding and flash size in check*/
 
+// Per-battery DTC storage to allow common display code
+struct DATALAYER_BATTERY_DTC_TYPE {
+  static constexpr int MAX_DTC_COUNT = 32;
+  // Raw 3-byte DTC codes packed into a uint32, one per slot. Can either
+  // rendered in the standard SAE format, or as a raw 6-digit hex code.
+  uint32_t dtc_codes[MAX_DTC_COUNT];
+  // Status for each DTC
+  uint8_t dtc_status[MAX_DTC_COUNT];
+  // Number of DTCs stored
+  uint8_t dtc_count;
+  // Last successful read (0 = never read)
+  unsigned long dtc_last_read_millis;
+  // Indicates that the last read failed
+  bool dtc_read_failed = false;
+};
+
 struct DATALAYER_BATTERY_INFO_TYPE {
   /** uint32_t */
   /** Total energy capacity in Watt-hours 
@@ -201,6 +217,7 @@ typedef struct {
   DATALAYER_BATTERY_INFO_TYPE info;
   DATALAYER_BATTERY_STATUS_TYPE status;
   DATALAYER_BATTERY_SETTINGS_TYPE settings;
+  DATALAYER_BATTERY_DTC_TYPE dtc;
 } DATALAYER_BATTERY_TYPE;
 
 struct DATALAYER_CHARGER_TYPE {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -199,12 +199,7 @@ struct DATALAYER_INFO_BYDATTO3 {
   bool autocal_crit_contactors;
 
   // DTC readout (UDS 0x19 0x02). Codes packed as raw 3 bytes in a uint32, rendered to string in HTML.
-  uint32_t dtc_codes[32];
-  uint8_t dtc_status[32];
-  uint8_t dtc_count;
-  unsigned long dtc_last_read_millis;
   bool dtc_read_in_progress;
-  bool dtc_read_failed;
   bool UserRequestDTCreadout;  // User requesting DTC readout via WebUI
   bool UserRequestDTCreset;    // User requesting DTC erase via WebUI
 };
@@ -893,14 +888,9 @@ struct DATALAYER_INFO_MEB {
 
   // DTC readout (UDS 0x19 0x02) and clear (OBD service 0x04). Codes stored as raw 3 bytes
   // packed in a uint32, rendered to string in HTML.
-  uint32_t dtc_codes[32] = {0};
-  uint8_t dtc_status[32] = {0};
-  uint8_t dtc_count = 0;
-  unsigned long dtc_last_read_millis = 0;  // Timestamp of last successful read
-  bool dtc_read_in_progress = false;       // Flag to prevent concurrent reads
-  bool dtc_read_failed = false;            // Indicates last read attempt failed
-  bool UserRequestDTCreset = false;        // User requesting DTC erase via WebUI
-  bool UserRequestDTCreadout = false;      // User requesting DTC readout via WebUI
+  bool dtc_read_in_progress = false;   // Flag to prevent concurrent reads
+  bool UserRequestDTCreset = false;    // User requesting DTC erase via WebUI
+  bool UserRequestDTCreadout = false;  // User requesting DTC readout via WebUI
 };
 
 struct DATALAYER_INFO_VOLVO_POLESTAR {

--- a/Software/src/devboard/webserver/BatteryHtmlRenderer.h
+++ b/Software/src/devboard/webserver/BatteryHtmlRenderer.h
@@ -1,13 +1,100 @@
 #ifndef _BATTERY_HTML_RENDERER_H
 #define _BATTERY_HTML_RENDERER_H
 
+#include "../../datalayer/datalayer.h"
+
+#include <Arduino.h>
 #include <WString.h>
+#include <stdio.h>
 
 // Each battery can implement this interface to render more battery specific HTML
 // content
 class BatteryHtmlRenderer {
  public:
   virtual String get_status_html() = 0;
+
+  static String render_dtc_section_html(DATALAYER_BATTERY_DTC_TYPE& dtc, const char* json_filename,
+                                        bool standard_code_string) {
+    String content;
+
+    // Reserve enough space to avoid reallocs
+    content.reserve(3300 + dtc.dtc_count * 320);
+    content +=
+        "<h4 style='margin-top:20px;color:#27b06c;border-bottom:2px solid #27b06c;padding-bottom:5px;'>&#128295; "
+        "Diagnostic Trouble Codes</h4>";
+    if (dtc.dtc_last_read_millis == 0) {
+      content += "<p style='color:#bbb;'>Not read yet &mdash; use the Read DTC button below to scan.</p>";
+    } else if (dtc.dtc_read_failed) {
+      content += "<p style='color:#ff8a80;'>&#9888; Last DTC read failed or timed out.</p>";
+    } else if (dtc.dtc_count == 0) {
+      content += "<p style='color:#69f0ae;'>&#10003; No DTCs present.</p>";
+    } else {
+      unsigned long age_s = (millis() - dtc.dtc_last_read_millis) / 1000;
+      content +=
+          "<p style='color:#bbb;'>" + String(dtc.dtc_count) + " codes &mdash; read " + String(age_s) + "s ago</p>";
+      content += "<div style='overflow-x:auto;margin-bottom:12px;'>";
+      content +=
+          "<table style='margin:0 auto;text-align:left;border-collapse:separate;border-spacing:0;"
+          "border:1px solid #4a5a64;border-radius:8px;overflow:hidden;'>";
+      content +=
+          "<thead><tr style='background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);color:#fff;'>"
+          "<th style='padding:10px 18px;text-align:left;'>DTC</th>"
+          "<th style='padding:10px 18px;text-align:left;'>Status</th>"
+          "<th style='padding:10px 18px;text-align:left;'>Description</th></tr></thead><tbody>";
+
+      const char SYS[5] = "PCBU";
+      for (int i = 0; i < dtc.dtc_count; i++) {
+        uint32_t code = dtc.dtc_codes[i];
+        uint8_t status = dtc.dtc_status[i];
+
+        char dtcStr[12];
+        String matchKey;
+        if (standard_code_string) {
+          // SAE format (P0C9500, B1B4E12, etc.)
+          snprintf(dtcStr, sizeof(dtcStr), "%c%02lX%02lX%02lX", SYS[(code >> 22) & 0x03],
+                   (unsigned long)((code >> 16) & 0x3F), (unsigned long)((code >> 8) & 0xFF),
+                   (unsigned long)(code & 0xFF));
+          matchKey = String(dtcStr);
+        } else {
+          // Raw 6-digit hex code (9B4E12, DB4E12, etc.)
+          snprintf(dtcStr, sizeof(dtcStr), "%06lX", (unsigned long)code);
+          matchKey = String(code);
+        }
+
+        // Status precedence: Active (bit 0x01) > Confirmed (bit 0x08) > Stored.
+        const char* statusStr = "Stored";
+        const char* statusColor = "#9e9e9e";
+        if (status & 0x08) {
+          statusStr = "Confirmed";
+          statusColor = "#d29922";
+        }
+        if (status & 0x01) {
+          statusStr = "Active";
+          statusColor = "#ff5252";
+        }
+
+        content +=
+            "<tr><td style='padding:8px 18px;border-top:1px solid #3a4750;font-family:monospace;"
+            "font-weight:600;'>";
+        content += dtcStr;
+        content +=
+            "</td>"
+            "<td style='padding:8px 18px;border-top:1px solid #3a4750;color:";
+        content += statusColor;
+        content += ";font-weight:600;'>";
+        content += statusStr;
+        content +=
+            "</td>"
+            "<td data-dtc-code='";
+        content += matchKey;
+        content += "' style='padding:8px 18px;border-top:1px solid #3a4750;'>Unknown</td></tr>";
+      }
+      content += "</tbody></table></div>";
+      content += get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, json_filename);
+    }
+
+    return content;
+  }
 
   // Base URL for the upstream GitHub repository's data folder.
   // Battery renderers can pass this to get_dtc_json_loader_html() directly,


### PR DESCRIPTION
### What
Combine the new MEB DTC renderer code with the BYD code to reduce duplication (can roll it out to the other batteries that have similar code too if acceptable).

### Why
Reduces complexity of individual integrations, saves a bunch of flash.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
