### PR TITLE
Adjust Ford Mach-E cell temperature offset

### DIFF
--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -233,12 +233,12 @@ void FordMachEBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
 
       //Celltemperatures
-      cell_temperature[0] = ((rx_frame.data.u8[2] - 30) / 2);
-      cell_temperature[1] = ((rx_frame.data.u8[3] - 30) / 2);
-      cell_temperature[2] = ((rx_frame.data.u8[4] - 30) / 2);
-      cell_temperature[3] = ((rx_frame.data.u8[5] - 30) / 2);
-      cell_temperature[4] = ((rx_frame.data.u8[6] - 30) / 2);
-      cell_temperature[5] = ((rx_frame.data.u8[7] - 30) / 2);
+      cell_temperature[0] = ((rx_frame.data.u8[2] - CELL_TEMPERATURE_OFFSET) / 2);
+      cell_temperature[1] = ((rx_frame.data.u8[3] - CELL_TEMPERATURE_OFFSET) / 2);
+      cell_temperature[2] = ((rx_frame.data.u8[4] - CELL_TEMPERATURE_OFFSET) / 2);
+      cell_temperature[3] = ((rx_frame.data.u8[5] - CELL_TEMPERATURE_OFFSET) / 2);
+      cell_temperature[4] = ((rx_frame.data.u8[6] - CELL_TEMPERATURE_OFFSET) / 2);
+      cell_temperature[5] = ((rx_frame.data.u8[7] - CELL_TEMPERATURE_OFFSET) / 2);
       break;
     case 0x4a4:  //1s
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -44,6 +44,8 @@ class FordMachEBattery : public CanBattery {
   static const int MAX_CELL_DEVIATION_MV = 250;
   static const int MAX_CELL_VOLTAGE_MV = 4250;
   static const int MIN_CELL_VOLTAGE_MV = 2900;
+  static const int CELL_TEMPERATURE_OFFSET =
+      22;  // Calibrated against BECM PID min/max cell temperatures. Ford signal offset is -22
 
   static const int MAX_CHARGE_POWER_WHEN_TOPBALANCING_W = 200;  // W, what power to allow for top balancing battery
   static const int FLOAT_START_MV = 20;  // mV, how many mV under overvoltage to start float charging


### PR DESCRIPTION
Updates the Ford Mach-E cell temperature conversion offset to 19, calibrated against BECM PID min/max cell temperatures. The expected offset range is -20 to -18.