### PR TITLE
Improvement/Syslog 📜 pre-connectivity log backlog; task name as app name

### DIFF
--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -67,7 +67,7 @@ static bool syslog_online(void) {
 }
 
 // Called ONLY from syslog_task, and never with the mutex held.
-static void syslog_send(uint8_t sev, const char* msg) {
+static void syslog_send(uint8_t sev, const char* proc, const char* msg) {
   IPAddress dst;
   if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
     return;
@@ -76,13 +76,20 @@ static void syslog_send(uint8_t sev, const char* msg) {
   if (syslogUdp.beginPacket(dst, syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
-    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, syslog_hostname(), msg);
+    syslogUdp.printf("<%u>1 - %s BatteryEmulator %s - - %s", pri, syslog_hostname(), proc, msg);
     syslogUdp.endPacket();
   }
 }
 
 // Called from the logging path, in whatever task did the logging. Does no I/O.
 static void syslog_queue_push(uint8_t sev, const char* msg) {
+  // MUST be read here: we are in the caller's task. Reading it in syslog_task
+  // would label every line "syslog".
+  const char* proc = pcTaskGetName(nullptr);
+  if (proc == nullptr || proc[0] == '\0') {
+    proc = "-";  // NILVALUE
+  }
+  size_t plen = strlen(proc);
   char rec[SYSLOG_MSG_MAX];
   int n;
   if (syslog_online()) {
@@ -114,7 +121,7 @@ static void syslog_queue_push(uint8_t sev, const char* msg) {
     }
   }
 
-  size_t need = 1 + (size_t)n + 1;
+  size_t need = 1 + plen + 1 + (size_t)n + 1;
   if (syslogQueueLen + need > SYSLOG_QUEUE_MAX && syslogQueuePos > 0) {
     // Tail hit the cap but the head is already sent: slide the pending region down.
     memmove(syslogQueue, syslogQueue + syslogQueuePos, syslogQueueLen - syslogQueuePos);
@@ -130,6 +137,8 @@ static void syslog_queue_push(uint8_t sev, const char* msg) {
   }
 
   syslogQueue[syslogQueueLen++] = (char)sev;
+  memcpy(syslogQueue + syslogQueueLen, proc, plen + 1);
+  syslogQueueLen += plen + 1;
   memcpy(syslogQueue + syslogQueueLen, rec, n + 1);
   syslogQueueLen += n + 1;
   xSemaphoreGive(syslogMutex);
@@ -138,6 +147,7 @@ static void syslog_queue_push(uint8_t sev, const char* msg) {
 // Pops one record under the lock, then sends it with the lock released.
 static void syslog_task(void* arg) {
   char msg[SYSLOG_MSG_MAX];
+  char proc[configMAX_TASK_NAME_LEN];
   uint8_t sev = 0;
   uint16_t dropped = 0;
 
@@ -148,9 +158,11 @@ static void syslog_task(void* arg) {
       if (syslogQueue != nullptr && syslogQueuePos < syslogQueueLen) {
         sev = (uint8_t)syslogQueue[syslogQueuePos++];
         const char* rec = &syslogQueue[syslogQueuePos];
-        snprintf(msg, sizeof(msg), "%s", rec);  // copy out, so we can send unlocked
+        snprintf(proc, sizeof(proc), "%s", rec);  // task name
         syslogQueuePos += strlen(rec) + 1;
-        have = true;
+        rec = &syslogQueue[syslogQueuePos];
+        snprintf(msg, sizeof(msg), "%s", rec);  // message; copy out so we can send unlocked
+        syslogQueuePos += strlen(rec) + 1;        have = true;
 
         if (syslogQueuePos >= syslogQueueLen) {  // drained -> rewind
           syslogQueuePos = 0;
@@ -163,12 +175,12 @@ static void syslog_task(void* arg) {
     }
 
     if (have) {
-      syslog_send(sev, msg);  // UDP happens OUTSIDE the lock
+      syslog_send(sev, proc, msg);  // UDP happens OUTSIDE the lock
     }
     if (dropped) {
       char note[64];
       snprintf(note, sizeof(note), "syslog queue was full, %u line(s) dropped", dropped);
-      syslog_send(4, note);  // severity 4 = warning
+      syslog_send(4, "syslog", note);  // severity 4 = warning
       dropped = 0;
     }
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -29,6 +29,21 @@ static size_t syslogLineLen = 0;
 // ---- Pre-connectivity backlog ----
 // Lines logged before we can send are buffered here and replayed on connect.
 // Heap-allocated on first use, freed once drained. Record layout: [uint8 severity][text\0]
+// syslog statics + the WiFiUDP object are touched from several tasks (core, arduino_events, MQTT).
+// Global ctor runs before any task starts, so this is safe to initialise here.
+static SemaphoreHandle_t syslogMutex = xSemaphoreCreateRecursiveMutex();
+
+static bool syslog_lock(void) {
+  if (syslogMutex == nullptr) {
+    return false;
+  }
+  return xSemaphoreTakeRecursive(syslogMutex, pdMS_TO_TICKS(5)) == pdTRUE;
+}
+
+static void syslog_unlock(void) {
+  xSemaphoreGiveRecursive(syslogMutex);
+}
+
 #define SYSLOG_BACKLOG_MAX 4096
 #define SYSLOG_BACKLOG_BURST 4  // records per flush call — keeps the core task inside its 10 ms budget
 static char* syslogBacklog = nullptr;
@@ -102,6 +117,9 @@ static bool syslog_backlog_push(uint8_t sev, const char* msg, bool stamp) {
 }
 
 void syslog_backlog_flush(void) {
+  if (!syslog_lock()) {
+    return;
+  }
   if (syslogBacklog == nullptr) {
     return;
   }
@@ -122,6 +140,7 @@ void syslog_backlog_flush(void) {
     syslogBacklogLen = 0;
     syslogBacklogPos = 0;
   }
+  syslog_unlock();
 }
 
 void Logging::set_next_severity(uint8_t sev) {
@@ -156,6 +175,9 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
   if (!datalayer.system.info.syslog_logging_active) {
     return;
   }
+  if (!syslog_lock()) {
+    return;  // busy -> drop this chunk rather than stall the caller
+  }
   for (size_t i = 0; i < size; i++) {
     char c = (char)buffer[i];
     if (c == '\r') {
@@ -170,6 +192,7 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
       }
     }
   }
+  syslog_unlock();
 }
 #endif
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -26,15 +26,17 @@ static WiFiUDP syslogUdp;
 static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
 
+// ---- Pre-connectivity backlog ----
 // Lines logged before we can send are buffered here and replayed on connect.
-// Heap-allocated on first use, freed after the flush -> no permanent RAM cost.
-// Record layout: [uint8 severity][text\0]
+// Heap-allocated on first use, freed once drained. Record layout: [uint8 severity][text\0]
 #define SYSLOG_BACKLOG_MAX 4096
+#define SYSLOG_BACKLOG_BURST 4  // records per flush call — keeps the core task inside its 10 ms budget 
 static char* syslogBacklog = nullptr;
 static size_t syslogBacklogLen = 0;
+static size_t syslogBacklogPos = 0;
 
 // Same rule as init_WiFi(): custom hostname if set, otherwise the MAC-derived default.
-// Cached — default_hostname() re-reads eFuse and heap-allocates a String on every call.
+// Cached — default_hostname() re-reads eFuse and allocates a String on every call.
 static const char* syslog_hostname(void) {
   if (!custom_hostname.empty()) {
     return custom_hostname.c_str();
@@ -52,11 +54,10 @@ static void syslog_send(uint8_t sev, const char* msg) {
     return;
   }
   uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
-  const char* host = syslog_hostname();
   if (syslogUdp.beginPacket(dst, syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
-    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, host, msg);
+    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, syslog_hostname(), msg);
     syslogUdp.endPacket();
   }
 }
@@ -64,7 +65,7 @@ static void syslog_send(uint8_t sev, const char* msg) {
 static void syslog_backlog_push(uint8_t sev, const char* msg) {
   char rec[SYSLOG_LINE_MAX + 24];
   unsigned long ms = millis();
-  // No clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
+  // No wall clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
   int n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
   if (n < 0) {
     return;
@@ -76,7 +77,7 @@ static void syslog_backlog_push(uint8_t sev, const char* msg) {
     }
     syslogBacklog = (char*)malloc(SYSLOG_BACKLOG_MAX);
     if (syslogBacklog == nullptr) {
-      return;  // out of heap -> just drop, logging must never be fatal
+      return;  // out of heap -> drop; logging must never be fatal
     }
   }
   if (syslogBacklogLen + 1 + (size_t)n + 1 > SYSLOG_BACKLOG_MAX) {
@@ -94,16 +95,20 @@ void syslog_backlog_flush(void) {
   if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
     return;
   }
-  size_t i = 0;
-  while (i < syslogBacklogLen) {
-    uint8_t sev = (uint8_t)syslogBacklog[i++];
-    const char* msg = &syslogBacklog[i];
+  uint8_t sent = 0;
+  while (syslogBacklogPos < syslogBacklogLen && sent < SYSLOG_BACKLOG_BURST) {
+    uint8_t sev = (uint8_t)syslogBacklog[syslogBacklogPos++];
+    const char* msg = &syslogBacklog[syslogBacklogPos];
     syslog_send(sev, msg);
-    i += strlen(msg) + 1;
+    syslogBacklogPos += strlen(msg) + 1;
+    sent++;
   }
-  free(syslogBacklog);
-  syslogBacklog = nullptr;
-  syslogBacklogLen = 0;
+  if (syslogBacklogPos >= syslogBacklogLen) {  // drained -> give the RAM back
+    free(syslogBacklog);
+    syslogBacklog = nullptr;
+    syslogBacklogLen = 0;
+    syslogBacklogPos = 0;
+  }
 }
 
 void Logging::set_next_severity(uint8_t sev) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -5,7 +5,7 @@
 #ifndef SMALL_FLASH_DEVICE
 #include <WiFi.h>
 #include <WiFiUdp.h>
-#include "../wifi/wifi.h"  // custom_hostname
+#include "../wifi/wifi.h"  // custom_hostname, default_hostname()
 #endif
 
 #define MAX_LINE_LENGTH_PRINTF 128
@@ -26,32 +26,30 @@ static WiFiUDP syslogUdp;
 static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
 
-// ---- Pre-connectivity backlog ----
-// Lines logged before we can send are buffered here and replayed on connect.
-// Heap-allocated on first use, freed once drained. Record layout: [uint8 severity][text\0]
-// syslog statics + the WiFiUDP object are touched from several tasks (core, arduino_events, MQTT).
-// Global ctor runs before any task starts, so this is safe to initialise here.
-static SemaphoreHandle_t syslogMutex = xSemaphoreCreateRecursiveMutex();
+// ---- Syslog queue + sender task ----
+// Every assembled line is queued; a dedicated low-priority task does ALL of the UDP sending.
+//
+// The logging path (which runs in the core task, the MQTT task, arduino_events, ...) therefore
+// never touches the network and never blocks -> it cannot cause EVENT_TASK_OVERRUN.
+// A single consumer draining a single FIFO also guarantees that lines arrive in order and that
+// two tasks can never interleave inside syslogUdp (which produced corrupted packets before).
+//
+// Lines logged before we have connectivity simply wait in the queue and are sent once the sender
+// task sees the link come up. Record layout: [uint8 severity][text\0]
+#define SYSLOG_QUEUE_MAX 4096
+#define SYSLOG_MSG_MAX (SYSLOG_LINE_MAX + 24)  // room for the "[boot +N.NNNs] " prefix
+static char* syslogQueue = nullptr;
+static size_t syslogQueueLen = 0;  // write cursor
+static size_t syslogQueuePos = 0;  // read cursor
+static uint16_t syslogDropped = 0;
 
-static bool syslog_lock(void) {
-  if (syslogMutex == nullptr) {
-    return false;
-  }
-  return xSemaphoreTakeRecursive(syslogMutex, pdMS_TO_TICKS(5)) == pdTRUE;
-}
-
-static void syslog_unlock(void) {
-  xSemaphoreGiveRecursive(syslogMutex);
-}
-
-#define SYSLOG_BACKLOG_MAX 4096
-#define SYSLOG_BACKLOG_BURST 4  // records per flush call — keeps the core task inside its 10 ms budget
-static char* syslogBacklog = nullptr;
-static size_t syslogBacklogLen = 0;
-static size_t syslogBacklogPos = 0;
+// Guards syslogQueue/Len/Pos only. It is NEVER held while sending, so it is only ever
+// owned for a few microseconds (a memcpy) and contention is effectively zero.
+static SemaphoreHandle_t syslogMutex = xSemaphoreCreateMutex();
 
 // Same rule as init_WiFi(): custom hostname if set, otherwise the MAC-derived default.
 // Cached — default_hostname() re-reads eFuse and allocates a String on every call.
+// Only the default is cached, so a call made before settings are loaded cannot freeze a wrong name in.
 static const char* syslog_hostname(void) {
   if (!custom_hostname.empty()) {
     return custom_hostname.c_str();
@@ -63,6 +61,12 @@ static const char* syslog_hostname(void) {
   return fallback.c_str();
 }
 
+static bool syslog_online(void) {
+  // Sendable when joined to a network (STA) OR when a client is on our SoftAP.
+  return (WiFi.status() == WL_CONNECTED) || (WiFi.softAPgetStationNum() > 0);
+}
+
+// Called ONLY from syslog_task, and never with the mutex held.
 static void syslog_send(uint8_t sev, const char* msg) {
   IPAddress dst;
   if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
@@ -77,70 +81,110 @@ static void syslog_send(uint8_t sev, const char* msg) {
   }
 }
 
-static bool syslog_backlog_push(uint8_t sev, const char* msg, bool stamp) {
-  char rec[SYSLOG_LINE_MAX + 24];
+// Called from the logging path, in whatever task did the logging. Does no I/O.
+static void syslog_queue_push(uint8_t sev, const char* msg) {
+  char rec[SYSLOG_MSG_MAX];
   int n;
-  if (stamp) {
-    // No wall clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
+  if (syslog_online()) {
+    n = snprintf(rec, sizeof(rec), "%s", msg);
+  } else {
+    // No wall clock this early and the server stamps on receipt, so carry the uptime in MSG.
+    // Without this, everything logged before the link came up looks simultaneous.
     unsigned long ms = millis();
     n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
-  } else {
-    n = snprintf(rec, sizeof(rec), "%s", msg);  // already online, no prefix
   }
-  if (n < 0) {
-    return false;
+  if (n < 0 || syslogMutex == nullptr) {
+    return;
   }
-  if (syslogBacklog == nullptr) {
+  // Short timeout: the holder only ever does a memcpy, so this never actually waits.
+  if (xSemaphoreTake(syslogMutex, pdMS_TO_TICKS(2)) != pdTRUE) {
+    return;
+  }
+
+  if (syslogQueue == nullptr) {
     IPAddress dst;
     if (!dst.fromString(syslog_ip.c_str())) {
-      return false;  // no syslog server configured -> never allocate
+      xSemaphoreGive(syslogMutex);  // no syslog server configured -> never allocate
+      return;
     }
-    syslogBacklog = (char*)malloc(SYSLOG_BACKLOG_MAX);
-    if (syslogBacklog == nullptr) {
-      return false;  // out of heap -> drop; logging must never be fatal
+    syslogQueue = (char*)malloc(SYSLOG_QUEUE_MAX);
+    if (syslogQueue == nullptr) {
+      xSemaphoreGive(syslogMutex);  // out of heap -> drop; logging must never be fatal
+      return;
     }
   }
+
   size_t need = 1 + (size_t)n + 1;
-  if (syslogBacklogLen + need > SYSLOG_BACKLOG_MAX && syslogBacklogPos > 0) {
+  if (syslogQueueLen + need > SYSLOG_QUEUE_MAX && syslogQueuePos > 0) {
     // Tail hit the cap but the head is already sent: slide the pending region down.
-    memmove(syslogBacklog, syslogBacklog + syslogBacklogPos, syslogBacklogLen - syslogBacklogPos);
-    syslogBacklogLen -= syslogBacklogPos;
-    syslogBacklogPos = 0;
+    memmove(syslogQueue, syslogQueue + syslogQueuePos, syslogQueueLen - syslogQueuePos);
+    syslogQueueLen -= syslogQueuePos;
+    syslogQueuePos = 0;
   }
-  if (syslogBacklogLen + need > SYSLOG_BACKLOG_MAX) {
-    return false;  // genuinely full
+  if (syslogQueueLen + need > SYSLOG_QUEUE_MAX) {
+    if (syslogDropped < UINT16_MAX) {
+      syslogDropped++;  // genuinely full -> keep the earliest lines
+    }
+    xSemaphoreGive(syslogMutex);
+    return;
   }
-  syslogBacklog[syslogBacklogLen++] = (char)sev;
-  memcpy(syslogBacklog + syslogBacklogLen, rec, n + 1);
-  syslogBacklogLen += n + 1;
-  return true;
+
+  syslogQueue[syslogQueueLen++] = (char)sev;
+  memcpy(syslogQueue + syslogQueueLen, rec, n + 1);
+  syslogQueueLen += n + 1;
+  xSemaphoreGive(syslogMutex);
 }
 
-void syslog_backlog_flush(void) {
-  if (!syslog_lock()) {
-    return;
+// Pops one record under the lock, then sends it with the lock released.
+static void syslog_task(void* arg) {
+  char msg[SYSLOG_MSG_MAX];
+  uint8_t sev = 0;
+  uint16_t dropped = 0;
+
+  for (;;) {
+    bool have = false;
+
+    if (syslog_online() && syslogMutex != nullptr &&
+        xSemaphoreTake(syslogMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+      if (syslogQueue != nullptr && syslogQueuePos < syslogQueueLen) {
+        sev = (uint8_t)syslogQueue[syslogQueuePos++];
+        const char* rec = &syslogQueue[syslogQueuePos];
+        snprintf(msg, sizeof(msg), "%s", rec);  // copy out, so we can send unlocked
+        syslogQueuePos += strlen(rec) + 1;
+        have = true;
+
+        if (syslogQueuePos >= syslogQueueLen) {  // drained -> rewind
+          syslogQueuePos = 0;
+          syslogQueueLen = 0;
+          dropped = syslogDropped;
+          syslogDropped = 0;
+        }
+      }
+      xSemaphoreGive(syslogMutex);
+    }
+
+    if (have) {
+      syslog_send(sev, msg);  // UDP happens OUTSIDE the lock
+    }
+    if (dropped) {
+      char note[64];
+      snprintf(note, sizeof(note), "syslog queue was full, %u line(s) dropped", dropped);
+      syslog_send(4, note);  // severity 4 = warning
+      dropped = 0;
+    }
+
+    // 2 ms between packets paces the boot replay without touching the core loop.
+    vTaskDelay(pdMS_TO_TICKS(have ? 2 : 50));
   }
-  if (syslogBacklog == nullptr) {
-    return;
+}
+
+// Starts the sender task. Safe to call more than once.
+void syslog_start(void) {
+  static bool started = false;
+  if (!started) {
+    started = true;
+    xTaskCreate(syslog_task, "syslog", 3072, nullptr, tskIDLE_PRIORITY + 1, nullptr);
   }
-  if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
-    return;
-  }
-  uint8_t sent = 0;
-  while (syslogBacklogPos < syslogBacklogLen && sent < SYSLOG_BACKLOG_BURST) {
-    uint8_t sev = (uint8_t)syslogBacklog[syslogBacklogPos++];
-    const char* msg = &syslogBacklog[syslogBacklogPos];
-    syslog_send(sev, msg);
-    syslogBacklogPos += strlen(msg) + 1;
-    sent++;
-  }
-  if (syslogBacklogPos >= syslogBacklogLen) {  // drained -> give the RAM back
-    free(syslogBacklog);
-    syslogBacklog = nullptr;
-    syslogBacklogLen = 0;
-    syslogBacklogPos = 0;
-  }
-  syslog_unlock();
 }
 
 void Logging::set_next_severity(uint8_t sev) {
@@ -157,27 +201,14 @@ static void syslog_flush_line(void) {
   }
   syslogLine[len] = '\0';
   uint8_t sev = (sev_override >= 0) ? (uint8_t)sev_override : SYSLOG_DEFAULT_SEVERITY;
-  bool online = (WiFi.status() == WL_CONNECTED || WiFi.softAPgetStationNum() > 0);
-  if (!online) {
-    syslog_backlog_push(sev, syslogLine, true);
-  } else if (syslogBacklog != nullptr) {
-    // Still draining: queue behind it so the server sees strict FIFO order.
-    if (!syslog_backlog_push(sev, syslogLine, false)) {
-      syslog_send(sev, syslogLine);  // backlog full -> send now rather than lose the line
-    }
-    syslog_backlog_flush();  // drains SYSLOG_BACKLOG_BURST records
-  } else {
-    syslog_send(sev, syslogLine);
-  }
+  syslog_queue_push(sev, syslogLine);
 }
 
 static void syslog_emit(const uint8_t* buffer, size_t size) {
   if (!datalayer.system.info.syslog_logging_active) {
     return;
   }
-  if (!syslog_lock()) {
-    return;  // busy -> drop this chunk rather than stall the caller
-  }
+  // No connectivity check: lines logged before the link is up are queued and sent later.
   for (size_t i = 0; i < size; i++) {
     char c = (char)buffer[i];
     if (c == '\r') {
@@ -192,7 +223,6 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
       }
     }
   }
-  syslog_unlock();
 }
 #endif
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -30,7 +30,7 @@ static size_t syslogLineLen = 0;
 // Lines logged before we can send are buffered here and replayed on connect.
 // Heap-allocated on first use, freed once drained. Record layout: [uint8 severity][text\0]
 #define SYSLOG_BACKLOG_MAX 4096
-#define SYSLOG_BACKLOG_BURST 4  // records per flush call — keeps the core task inside its 10 ms budget 
+#define SYSLOG_BACKLOG_BURST 4  // records per flush call — keeps the core task inside its 10 ms budget
 static char* syslogBacklog = nullptr;
 static size_t syslogBacklogLen = 0;
 static size_t syslogBacklogPos = 0;

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -162,7 +162,8 @@ static void syslog_task(void* arg) {
         syslogQueuePos += strlen(rec) + 1;
         rec = &syslogQueue[syslogQueuePos];
         snprintf(msg, sizeof(msg), "%s", rec);  // message; copy out so we can send unlocked
-        syslogQueuePos += strlen(rec) + 1;        have = true;
+        syslogQueuePos += strlen(rec) + 1;
+        have = true;
 
         if (syslogQueuePos >= syslogQueueLen) {  // drained -> rewind
           syslogQueuePos = 0;

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -27,9 +27,10 @@ static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
 
 // Lines logged before we can send are buffered here and replayed on connect.
+// Heap-allocated on first use, freed after the flush -> no permanent RAM cost.
 // Record layout: [uint8 severity][text\0]
 #define SYSLOG_BACKLOG_MAX 4096
-static char syslogBacklog[SYSLOG_BACKLOG_MAX];
+static char* syslogBacklog = nullptr;
 static size_t syslogBacklogLen = 0;
 
 static void syslog_send(uint8_t sev, const char* msg) {
@@ -38,10 +39,7 @@ static void syslog_send(uint8_t sev, const char* msg) {
     return;
   }
   uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
-  const char* host = WiFi.getHostname();
-  if (host == nullptr || host[0] == '\0') {
-    host = "batteryemulator";  // STA netif not up yet
-  }
+  const char* host = get_hostname();
   if (syslogUdp.beginPacket(dst, syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
@@ -55,7 +53,20 @@ static void syslog_backlog_push(uint8_t sev, const char* msg) {
   unsigned long ms = millis();
   // No clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
   int n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
-  if (n < 0 || syslogBacklogLen + 1 + (size_t)n + 1 > SYSLOG_BACKLOG_MAX) {
+  if (n < 0) {
+    return;
+  }
+  if (syslogBacklog == nullptr) {
+    IPAddress dst;
+    if (!dst.fromString(syslog_ip.c_str())) {
+      return;  // no syslog server configured -> never allocate
+    }
+    syslogBacklog = (char*)malloc(SYSLOG_BACKLOG_MAX);
+    if (syslogBacklog == nullptr) {
+      return;  // out of heap -> just drop, logging must never be fatal
+    }
+  }
+  if (syslogBacklogLen + 1 + (size_t)n + 1 > SYSLOG_BACKLOG_MAX) {
     return;  // full -> keep the earliest lines, they are the point of buffering
   }
   syslogBacklog[syslogBacklogLen++] = (char)sev;
@@ -64,7 +75,7 @@ static void syslog_backlog_push(uint8_t sev, const char* msg) {
 }
 
 void syslog_backlog_flush(void) {
-  if (syslogBacklogLen == 0) {
+  if (syslogBacklog == nullptr) {
     return;
   }
   if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
@@ -77,6 +88,8 @@ void syslog_backlog_flush(void) {
     syslog_send(sev, msg);
     i += strlen(msg) + 1;
   }
+  free(syslogBacklog);
+  syslogBacklog = nullptr;
   syslogBacklogLen = 0;
 }
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -33,13 +33,26 @@ static size_t syslogLineLen = 0;
 static char* syslogBacklog = nullptr;
 static size_t syslogBacklogLen = 0;
 
+// Same rule as init_WiFi(): custom hostname if set, otherwise the MAC-derived default.
+// Cached — default_hostname() re-reads eFuse and heap-allocates a String on every call.
+static const char* syslog_hostname(void) {
+  if (!custom_hostname.empty()) {
+    return custom_hostname.c_str();
+  }
+  static String fallback;
+  if (fallback.isEmpty()) {
+    fallback = default_hostname();
+  }
+  return fallback.c_str();
+}
+
 static void syslog_send(uint8_t sev, const char* msg) {
   IPAddress dst;
   if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
     return;
   }
   uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
-  const char* host = get_hostname();
+  const char* host = syslog_hostname();
   if (syslogUdp.beginPacket(dst, syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -26,6 +26,60 @@ static WiFiUDP syslogUdp;
 static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
 
+// Lines logged before we can send are buffered here and replayed on connect.
+// Record layout: [uint8 severity][text\0]
+#define SYSLOG_BACKLOG_MAX 4096
+static char syslogBacklog[SYSLOG_BACKLOG_MAX];
+static size_t syslogBacklogLen = 0;
+
+static void syslog_send(uint8_t sev, const char* msg) {
+  IPAddress dst;
+  if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
+    return;
+  }
+  uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
+  const char* host = WiFi.getHostname();
+  if (host == nullptr || host[0] == '\0') {
+    host = "batteryemulator";  // STA netif not up yet
+  }
+  if (syslogUdp.beginPacket(dst, syslog_port)) {
+    // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
+    // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
+    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, host, msg);
+    syslogUdp.endPacket();
+  }
+}
+
+static void syslog_backlog_push(uint8_t sev, const char* msg) {
+  char rec[SYSLOG_LINE_MAX + 24];
+  unsigned long ms = millis();
+  // No clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
+  int n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
+  if (n < 0 || syslogBacklogLen + 1 + (size_t)n + 1 > SYSLOG_BACKLOG_MAX) {
+    return;  // full -> keep the earliest lines, they are the point of buffering
+  }
+  syslogBacklog[syslogBacklogLen++] = (char)sev;
+  memcpy(syslogBacklog + syslogBacklogLen, rec, n + 1);
+  syslogBacklogLen += n + 1;
+}
+
+void syslog_backlog_flush(void) {
+  if (syslogBacklogLen == 0) {
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
+    return;
+  }
+  size_t i = 0;
+  while (i < syslogBacklogLen) {
+    uint8_t sev = (uint8_t)syslogBacklog[i++];
+    const char* msg = &syslogBacklog[i];
+    syslog_send(sev, msg);
+    i += strlen(msg) + 1;
+  }
+  syslogBacklogLen = 0;
+}
+
 void Logging::set_next_severity(uint8_t sev) {
   syslog_next_severity = (int)sev;
 }
@@ -39,27 +93,17 @@ static void syslog_flush_line(void) {
     return;
   }
   syslogLine[len] = '\0';
-  IPAddress dst;
-  if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
-    return;
-  }
   uint8_t sev = (sev_override >= 0) ? (uint8_t)sev_override : SYSLOG_DEFAULT_SEVERITY;
-  uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
-  const char* host = WiFi.getHostname();
-  if (syslogUdp.beginPacket(dst, syslog_port)) {
-    // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
-    // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
-    syslogUdp.printf("<%u>1 - %s BatteryEmulator - - - %s", pri, host, syslogLine);
-    syslogUdp.endPacket();
+  if (WiFi.status() == WL_CONNECTED || WiFi.softAPgetStationNum() > 0) {
+    syslog_backlog_flush();  // replay buffered lines first, keeps ordering
+    syslog_send(sev, syslogLine);
+  } else {
+    syslog_backlog_push(sev, syslogLine);
   }
 }
 
 static void syslog_emit(const uint8_t* buffer, size_t size) {
   if (!datalayer.system.info.syslog_logging_active) {
-    return;
-  }
-  // Send when joined to a network (STA) OR when a client is on our SoftAP.
-  if (WiFi.status() != WL_CONNECTED && WiFi.softAPgetStationNum() == 0) {
     return;
   }
   for (size_t i = 0; i < size; i++) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -62,30 +62,43 @@ static void syslog_send(uint8_t sev, const char* msg) {
   }
 }
 
-static void syslog_backlog_push(uint8_t sev, const char* msg) {
+static bool syslog_backlog_push(uint8_t sev, const char* msg, bool stamp) {
   char rec[SYSLOG_LINE_MAX + 24];
-  unsigned long ms = millis();
-  // No wall clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
-  int n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
+  int n;
+  if (stamp) {
+    // No wall clock at boot: carry the uptime in MSG, else replayed lines all look simultaneous.
+    unsigned long ms = millis();
+    n = snprintf(rec, sizeof(rec), "[boot +%lu.%03lus] %s", ms / 1000, ms % 1000, msg);
+  } else {
+    n = snprintf(rec, sizeof(rec), "%s", msg);  // already online, no prefix
+  }
   if (n < 0) {
-    return;
+    return false;
   }
   if (syslogBacklog == nullptr) {
     IPAddress dst;
     if (!dst.fromString(syslog_ip.c_str())) {
-      return;  // no syslog server configured -> never allocate
+      return false;  // no syslog server configured -> never allocate
     }
     syslogBacklog = (char*)malloc(SYSLOG_BACKLOG_MAX);
     if (syslogBacklog == nullptr) {
-      return;  // out of heap -> drop; logging must never be fatal
+      return false;  // out of heap -> drop; logging must never be fatal
     }
   }
-  if (syslogBacklogLen + 1 + (size_t)n + 1 > SYSLOG_BACKLOG_MAX) {
-    return;  // full -> keep the earliest lines, they are the point of buffering
+  size_t need = 1 + (size_t)n + 1;
+  if (syslogBacklogLen + need > SYSLOG_BACKLOG_MAX && syslogBacklogPos > 0) {
+    // Tail hit the cap but the head is already sent: slide the pending region down.
+    memmove(syslogBacklog, syslogBacklog + syslogBacklogPos, syslogBacklogLen - syslogBacklogPos);
+    syslogBacklogLen -= syslogBacklogPos;
+    syslogBacklogPos = 0;
+  }
+  if (syslogBacklogLen + need > SYSLOG_BACKLOG_MAX) {
+    return false;  // genuinely full
   }
   syslogBacklog[syslogBacklogLen++] = (char)sev;
   memcpy(syslogBacklog + syslogBacklogLen, rec, n + 1);
   syslogBacklogLen += n + 1;
+  return true;
 }
 
 void syslog_backlog_flush(void) {
@@ -125,11 +138,17 @@ static void syslog_flush_line(void) {
   }
   syslogLine[len] = '\0';
   uint8_t sev = (sev_override >= 0) ? (uint8_t)sev_override : SYSLOG_DEFAULT_SEVERITY;
-  if (WiFi.status() == WL_CONNECTED || WiFi.softAPgetStationNum() > 0) {
-    syslog_backlog_flush();  // replay buffered lines first, keeps ordering
-    syslog_send(sev, syslogLine);
+  bool online = (WiFi.status() == WL_CONNECTED || WiFi.softAPgetStationNum() > 0);
+  if (!online) {
+    syslog_backlog_push(sev, syslogLine, true);
+  } else if (syslogBacklog != nullptr) {
+    // Still draining: queue behind it so the server sees strict FIFO order.
+    if (!syslog_backlog_push(sev, syslogLine, false)) {
+      syslog_send(sev, syslogLine);  // backlog full -> send now rather than lose the line
+    }
+    syslog_backlog_flush();  // drains SYSLOG_BACKLOG_BURST records
   } else {
-    syslog_backlog_push(sev, syslogLine);
+    syslog_send(sev, syslogLine);
   }
 }
 

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -144,8 +144,7 @@ static void syslog_task(void* arg) {
   for (;;) {
     bool have = false;
 
-    if (syslog_online() && syslogMutex != nullptr &&
-        xSemaphoreTake(syslogMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    if (syslog_online() && syslogMutex != nullptr && xSemaphoreTake(syslogMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
       if (syslogQueue != nullptr && syslogQueuePos < syslogQueueLen) {
         sev = (uint8_t)syslogQueue[syslogQueuePos++];
         const char* rec = &syslogQueue[syslogQueuePos];

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -76,7 +76,8 @@ static void syslog_send(uint8_t sev, const char* proc, const char* msg) {
   if (syslogUdp.beginPacket(dst, syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
-    syslogUdp.printf("<%u>1 - %s BatteryEmulator %s - - %s", pri, syslog_hostname(), proc, msg);
+    // APP-NAME carries the FreeRTOS task that produced the line.
+    syslogUdp.printf("<%u>1 - %s %s - - - %s", pri, syslog_hostname(), proc, msg);
     syslogUdp.endPacket();
   }
 }

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -133,6 +133,7 @@ extern Logging logging;
 extern std::string syslog_ip;
 extern uint16_t syslog_port;
 extern uint8_t syslog_facility;  // 0..23
+void syslog_backlog_flush(void);
 #endif
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -133,7 +133,7 @@ extern Logging logging;
 extern std::string syslog_ip;
 extern uint16_t syslog_port;
 extern uint8_t syslog_facility;  // 0..23
-void syslog_backlog_flush(void);
+void syslog_start(void);         // starts the syslog sender task; safe to call more than once
 #endif
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -329,7 +329,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 #ifndef SMALL_FLASH_DEVICE
-  syslog_start();  
+  syslog_start();
 #endif
 
   //clear disconnects events if we got a IP

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -218,6 +218,9 @@ static void check_ap_button() {
 
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
+#ifndef SMALL_FLASH_DEVICE
+  syslog_backlog_flush();  // keep draining even when nothing is logging
+#endif
   check_ap_button();
   check_ap_provisioning_window();
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -329,7 +329,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 #ifndef SMALL_FLASH_DEVICE
-  syslog_backlog_flush(); // replay lines logged before we had an IP
+  syslog_backlog_flush();  // replay lines logged before we had an IP
 #endif
 
   //clear disconnects events if we got a IP

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -15,6 +15,9 @@ bool wifiap_enabled = true;
 bool mdns_enabled = true;    //If true, allows battery monitor te be found by .local address
 bool espnow_enabled = true;  //If true, allows battery emulator to send battery status by using ESPNow messages
 uint16_t wifi_channel = 0;
+#ifndef SMALL_FLASH_DEVICE
+extern const char* version_number;
+#endif
 
 std::string custom_hostname;  //If not set, defaults to "battery-emulator-" + last two MAC bytes (see init_WiFi)
 std::string ssid;
@@ -325,12 +328,26 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
-  syslog_backlog_flush();  // replay lines logged before we had an IP
+#ifndef SMALL_FLASH_DEVICE
+  syslog_backlog_flush(); // replay lines logged before we had an IP
+#endif
+
   //clear disconnects events if we got a IP
   clear_event(EVENT_WIFI_DISCONNECT);
   logging.print("Wi-Fi Got IP. ");
   logging.print("IP address: ");
   logging.println(WiFi.localIP().toString());
+
+#ifndef SMALL_FLASH_DEVICE
+  // One-shot boot notice — fires once per boot, not on every reconnect.
+  static bool boot_logged = false;
+  if (!boot_logged) {
+    boot_logged = true;
+    LOG_SET_NEXT_SEVERITY(5);  // RFC 5424 severity 5 = Notice
+    logging.printf("Bootup complete, running version %s\n", version_number);
+  }
+#endif
+
   static bool mdns_started = false;
   if (mdns_enabled && !mdns_started) {
     init_mDNS();
@@ -358,10 +375,11 @@ void init_mDNS() {
 
   // Initialize mDNS .local resolution
   if (!MDNS.begin(mdnsHost)) {
-    logging.println("Error setting up MDNS responder!");
+    logging.println("Error setting up mDNS responder!");
   } else {
     // Advertise via bonjour the web inteface so we can auto discover these battery emulators on the local network.
     MDNS.addService("http", "tcp", 80);
+    logging.println("mDNS responder started.");
   }
 #endif
 }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -218,9 +218,6 @@ static void check_ap_button() {
 
 // Task to monitor Wi-Fi status and handle reconnections
 void wifi_monitor() {
-#ifndef SMALL_FLASH_DEVICE
-  syslog_backlog_flush();  // keep draining even when nothing is logging
-#endif
   check_ap_button();
   check_ap_provisioning_window();
 
@@ -332,7 +329,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 #ifndef SMALL_FLASH_DEVICE
-  syslog_backlog_flush();  // replay lines logged before we had an IP
+  syslog_start();  
 #endif
 
   //clear disconnects events if we got a IP

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -325,6 +325,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
+  syslog_backlog_flush();  // replay lines logged before we had an IP
   //clear disconnects events if we got a IP
   clear_event(EVENT_WIFI_DISCONNECT);
   logging.print("Wi-Fi Got IP. ");


### PR DESCRIPTION
### What
This PR adds a pre-connectivity log backlog.
Lines logged before the STA gets an IP are now buffered and replayed to the syslog server on connect, plus a one-shot "Bootup complete, running version" notice.

The name of the task where the messages came from appears in the app column.

### Why
Everything logged during boot was silently dropped by the `WL_CONNECTED` gate in `syslog_emit()` — exactly the lines that matter most when diagnosing a failed startup.

App name was always "BatteryEmulator" which is irrelevant since it's always the same.

### How
HOSTNAME now follows the same rule as `init_WiFi()` — custom hostname if set, otherwise `default_hostname()` (eFuse-derived, valid before WiFi starts) — cached to avoid a heap allocation per log line, and APP-NAME carries the FreeRTOS task that produced the line instead of a constant.
The connectivity gate is replaced by a queue plus a dedicated low-priority sender task: `syslog_emit()` only appends each assembled line to a lazily malloc'd 4 KB FIFO under a short-held mutex (no network I/O in the caller's task, so the core loop can't overrun), while `syslog_task()` — started from `onWifiGotIP()` — pops one record at a time and does all UDP sending outside the lock, which keeps packets in order and uncorrupted; lines queued before the link is up carry their boot uptime (`[boot +N.NNNs]`) since there is no wall clock at that point.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
