### PR TITLE
Improvement: Nissan Leaf 🔋 balancing status

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -203,9 +203,8 @@ void NissanLeafBattery::
       balancing_idle_polls++;
     }
 
-    balancing_status_enum new_status = (balancing_idle_polls < BALANCING_IDLE_POLLS_TO_END)
-                                           ? BALANCING_STATUS_ACTIVE
-                                           : BALANCING_STATUS_READY;
+    balancing_status_enum new_status =
+        (balancing_idle_polls < BALANCING_IDLE_POLLS_TO_END) ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
 
     if (new_status != datalayer_battery->status.balancing_status) {
       if (new_status == BALANCING_STATUS_ACTIVE) {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -180,7 +180,7 @@ void NissanLeafBattery::
   }
 
   // Derive aggregate balancing status from the per-cell shunt bits polled from group 0x06.
-  // Recomputed every cycle in both directions.
+  // Recomputed every cycle in both directions; events fire on transitions only.
   if (balancing_data_received) {
     bool any_shunt_active = false;
     for (uint8_t i = 0; i < 96; i++) {
@@ -189,8 +189,15 @@ void NissanLeafBattery::
         break;
       }
     }
-    datalayer_battery->status.balancing_status =
-        any_shunt_active ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
+    balancing_status_enum new_status = any_shunt_active ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
+    if (new_status != datalayer_battery->status.balancing_status) {
+      if (new_status == BALANCING_STATUS_ACTIVE) {
+        set_event_latched(EVENT_BALANCING_START, 0);
+      } else if (datalayer_battery->status.balancing_status == BALANCING_STATUS_ACTIVE) {
+        set_event(EVENT_BALANCING_END, 0);  // only on ACTIVE -> READY, not on the initial UNKNOWN -> READY
+      }
+    }
+    datalayer_battery->status.balancing_status = new_status;
   }
 
   // Update webserver datalayer

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -179,9 +179,16 @@ void NissanLeafBattery::
     }
   }
 
-  // Derive aggregate balancing status from the per-cell shunt bits polled from group 0x06.
-  // Recomputed every cycle in both directions; events fire on transitions only.
-  if (balancing_data_received) {
+  // Derive aggregate balancing status from the per-cell shunt bits polled from LBC group 0x06.
+  // The LBC duty-cycles its bleed resistors (and disables them while sampling cell voltages), and we
+  // only see one snapshot per ~70s poll rotation, so a single all-clear poll is not proof that the
+  // balancing phase has ended. Require BALANCING_IDLE_POLLS_TO_END consecutive idle polls before
+  // dropping back to READY. Evaluated only on fresh group 0x06 data, never on the 1s update tick.
+  static constexpr uint8_t BALANCING_IDLE_POLLS_TO_END = 3;  // ~3.5 minutes of quiet
+
+  if (balancing_data_received && balancing_data_fresh) {
+    balancing_data_fresh = false;
+
     bool any_shunt_active = false;
     for (uint8_t i = 0; i < 96; i++) {
       if (battery_balancing_shunts[i]) {
@@ -189,12 +196,22 @@ void NissanLeafBattery::
         break;
       }
     }
-    balancing_status_enum new_status = any_shunt_active ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
+
+    if (any_shunt_active) {
+      balancing_idle_polls = 0;
+    } else if (balancing_idle_polls < BALANCING_IDLE_POLLS_TO_END) {
+      balancing_idle_polls++;
+    }
+
+    balancing_status_enum new_status = (balancing_idle_polls < BALANCING_IDLE_POLLS_TO_END)
+                                           ? BALANCING_STATUS_ACTIVE
+                                           : BALANCING_STATUS_READY;
+
     if (new_status != datalayer_battery->status.balancing_status) {
       if (new_status == BALANCING_STATUS_ACTIVE) {
         set_event_latched(EVENT_BALANCING_START, 0);
       } else if (datalayer_battery->status.balancing_status == BALANCING_STATUS_ACTIVE) {
-        set_event(EVENT_BALANCING_END, 0);  // only on ACTIVE -> READY, not on the initial UNKNOWN -> READY
+        set_event(EVENT_BALANCING_END, 0);  // only ACTIVE -> READY, not the initial UNKNOWN -> READY
       }
     }
     datalayer_battery->status.balancing_status = new_status;
@@ -526,6 +543,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           }
           memcpy(datalayer_battery->status.cell_balancing_status, battery_balancing_shunts, 96 * sizeof(bool));
           balancing_data_received = true;
+          balancing_data_fresh = true;
         }
 
         if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23 FF FF FF FF FF FF FF)

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -179,6 +179,20 @@ void NissanLeafBattery::
     }
   }
 
+  // Derive aggregate balancing status from the per-cell shunt bits polled from group 0x06.
+  // Recomputed every cycle in both directions.
+  if (balancing_data_received) {
+    bool any_shunt_active = false;
+    for (uint8_t i = 0; i < 96; i++) {
+      if (battery_balancing_shunts[i]) {
+        any_shunt_active = true;
+        break;
+      }
+    }
+    datalayer_battery->status.balancing_status =
+        any_shunt_active ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
+  }
+
   // Update webserver datalayer
   if (datalayer_nissan) {
     memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
@@ -504,6 +518,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             battery_balancing_shunts[88 + i] = (rx_frame.data.u8[1] & (1 << i)) >> i;
           }
           memcpy(datalayer_battery->status.cell_balancing_status, battery_balancing_shunts, 96 * sizeof(bool));
+          balancing_data_received = true;
         }
 
         if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23 FF FF FF FF FF FF FF)

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -186,6 +186,7 @@ class NissanLeafBattery : public CanBattery {
   uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
   uint16_t battery_cell_voltages[96];           //array with all the cellvoltages
   bool battery_balancing_shunts[96];            //array with all the balancing resistors
+  bool balancing_data_received = false;         //true once group 0x06 has answered at least once
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
   uint16_t battery_HX = 0;              //Internal resistance

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -187,6 +187,8 @@ class NissanLeafBattery : public CanBattery {
   uint16_t battery_cell_voltages[96];           //array with all the cellvoltages
   bool battery_balancing_shunts[96];            //array with all the balancing resistors
   bool balancing_data_received = false;         //true once group 0x06 has answered at least once
+  bool balancing_data_fresh = false;            //set by group 0x06 handler, consumed by update_values()
+  uint8_t balancing_idle_polls = 0;             //consecutive group 0x06 polls with no shunt active
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
   uint16_t battery_HX = 0;              //Internal resistance


### PR DESCRIPTION
### WHAT
Noticed that though MQTT "Balancing Status" sensor reports `Unknown` for Nissan LEAF.


### WHY
`balancing_status` is an opt-in field: a handful of drivers (MEB, Zoe Gen2, the BMWs, RJXZS) set it, if silently inherits the `UNKNOWN` default the user has no way to tell "not supported" apart from "not working". Data is there though.

Users on Discord think there's an issue with the pack, generating potential support pressure.

### HOW
Inspired from Zoe, derive the aggregate state from the shunt bits the driver is already collecting — active if any resistor is on, ready if none are — and hold the field at `UNKNOWN` until group `0x06` has actually answered once, because polling is paused at boot.

#### Hysteresis
The LBC duty-cycles its bleed resistors and switches them off while it samples cell voltages, so a single snapshot showing no active shunt does not mean balancing has finished — it usually means we asked at the wrong instant.
Group `0x06` is one of seven PID groups on a 10 s rotation, so we get one snapshot per ~70 s and cannot distinguish a resistor that is on 90% of the time from one that is on 10%; taken naively, the status flaps between Active and Ready every poll and buries the event log in start/end pairs.
Requiring several consecutive all-clear polls before dropping back to `READY` makes the field mean "the pack is in a balancing phase", which is what a user actually wants on a dashboard, while the raw per-cell array and `balancing_active_cells` stay unsmoothed for anyone who wants the instantaneous truth.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
