### PR TITLE
Volkswagen MEB: Add sending of Klima_07 message to reduce number of DTCs

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -839,6 +839,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     counter_10ms = (counter_10ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
     transmit_can_frame(&ESC_51_Auth_frame);  // Required for contactor closing
+    transmit_can_frame(&HVLM_13_frame);      // Some newer packs throw "00A767" DTC incase this message is missing
   }
   // Send 20ms CAN Message
   if (currentMillis - previousMillis20ms >= INTERVAL_20_MS) {

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -989,6 +989,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&Klemmen_Status_01_frame);
     transmit_can_frame(&Motor_14_frame);
     transmit_can_frame(&Motor_54_frame);
+    transmit_can_frame(&Klima_EV_07_frame);  //PTC / EKK voltage free or not
   }
   //Send 200ms message
   if (currentMillis - previousMillis200ms >= INTERVAL_200_MS) {

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -241,6 +241,7 @@ class MebBattery : public CanBattery, public IsoTp {
   static const int Standklima_01 = 0x16A954FB;
   static const int ORU_01 = 0x1A555548;
   static const int Klima_EV_06 = 0x1A55552B;
+  static const int Klima_EV_07 = 0x12DD5513;
   static const int HVEM_04 = 0x569;
   static const int eTM_01 = 0x16A954B4;
   static const int NMH_Gateway = 0x1B000010;
@@ -540,6 +541,11 @@ class MebBattery : public CanBattery, public IsoTp {
                                                   .DLC = 8,
                                                   .ID = Klima_EV_06,
                                                   .data = {0x00, 0x00, 0x00, 0xA0, 0x02, 0x04, 0x00, 0x30}};
+  static constexpr CAN_frame Klima_EV_07_frame = {.FD = true,
+                                                  .ext_ID = true,
+                                                  .DLC = 8,
+                                                  .ID = Klima_EV_07,
+                                                  .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   static constexpr CAN_frame HVEM_04_frame = {.FD = true,
                                               .ext_ID = false,
                                               .DLC = 8,

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -252,6 +252,7 @@ class MebBattery : public CanBattery, public IsoTp {
   static const int Klima_Sensor_02 = 0x5E1;
   static const int Motor_14 = 0x3BE;
   static const int Motor_54 = 0x14C;
+  static const int HVLM_13 = 0x271;
   static const int HVLM_14 = 0x272;
   static const int HVK_01 = 0x503;
   static const int KN_Hybrid_01 = 0x17F0007B;
@@ -586,6 +587,11 @@ class MebBattery : public CanBattery, public IsoTp {
                               .DLC = 8,
                               .ID = Motor_14,  // CRC, otherwise content
                               .data = {0x57, 0x0D, 0x00, 0x00, 0x00, 0x02, 0x04, 0x40}};
+  CAN_frame HVLM_13_frame = {.FD = true,  //HVLM_13
+                             .ext_ID = false,
+                             .DLC = 8,
+                             .ID = HVLM_13,  // content still TODO
+                             .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame HVLM_14_frame = {.FD = true,  //HVLM_14
                              .ext_ID = false,
                              .DLC = 8,


### PR DESCRIPTION
### What
This PR adds sending of Klima_07 & HVLM_13 message to reduce number of DTCs for the Volkswagen MEB implementation

### Why
Less DTCs is better! These two should be fixed:

<img width="674" height="119" alt="image" src="https://github.com/user-attachments/assets/c06c87c6-8444-4a47-ab90-dac72691933a" />

### How
We add the messages to 10/100ms send routine. Message completely empty for now.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
