### PR TITLE
Bugfix: 🐛 Disable WiFi driver persistence which may cause task stalls 

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -106,6 +106,13 @@ String default_hostname() {
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
 
+  // Keep the WiFi driver's mode/config changes in RAM instead of NVS. Credentials
+  // are stored in our own Preferences and reapplied at boot, so driver-level
+  // persistence is redundant. Without this, esp_wifi_set_config()/set_mode() (e.g.
+  // softAPdisconnect() on AP provisioning timeout) write to NVS, and the flash
+  // erase suspends the cache, stalling tasks on BOTH cores for up to ~45 ms.
+  WiFi.persistent(false);
+
   // Register event handlers BEFORE WiFi.mode() creates the arduino_events task.
   // WiFi events can fire immediately once the task exists, and vector reallocation
   // during concurrent emplace_back() would corrupt the iterator in _checkForEvent().


### PR DESCRIPTION
Disable WiFi driver persistence to avoid flash write delays.

### What

This PR disables WiFi driver-level persistence by calling `WiFi.persistent(false)` in `init_WiFi()`, before the WiFi driver is initialized.

This keeps the ESP-IDF WiFi driver's mode and configuration state in RAM (`WIFI_STORAGE_RAM`) instead of the default NVS flash storage (`WIFI_STORAGE_FLASH`). It eliminates hidden NVS flash writes that occur on every `WiFi.mode()`, `WiFi.begin()`, `WiFi.softAP()` and `WiFi.softAPdisconnect()` call — most visibly the write triggered by the AP provisioning window timeout, which was stalling the 10 ms `core_loop` task for up to ~45 ms.

### Why

**Observed problem:** when the AP provisioning window expires and `check_ap_provisioning_window()` shuts the access point down, the 10 ms `core_loop` task stalls for up to ~45 ms (visible as `EVENT_TASK_OVERRUN`), even though `core_loop` runs on a different core (`CORE_FUNCTION_CORE`, core 1) at higher priority than the connectivity task (`WIFICORE`, core 0) issuing the shutdown.

**Root cause** (traced through arduino-esp32 3.x sources):

1. `WiFi.softAPdisconnect(true)` → `APClass::clear()` + `APClass::end()`
2. `APClass::clear()` calls `esp_wifi_set_config(WIFI_IF_AP, …)`; `APClass::end()` → `WiFi.enableAP(false)` → `esp_wifi_set_mode(…)`
3. In the Arduino core, `wifiLowLevelInit()` only switches the driver to RAM storage conditionally: `if (!persistent) esp_wifi_set_storage(WIFI_STORAGE_RAM);` — and `WiFiGenericClass::_persistent` defaults to **`true`**. Battery-Emulator never calls `WiFi.persistent()`, so the driver runs with the IDF default `WIFI_STORAGE_FLASH`
4. With flash storage active, both `esp_wifi_set_config()` and `esp_wifi_set_mode()` commit the change to NVS (`nvs.net80211` namespace). When a commit lands on a full page, it triggers a 4 KB flash sector erase
5. During a flash erase/write, the SPI flash cache is disabled and **every task on both cores executing flash-resident code halts** until the operation completes. Task priorities and core pinning offer no protection — this is the flash controller, not the scheduler. A sector erase takes tens of milliseconds, matching the observed "up to 45 ms" (plain commits cost a few ms; the ones requiring an erase produce the worst case)

**Why the persistence is safe to drop:** the driver's NVS copy of WiFi state was never used by this project. All credentials (STA SSID/password, AP SSID/password, hostname, static IP settings) are stored in Battery-Emulator's own `Preferences` namespace (`comm_nvm`) and passed explicitly to `WiFi.begin()` / `WiFi.softAP()` on every boot. The driver-level copy was pure overhead:

- unnecessary flash writes (and flash wear) on every WiFi mode/config change since boot
- an autonomous, non-user-initiated background event (the AP provisioning timeout) perturbing the real-time control loop of a device managing a high-voltage battery

Disabling driver persistence when the application manages its own credentials is also the standing Espressif recommendation.

### How

- `Software/src/devboard/wifi/wifi.cpp`: added `WiFi.persistent(false);` at the top of `init_WiFi()`, immediately after the initial `DEBUG_PRINTF`, with a comment documenting the rationale and the stall mechanism.

**Placement is load-bearing:** the storage mode is applied once, inside `wifiLowLevelInit()`, when the driver first initializes. The call must therefore execute before the first `WiFi.mode()` call. `init_WiFi()` is the single entry point for WiFi bring-up (called once from `connectivity_loop`), so this position covers every downstream path: boot-time AP start, BOOT-button (≥5 s) AP start, the STA reconnect rescue-AP fallback, and the provisioning-timeout shutdown.

**Effect:** with `WIFI_STORAGE_RAM`, `esp_wifi_set_config()` / `esp_wifi_set_mode()` no longer touch NVS. The AP teardown at provisioning timeout becomes a RAM-only driver operation confined to the connectivity task on `WIFICORE`; no flash operation occurs, so the flash cache is never suspended and `core_loop` on `CORE_FUNCTION_CORE` is unaffected.

**Behavior unchanged:**
- WiFi connectivity, AP behavior, and the provisioning window logic are untouched — credentials continue to be loaded from the project's own `Preferences` at boot and applied explicitly
- Intentional flash writes (saving settings via the web UI, OTA) still cause the inherent cross-core cache-suspension cost; those are user-initiated and unavoidable. This PR only removes the *redundant* writes issued autonomously by the WiFi driver

**Verification:** confirm that `EVENT_TASK_OVERRUN` no longer fires (and `core_task_10s_max_us` stays flat) across an AP provisioning timeout with the factory-default password.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
