### PR TITLE
Add configurable Home Assistant MQTT discovery topic

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -211,6 +211,7 @@ void init_stored_settings() {
   mqtt_timeout_ms = settings.getUInt("MQTTTIMEOUT", 2000);
   mqtt_publish_interval_ms = settings.getUInt("MQTTPUBLISHMS", 5000);
   ha_autodiscovery_enabled = settings.getBool("HADISC", false);
+  ha_autodiscovery_topic = settings.getString("HADISCTOPIC", "homeassistant").c_str();
   mqtt_transmit_all_cellvoltages = settings.getBool("MQTTCELLV", false);
   custom_hostname = settings.getString("HOSTNAME").c_str();
 

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -22,6 +22,7 @@ std::string mqtt_password;
 
 bool mqtt_enabled = false;
 bool ha_autodiscovery_enabled = false;
+std::string ha_autodiscovery_topic = "homeassistant";
 bool mqtt_transmit_all_cellvoltages = false;
 uint16_t mqtt_timeout_ms = 2000;
 uint16_t mqtt_publish_interval_ms = 5000;
@@ -180,19 +181,20 @@ SensorConfig buttonConfigs[] = {{"BMSRESET", "Reset BMS", nullptr, nullptr, null
                                 {"STOP", "Open Contactors", nullptr, nullptr, nullptr, nullptr}};
 
 static String generateCommonInfoAutoConfigTopic(const char* default_entity_id) {
-  return "homeassistant/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
+  return String(ha_autodiscovery_topic.c_str()) + "/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
 }
 
 static String generateCellVoltageAutoConfigTopic(int cell_number, String battery_suffix) {
-  return "homeassistant/sensor/" + topic_name + "/cell_voltage" + battery_suffix + String(cell_number) + "/config";
+  return String(ha_autodiscovery_topic.c_str()) + "/sensor/" + topic_name + "/cell_voltage" + battery_suffix +
+         String(cell_number) + "/config";
 }
 
 static String generateEventsAutoConfigTopic(const char* default_entity_id) {
-  return "homeassistant/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
+  return String(ha_autodiscovery_topic.c_str()) + "/sensor/" + topic_name + "/" + String(default_entity_id) + "/config";
 }
 
 static String generateButtonAutoConfigTopic(const char* subtype) {
-  return "homeassistant/button/" + topic_name + "/" + String(subtype) + "/config";
+  return String(ha_autodiscovery_topic.c_str()) + "/button/" + topic_name + "/" + String(subtype) + "/config";
 }
 
 static String generateSensorDefaultEntityId(const String& object_id) {

--- a/Software/src/devboard/mqtt/mqtt.h
+++ b/Software/src/devboard/mqtt/mqtt.h
@@ -47,6 +47,7 @@ extern bool mqtt_transmit_all_cellvoltages;
 extern uint16_t mqtt_timeout_ms;
 extern uint16_t mqtt_publish_interval_ms;
 extern bool ha_autodiscovery_enabled;
+extern std::string ha_autodiscovery_topic;
 extern std::string mqtt_server;
 extern std::string mqtt_user;
 extern std::string mqtt_password;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -681,6 +681,10 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("HADISC") ? "checked" : "";
   }
 
+  if (var == "HADISCTOPIC") {
+    return settings.getString("HADISCTOPIC", "homeassistant");
+  }
+
   if (var == "MANUAL_BAL_CLASS") {
     if (battery && battery->supports_manual_balancing()) {
       return "";
@@ -1999,6 +2003,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <input type='checkbox' name='REMBMSRESET' value='on' %REMBMSRESET% />
         <label>Enable Home Assistant auto discovery: </label>
         <input type='checkbox' name='HADISC' value='on' %HADISC% />
+        <label>Home Assistant auto discovery topic: </label>
+        <input type='text' name='HADISCTOPIC' value="%HADISCTOPIC%"
+        pattern="[A-Za-z0-9_\-]+"
+        title="MQTT auto discovery base topic (letters, numbers, '_', '-')" />
 
         </div>
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -445,7 +445,7 @@ void init_webserver() {
   };
 
   const char* stringSettingNames[] = {"APPASSWORD",   "HOSTNAME", "MQTTSERVER", "MQTTUSER",
-                                      "MQTTPASSWORD", "HTTPUSER", "HTTPPASS",
+                                      "MQTTPASSWORD", "HTTPUSER", "HTTPPASS",   "HADISCTOPIC",
 #ifndef SMALL_FLASH_DEVICE
                                       "SYSLOGIP"
 #endif

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -443,7 +443,7 @@ void init_webserver() {
   };
 
   const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME", "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD", "HTTPUSER",
-                                      "HTTPPASS",   "LOCALIP",  "GATEWAY",    "SUBNET",   "DNS", "HADISCTOPIC",
+                                      "HTTPPASS",   "LOCALIP",  "GATEWAY",    "SUBNET",   "DNS",          "HADISCTOPIC",
 #ifndef SMALL_FLASH_DEVICE
                                       "SYSLOGIP"
 #endif


### PR DESCRIPTION
## Summary
- Adds a `HADISCTOPIC` setting so the Home Assistant MQTT auto-discovery base topic (previously hardcoded as `"homeassistant"`) can be changed from the web UI, for users running a non-default HA discovery prefix.
- New `ha_autodiscovery_topic` string is read from NVM (default `"homeassistant"`) and used when building all discovery topics (sensor/button config topics).
- Adds the text input to the settings page, with a pattern restricting it to letters, numbers, `_`, and `-`.
- Registers `HADISCTOPIC` in the webserver's string settings list so it's persisted/loaded like the other string settings.

![Home Assistant auto discovery topic setting](https://redispose.se/image/ha_discovery_topic.png)