### PR TITLE
Improvement: Warn when AP starts with default password, log provisioning window expiry

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -162,6 +162,7 @@ void init_events(void) {
   events.entries[EVENT_PID_FAILED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_CONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_DISCONNECT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_WIFI_AP_PASSWORD_DEFAULT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_WIFI_AP_PROVISION_TIMEOUT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MQTT_CONNECT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_MQTT_DISCONNECT].level = EVENT_LEVEL_INFO;
@@ -442,6 +443,8 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
       return "Wifi connected.";
     case EVENT_WIFI_DISCONNECT:
       return "Wifi disconnected.";
+    case EVENT_WIFI_AP_PASSWORD_DEFAULT:
+      return "The AP will be disabled after 5 idle minutes. Change default password to keep AP constantly on!";
     case EVENT_WIFI_AP_PROVISION_TIMEOUT:
       return "Wifi AP disabled due to cybersecurity concern. Change default password to keep AP "
              "constantly on! Reboot/Hold BOOT button 5-15 seconds to re-enable AP temporarily.";

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -124,6 +124,7 @@
   XX(EVENT_PID_FAILED)                  \
   XX(EVENT_WIFI_CONNECT)                \
   XX(EVENT_WIFI_DISCONNECT)             \
+  XX(EVENT_WIFI_AP_PASSWORD_DEFAULT)    \
   XX(EVENT_WIFI_AP_PROVISION_TIMEOUT)   \
   XX(EVENT_MQTT_CONNECT)                \
   XX(EVENT_MQTT_DISCONNECT)             \

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -89,9 +89,15 @@ static void check_ap_provisioning_window() {
   if (WiFi.softAPgetStationNum() > 0) {
     return;  // a client is connected: don't cut off an active provisioning session
   }
+  // Direct log so EVERY expiry produces a log/syslog line, not just the first per
+  // boot (set_event only emits its log line on the inactive->active transition).
+  LOG_SET_NEXT_SEVERITY(6);  // info
+  logging.println("AP provisioning window expired (factory-default AP password), disabling access point.");
   WiFi.softAPdisconnect(true);  // stop the AP and drop the AP bit from the WiFi mode; STA stays up
   ap_active = false;
   ap_provisioning_expired = true;
+  // The advance warning is about a *running* AP; the timeout event below takes over from here.
+  clear_event(EVENT_WIFI_AP_PASSWORD_DEFAULT);
   set_event(EVENT_WIFI_AP_PROVISION_TIMEOUT, 0);
 }
 
@@ -395,7 +401,17 @@ void init_WiFi_AP() {
   }
 
   WiFi.softAP(ssidAP.c_str(), passwordAP.c_str());
+  bool ap_was_active = ap_active;
   ap_active = true;
+
+  if (!ap_was_active && ap_password_is_default()) {
+    // Warn in advance that the provisioning window is ticking. Direct log fires on
+    // every AP start; the event additionally shows on the web UI / MQTT (set_event
+    // emits its own log line only on the first inactive->active transition per boot).
+    LOG_SET_NEXT_SEVERITY(6);  // info
+    logging.println("AP using default password.");
+    set_event(EVENT_WIFI_AP_PASSWORD_DEFAULT, 0);
+  }
   IPAddress IP = WiFi.softAPIP();
 
   DEBUG_PRINTF("Access Point created, IP address: %s\n", IP.toString().c_str());


### PR DESCRIPTION
### What
- New EVENT_WIFI_AP_PASSWORD_DEFAULT (info) fired on AP start with the factory-default password, cleared again when the window expires
- Direct log 'AP using default password.' on every AP start (off->on only, so the STA reconnect fallback does not spam it)
- Direct log on window expiry, so every expiry is logged, not just the first per boot (set_event only logs on the inactive->active transition)

### Why
- Let's inform the user in advance that this something he has to deal with
- Properly save it in the events table and in the log backends like syslog

### How
Implemented a dedicated event for this.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
