### PR TITLE
Improve binary size tracking v3

### DIFF
--- a/.github/scripts/parse_size.py
+++ b/.github/scripts/parse_size.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Parse `pio run -t checkprogsize` output into a per-env size report.
+
+Consumed by .github/workflows/measure-firmware-size.yml to produce a
+firmware-size PR comment without rebuilding.
+
+checkprogsize output looks like:
+
+    RAM:   [==        ]  13.9% (used 45678 bytes from 327680 bytes)
+    Flash: [======    ]  62.8% (used 1234567 bytes from 1966080 bytes)
+"""
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict
+
+from size_report import BoardSize, MemoryBytes, Toolchain
+
+
+RAM_RE = re.compile(r"^RAM:.*used\s+(\d+)\s+bytes\s+from\s+(\d+)\s+bytes", re.MULTILINE)
+FLASH_RE = re.compile(r"^Flash:.*used\s+(\d+)\s+bytes\s+from\s+(\d+)\s+bytes", re.MULTILINE)
+
+
+def _parse_usage(regex: re.Pattern[str], text: str) -> MemoryBytes | None:
+    m = regex.search(text)
+    if m is None:
+        return None
+    return MemoryBytes(used=int(m.group(1)), total=int(m.group(2)))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pio-env", required=True)
+    ap.add_argument("--board-name", required=True)
+    ap.add_argument("--sha", required=True)
+    ap.add_argument(
+        "--pio-system-info",
+        required=True,
+        help="raw JSON from `pio system info --json-output`",
+    )
+    ap.add_argument(
+        "--platform-json",
+        required=True,
+        help="contents of the installed platform.json",
+    )
+    args = ap.parse_args()
+
+    text = sys.stdin.read()
+    ram = _parse_usage(RAM_RE, text)
+    flash = _parse_usage(FLASH_RE, text)
+    if ram is None and flash is None:
+        # Neither line found — checkprogsize probably didn't run. Fail loudly
+        # so a broken producer surfaces at PR time instead of silently
+        # emitting empty size reports.
+        print("parse_size: no Flash: or RAM: lines found on stdin", file=sys.stderr)
+        return 2
+
+    toolchain = Toolchain(
+        pio_core=json.loads(args.pio_system_info)["core_version"]["value"],
+        platform=json.loads(args.platform_json)["version"],
+    )
+
+    doc = BoardSize(
+        schema_version=1,
+        pio_env=args.pio_env,
+        board_name=args.board_name,
+        sha=args.sha,
+        flash=flash,
+        ram=ram,
+        toolchain=toolchain,
+    )
+    with open(f"{args.pio_env}.size.json", "w", encoding="utf-8") as f:
+        json.dump(asdict(doc), f, indent=2)
+        f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Render a firmware-size PR comment from base-side and PR-side size reports.
+
+Consumed by .github/workflows/measure-firmware-size.yml. Each side is a
+directory (potentially with subdirectories from `merge-multiple: true`)
+containing one `<pio_env>.size.json` per board built by
+`.github/workflows/compile-common-image.yml`.
+"""
+import argparse
+import json
+import pathlib
+import sys
+from dataclasses import dataclass
+
+from size_report import BoardSize, MemoryBytes, Toolchain
+
+
+STICKY_MARKER = "<!-- firmware-size-report -->"
+WARN_FILL_THRESHOLD = 0.90  # append ⚠️ when PR fill > 90% AND flash grew
+
+
+@dataclass
+class RowCells:
+    """One rendered markdown cell per column, plus the table's header/alignment.
+
+    The column schema lives entirely on this class: field order, header
+    labels, alignment markers, and body formatting are all in the three
+    adjacent methods below. Adding or removing a column means editing
+    a field, a header entry, an alignment entry, and a render entry
+    """
+    board: str
+    env: str
+    base_flash: str
+    pr_flash: str
+    max_flash: str
+    pr_pct: str
+    delta_flash: str
+    pr_ram: str
+    delta_ram: str
+
+    @staticmethod
+    def header() -> tuple[str, str]:
+        """Return (header row, alignment row) for the markdown table."""
+        return (
+            "| Board | Env | Base flash | PR flash | Max | PR % | Δ flash | PR RAM | Δ RAM |",
+            "| - | - | -: | -: | -: | -: | -: | -: | -: |",
+        )
+
+    def render(self) -> str:
+        """Format as a single markdown table row."""
+        return (
+            f"| {self.board} | {self.env} "
+            f"| {self.base_flash} | {self.pr_flash} | {self.max_flash} "
+            f"| {self.pr_pct} | {self.delta_flash} "
+            f"| {self.pr_ram} | {self.delta_ram} |"
+        )
+
+
+def load_size_reports(root: str) -> dict[str, BoardSize]:
+    """Return {pio_env: BoardSize} for every *.size.json under root."""
+    out: dict[str, BoardSize] = {}
+    p = pathlib.Path(root)
+    if not p.exists():
+        return out
+    for f in p.rglob("*.size.json"):
+        try:
+            with f.open(encoding="utf-8") as fh:
+                doc = json.load(fh)
+            board = BoardSize.from_dict(doc)
+        except (OSError, json.JSONDecodeError, KeyError) as exc:
+            print(f"render_size_comment: skipping {f}: {exc}", file=sys.stderr)
+            continue
+        out[board.pio_env] = board
+    return out
+
+
+def short(sha: str) -> str:
+    return (sha or "")[:7] or "?"
+
+
+def fmt_bytes(n: int | None) -> str:
+    if n is None:
+        return "—"
+    return f"{n:,}"
+
+
+def fmt_delta(delta: int | None) -> str:
+    if delta is None:
+        return ""
+    if delta == 0:
+        return "0"
+    return f"{delta:+,}"
+
+
+def fmt_pct(usage: MemoryBytes | None) -> str:
+    if usage is None or not usage.total:
+        return "—"
+    return f"{(usage.used / usage.total) * 100:.2f}%"
+
+
+def sort_key(env: str, pr: BoardSize | None) -> tuple[float, str]:
+    """Sort by PR-side flash fill % desc; envs without PR data go last."""
+    if pr and pr.flash and pr.flash.total:
+        return (-(pr.flash.used / pr.flash.total), env)
+    return (float("inf"), env)
+
+
+def flash_delta_cell(base: MemoryBytes | None, pr: MemoryBytes | None) -> str:
+    """Signed flash delta. ⚠️ if tight (>90%) and grew; ⬆️ if grew; ⬇️ if shrank."""
+    if base is None or pr is None:
+        return "—"
+    delta = pr.used - base.used
+    cell = fmt_delta(delta)
+    if delta > 0 and pr.total and (pr.used / pr.total) > WARN_FILL_THRESHOLD:
+        return "⚠️ " + cell
+    elif delta > 0:
+        return "⬆️ " + cell
+    elif delta < 0:
+        return "⬇️ " + cell
+    return cell
+
+
+def ram_delta_cell(base: MemoryBytes | None, pr: MemoryBytes | None) -> str:
+    """Signed RAM delta, or — if either side is missing.
+
+    No fill % for RAM: heap allocations dominate runtime RAM anyway, so
+    absolute deltas are what reviewers care about.
+    """
+    if base is None or pr is None:
+        return "—"
+    delta = pr.used - base.used
+    cell = fmt_delta(delta)
+    if delta > 0:
+        return "⬆️ " + cell
+    elif delta < 0:
+        return "⬇️ " + cell
+    return cell
+
+
+def _row_pr_missing(env: str, base: BoardSize | None) -> RowCells:
+    """PR-side build failed for this env — show base numbers, blank PR side."""
+    flash = base.flash if base else None
+    return RowCells(
+        board=(base.board_name if base else env),
+        env=f"`{env}`",
+        base_flash=fmt_bytes(flash.used if flash else None),
+        pr_flash="build failed",
+        max_flash=fmt_bytes(flash.total if flash else None),
+        pr_pct="—",
+        delta_flash="—",
+        pr_ram="—",
+        delta_ram="—",
+    )
+
+
+def _row_base_missing(env: str, pr: BoardSize) -> RowCells:
+    """No base report to diff against — new env, or its base build produced none.
+
+    We can't tell those two apart (a missing base entry carries no reason), so
+    we don't assert one: show the PR's absolute sizes and leave the deltas as —.
+    """
+    return RowCells(
+        board=pr.board_name,
+        env=f"`{env}`",
+        base_flash="—",
+        pr_flash=fmt_bytes(pr.flash.used if pr.flash else None),
+        max_flash=fmt_bytes(pr.flash.total if pr.flash else None),
+        pr_pct=fmt_pct(pr.flash),
+        delta_flash="—",
+        pr_ram=fmt_bytes(pr.ram.used if pr.ram else None),
+        delta_ram="—",
+    )
+
+
+def _row_normal(env: str, base: BoardSize, pr: BoardSize) -> RowCells:
+    """Both builds succeeded — show sizes, deltas, and flag if tight+growing."""
+    return RowCells(
+        board=pr.board_name,
+        env=f"`{env}`",
+        base_flash=fmt_bytes(base.flash.used if base.flash else None),
+        pr_flash=fmt_bytes(pr.flash.used if pr.flash else None),
+        max_flash=fmt_bytes(pr.flash.total if pr.flash else None),
+        pr_pct=fmt_pct(pr.flash),
+        delta_flash=flash_delta_cell(base.flash, pr.flash),
+        pr_ram=fmt_bytes(pr.ram.used if pr.ram else None),
+        delta_ram=ram_delta_cell(base.ram, pr.ram),
+    )
+
+
+def render_row(env: str, base: BoardSize | None, pr: BoardSize | None) -> str:
+    """Dispatch to the right case builder and format the resulting row."""
+    if pr is None:
+        cells = _row_pr_missing(env, base)
+    elif base is None:
+        cells = _row_base_missing(env, pr)
+    else:
+        cells = _row_normal(env, base, pr)
+    return cells.render()
+
+
+def render(
+    base: dict[str, BoardSize],
+    pr: dict[str, BoardSize],
+    base_branch: str,
+    base_sha: str,
+    head_sha: str,
+) -> str:
+    envs = sorted(set(base) | set(pr), key=lambda e: sort_key(e, pr.get(e)))
+
+    lines: list[str] = [
+        STICKY_MARKER,
+        "## Firmware size report",
+        "",
+    ]
+
+    if not base:
+        lines.append(
+            f"> No base-branch size reports available for `{base_branch}` yet; "
+            "showing absolute sizes only. Deltas will appear once a compile run "
+            "on the base branch has published size artifacts."
+        )
+        lines.append("")
+    else:
+        lines.append(
+            f"Base: `{short(base_sha)}` on `{base_branch}` · This PR: `{short(head_sha)}`"
+        )
+        lines.append("")
+
+    # Every report feeding one comparison should have been built with the same
+    # toolchain. If more than one shows up — base vs PR, or board vs board on
+    # either side — the deltas below may reflect the toolchain change rather
+    # than this PR's code, so warn and list the distinct toolchains.
+    all_reports = list(base.values()) + list(pr.values())
+    toolchains = {report.toolchain for report in all_reports}
+    if len(toolchains) > 1:
+        labels = "  \n".join(
+            f"> - {t.label()}"
+            for t in sorted(toolchains, key=lambda t: (t.pio_core, t.platform))
+        )
+        lines.append(
+            "> ⚠️ **Builds used more than one toolchain** — size deltas below "
+            "may reflect the toolchain change, not this PR's code.  \n"
+            f"{labels}"
+        )
+        lines.append("")
+
+    header, sep = RowCells.header()
+    lines.append(header)
+    lines.append(sep)
+
+    for env in envs:
+        lines.append(render_row(env, base.get(env), pr.get(env)))
+
+    lines.append("")
+    lines.append(
+        "⚠️ = board already >90% full and flash grew. "
+        "Sorted by PR flash fill % (tightest first)."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pr-dir", required=True)
+    ap.add_argument("--base-dir", required=True)
+    ap.add_argument("--base-branch", required=True)
+    ap.add_argument("--base-sha", required=True)
+    ap.add_argument("--head-sha", required=True)
+    args = ap.parse_args()
+
+    base = load_size_reports(args.base_dir)
+    pr = load_size_reports(args.pr_dir)
+
+    if not pr and not base:
+        # Nothing to say. Emit a minimal note so the sticky comment
+        # updates in place instead of leaving stale numbers.
+        body = (
+            f"{STICKY_MARKER}\n"
+            "## Firmware size report\n\n"
+            "> No size reports found in either the PR build or the base build.\n"
+        )
+    else:
+        body = render(base, pr, args.base_branch, args.base_sha, args.head_sha)
+
+    sys.stdout.buffer.write(body.encode("utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -98,6 +98,14 @@ def fmt_pct(usage: MemoryBytes | None) -> str:
     return f"{(usage.used / usage.total) * 100:.2f}%"
 
 
+def check_sha_consistency(reports: dict[str, BoardSize], expected_sha: str, label: str) -> list[str]:
+    warnings = []
+    for env, r in reports.items():
+        if r.sha != expected_sha:
+            warnings.append(f"`{env}` ({label}): retrieved `{r.sha[:7]}`, expected `{expected_sha[:7]}`")
+    return warnings
+
+
 def sort_key(env: str, pr: BoardSize | None) -> tuple[float, str]:
     """Sort by PR-side flash fill % desc; envs without PR data go last."""
     if pr and pr.flash and pr.flash.total:
@@ -223,6 +231,19 @@ def render(
     else:
         lines.append(
             f"Base: `{short(base_sha)}` on `{base_branch}` · This PR: `{short(head_sha)}`"
+        )
+        lines.append("")
+
+    sha_warnings = (
+        check_sha_consistency(pr, head_sha, "PR")
+        + check_sha_consistency(base, base_sha, "Base")
+    )
+    if sha_warnings:
+        joined = "  \n".join(f"> - {w}" for w in sha_warnings)
+        lines.append(
+            "> ⚠️ **SHA mismatch** — one or more artifacts were not built from "
+            "the expected commit. Size numbers may be stale or wrong.  \n"
+            f"{joined}"
         )
         lines.append("")
 

--- a/.github/scripts/size_report.py
+++ b/.github/scripts/size_report.py
@@ -1,0 +1,63 @@
+"""Shared dataclasses for firmware size reports.
+
+Both `parse_size.py` (producer, writes JSON) and `render_size_comment.py`
+(consumer, reads JSON) speak this schema. Keeping it in one file means the
+consumer doesn't have to re-derive the shape from raw dicts.
+
+The on-disk format is `dataclasses.asdict(board)` — each `*.size.json`
+artifact deserialises back into a `BoardSize` via `BoardSize.from_dict`.
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class MemoryBytes:
+    used: int
+    total: int
+
+    @classmethod
+    def from_dict(cls, d: dict | None) -> "MemoryBytes | None":
+        if not d:
+            return None
+        return cls(used=d["used"], total=d["total"])
+
+
+@dataclass(frozen=True)
+class Toolchain:
+    """Identity of the toolchain a board was built with.
+
+    Frozen so instances are hashable — the consumer collects the distinct
+    toolchains across a comparison into a set and warns if there's more than one.
+    """
+    pio_core: str          # PlatformIO Core version, e.g. "6.1.18"
+    platform: str          # resolved platform-espressif32, e.g. "55.03.39"
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Toolchain":
+        return cls(pio_core=d["pio_core"], platform=d["platform"])
+
+    def label(self) -> str:
+        return f"PlatformIO Core {self.pio_core} · platform-espressif32 {self.platform}"
+
+
+@dataclass
+class BoardSize:
+    schema_version: int
+    pio_env: str
+    board_name: str
+    sha: str
+    flash: MemoryBytes | None
+    ram: MemoryBytes | None
+    toolchain: Toolchain
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "BoardSize":
+        return cls(
+            schema_version=d["schema_version"],
+            pio_env=d["pio_env"],
+            board_name=d["board_name"],
+            sha=d["sha"],
+            flash=MemoryBytes.from_dict(d.get("flash")),
+            ram=MemoryBytes.from_dict(d.get("ram")),
+            toolchain=Toolchain.from_dict(d["toolchain"]),
+        )

--- a/.github/workflows/add-comment-to-pr.yml
+++ b/.github/workflows/add-comment-to-pr.yml
@@ -2,20 +2,20 @@ name: 💬 Add comment to PR
 
 on:
   workflow_run:
-    workflows: ["⚖️ Measure firmware size"]
+    workflows: ["🔋 Compile Common Images"] # "Measure firmware size" is embedded here
     types:
       - completed
 
 jobs:
   comment:
     runs-on: ubuntu-latest
-    # Only run if the building workflow actually succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only for PR-triggered compile runs
+    if: github.event.workflow_run.event == 'pull_request'
     permissions:
       pull-requests: write
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: comment-for-pr
         run-id: ${{ github.event.workflow_run.id }}
@@ -27,7 +27,7 @@ jobs:
         echo "num=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
 
     - name: Add comment to PR
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       with:
         number: ${{ steps.pr_number.outputs.num }}
         path: comment.md

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -104,3 +104,15 @@ jobs:
           firmware-*.bin
           ${{ matrix.pio_env }}.size.json
         if-no-files-found: warn
+
+  measure-size:
+    needs: build
+    if: always() && github.event_name == 'pull_request' # Continue on compile failures
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/measure-firmware-size.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      base_ref:  ${{ github.event.pull_request.base.ref }}
+      base_sha:  ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -72,6 +72,17 @@ jobs:
     - name: Build image for ${{ matrix.board_name }}
       run: pio run -e ${{ matrix.pio_env }}
 
+    - name: Capture size report for ${{ matrix.board_name }}
+      if: matrix.pio_env != 'compiler_warning_check'
+      run: |
+        pio run -e ${{ matrix.pio_env }} -t checkprogsize 2>&1 | tee checkprogsize.txt
+        cat checkprogsize.txt | python .github/scripts/parse_size.py \
+          --pio-env "${{ matrix.pio_env }}" \
+          --board-name "${{ matrix.board_name }}" \
+          --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+          --pio-system-info "$(pio system info --json-output)" \
+          --platform-json "$(cat "$HOME"/.platformio/platforms/espressif32*/platform.json)"
+
     #rename firmware.bin to contain pr number and commit short sha for easier location after saved on disk
     - name: Rename firmware.bin with PR number and commit short SHA
       run: |
@@ -85,7 +96,11 @@ jobs:
              .pio/build/${{ matrix.pio_env }}/firmware-${PR_PART}${SHORT_SHA}.bin
 
     - name: Upload artifact for ${{ matrix.board_name }}
+      if: matrix.pio_env != 'compiler_warning_check'
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ matrix.artifact_name }}.bin
-        path: .pio/build/${{ matrix.pio_env }}/firmware-*.bin
+        name: ${{ matrix.artifact_name }}
+        path: |
+          .pio/build/${{ matrix.pio_env }}/firmware-*.bin
+          ${{ matrix.pio_env }}.size.json
+        if-no-files-found: warn

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -93,7 +93,7 @@ jobs:
             PR_PART=""
           fi
           cp .pio/build/${{ matrix.pio_env }}/firmware.bin \
-             .pio/build/${{ matrix.pio_env }}/firmware-${PR_PART}${SHORT_SHA}.bin
+             firmware-${PR_PART}${SHORT_SHA}.bin
 
     - name: Upload artifact for ${{ matrix.board_name }}
       if: matrix.pio_env != 'compiler_warning_check'
@@ -101,6 +101,6 @@ jobs:
       with:
         name: ${{ matrix.artifact_name }}
         path: |
-          .pio/build/${{ matrix.pio_env }}/firmware-*.bin
+          firmware-*.bin
           ${{ matrix.pio_env }}.size.json
         if-no-files-found: warn

--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -1,120 +1,103 @@
 name: ⚖️ Measure firmware size
 
+# Runs as a consumer of the compile workflow's per-board size reports
+# (${{ matrix.pio_env }}.size.json inside each per-board artifact).
+# No PlatformIO, no rebuilds — just download, diff, and comment.
+
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["🔋 Compile Common Images"]
+    types: [completed]
+
+permissions:
+  actions: read       # list workflow runs; cross-run artifact download
+  contents: read
 
 jobs:
-  measure-firmware-size:
+  measure:
+    # Only when the triggering compile run was itself started by a PR,
+    # and it didn't get cancelled outright. Individual board failures
+    # are tolerated — the render script handles missing size reports.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout PR base
+    - name: Checkout scripts
       uses: actions/checkout@v7
       with:
-        fetch-depth: 200
+        sparse-checkout: .github/scripts
 
-    - name: Find true base Commit
-      id: get_base
-      run: |
-        # Find the common ancestor between the two parents of the merge commit
-        TRUE_BASE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-        echo "PR base commit is: $TRUE_BASE_SHA"
-        git checkout $TRUE_BASE_SHA
-        echo "base_sha=$TRUE_BASE_SHA" >> $GITHUB_OUTPUT
-
-    - name: Get platformio.ini hash
-      id: platformio_ini_hash
-      run: |
-        PLATFORMIO_INI_HASH=$(md5sum platformio.ini | awk '{ print $1 }')
-        echo "platformio_ini_hash=$PLATFORMIO_INI_HASH" >> $GITHUB_OUTPUT
-
-    # Broader cache (just the download files)
-    - uses: actions/cache@v6
+    - name: Download PR-side artifacts from triggering run
+      uses: actions/download-artifact@v4
       with:
-        path: |
-          ~/.cache/pip
-          ~/.platformio/.cache
-        key: ${{ runner.os }}-pio
+        path: ./pr
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pattern: "battery-emulator-*"
+        merge-multiple: true
 
-    # Tighter cache (of platformio itself)
-    - uses: actions/cache@v6
+    - name: Resolve PR context and base compile run
+      id: ctx
+      uses: actions/github-script@v7
       with:
-        path: |
-          ~/.cache/pip
-          ~/.platformio
-        key: ${{ runner.os }}-pio-${{ steps.platformio_ini_hash.outputs.platformio_ini_hash }}
-    
-    - uses: actions/setup-python@v6
+        script: |
+          const head_sha = context.payload.workflow_run.head_sha;
+          const { owner, repo } = context.repo;
+
+          // commits/{sha}/pulls works for fork PRs too, unlike workflow_run.pull_requests.
+          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            owner, repo, commit_sha: head_sha,
+          });
+          const pr = prs[0];
+          if (!pr) {
+            core.info(`No PR found for head SHA ${head_sha}; nothing to comment on.`);
+            return;
+          }
+
+          // Most recent successful push-triggered compile run on the PR's base branch.
+          const { data: runs } = await github.rest.actions.listWorkflowRuns({
+            owner, repo,
+            workflow_id: 'compile-common-image.yml',
+            branch: pr.base.ref,
+            event: 'push',
+            status: 'success',
+            per_page: 1,
+          });
+
+          core.setOutput('pr_number',   pr.number);
+          core.setOutput('base_branch', pr.base.ref);
+          core.setOutput('base_sha',    pr.base.sha);
+          core.setOutput('run_id',      runs.workflow_runs[0]?.id ?? '');
+
+    - name: Download base-branch artifacts
+      if: steps.ctx.outputs.pr_number != '' && steps.ctx.outputs.run_id != ''
+      uses: actions/download-artifact@v4
       with:
-        python-version: '3.13'
+        path: ./base
+        run-id: ${{ steps.ctx.outputs.run_id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pattern: "battery-emulator-*"
+        merge-multiple: true
 
-    - name: Install PlatformIO Core
-      run: pip install --upgrade platformio
-
-    - name: Build base image for lilygo_330
-      run: pio run -e lilygo_330
-
-    - name: Measure base firmware size for lilygo_330
-      id: measure_base_size
+    - name: Render comment
+      if: steps.ctx.outputs.pr_number != ''
       run: |
-        pio run -e lilygo_330 -t checkprogsize > base_output.txt
-
-    - name: Checkout PR head
-      run: |
-        git fetch origin refs/pull/${{ github.event.number }}/head
-        git checkout ${{ github.event.pull_request.head.sha }}
-    
-    - name: Build image for lilygo_330
-      run: pio run -e lilygo_330
-
-    - name: Measure PR firmware size for lilygo_330
-      id: measure_pr_size
-      run: |
-        pio run -e lilygo_330 -t checkprogsize > pr_output.txt
-
-    - name: Compare firmware sizes
-      shell: python -u {0}
-      env:
-        BASE_SHA: ${{ steps.get_base.outputs.base_sha }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      run: |
-        import os
-
-        base_output = open("base_output.txt").read()
-        pr_output = open("pr_output.txt").read()
-        base_line = base_output.split("\nFlash:")[1].split("\n")[0]
-        pr_line = pr_output.split("\nFlash:")[1].split("\n")[0]
-        base_used = int(base_line.split("used")[1].split("bytes")[0].strip())
-        base_total = int(base_line.split("from")[1].split("bytes")[0].strip())
-        base_percent = "%.2f"%((base_used / base_total) * 100)
-        pr_used = int(pr_line.split("used")[1].split("bytes")[0].strip())
-        pr_total = int(pr_line.split("from")[1].split("bytes")[0].strip())
-        pr_percent = "%.2f"%((pr_used / pr_total) * 100)
-        size_diff = pr_used - base_used
-        size_diff = f"+{size_diff}" if size_diff >= 0 else str(size_diff)
-
-        base_sha = os.environ.get('BASE_SHA', 'unknown')
-        head_sha = os.environ.get('HEAD_SHA', 'unknown')
-
-        # Generate the full markdown table directly into a file
-        markdown = (
-            "## Firmware size (LilyGo T-CAN485 build)\n"
-            "| | Commit | Size | Max | % | Delta |\n"
-            "| - | - | - | - | - | - |\n"
-            f"| Base | {base_sha} | {base_used} | {base_total} | {base_percent}% | |\n"
-            f"| This PR | {head_sha} | {pr_used} | {pr_total} | {pr_percent}% | {size_diff} bytes |\n"
-        )
-
-        with open("comment.md", "w") as f:
-            f.write(markdown)
-
-    - name: Save PR number
-      run: |
-        echo "${{ github.event.pull_request.number }}" > pr_number.txt
+        python .github/scripts/render_size_comment.py \
+          --pr-dir ./pr \
+          --base-dir ./base \
+          --base-branch "${{ steps.ctx.outputs.base_branch }}" \
+          --base-sha    "${{ steps.ctx.outputs.base_sha }}" \
+          --head-sha    "${{ github.event.workflow_run.head_sha }}" \
+          > comment.md
+        echo "${{ steps.ctx.outputs.pr_number }}" > pr_number.txt
 
     - name: Upload firmware size report
+      if: steps.ctx.outputs.pr_number != ''
       uses: actions/upload-artifact@v4
       with:
         name: comment-for-pr
+        if-no-files-found: error
         path: |
           comment.md
-          pr_number.txt            
+          pr_number.txt

--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -1,13 +1,23 @@
 name: ⚖️ Measure firmware size
 
-# Runs as a consumer of the compile workflow's per-board size reports
-# (${{ matrix.pio_env }}.size.json inside each per-board artifact).
+# Reusable workflow called by "🔋 Compile Common Images" on pull_request.
 # No PlatformIO, no rebuilds — just download, diff, and comment.
 
 on:
-  workflow_run:
-    workflows: ["🔋 Compile Common Images"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Number of the PR being measured."
+        required: true
+        type: string
+      base_ref:
+        description: "Base branch the PR targets (e.g. main)."
+        required: true
+        type: string
+      base_sha:
+        description: "Base branch tip SHA, for the comment header."
+        required: true
+        type: string
 
 permissions:
   actions: read       # list workflow runs; cross-run artifact download
@@ -15,64 +25,64 @@ permissions:
 
 jobs:
   measure:
-    # Only when the triggering compile run was itself started by a PR,
-    # and it didn't get cancelled outright. Individual board failures
-    # are tolerated — the render script handles missing size reports.
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
+    - name: Check PR context
+      if: inputs.pr_number == '' || inputs.base_ref == ''
+      run: |
+        echo "::error::measure was called without a PR number / base ref." >&2
+        exit 1
+
     - name: Checkout scripts
       uses: actions/checkout@v7
       with:
         sparse-checkout: .github/scripts
 
-    - name: Download PR-side artifacts from triggering run
-      uses: actions/download-artifact@v4
+    - name: Download PR-side size reports from this run
+      uses: actions/download-artifact@v8
       with:
         path: ./pr
-        run-id: ${{ github.event.workflow_run.id }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         pattern: "battery-emulator-*"
         merge-multiple: true
 
-    - name: Resolve PR context and base compile run
+    - name: Resolve base compile run
       id: ctx
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
-          const head_sha = context.payload.workflow_run.head_sha;
           const { owner, repo } = context.repo;
 
-          // commits/{sha}/pulls works for fork PRs too, unlike workflow_run.pull_requests.
-          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-            owner, repo, commit_sha: head_sha,
-          });
-          const pr = prs[0];
-          if (!pr) {
-            core.info(`No PR found for head SHA ${head_sha}; nothing to comment on.`);
-            return;
-          }
-
-          // Most recent successful push-triggered compile run on the PR's base branch.
+          // Find every compile run for the PRs EXACT base commit
           const { data: runs } = await github.rest.actions.listWorkflowRuns({
             owner, repo,
             workflow_id: 'compile-common-image.yml',
-            branch: pr.base.ref,
             event: 'push',
-            status: 'success',
-            per_page: 1,
+            head_sha: '${{ inputs.base_sha }}',
+            per_page: 20,
           });
 
-          core.setOutput('pr_number',   pr.number);
-          core.setOutput('base_branch', pr.base.ref);
-          core.setOutput('base_sha',    pr.base.sha);
-          core.setOutput('run_id',      runs.workflow_runs[0]?.id ?? '');
+          // Retrieve the number of usable (non-expired) artifacts
+          const scored = [];
+          for (const run of runs.workflow_runs) {
+            const { data: arts } =
+              await github.rest.actions.listWorkflowRunArtifacts({
+                owner, repo, run_id: run.id, per_page: 100,
+              });
+            const usable = arts.artifacts.filter(a => !a.expired).length;
+            if (usable > 0) {
+              scored.push({ id: run.id, usable, created: run.created_at });
+            }
+          }
+          // Find the run with the most artifacts, or the newest
+          scored.sort((a, b) =>
+            b.usable - a.usable || b.created.localeCompare(a.created)
+          );
+
+          core.setOutput('run_id', scored[0]?.id ?? '');
 
     - name: Download base-branch artifacts
-      if: steps.ctx.outputs.pr_number != '' && steps.ctx.outputs.run_id != ''
-      uses: actions/download-artifact@v4
+      if: steps.ctx.outputs.run_id != ''
+      uses: actions/download-artifact@v8
       with:
         path: ./base
         run-id: ${{ steps.ctx.outputs.run_id }}
@@ -81,20 +91,18 @@ jobs:
         merge-multiple: true
 
     - name: Render comment
-      if: steps.ctx.outputs.pr_number != ''
       run: |
         python .github/scripts/render_size_comment.py \
           --pr-dir ./pr \
           --base-dir ./base \
-          --base-branch "${{ steps.ctx.outputs.base_branch }}" \
-          --base-sha    "${{ steps.ctx.outputs.base_sha }}" \
-          --head-sha    "${{ github.event.workflow_run.head_sha }}" \
+          --base-branch "${{ inputs.base_ref }}" \
+          --base-sha    "${{ inputs.base_sha }}" \
+          --head-sha    "${{ github.event.pull_request.head.sha }}" \
           > comment.md
-        echo "${{ steps.ctx.outputs.pr_number }}" > pr_number.txt
+        echo "${{ inputs.pr_number }}" > pr_number.txt
 
     - name: Upload firmware size report
-      if: steps.ctx.outputs.pr_number != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: comment-for-pr
         if-no-files-found: error

--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  measure:
+  measure-firmware-size:
     runs-on: ubuntu-latest
     steps:
     - name: Check PR context


### PR DESCRIPTION
This PR is a repeat of #2561 while addressing the major issues:

1. The zip file structure is now the same as before with the only difference being that the artifacts have removed the `.bin` suffix so `battery-emulator-esp32devkit` instead of `battery-emulator-esp32devkit.bin`. This was done because tha artifact is actually a zip file containing the bin, so the previous naming was misleading.
2. The previous PR relied on an error prone Github lookup to identify what PR a comment should be posted on. The other downside of this design was that the measure step was no longer listed on the PR which made it harder to track failed runs. This PR calls the measure workflow from the compile workflow which solves both of these issues.
3. Previously we only searched for the last run of the compile workflow on the `main` branch. Instead we now search for the exact PR base SHA and if there are multiple runs we compare against the most recent run that has the most artifacts.

Tested on https://github.com/ngehrsitz/Battery-Emulator/pull/17

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
