### PR TITLE
Improvement: 🛜 Wipe RF PHY calibration data on factory reset and network reset

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -1,4 +1,5 @@
 #include "comm_nvm.h"
+#include <esp_phy_init.h>  // esp_phy_erase_cal_data_in_nvs()
 #include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
 #include "../../battery/Shunt.h"
@@ -126,7 +127,7 @@ void init_stored_settings() {
   user_selected_inverter_cells_per_module = settings.getUInt("INVCELLSPER", 0);
   user_selected_inverter_voltage_level = settings.getUInt("INVVLEVEL", 0);
   user_selected_inverter_ah_capacity = settings.getUInt("INVCAPACITY", 0);
-  user_selected_inverter_battery_type = settings.getUInt("INVBTYPE", 0);
+  user_selected_inverter_battery_type = settings.getUInt(#include <esp_phy_init.h>  // esp_phy_erase_cal_data_in_nvs()"INVBTYPE", 0);
   user_selected_inverter_sungrow_type = settings.getUInt("INVSUNTYPE", 0);
   user_selected_inverter_pylon_type = settings.getUInt("PYLONBRAND", 0);
   user_selected_inverter_foxess_type = settings.getUInt("FOXESSTYPE", 0);
@@ -289,6 +290,18 @@ void clear_wifi_sta_settings() {
 void store_settings_equipment_stop() {
   BatteryEmulatorSettingsStore settings(false);
   settings.saveBool("EQUIPMENT_STOP", datalayer.system.info.equipment_stop_active);
+}
+
+// Erase RF PHY calibration data (the "phy" NVS namespace — untouched by
+// clearAll(), which only clears our own settings namespace). A full RF
+// calibration runs on the next boot (~100 ms extra WiFi/RF init).
+void erase_phy_cal_data() {
+  esp_err_t err = esp_phy_erase_cal_data_in_nvs();
+  if (err == ESP_OK) {
+    logging.println("RF PHY calibration data erased, full RF calibration will run on next boot.");
+  } else {
+    logging.printf("RF PHY calibration data erase failed (err %d)\n", err);
+  }
 }
 
 void store_settings() {

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -127,7 +127,7 @@ void init_stored_settings() {
   user_selected_inverter_cells_per_module = settings.getUInt("INVCELLSPER", 0);
   user_selected_inverter_voltage_level = settings.getUInt("INVVLEVEL", 0);
   user_selected_inverter_ah_capacity = settings.getUInt("INVCAPACITY", 0);
-  user_selected_inverter_battery_type = settings.getUInt(#include <esp_phy_init.h>  // esp_phy_erase_cal_data_in_nvs()"INVBTYPE", 0);
+  user_selected_inverter_battery_type = settings.getUInt("INVBTYPE", 0);
   user_selected_inverter_sungrow_type = settings.getUInt("INVSUNTYPE", 0);
   user_selected_inverter_pylon_type = settings.getUInt("PYLONBRAND", 0);
   user_selected_inverter_foxess_type = settings.getUInt("FOXESSTYPE", 0);

--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -27,6 +27,8 @@ void init_stored_settings();
  */
 void store_settings_equipment_stop();
 
+void erase_phy_cal_data();
+
 /**
  * @brief Store settings
  *

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,7 +1,6 @@
 #include "webserver.h"
 #include <Preferences.h>
 #include <ctime>
-#include <esp_phy_init.h>  // esp_phy_erase_cal_data_in_nvs()
 #include <vector>
 #include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
@@ -414,16 +413,8 @@ void init_webserver() {
     // Reset all settings to factory defaults
     BatteryEmulatorSettingsStore settings;
     settings.clearAll();
-
-    // Also erase RF PHY calibration data ("phy" NVS namespace, untouched by
-    // clearAll) so a full RF calibration runs on the next boot.
-    esp_err_t phy_err = esp_phy_erase_cal_data_in_nvs();
-    if (phy_err == ESP_OK) {
-      logging.println("Factory reset and erased RF PHY calibration data (full RF calibration on next boot).");
-    } else {
-      logging.printf("Factory reset: RF PHY calibration data erase failed (err %d)\n", phy_err);
-    }
-
+    erase_phy_cal_data();
+    logging.println("Factory reset performed from the web interface.");
     request->send(200, "text/html", "OK");
   });
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,6 +1,7 @@
 #include "webserver.h"
 #include <Preferences.h>
 #include <ctime>
+#include <esp_phy_init.h>  // esp_phy_erase_cal_data_in_nvs()
 #include <vector>
 #include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
@@ -413,6 +414,15 @@ void init_webserver() {
     // Reset all settings to factory defaults
     BatteryEmulatorSettingsStore settings;
     settings.clearAll();
+
+    // Also erase RF PHY calibration data ("phy" NVS namespace, untouched by
+    // clearAll) so a full RF calibration runs on the next boot.
+    esp_err_t phy_err = esp_phy_erase_cal_data_in_nvs();
+    if (phy_err == ESP_OK) {
+      logging.println("Factory reset and erased RF PHY calibration data (full RF calibration on next boot).");
+    } else {
+      logging.printf("Factory reset: RF PHY calibration data erase failed (err %d)\n", phy_err);
+    }
 
     request->send(200, "text/html", "OK");
   });

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -214,9 +214,13 @@ static void check_ap_button() {
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
+      erase_phy_cal_data();
+      logging.println("Factory reset performed from the board button.");
       graceful_restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
       clear_wifi_sta_settings();
+      erase_phy_cal_data();
+      logging.println("Network settings wiped from the board button.");
       hold_pins_across_reset();
       graceful_restart();
     } else if (held >= AP_BUTTON_AP_MS) {
@@ -224,6 +228,7 @@ static void check_ap_button() {
         ap_provisioning_expired = false;  // manual start opens a fresh provisioning window
         WiFi.mode(WIFI_AP_STA);
         init_WiFi_AP();  // sets ap_active, restarts the provisioning window timer
+        logging.println("AP started from the board button.");
       }
     }
   }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -214,13 +214,13 @@ static void check_ap_button() {
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
-      erase_phy_cal_data();
       logging.println("Factory reset performed from the board button.");
+      erase_phy_cal_data();
       graceful_restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
       clear_wifi_sta_settings();
-      erase_phy_cal_data();
       logging.println("Network settings wiped from the board button.");
+      erase_phy_cal_data();
       hold_pins_across_reset();
       graceful_restart();
     } else if (held >= AP_BUTTON_AP_MS) {


### PR DESCRIPTION
### What

This PR erases the RF PHY calibration data (the `phy` NVS namespace) during factory reset — both via the `/factoryReset` web route and the ≥30 s BOOT button hold — and also on the ≥15 s BOOT button WiFi-wipe, forcing a full RF calibration on the next boot. A log entry records the erase result.

### Why

Factory reset only clears the emulator's own settings namespace (`clearAll()`), leaving stale PHY calibration data behind — undesirable after board rework, antenna changes, drastic changes to wifi environment, or when RF misbehaves, which is exactly when these recovery gestures are used. The 15 s tier is the "WiFi is broken" gesture, so RF recalibration fits its intent.

This could otherwise be cleared only by fully erasing the board and reflashing a full image via serial.

### How

New `erase_phy_cal_data()` helper in `comm_nvm` wraps `esp_phy_erase_cal_data_in_nvs()` and logs success/failure; it is called from the three reset paths (webserver `/factoryReset`, wifi.cpp 30 s and 15 s button branches). A failed erase is logged but never blocks the reset; next boot performs full RF calibration (~100 ms extra RF init) and rewrites fresh cal data only once.

Log entries introduced as we can have a record on backends like syslog how this has been done.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
