### PR TITLE
Add MQTT auto-discovery sensor for charging status

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -304,10 +304,9 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   }
   doc["balancing_active_cells" + suffix] = active_cells;
   doc["balancing_status" + suffix] = get_balancing_status_text(battery.status.balancing_status);
-  doc["charging_status" + suffix] =
-      get_charging_status_text(battery.status.current_dA, battery.settings.inverter_limits_charge,
-                                battery.settings.inverter_limits_discharge, battery.settings.user_settings_limit_charge,
-                                battery.settings.user_settings_limit_discharge);
+  doc["charging_status" + suffix] = get_charging_status_text(
+      battery.status.current_dA, battery.settings.inverter_limits_charge, battery.settings.inverter_limits_discharge,
+      battery.settings.user_settings_limit_charge, battery.settings.user_settings_limit_discharge);
   if (suffix.length() == 0u && supports_tesla_dcdc_metrics(::battery)) {
     doc["dc_dc_current" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     doc["dc_dc_voltage" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -130,6 +130,7 @@ SensorConfig batterySensorConfigTemplate[] = {
     {"discharged_energy", "Battery Discharged Energy", "", "Wh", "energy", supports_charged},
     {"balancing_active_cells", "Balancing Active Cells", "", "", "", always},
     {"balancing_status", "Balancing Status", "", "", "", always},
+    {"charging_status", "Charging Status", "", "", "", always},
     {"dc_dc_current", "DC-DC Current", "", "A", "current", supports_tesla_dcdc_metrics},
     {"dc_dc_voltage", "DC-DC Voltage", "", "V", "voltage", supports_tesla_dcdc_metrics},
     {"autocal_taper", "BYD Auto-cal: In Taper", "", "", "", supports_byd_autocal_metrics},
@@ -303,6 +304,10 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   }
   doc["balancing_active_cells" + suffix] = active_cells;
   doc["balancing_status" + suffix] = get_balancing_status_text(battery.status.balancing_status);
+  doc["charging_status" + suffix] =
+      get_charging_status_text(battery.status.current_dA, battery.settings.inverter_limits_charge,
+                                battery.settings.inverter_limits_discharge, battery.settings.user_settings_limit_charge,
+                                battery.settings.user_settings_limit_discharge);
   if (suffix.length() == 0u && supports_tesla_dcdc_metrics(::battery)) {
     doc["dc_dc_current" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     doc["dc_dc_voltage" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -18,7 +18,7 @@ std::string getBMSStatus(system_status_enum status) {
   }
 }
 const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
-                                      bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+                                     bool user_settings_limit_charge, bool user_settings_limit_discharge) {
   if (current_dA == 0) {
     return "Battery idle";
   }

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -17,6 +17,29 @@ std::string getBMSStatus(system_status_enum status) {
       return "UNKNOWN";
   }
 }
+const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                      bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+  if (current_dA == 0) {
+    return "Battery idle";
+  }
+  if (current_dA < 0) {
+    if (inverter_limits_discharge) {
+      return "Battery discharging! (Inverter limiting)";
+    }
+    if (user_settings_limit_discharge) {
+      return "Battery discharging! (Settings limiting)";
+    }
+    return "Battery discharging! (Battery limiting)";
+  }
+  if (inverter_limits_charge) {
+    return "Battery charging! (Inverter limiting)";
+  }
+  if (user_settings_limit_charge) {
+    return "Battery charging! (Settings limiting)";
+  }
+  return "Battery charging! (Battery limiting)";
+}
+
 #ifdef HW_LILYGO2CAN
 GPIOOPT1 user_selected_gpioopt1 = GPIOOPT1::DEFAULT_OPT;
 #endif

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -2,6 +2,7 @@
 #define _TYPES_H_
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 
 using milliseconds = std::chrono::milliseconds;
@@ -120,6 +121,10 @@ typedef struct {
 } CAN_log_frame;
 
 std::string getBMSStatus(system_status_enum status);
+
+/** Human readable battery status, e.g. "Battery charging (Inverter limiting)". Used for the web UI and MQTT. */
+const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                      bool user_settings_limit_charge, bool user_settings_limit_discharge);
 
 #ifdef HW_LILYGO2CAN
 /* Configurable GPIO options (device specific) */

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -124,7 +124,7 @@ std::string getBMSStatus(system_status_enum status);
 
 /** Human readable battery status, e.g. "Battery charging (Inverter limiting)". Used for the web UI and MQTT. */
 const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
-                                      bool user_settings_limit_charge, bool user_settings_limit_discharge);
+                                     bool user_settings_limit_charge, bool user_settings_limit_discharge);
 
 #ifdef HW_LILYGO2CAN
 /* Configurable GPIO options (device specific) */

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1222,32 +1222,13 @@ String processor(const String& var) {
         content += "</h4>";
       }
 
-      if (datalayer.battery.status.current_dA == 0) {
-        content += "<h4>Battery idle</h4>";
-      } else if (datalayer.battery.status.current_dA < 0) {
-        content += "<h4>Battery discharging!";
-        if (datalayer.battery.settings.inverter_limits_discharge) {
-          content += " (Inverter limiting)</h4>";
-        } else {
-          if (datalayer.battery.settings.user_settings_limit_discharge) {
-            content += " (Settings limiting)</h4>";
-          } else {
-            content += " (Battery limiting)</h4>";
-          }
-        }
-        content += "</h4>";
-      } else {  // > 0 , positive current
-        content += "<h4>Battery charging!";
-        if (datalayer.battery.settings.inverter_limits_charge) {
-          content += " (Inverter limiting)</h4>";
-        } else {
-          if (datalayer.battery.settings.user_settings_limit_charge) {
-            content += " (Settings limiting)</h4>";
-          } else {
-            content += " (Battery limiting)</h4>";
-          }
-        }
-      }
+      content += "<h4>" +
+                 String(get_charging_status_text(datalayer.battery.status.current_dA,
+                                                  datalayer.battery.settings.inverter_limits_charge,
+                                                  datalayer.battery.settings.inverter_limits_discharge,
+                                                  datalayer.battery.settings.user_settings_limit_charge,
+                                                  datalayer.battery.settings.user_settings_limit_discharge)) +
+                 "</h4>";
 
       content += "<h4>System status: ";
       switch (datalayer.system.status.system_status) {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1224,10 +1224,10 @@ String processor(const String& var) {
 
       content += "<h4>" +
                  String(get_charging_status_text(datalayer.battery.status.current_dA,
-                                                  datalayer.battery.settings.inverter_limits_charge,
-                                                  datalayer.battery.settings.inverter_limits_discharge,
-                                                  datalayer.battery.settings.user_settings_limit_charge,
-                                                  datalayer.battery.settings.user_settings_limit_discharge)) +
+                                                 datalayer.battery.settings.inverter_limits_charge,
+                                                 datalayer.battery.settings.inverter_limits_discharge,
+                                                 datalayer.battery.settings.user_settings_limit_charge,
+                                                 datalayer.battery.settings.user_settings_limit_discharge)) +
                  "</h4>";
 
       content += "<h4>System status: ";


### PR DESCRIPTION
Adds a new charging_status MQTT auto-discovery sensor per battery, showing the same human-readable charge/discharge text already shown on the web page (e.g. "Battery charging! (Inverter limiting)", "Battery idle").
Extracts that value into a shared get_charging_status_text() helper (Software/src/devboard/utils/types.h/.cpp) so the web UI and MQTT sensor looks the same. Previously the text was constructed by the web page.
Web page rendering for the battery status now calls this helper instead.
Registers charging_status in batterySensorConfigTemplate[] in mqtt.cpp, so it's automatically cloned per battery (_2/_3) via the existing sensor-config machinery.
get_charging_status_text() returns const char* to avoid unnecessary allocation, consistent with the existing get_balancing_status_text() helper.