### PR TITLE
Adds the "Battery charging! (Inverter limiting)" info via MQTT sensors

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -130,7 +130,8 @@ SensorConfig batterySensorConfigTemplate[] = {
     {"discharged_energy", "Battery Discharged Energy", "", "Wh", "energy", supports_charged},
     {"balancing_active_cells", "Balancing Active Cells", "", "", "", always},
     {"balancing_status", "Balancing Status", "", "", "", always},
-    {"charging_status", "Charging Status", "", "", "", always},
+    {"charging_state", "Charging State", "", "", "", always},
+    {"limiting_factor", "Limiting Factor", "", "", "", always},
     {"dc_dc_current", "DC-DC Current", "", "A", "current", supports_tesla_dcdc_metrics},
     {"dc_dc_voltage", "DC-DC Voltage", "", "V", "voltage", supports_tesla_dcdc_metrics},
     {"autocal_taper", "BYD Auto-cal: In Taper", "", "", "", supports_byd_autocal_metrics},
@@ -304,10 +305,11 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   }
   doc["balancing_active_cells" + suffix] = active_cells;
   doc["balancing_status" + suffix] = get_balancing_status_text(battery.status.balancing_status);
-  doc["charging_status" + suffix] =
-      get_charging_status_text(battery.status.current_dA, battery.settings.inverter_limits_charge,
-                                battery.settings.inverter_limits_discharge, battery.settings.user_settings_limit_charge,
-                                battery.settings.user_settings_limit_discharge);
+  ChargingState charging_state = get_charging_state(battery.status.current_dA);
+  doc["charging_state" + suffix] = charging_state_to_text(charging_state);
+  doc["limiting_factor" + suffix] = limiting_factor_to_text(get_limiting_factor(
+      charging_state, battery.settings.inverter_limits_charge, battery.settings.inverter_limits_discharge,
+      battery.settings.user_settings_limit_charge, battery.settings.user_settings_limit_discharge));
   if (suffix.length() == 0u && supports_tesla_dcdc_metrics(::battery)) {
     doc["dc_dc_current" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     doc["dc_dc_voltage" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;
@@ -334,6 +336,12 @@ static const char* sensor_discovery_icon(const char* entity_id, const char* devi
     }
     if (strncmp(entity_id, "bms_status", strlen("bms_status")) == 0) {
       return "mdi:information-box-outline";
+    }
+    if (strncmp(entity_id, "charging_state", strlen("charging_state")) == 0) {
+      return "mdi:home-battery";
+    }
+    if (strncmp(entity_id, "limiting_factor", strlen("limiting_factor")) == 0) {
+      return "mdi:home-battery-outline";
     }
     if (strncmp(entity_id, "emulator_status", strlen("emulator_status")) == 0 ||
         strncmp(entity_id, "event_level", strlen("event_level")) == 0) {

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -130,6 +130,7 @@ SensorConfig batterySensorConfigTemplate[] = {
     {"discharged_energy", "Battery Discharged Energy", "", "Wh", "energy", supports_charged},
     {"balancing_active_cells", "Balancing Active Cells", "", "", "", always},
     {"balancing_status", "Balancing Status", "", "", "", always},
+    {"charging_status", "Charging Status", "", "", "", always},
     {"dc_dc_current", "DC-DC Current", "", "A", "current", supports_tesla_dcdc_metrics},
     {"dc_dc_voltage", "DC-DC Voltage", "", "V", "voltage", supports_tesla_dcdc_metrics},
     {"autocal_taper", "BYD Auto-cal: In Taper", "", "", "", supports_byd_autocal_metrics},
@@ -303,6 +304,10 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   }
   doc["balancing_active_cells" + suffix] = active_cells;
   doc["balancing_status" + suffix] = get_balancing_status_text(battery.status.balancing_status);
+  doc["charging_status" + suffix] =
+      get_charging_status_text(battery.status.current_dA, battery.settings.inverter_limits_charge,
+                                battery.settings.inverter_limits_discharge, battery.settings.user_settings_limit_charge,
+                                battery.settings.user_settings_limit_discharge);
   if (suffix.length() == 0u && supports_tesla_dcdc_metrics(::battery)) {
     doc["dc_dc_current" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvOutputCurrent) * 0.1f;
     doc["dc_dc_voltage" + suffix] = static_cast<float>(datalayer_extended.tesla.battery_dcdcLvBusVolt) * 0.0390625f;

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -31,7 +31,7 @@ LimitingFactor get_limiting_factor(ChargingState state, bool inverter_limits_cha
       return LimitingFactor::Inverter;
     }
     if (user_settings_limit_discharge) {
-      return LimitingFactor::Emulator;
+      return LimitingFactor::UserSetting;
     }
     return LimitingFactor::Battery;
   }
@@ -40,7 +40,7 @@ LimitingFactor get_limiting_factor(ChargingState state, bool inverter_limits_cha
       return LimitingFactor::Inverter;
     }
     if (user_settings_limit_charge) {
-      return LimitingFactor::Emulator;
+      return LimitingFactor::UserSetting;
     }
     return LimitingFactor::Battery;
   }
@@ -62,8 +62,8 @@ const char* limiting_factor_to_text(LimitingFactor factor) {
   switch (factor) {
     case LimitingFactor::Inverter:
       return "Inverter";
-    case LimitingFactor::Emulator:
-      return "Emulator";
+    case LimitingFactor::UserSetting:
+      return "UserSetting";
     case LimitingFactor::Battery:
       return "Battery";
     default:
@@ -83,7 +83,7 @@ const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_ch
     switch (factor) {
       case LimitingFactor::Inverter:
         return "Battery discharging! (Inverter limiting)";
-      case LimitingFactor::Emulator:
+      case LimitingFactor::UserSetting:
         return "Battery discharging! (Settings limiting)";
       default:
         return "Battery discharging! (Battery limiting)";
@@ -92,7 +92,7 @@ const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_ch
   switch (factor) {
     case LimitingFactor::Inverter:
       return "Battery charging! (Inverter limiting)";
-    case LimitingFactor::Emulator:
+    case LimitingFactor::UserSetting:
       return "Battery charging! (Settings limiting)";
     default:
       return "Battery charging! (Battery limiting)";

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -17,27 +17,86 @@ std::string getBMSStatus(system_status_enum status) {
       return "UNKNOWN";
   }
 }
-const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
-                                      bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+ChargingState get_charging_state(int32_t current_dA) {
   if (current_dA == 0) {
-    return "Battery idle";
+    return ChargingState::Idle;
   }
-  if (current_dA < 0) {
+  return current_dA < 0 ? ChargingState::Discharging : ChargingState::Charging;
+}
+
+LimitingFactor get_limiting_factor(ChargingState state, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                   bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+  if (state == ChargingState::Discharging) {
     if (inverter_limits_discharge) {
-      return "Battery discharging! (Inverter limiting)";
+      return LimitingFactor::Inverter;
     }
     if (user_settings_limit_discharge) {
-      return "Battery discharging! (Settings limiting)";
+      return LimitingFactor::Emulator;
     }
-    return "Battery discharging! (Battery limiting)";
+    return LimitingFactor::Battery;
   }
-  if (inverter_limits_charge) {
-    return "Battery charging! (Inverter limiting)";
+  if (state == ChargingState::Charging) {
+    if (inverter_limits_charge) {
+      return LimitingFactor::Inverter;
+    }
+    if (user_settings_limit_charge) {
+      return LimitingFactor::Emulator;
+    }
+    return LimitingFactor::Battery;
   }
-  if (user_settings_limit_charge) {
-    return "Battery charging! (Settings limiting)";
+  return LimitingFactor::None;
+}
+
+const char* charging_state_to_text(ChargingState state) {
+  switch (state) {
+    case ChargingState::Charging:
+      return "Charging";
+    case ChargingState::Discharging:
+      return "Discharging";
+    default:
+      return "Idle";
   }
-  return "Battery charging! (Battery limiting)";
+}
+
+const char* limiting_factor_to_text(LimitingFactor factor) {
+  switch (factor) {
+    case LimitingFactor::Inverter:
+      return "Inverter";
+    case LimitingFactor::Emulator:
+      return "Emulator";
+    case LimitingFactor::Battery:
+      return "Battery";
+    default:
+      return "Idle";
+  }
+}
+
+const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                     bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+  ChargingState state = get_charging_state(current_dA);
+  if (state == ChargingState::Idle) {
+    return "Battery idle";
+  }
+  LimitingFactor factor = get_limiting_factor(state, inverter_limits_charge, inverter_limits_discharge,
+                                              user_settings_limit_charge, user_settings_limit_discharge);
+  if (state == ChargingState::Discharging) {
+    switch (factor) {
+      case LimitingFactor::Inverter:
+        return "Battery discharging! (Inverter limiting)";
+      case LimitingFactor::Emulator:
+        return "Battery discharging! (Settings limiting)";
+      default:
+        return "Battery discharging! (Battery limiting)";
+    }
+  }
+  switch (factor) {
+    case LimitingFactor::Inverter:
+      return "Battery charging! (Inverter limiting)";
+    case LimitingFactor::Emulator:
+      return "Battery charging! (Settings limiting)";
+    default:
+      return "Battery charging! (Battery limiting)";
+  }
 }
 
 #ifdef HW_LILYGO2CAN

--- a/Software/src/devboard/utils/types.cpp
+++ b/Software/src/devboard/utils/types.cpp
@@ -17,6 +17,29 @@ std::string getBMSStatus(system_status_enum status) {
       return "UNKNOWN";
   }
 }
+const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                      bool user_settings_limit_charge, bool user_settings_limit_discharge) {
+  if (current_dA == 0) {
+    return "Battery idle";
+  }
+  if (current_dA < 0) {
+    if (inverter_limits_discharge) {
+      return "Battery discharging! (Inverter limiting)";
+    }
+    if (user_settings_limit_discharge) {
+      return "Battery discharging! (Settings limiting)";
+    }
+    return "Battery discharging! (Battery limiting)";
+  }
+  if (inverter_limits_charge) {
+    return "Battery charging! (Inverter limiting)";
+  }
+  if (user_settings_limit_charge) {
+    return "Battery charging! (Settings limiting)";
+  }
+  return "Battery charging! (Battery limiting)";
+}
+
 #ifdef HW_LILYGO2CAN
 GPIOOPT1 user_selected_gpioopt1 = GPIOOPT1::DEFAULT_OPT;
 #endif

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -2,6 +2,7 @@
 #define _TYPES_H_
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 
 using milliseconds = std::chrono::milliseconds;
@@ -120,6 +121,10 @@ typedef struct {
 } CAN_log_frame;
 
 std::string getBMSStatus(system_status_enum status);
+
+/** Human readable battery status, e.g. "Battery charging (Inverter limiting)". Used for the web UI and MQTT. */
+const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                      bool user_settings_limit_charge, bool user_settings_limit_discharge);
 
 #ifdef HW_LILYGO2CAN
 /* Configurable GPIO options (device specific) */

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -123,7 +123,7 @@ typedef struct {
 std::string getBMSStatus(system_status_enum status);
 
 enum class ChargingState { Idle, Charging, Discharging };
-enum class LimitingFactor { None, Inverter, Emulator, Battery };
+enum class LimitingFactor { None, Inverter, UserSetting, Battery };
 
 ChargingState get_charging_state(int32_t current_dA);
 LimitingFactor get_limiting_factor(ChargingState state, bool inverter_limits_charge, bool inverter_limits_discharge,

--- a/Software/src/devboard/utils/types.h
+++ b/Software/src/devboard/utils/types.h
@@ -122,9 +122,18 @@ typedef struct {
 
 std::string getBMSStatus(system_status_enum status);
 
-/** Human readable battery status, e.g. "Battery charging (Inverter limiting)". Used for the web UI and MQTT. */
+enum class ChargingState { Idle, Charging, Discharging };
+enum class LimitingFactor { None, Inverter, Emulator, Battery };
+
+ChargingState get_charging_state(int32_t current_dA);
+LimitingFactor get_limiting_factor(ChargingState state, bool inverter_limits_charge, bool inverter_limits_discharge,
+                                   bool user_settings_limit_charge, bool user_settings_limit_discharge);
+const char* charging_state_to_text(ChargingState state);
+const char* limiting_factor_to_text(LimitingFactor factor);
+
+/** Human readable battery status, e.g. "Battery charging (Inverter limiting)". Used for the web UI. */
 const char* get_charging_status_text(int32_t current_dA, bool inverter_limits_charge, bool inverter_limits_discharge,
-                                      bool user_settings_limit_charge, bool user_settings_limit_discharge);
+                                     bool user_settings_limit_charge, bool user_settings_limit_discharge);
 
 #ifdef HW_LILYGO2CAN
 /* Configurable GPIO options (device specific) */

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1222,32 +1222,13 @@ String processor(const String& var) {
         content += "</h4>";
       }
 
-      if (datalayer.battery.status.current_dA == 0) {
-        content += "<h4>Battery idle</h4>";
-      } else if (datalayer.battery.status.current_dA < 0) {
-        content += "<h4>Battery discharging!";
-        if (datalayer.battery.settings.inverter_limits_discharge) {
-          content += " (Inverter limiting)</h4>";
-        } else {
-          if (datalayer.battery.settings.user_settings_limit_discharge) {
-            content += " (Settings limiting)</h4>";
-          } else {
-            content += " (Battery limiting)</h4>";
-          }
-        }
-        content += "</h4>";
-      } else {  // > 0 , positive current
-        content += "<h4>Battery charging!";
-        if (datalayer.battery.settings.inverter_limits_charge) {
-          content += " (Inverter limiting)</h4>";
-        } else {
-          if (datalayer.battery.settings.user_settings_limit_charge) {
-            content += " (Settings limiting)</h4>";
-          } else {
-            content += " (Battery limiting)</h4>";
-          }
-        }
-      }
+      content += "<h4>" +
+                 String(get_charging_status_text(datalayer.battery.status.current_dA,
+                                                  datalayer.battery.settings.inverter_limits_charge,
+                                                  datalayer.battery.settings.inverter_limits_discharge,
+                                                  datalayer.battery.settings.user_settings_limit_charge,
+                                                  datalayer.battery.settings.user_settings_limit_discharge)) +
+                 "</h4>";
 
       content += "<h4>System status: ";
       switch (datalayer.system.status.system_status) {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1224,10 +1224,10 @@ String processor(const String& var) {
 
       content += "<h4>" +
                  String(get_charging_status_text(datalayer.battery.status.current_dA,
-                                                  datalayer.battery.settings.inverter_limits_charge,
-                                                  datalayer.battery.settings.inverter_limits_discharge,
-                                                  datalayer.battery.settings.user_settings_limit_charge,
-                                                  datalayer.battery.settings.user_settings_limit_discharge)) +
+                                                 datalayer.battery.settings.inverter_limits_charge,
+                                                 datalayer.battery.settings.inverter_limits_discharge,
+                                                 datalayer.battery.settings.user_settings_limit_charge,
+                                                 datalayer.battery.settings.user_settings_limit_discharge)) +
                  "</h4>";
 
       content += "<h4>System status: ";


### PR DESCRIPTION
Adds the "Battery charging! (Inverter limiting)" info via MQTT sensors with two typed fields, charging_state (Idle/Charging/Discharging) and limiting_factor (Idle/Inverter/Emulator/Battery). This gives us access to more structured backend data instead of just generating info on the web page and a nice clear status via MQTT. The web UI looks the same by using get_charging_status_text() composed from the same two helpers. The limiting factor falls back to "Idle" when no limiting factor is set to better visualize the logic connection to the charging state.

<img width="467" height="248" alt="image" src="https://github.com/user-attachments/assets/f737b3ea-f157-45a7-8440-21b7716498d2" />
