### PR TITLE
GitHub: Remove extraneous + signs from measure action

### DIFF
--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -95,8 +95,6 @@ def fmt_bytes(n: int | None) -> str:
 def fmt_delta(delta: int | None) -> str:
     if delta is None:
         return ""
-    if delta == 0:
-        return "0"
     return f"{delta:+,}"
 
 
@@ -130,9 +128,7 @@ def flash_delta_cell(base: MemoryBytes | None, pr: MemoryBytes | None) -> str:
     delta = pr.used - base.used
     cell = fmt_delta(delta)
     if delta > 0 and pr.total and (pr.used / pr.total) > WARN_FILL_THRESHOLD:
-        return "**+" + cell + "**"
-    elif delta >= 0:
-        return "+" + cell
+        return "**" + cell + "**"
     return cell
 
 
@@ -145,10 +141,7 @@ def ram_delta_cell(base: MemoryBytes | None, pr: MemoryBytes | None) -> str:
     if base is None or pr is None:
         return "—"
     delta = pr.used - base.used
-    cell = fmt_delta(delta)
-    if delta >= 0:
-        return "+" + cell
-    return cell
+    return fmt_delta(delta)
 
 
 def _row_pr_missing(env: str, base: BoardSize | None, artifact_url: str | None) -> RowCells:


### PR DESCRIPTION
### What
It seems I didn't test it enough, increases on the firmware size measurement are showing as `++4` instead of `+4`, this fixes that.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
