### PR TITLE
Unifiy build & release

### DIFF
--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -204,6 +204,15 @@ def _row_normal(env: str, base: BoardSize, pr: BoardSize, artifact_url: str | No
     )
 
 
+def find_artifact_url(board_name: str, artifact_urls: dict[str, str]) -> str | None:
+    """Return the artifact URL for a board, or None if there isn't one."""
+    release_label = board_name.lower().replace(" ", "-").replace("_", "-")
+    for artifact_name, url in artifact_urls.items():
+        if release_label in artifact_name:
+            return url
+    return None
+
+
 def render_row(env: str, base: BoardSize | None, pr: BoardSize | None, artifact_url: str | None) -> str:
     """Dispatch to the right case builder and format the resulting row."""
     if pr is None:
@@ -280,7 +289,8 @@ def render(
     lines.append(sep)
 
     for env in envs:
-        artifact_url = artifact_urls.get(pr.get(env, base.get(env)).get_artifact_slug(), None)
+        board = pr.get(env, base.get(env))
+        artifact_url = find_artifact_url(board.board_name, artifact_urls)
         lines.append(render_row(env, base.get(env), pr.get(env), artifact_url))
 
     lines.append("")

--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -287,8 +287,8 @@ def render(
     lines.append("### To test this firmware on your device:")
     lines.append("1. Make sure you're logged into GitHub")
     lines.append("2. Click the link above corresponding to your hardware type")
-    lines.append("3. Download and unzip it , and grab the file ending `.bin`")
-    lines.append("4. Upload the `.bin` to your board via OTA")
+    lines.append("3. Download and unzip it , and grab the file ending `.ota.bin`")
+    lines.append("4. Upload the `.ota.bin` to your board via OTA")
 
     return "\n".join(lines)
 

--- a/.github/scripts/size_report.py
+++ b/.github/scripts/size_report.py
@@ -10,10 +10,6 @@ artifact deserialises back into a `BoardSize` via `BoardSize.from_dict`.
 from dataclasses import dataclass
 
 
-def slugify(s):
-    return s.lower().replace(" ", "-").replace("_", "-")
-
-
 @dataclass
 class MemoryBytes:
     used: int
@@ -65,10 +61,3 @@ class BoardSize:
             ram=MemoryBytes.from_dict(d.get("ram")),
             toolchain=Toolchain.from_dict(d["toolchain"]),
         )
-
-    def get_artifact_slug(self) -> str:
-        """Return the slug used to name the artifact for this board.
-
-        This is used to look up the artifact URL in the consumer.
-        """
-        return "battery-emulator-" + slugify(self.board_name)

--- a/.github/workflows/add-comment-to-pr.yml
+++ b/.github/workflows/add-comment-to-pr.yml
@@ -6,13 +6,15 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read          # cross-run artifact download
+  pull-requests: write   # post the comment
+
 jobs:
   comment:
     runs-on: ubuntu-latest
     # Only for PR-triggered compile runs
     if: github.event.workflow_run.event == 'pull_request'
-    permissions:
-      pull-requests: write
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v8

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 # This is the list of jobs that will be run concurrently.
 jobs:
   build:

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -103,13 +103,16 @@ jobs:
         SHORT_SHA="${SHA:0:7}"
         cp "$BUILD/firmware.factory.bin" "fw/BE_${SHORT_SHA}_${{ matrix.release_label }}.factory.bin"
         cp "$BUILD/firmware.bin"         "fw/BE_${SHORT_SHA}_${{ matrix.release_label }}.ota.bin"
+        cd fw
+        tar -cJf "../${{ matrix.artifact_name }}.tar.xz" *
 
     - name: Upload artifact for ${{ matrix.board_name }}
       if: matrix.release_label
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.artifact_name }}
-        path: fw
+        path: ${{ matrix.artifact_name }}.tar.xz
+        archive: false # No additional zip compression
         if-no-files-found: warn
 
   measure-size:

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -20,21 +21,27 @@ jobs:
           - board_name: "Lilygo T-CAN485"
             pio_env: "lilygo_330"
             artifact_name: "battery-emulator-lilygo-t-can485"
+            release_label: "LilygoT-CAN485"
           - board_name: "Stark CMR"
             pio_env: "stark_330"
             artifact_name: "battery-emulator-stark-cmr"
+            release_label: "StarkCMR"
           - board_name: "Lilygo T-2CAN"
             pio_env: "lilygo_2CAN_330"
             artifact_name: "battery-emulator-lilygo-t-2can"
+            release_label: "LilygoT-2CAN"
           - board_name: "ESP32 DevKit V1"
             pio_env: "esp32devkit_330"
             artifact_name: "battery-emulator-esp32-devkit-v1"
+            release_label: "ESP32DevKitV1"
           - board_name: "BECom"
             pio_env: "BECom_330"
             artifact_name: "battery-emulator-becom"
+            release_label: "BECom_ES32S3"
           - board_name: "Waveshare RS485CAN"
             pio_env: "waveshare_330"
             artifact_name: "battery-emulator-waveshare-rs485can"
+            release_label: "WaveshareESP32S3RS485CAN"
           - board_name: "Compiler warning check"
             pio_env: "compiler_warning_check"
             artifact_name: "battery-dummy-check"
@@ -86,26 +93,23 @@ jobs:
           --pio-system-info "$(pio system info --json-output)" \
           --platform-json "$(cat "$HOME"/.platformio/platforms/espressif32*/platform.json)"
 
-    #rename firmware.bin to contain pr number and commit short sha for easier location after saved on disk
-    - name: Rename firmware.bin with PR number and commit short SHA
+    - name: Stage release artifacts for ${{ matrix.board_name }}
+      if: matrix.release_label
       run: |
-          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-7)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_PART="pr${{ github.event.pull_request.number }}-"
-          else
-            PR_PART=""
-          fi
-          cp .pio/build/${{ matrix.pio_env }}/firmware.bin \
-             firmware-${PR_PART}${SHORT_SHA}.bin
+        mkdir fw
+        cp "${{ matrix.pio_env }}.size.json" fw
+        BUILD=.pio/build/${{ matrix.pio_env }}
+        SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+        SHORT_SHA="${SHA:0:7}"
+        cp "$BUILD/firmware.factory.bin" "fw/BE_${SHORT_SHA}_${{ matrix.release_label }}.factory.bin"
+        cp "$BUILD/firmware.bin"         "fw/BE_${SHORT_SHA}_${{ matrix.release_label }}.ota.bin"
 
     - name: Upload artifact for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
+      if: matrix.release_label
       uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.artifact_name }}
-        path: |
-          firmware-*.bin
-          ${{ matrix.pio_env }}.size.json
+        path: fw
         if-no-files-found: warn
 
   measure-size:

--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -41,9 +41,16 @@ jobs:
     - name: Download PR-side size reports from this run
       uses: actions/download-artifact@v8
       with:
-        path: ./pr
+        path: ./pr-archives
         pattern: "battery-emulator-*"
         merge-multiple: true
+
+    - name: Extract PR-side size reports
+      run: |
+        mkdir -p ./pr
+        for p in ./pr-archives/*.tar.xz; do
+          tar -C ./pr -xf "$p" --wildcards '*.size.json'
+        done
 
     - name: Resolve base compile run
       id: ctx
@@ -84,11 +91,19 @@ jobs:
       if: steps.ctx.outputs.run_id != ''
       uses: actions/download-artifact@v8
       with:
-        path: ./base
+        path: ./base-archives
         run-id: ${{ steps.ctx.outputs.run_id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         pattern: "battery-emulator-*"
         merge-multiple: true
+
+    - name: Extract base-branch size reports
+      if: steps.ctx.outputs.run_id != ''
+      run: |
+        mkdir -p ./base
+        for b in ./base-archives/*.tar.xz; do
+          tar -C ./base -xf "$b" --wildcards '*.size.json'
+        done
 
     - name: Get Artifact URLs JSON Map
       if: steps.ctx.outputs.run_id != ''
@@ -99,7 +114,7 @@ jobs:
         # Creates a single JSON object mapping names to URLs
         JSON_MAP=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
           --jq '[.artifacts[] | select(.name | startswith("battery-emulator-")) | {key: .name, value: ("${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/" + (.id | tostring))}] | from_entries')
-        
+
         echo "JSON_MAP=$JSON_MAP" >> $GITHUB_OUTPUT
 
     - name: Render comment

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,11 +9,12 @@ on:
         description: 'Release tag (e.g. v1.0.0)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
     - name: Set release tag
       id: vars

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -9,12 +9,20 @@ on:
         description: 'Release tag (e.g. v1.0.0)'
         required: true
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
-  build-and-upload:
+  build:
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/compile-common-image.yml
+
+  publish:
+    needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Set release tag
       id: vars
@@ -25,78 +33,21 @@ jobs:
           echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Checkout code at tag
-      uses: actions/checkout@v7
+    - name: Download compiled artifacts
+      uses: actions/download-artifact@v8
       with:
-        ref: refs/tags/${{ steps.vars.outputs.tag }}
+        pattern: battery-emulator-*
+        path: ./firmware
+        merge-multiple: true
 
-    - name: Build artifacts
+    - name: Rename firmware images
       run: |
-        mkdir output
-        echo "Built for tag ${{ steps.vars.outputs.tag }}" > output/info.txt
-
-    - uses: actions/cache@v6
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.platformio/.cache
-        key: ${{ runner.os }}-pio
-
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.13'
-    - name: Install PlatformIO Core
-      run: pip install --upgrade platformio esptool
-
-    - name: 🛠 Build ota image for Lilygo T-CAN
-      run: |
-        pio run -e lilygo_330
-        cp .pio/build/lilygo_330/firmware.bin output/BE_${{ steps.vars.outputs.tag }}_LilygoT-CAN485.ota.bin
-
-    - name: 🛠 Build factory image for Lilygo T-CAN
-      run: |
-        esptool --chip esp32 merge-bin -o .pio/build/lilygo_330/factory.bin --flash-mode dio --flash-freq 80m --flash-size 4MB 0x1000 .pio/build/lilygo_330/bootloader.bin 0x8000 .pio/build/lilygo_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/lilygo_330/firmware.bin
-        mv .pio/build/lilygo_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_LilygoT-CAN485.factory.bin
-
-    - name: 🛠 Build ota image for Lilygo 2-CAN
-      run: |
-        pio run -e lilygo_2CAN_330
-        cp .pio/build/lilygo_2CAN_330/firmware.bin output/BE_${{ steps.vars.outputs.tag }}_LilygoT-2CAN.ota.bin
-
-    - name: 🛠 Build factory image for Lilygo 2-CAN
-      run: |
-        esptool --chip esp32s3 merge-bin -o .pio/build/lilygo_2CAN_330/factory.bin --flash-mode dio --flash-freq 80m --flash-size 16MB 0x0000 .pio/build/lilygo_2CAN_330/bootloader.bin 0x8000 .pio/build/lilygo_2CAN_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/lilygo_2CAN_330/firmware.bin
-        mv .pio/build/lilygo_2CAN_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_LilygoT-2CAN.factory.bin
-
-    - name: 🛠 Build ota image for Stark
-      run: |
-        pio run -e stark_330
-        cp .pio/build/stark_330/firmware.bin output/BE_${{ steps.vars.outputs.tag }}_StarkCMR.ota.bin
-
-    - name: 🛠 Build factory image for Stark
-      run: |
-        esptool --chip esp32 merge-bin -o .pio/build/stark_330/factory.bin --flash-mode dio --flash-freq 80m --flash-size 8MB 0x1000 .pio/build/stark_330/bootloader.bin 0x8000 .pio/build/stark_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/stark_330/firmware.bin
-        mv .pio/build/stark_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_StarkCMR.factory.bin
-
-    - name: 🛠 Build ota image for Waveshare ESP32-S3-RS485-CAN
-      run: |
-        pio run -e waveshare_330
-        cp .pio/build/waveshare_330/firmware.bin output/BE_${{ steps.vars.outputs.tag }}_WaveshareESP32S3RS485CAN.ota.bin
-
-    - name: 🛠 Build factory image for Waveshare ESP32-S3-RS485-CAN
-      run: |
-        esptool --chip esp32s3 merge-bin -o .pio/build/waveshare_330/factory.bin --flash-mode dio --flash-freq 80m --flash-size 16MB 0x0000 .pio/build/waveshare_330/bootloader.bin 0x8000 .pio/build/waveshare_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/waveshare_330/firmware.bin
-        mv .pio/build/waveshare_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_WaveshareESP32S3RS485CAN.factory.bin
-
-    - name: 🛠 Build ota image for BECom
-      run: |
-        pio run -e BECom_330
-        cp .pio/build/BECom_330/firmware.bin output/BE_${{ steps.vars.outputs.tag }}_BECom_ES32S3.ota.bin
-
-    - name: 🛠 Build factory image for BECom
-      run: |
-        esptool --chip esp32s3 merge-bin -o .pio/build/BECom_330/factory.bin --flash-mode dio --flash-freq 80m --flash-size 16MB 0x0000 .pio/build/BECom_330/bootloader.bin 0x8000 .pio/build/BECom_330/partitions.bin 0xe000 ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin 0x10000 .pio/build/BECom_330/firmware.bin
-        mv .pio/build/BECom_330/factory.bin output/BE_${{ steps.vars.outputs.tag }}_BECom_ES32S3.factory.bin
+        mkdir -p output
+        TAG=${{ steps.vars.outputs.tag }}
+        for f in ./firmware/BE_*.{factory,ota}.bin; do
+          dest=$(basename "$f" | sed "s/^BE_[^_]*_/BE_${TAG}_/")
+          cp "$f" "output/$dest"
+        done
 
     - name: 🌐 Deploy to Web Installer repo
       env:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -37,8 +37,15 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         pattern: battery-emulator-*
-        path: ./firmware
+        path: ./archives
         merge-multiple: true
+
+    - name: Extract firmware archives
+      run: |
+        mkdir -p ./firmware
+        for p in ./archives/*.tar.xz; do
+          tar -C ./firmware -xf "$p"
+        done
 
     - name: Rename firmware images
       run: |

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,8 @@ board_build.flash_mode = qio
 board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = default_8MB.csv
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
 framework = arduino
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections


### PR DESCRIPTION
### What
This PR builds upon the changes in #2594 and now also reuses the compile step for the release process. This makes the compile step the single source of truth and removes the need to also adapt the release step when adding a new board.
It also removes the `esptool merge-bin` invocation and adds the factory images that the build already creates to the build artifact.

### Why

- Makes it easier to add new boards
- Increases release speed, since we reuse the matrix approach
- Prevents a mismatch between the `esptool merge-bin` parameters and `platformio.ini`
- Provide a directly flashable factory image for every build

### How
We now store both the factory and ota image in the build artifacts. The release step then only needs to replace the git shortref with the current release tag. A consequence of storing both images would be that this also duplicates the size of the archive since zip files can´t deduplicate over multiple files. To avoid this I have changed to artifact to be stored as a `.tar.xz` which does not have the same limitation and allows us to distribute both files without a size increase.

### Changes

- Release artifacts are now a `.tar.xz` instead of a `.zip`
- The filenames inside of the archive are now `BE_8828a0b_StarkCMR.factory.bin` and `BE_8828a0b_StarkCMR.ota.bin` instead of `firmware-pr1234-8828a0b.bin`. I removed the `pr` section for simplicity since it wouldn´t always be there.
- An artifact for `ESP32DevKitV1` will now also be created since adding the special handling to excluding it from the release did not seem worth it
- Added top level `permissions:` to restrict the default permissions that are available to a workflow
- `board_upload.flash_size`  for `stark_330` in `platformio.ini` has been aligned with the values from release-assets.yml, it probably makes sense to test this

Test release:
https://github.com/ngehrsitz/Battery-Emulator/releases/tag/v99.0.9
https://github.com/ngehrsitz/BE-Web-Installer/tree/main/images/v99.0.9

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)