### PR TITLE
MEB Battery: Read SoH from BMS

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -223,7 +223,7 @@ void MebBattery::
     // 0.935 and 0.9025 are the different conversions for different battery sizes to go from design capacity to
     // total_capacity_Wh calculated above.
 
-    if ( battery_soh_polled > 0) {
+    if (battery_soh_polled > 0) {
       datalayer_battery->status.soh_pptt = battery_soh_polled;
     } else {
       int Wh_max = 61832 * 0.935f;  // 108 cells
@@ -1233,7 +1233,8 @@ void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype 
           battery_soc_polled = data[3] * 4;  // 135*4 = 54.0%
           break;
         case PID_SOH:
-          if (len < 5) break;
+          if (len < 5)
+            break;
           battery_soh_polled = ((data[3] << 8) | data[4]);
           break;
         case PID_VOLTAGE:

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -223,13 +223,17 @@ void MebBattery::
     // 0.935 and 0.9025 are the different conversions for different battery sizes to go from design capacity to
     // total_capacity_Wh calculated above.
 
-    int Wh_max = 61832 * 0.935f;  // 108 cells
-    if (datalayer_battery->info.number_of_cells <= 84)
-      Wh_max = 48091 * 0.9025f;
-    else if (datalayer_battery->info.number_of_cells <= 96)
-      Wh_max = 82442 * 0.9025f;
-    if (BMS_capacity_ah > 0)
-      datalayer_battery->status.soh_pptt = 10000 * datalayer_battery->info.total_capacity_Wh / (Wh_max * 1.02564f);
+    if ( battery_soh_polled > 0) {
+      datalayer_battery->status.soh_pptt = battery_soh_polled;
+    } else {
+      int Wh_max = 61832 * 0.935f;  // 108 cells
+      if (datalayer_battery->info.number_of_cells <= 84)
+        Wh_max = 48091 * 0.9025f;
+      else if (datalayer_battery->info.number_of_cells <= 96)
+        Wh_max = 82442 * 0.9025f;
+      if (BMS_capacity_ah > 0)
+        datalayer_battery->status.soh_pptt = 10000 * datalayer_battery->info.total_capacity_Wh / (Wh_max * 1.02564f);
+    }
   }
 
   datalayer_battery->status.remaining_capacity_Wh = usable_energy_amount_Wh * 5;
@@ -1058,6 +1062,9 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
         poll_pid = PID_ALLOWED_DISCHARGE_POWER;
         break;
       case PID_ALLOWED_DISCHARGE_POWER:
+        poll_pid = PID_SOH;
+        break;
+      case PID_SOH:
         poll_pid = PID_CELLVOLTAGE_CELL_1;  // Start polling cell voltages
         break;
       // Cell Voltage Cases.
@@ -1224,6 +1231,10 @@ void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype 
           if (len < 4)
             break;
           battery_soc_polled = data[3] * 4;  // 135*4 = 54.0%
+          break;
+        case PID_SOH:
+          if (len < 5) break;
+          battery_soh_polled = ((data[3] << 8) | data[4]);
           break;
         case PID_VOLTAGE:
           if (len < 5)

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -58,7 +58,7 @@ class MebBattery : public CanBattery, public IsoTp {
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
   static const int PID_SOC = 0x028C;
-  static const int PID_SOH = 0x50CE; // This isn't available on older firmware versions, 1141 and higher only.
+  static const int PID_SOH = 0x50CE;  // This isn't available on older firmware versions, 1141 and higher only.
   static const int PID_VOLTAGE = 0x1E3B;
   static const int PID_CURRENT = 0x1E3D;
   static const int PID_MAX_TEMP = 0x1E0E;

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -58,6 +58,7 @@ class MebBattery : public CanBattery, public IsoTp {
   static const int MAX_CELL_VOLTAGE_MV = 4250;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2700;  //Battery is put into emergency stop if one cell goes below this value
   static const int PID_SOC = 0x028C;
+  static const int PID_SOH = 0x50CE; // This isn't available on older firmware versions, 1141 and higher only.
   static const int PID_VOLTAGE = 0x1E3B;
   static const int PID_CURRENT = 0x1E3D;
   static const int PID_MAX_TEMP = 0x1E0E;
@@ -296,6 +297,7 @@ class MebBattery : public CanBattery, public IsoTp {
   unsigned long uds_request_timestamp = 0;
 
   uint16_t battery_soc_polled = 0;
+  uint16_t battery_soh_polled = 0;
   uint16_t battery_voltage_polled = 1480;
   int16_t battery_current_polled = 0;
   int16_t battery_max_temp = 600;


### PR DESCRIPTION
### What
On newer firmware version SoH can be read from BMS. Use the read value instead of the calculated.

### Why
It might be closer to reality.

### How
Use UDS read data by ID and fetch the SoH from BMS.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
