### PR TITLE
Bugfix: remove double mDNS init 🐛

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -89,10 +89,6 @@ void connectivity_loop(void*) {
 
   init_webserver();
 
-  if (mdns_enabled) {
-    init_mDNS();
-  }
-
 #ifndef SMALL_FLASH_DEVICE
   init_display();
 #endif

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -110,6 +110,23 @@ String default_hostname() {
   return "battery-emulator-" + String(mac_suffix);
 }
 
+// Initialise mDNS 
+static void init_mDNS() {
+#ifndef SMALL_FLASH_DEVICE
+  // Reuse the network hostname (custom, or the "battery-emulator-<mac>" default set in init_WiFi()). Be consistent with AP too.
+  String mdnsHost = String(WiFi.getHostname());
+
+  // Initialize mDNS .local resolution
+  if (!MDNS.begin(mdnsHost)) {
+    logging.println("Error setting up mDNS responder!");
+  } else {
+    // Advertise via bonjour the web inteface so we can auto discover these battery emulators on the local network.
+    MDNS.addService("http", "tcp", 80);
+    logging.println("mDNS responder started.");
+  }
+#endif
+}
+
 void init_WiFi() {
   DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
 
@@ -386,22 +403,6 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
   //normal reconnect retry start at first 2 seconds
 }
 
-// Initialise mDNS (Only available on devices with )
-void init_mDNS() {
-#ifndef SMALL_FLASH_DEVICE
-  // Reuse the network hostname (custom, or the "battery-emulator-<mac>" default set in init_WiFi()). Be consistent with AP too.
-  String mdnsHost = String(WiFi.getHostname());
-
-  // Initialize mDNS .local resolution
-  if (!MDNS.begin(mdnsHost)) {
-    logging.println("Error setting up mDNS responder!");
-  } else {
-    // Advertise via bonjour the web inteface so we can auto discover these battery emulators on the local network.
-    MDNS.addService("http", "tcp", 80);
-    logging.println("mDNS responder started.");
-  }
-#endif
-}
 
 void init_WiFi_AP() {
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -110,7 +110,7 @@ String default_hostname() {
   return "battery-emulator-" + String(mac_suffix);
 }
 
-// Initialise mDNS 
+// Initialise mDNS
 static void init_mDNS() {
 #ifndef SMALL_FLASH_DEVICE
   // Reuse the network hostname (custom, or the "battery-emulator-<mac>" default set in init_WiFi()). Be consistent with AP too.
@@ -402,7 +402,6 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
   //too many events received when the connection is lost
   //normal reconnect retry start at first 2 seconds
 }
-
 
 void init_WiFi_AP() {
 

--- a/Software/src/devboard/wifi/wifi.h
+++ b/Software/src/devboard/wifi/wifi.h
@@ -38,9 +38,6 @@ String default_hostname();
 
 void init_WiFi_AP();
 
-// Initialise mDNS
-void init_mDNS();
-
 extern bool wifi_enabled;
 extern bool wifiap_enabled;
 extern bool ap_active;


### PR DESCRIPTION
**What:**
Remove the early `init_mDNS()` call from `connectivity_loop()`; mDNS now starts only from the guarded `onWifiGotIP()` path. The function becomes file-local to wifi.cpp with no public header declaration.

**Why:**
Both call sites ran at boot (the `mdns_started` guard only covers the event handler), starting the responder twice and logging "mDNS responder started." twice ~14 ms apart.

**How:**
Delete the block in `connectivity_loop()`, drop the declaration from wifi.h, and mark `init_mDNS()` `static` and move it up so no forward declaration is needed either.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
