### PR TITLE
Bugfix: 🐛Apply inverter limits low pass filter to power limits

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -201,7 +201,7 @@ void update_calculated_values(unsigned long currentMillis) {
     datalayer.battery.status.max_discharge_power_W = discharge_power_W_filtered;
   }
 
- /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
+  /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
      If unavailable (some drivers report 0 before battery comms are up), fall back to the design
      max voltage - conservative, since it under-estimates current for a given power. If that is
      also 0 (generic BMS drivers with no user-configured pack voltage, or BMS-reported cutoff

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -201,14 +201,21 @@ void update_calculated_values(unsigned long currentMillis) {
     datalayer.battery.status.max_discharge_power_W = discharge_power_W_filtered;
   }
 
-  /* Calculate allowed charge/discharge currents*/
-  if (datalayer.battery.status.voltage_dV > 10) {
-    // Only update value when we have voltage available to avoid div0. TODO: This should be based on nominal voltage
+ /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
+     If unavailable (some drivers report 0 before battery comms are up), fall back to the design
+     max voltage - conservative, since it under-estimates current for a given power. If that is
+     also 0 (generic BMS drivers with no user-configured pack voltage, or BMS-reported cutoff
+     values before first frame), keep the previous values to avoid div0. */
+  uint16_t conversion_voltage_dV = datalayer.battery.status.voltage_dV;
+  if (conversion_voltage_dV <= 10) {
+    conversion_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
+  }
+  if (conversion_voltage_dV > 10) {
     // Power limits are already low pass filtered above (if enabled), so the derived currents are too
     datalayer.battery.status.max_charge_current_dA =
-        ((datalayer.battery.status.max_charge_power_W * 100) / datalayer.battery.status.voltage_dV);
+        ((datalayer.battery.status.max_charge_power_W * 100) / conversion_voltage_dV);
     datalayer.battery.status.max_discharge_current_dA =
-        ((datalayer.battery.status.max_discharge_power_W * 100) / datalayer.battery.status.voltage_dV);
+        ((datalayer.battery.status.max_discharge_power_W * 100) / conversion_voltage_dV);
   }
 
   /* Apply remote restrictions if set*/

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -146,6 +146,61 @@ void logging_loop(void*) {
   vTaskDelete(NULL);
 }
 
+/* Low pass filter for the battery power limits sent to the inverter (only when increasing,
+   10% new / 90% old per 1s cycle, ~10s time constant). Decreases take effect immediately.
+   Runs AFTER update_machineryprotection() so its input includes safety-layer zeroing
+   (pause, fault, battery full, voltage/cell limits) - otherwise a safety block release
+   would expose a filter state that never saw the zero, skipping the ramp entirely.
+   Filter state is kept locally, since battery drivers and the safety layer rewrite the
+   datalayer values every cycle. */
+static void filter_inverter_limits(void) {
+  if (!inverter_low_pass_filter) {
+    return;  // Datalayer values pass through untouched - identical to legacy behavior
+  }
+  static uint32_t charge_power_W_filtered = 0;
+  static uint32_t discharge_power_W_filtered = 0;
+  static bool power_filter_initialized = false;
+
+  if (!power_filter_initialized) {
+    charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
+    discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+    power_filter_initialized = true;
+  } else {
+    if (datalayer.battery.status.max_charge_power_W > charge_power_W_filtered) {
+      charge_power_W_filtered = (datalayer.battery.status.max_charge_power_W * 10 + charge_power_W_filtered * 90) / 100;
+    } else {
+      charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
+    }
+
+    if (datalayer.battery.status.max_discharge_power_W > discharge_power_W_filtered) {
+      discharge_power_W_filtered =
+          (datalayer.battery.status.max_discharge_power_W * 10 + discharge_power_W_filtered * 90) / 100;
+    } else {
+      discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+    }
+  }
+  datalayer.battery.status.max_charge_power_W = charge_power_W_filtered;
+  datalayer.battery.status.max_discharge_power_W = discharge_power_W_filtered;
+
+  /* Cap the derived currents with values from the filtered power. min() logic is used so the
+     user/remote/safety clamps already applied to the _dA fields are never raised - both
+     are upper bounds. Same voltage fallback logic as in update_calculated_values(). */
+  uint16_t conversion_voltage_dV = datalayer.battery.status.voltage_dV;
+  if (conversion_voltage_dV <= 10) {
+    conversion_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
+  }
+  if (conversion_voltage_dV > 10) {
+    uint32_t charge_dA_from_power = (charge_power_W_filtered * 100) / conversion_voltage_dV;
+    uint32_t discharge_dA_from_power = (discharge_power_W_filtered * 100) / conversion_voltage_dV;
+    if (charge_dA_from_power < datalayer.battery.status.max_charge_current_dA) {
+      datalayer.battery.status.max_charge_current_dA = (uint16_t)charge_dA_from_power;
+    }
+    if (discharge_dA_from_power < datalayer.battery.status.max_discharge_current_dA) {
+      datalayer.battery.status.max_discharge_current_dA = (uint16_t)discharge_dA_from_power;
+    }
+  }
+}
+
 void update_calculated_values(unsigned long currentMillis) {
   /* Update CPU temperature*/
   union {
@@ -168,39 +223,6 @@ void update_calculated_values(unsigned long currentMillis) {
     datalayer.battery.settings.max_remote_set_discharge_dA = 0;
   }
 
-  /* Low pass filter the battery power limits (only when increasing, 10% new / 90% old).
-     Decreases take effect immediately for safety. Filtering is done on the power values so that
-     both power-based inverters (e.g. BYD-Modbus reading max_charge_power_W directly) and
-     current-based inverters (via the derived _dA values below) benefit from it.
-     Filter state is kept locally, since battery drivers overwrite the datalayer values every update. */
-  if (inverter_low_pass_filter) {
-    static uint32_t charge_power_W_filtered = 0;
-    static uint32_t discharge_power_W_filtered = 0;
-    static bool power_filter_initialized = false;
-
-    if (!power_filter_initialized) {
-      charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
-      discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
-      power_filter_initialized = true;
-    } else {
-      if (datalayer.battery.status.max_charge_power_W > charge_power_W_filtered) {
-        charge_power_W_filtered =
-            (datalayer.battery.status.max_charge_power_W * 10 + charge_power_W_filtered * 90) / 100;
-      } else {
-        charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
-      }
-
-      if (datalayer.battery.status.max_discharge_power_W > discharge_power_W_filtered) {
-        discharge_power_W_filtered =
-            (datalayer.battery.status.max_discharge_power_W * 10 + discharge_power_W_filtered * 90) / 100;
-      } else {
-        discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
-      }
-    }
-    datalayer.battery.status.max_charge_power_W = charge_power_W_filtered;
-    datalayer.battery.status.max_discharge_power_W = discharge_power_W_filtered;
-  }
-
   /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
      If unavailable (some drivers report 0 before battery comms are up), fall back to the design
      max voltage - conservative, since it under-estimates current for a given power. If that is
@@ -211,7 +233,6 @@ void update_calculated_values(unsigned long currentMillis) {
     conversion_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   }
   if (conversion_voltage_dV > 10) {
-    // Power limits are already low pass filtered above (if enabled), so the derived currents are too
     datalayer.battery.status.max_charge_current_dA =
         ((datalayer.battery.status.max_charge_power_W * 100) / conversion_voltage_dV);
     datalayer.battery.status.max_discharge_current_dA =
@@ -525,6 +546,7 @@ void core_loop(void*) {
       }
       update_calculated_values(currentMillis);
       update_machineryprotection();  // Check safeties
+      filter_inverter_limits();      // Smooth limits towards inverter (runs after safeties on purpose)
 
       // Update values heading towards inverter
       if (inverter) {

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -168,36 +168,47 @@ void update_calculated_values(unsigned long currentMillis) {
     datalayer.battery.settings.max_remote_set_discharge_dA = 0;
   }
 
+  /* Low pass filter the battery power limits (only when increasing, 10% new / 90% old).
+     Decreases take effect immediately for safety. Filtering is done on the power values so that
+     both power-based inverters (e.g. BYD-Modbus reading max_charge_power_W directly) and
+     current-based inverters (via the derived _dA values below) benefit from it.
+     Filter state is kept locally, since battery drivers overwrite the datalayer values every update. */
+  if (inverter_low_pass_filter) {
+    static uint32_t charge_power_W_filtered = 0;
+    static uint32_t discharge_power_W_filtered = 0;
+    static bool power_filter_initialized = false;
+
+    if (!power_filter_initialized) {
+      charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
+      discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+      power_filter_initialized = true;
+    } else {
+      if (datalayer.battery.status.max_charge_power_W > charge_power_W_filtered) {
+        charge_power_W_filtered =
+            (datalayer.battery.status.max_charge_power_W * 10 + charge_power_W_filtered * 90) / 100;
+      } else {
+        charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
+      }
+
+      if (datalayer.battery.status.max_discharge_power_W > discharge_power_W_filtered) {
+        discharge_power_W_filtered =
+            (datalayer.battery.status.max_discharge_power_W * 10 + discharge_power_W_filtered * 90) / 100;
+      } else {
+        discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+      }
+    }
+    datalayer.battery.status.max_charge_power_W = charge_power_W_filtered;
+    datalayer.battery.status.max_discharge_power_W = discharge_power_W_filtered;
+  }
+
   /* Calculate allowed charge/discharge currents*/
   if (datalayer.battery.status.voltage_dV > 10) {
     // Only update value when we have voltage available to avoid div0. TODO: This should be based on nominal voltage
-    int32_t target_charge = ((datalayer.battery.status.max_charge_power_W * 100) / datalayer.battery.status.voltage_dV);
-    int32_t target_discharge =
+    // Power limits are already low pass filtered above (if enabled), so the derived currents are too
+    datalayer.battery.status.max_charge_current_dA =
+        ((datalayer.battery.status.max_charge_power_W * 100) / datalayer.battery.status.voltage_dV);
+    datalayer.battery.status.max_discharge_current_dA =
         ((datalayer.battery.status.max_discharge_power_W * 100) / datalayer.battery.status.voltage_dV);
-
-    // Low pass filter only when increasing values (10% new, 90% old)
-    if (inverter_low_pass_filter) {
-      if (datalayer.battery.status.max_charge_current_dA == 0) {
-        datalayer.battery.status.max_charge_current_dA = target_charge;  // Initialize immediately if 0
-      } else if (target_charge > datalayer.battery.status.max_charge_current_dA) {
-        datalayer.battery.status.max_charge_current_dA =
-            (target_charge * 10 + datalayer.battery.status.max_charge_current_dA * 90) / 100;
-      } else {
-        datalayer.battery.status.max_charge_current_dA = target_charge;
-      }
-
-      if (datalayer.battery.status.max_discharge_current_dA == 0) {
-        datalayer.battery.status.max_discharge_current_dA = target_discharge;  // Initialize immediately if 0
-      } else if (target_discharge > datalayer.battery.status.max_discharge_current_dA) {
-        datalayer.battery.status.max_discharge_current_dA =
-            (target_discharge * 10 + datalayer.battery.status.max_discharge_current_dA * 90) / 100;
-      } else {
-        datalayer.battery.status.max_discharge_current_dA = target_discharge;
-      }
-    } else {
-      datalayer.battery.status.max_charge_current_dA = target_charge;
-      datalayer.battery.status.max_discharge_current_dA = target_discharge;
-    }
   }
 
   /* Apply remote restrictions if set*/

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -479,8 +479,8 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("CNTCTRL") ? "checked" : "";
   }
 
-  if (var == "LOWPASS") {
-    return settings.getBool("LOWPASS") ? "checked" : "";
+  if (var == "LOWPASSFILTER") {
+    return settings.getBool("LOWPASSFILTER") ? "checked" : "";
   }
 
   if (var == "SLOWCANINV") {

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -479,8 +479,8 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("CNTCTRL") ? "checked" : "";
   }
 
-  if (var == "LOWPASSFILTER") {
-    return settings.getBool("LOWPASSFILTER") ? "checked" : "";
+  if (var == "LOWPASS") {
+    return settings.getBool("LOWPASS") ? "checked" : "";
   }
 
   if (var == "SLOWCANINV") {
@@ -1737,9 +1737,9 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         %INVCOMM%     
         </select>
 
-        <label>Inverter limits low pass filter: </label>
+        <label>Ramp up charge limits gradually:</label>
         <input type='checkbox' name='LOWPASSFILTER' value='on' %LOWPASSFILTER% 
-        title="Applies a low pass filter to charge/discharge rates to prevent oscillation." />
+        title="Smooths sudden increases in the battery's charge power limits before sending them to the inverter to prevent oscillation, using a low pass filter." />
 
         <label>Allow longer CAN timeout: </label>
         <input type='checkbox' name='SLOWCANINV' value='on' %SLOWCANINV% 


### PR DESCRIPTION
### What
This PR makes the "Inverter limits low pass filter" setting effective for power-based inverters (e.g. BYD-Modbus) by filtering `max_charge/discharge_power_W` instead of the derived `_dA` currents.
Renames it in the web UI from "Inverter limits low pass filter:" to "Ramp up charge limits gradually:" to make it more self-explanatory for the end-users, adjusting the tooltip accordingly.

### Why
Previously the filter only touched the derived current fields, which BYD-Modbus never reads — so the setting was a no-op for it, and unfiltered limits (e.g. from a Nissan Leaf LBC bouncing near full SOC) cause inverter power oscillation.

### How
The filter is moved earlier in `update_calculated_values()` onto the power fields (state in local statics, since battery drivers overwrite the datalayer each cycle), and currents are then derived from the filtered power; initialization uses a first-run flag instead of `==0`, so ramp-up from a 0 limit is also smoothed while decreases stay instant.

#### Before, in `update_calculated_values()`:

1. Battery driver writes raw `max_charge/discharge_power_W` into the datalayer every 1 s.
2. Those are converted to target currents: `target = power_W * 100 / voltage_dV` (skipped if voltage ≤ 1.0 V).
3. If the checkbox on: per direction — if the stored `_dA` is 0, take the target immediately (init); if the target is *higher*, blend `new = (target*10 + old*90)/100` (~10 s time constant at the 1 s loop); if *lower or equal*, take it immediately (safety).
4. The filter's "memory" was the datalayer `_dA` field itself — which the user/remote limit clamps further down also modify, entangling filter state with clamping.
5. Consequence: only the `_dA` fields were smoothed; the power fields stayed raw, so power-based inverters (BYD-Modbus, VCU-CAN) bypassed the filter entirely — the checkbox was a no-op for them.
6. If the checkbox is off: targets are written straight to `max_charge/discharge_current_dA`. Done.


#### After, in `update_calculated_values()`:

1. Battery driver still writes raw `max_charge/discharge_power_W` into the datalayer every 1 s — drivers untouched. Filter moved to the power domain, before any conversion.
2. If the checkbox is on: on the very first loop pass, the raw values are taken as-is (one-time init flag). After that, per direction — if raw is *higher* than the filtered value, blend `new = (raw*10 + old*90)/100` (~10 s time constant); if *lower or equal*, take it immediately (safety drops still land within one cycle).
3. Filter state lives in local `static` variables, not the datalayer — so it survives the driver's overwrite each second and is no longer entangled with the user/remote clamping downstream.
4. The filtered values are written back into `max_charge/discharge_power_W`, so **everything** downstream sees smoothed limits: BYD-Modbus registers 306/307, VCU-CAN frames, MQTT, web UI.
5. Currents are then derived from the (already filtered) power: `_dA = power_W * 100 / conversion_voltage`, where conversion voltage is live pack voltage, falling back to `max_design_voltage_dV` if live reads ≤ 1.0 V, and skipping the update entirely if both are 0. Single filter stage — current-based inverters get equivalent smoothing to before, no double-filtering.
6. Checkbox off: raw power passes through untouched and currents derive exactly as on main — bit-for-bit legacy behavior.

Key behavioral difference vs. original: ramp-up from a 0 limit is now smoothed too (the old `==0` instant-init re-triggered on every dip to zero), which is what kills the GEN24 hunting when the Leaf bounces its limits near full SOC.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
