### PR TITLE
Fix Pylon protocol compatibility with GCE and similar BMS

### DIFF
--- a/Software/src/battery/PYLON-BATTERY.cpp
+++ b/Software/src/battery/PYLON-BATTERY.cpp
@@ -52,9 +52,17 @@ void PylonBattery::update_values() {
 
   datalayer_battery->status.temperature_max_dC = celltemperature_max_dC;
 
-  datalayer_battery->info.max_design_voltage_dV = charge_cutoff_voltage;
+  // Expose the BMS-announced cutoffs on the battery info page
+  extended_data.charge_cutoff_dV = charge_cutoff_voltage;
+  extended_data.discharge_cutoff_dV = discharge_cutoff_voltage;
 
-  datalayer_battery->info.min_design_voltage_dV = discharge_cutoff_voltage;
+  // BMS cutoffs only define the design voltage when the user has not set explicit limits
+  if (user_selected_max_pack_voltage_dV == 0) {
+    datalayer_battery->info.max_design_voltage_dV = charge_cutoff_voltage;
+  }
+  if (user_selected_min_pack_voltage_dV == 0) {
+    datalayer_battery->info.min_design_voltage_dV = discharge_cutoff_voltage;
+  }
 }
 
 void PylonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -122,17 +130,23 @@ void PylonBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       charge_cutoff_voltage = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
       discharge_cutoff_voltage = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
       max_charge_current_dA = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]) - 30000;
-      max_discharge_current_dA = -(((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]) - 30000);
+      // Some BMS (e.g. GCE) encode the discharge limit with a positive offset like the
+      // charge limit, instead of the standard negative offset. abs() handles both.
+      max_discharge_current_dA = abs((((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]) - 30000));
       break;
     case 0x4230:
     case 0x4231:
       cellvoltage_max_mV = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]);
       cellvoltage_min_mV = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]);
+      extended_data.cell_max_number = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]);
+      extended_data.cell_min_number = ((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]);
       break;
     case 0x4240:
     case 0x4241:
       celltemperature_max_dC = ((rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0]) - 1000;
       celltemperature_min_dC = ((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) - 1000;
+      extended_data.temp_max_sensor = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]);
+      extended_data.temp_min_sensor = ((rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6]);
       break;
     case 0x4250:
     case 0x4251:

--- a/Software/src/battery/PYLON-BATTERY.h
+++ b/Software/src/battery/PYLON-BATTERY.h
@@ -35,7 +35,8 @@ class PylonBattery : public CanBattery {
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
  private:
-  PylonHtmlRenderer renderer;
+  PylonExtendedData extended_data;
+  PylonHtmlRenderer renderer = PylonHtmlRenderer(&extended_data);
   static const int MAX_CELL_DEVIATION_MV = 150;
   static const int MAX_CELLS = 192;                                 // Maximum cells supported
   static const uint32_t EMUS_BASE_ID = 0x19B50000;                  // EMUS extended ID base for cell count

--- a/Software/src/battery/PYLON-HTML.h
+++ b/Software/src/battery/PYLON-HTML.h
@@ -5,14 +5,40 @@
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/webserver/BatteryHtmlRenderer.h"
 
+/** Extra data parsed from the Pylon HV protocol that has no datalayer home.
+ *  Filled by PylonBattery, displayed by PylonHtmlRenderer. */
+struct PylonExtendedData {
+  uint16_t charge_cutoff_dV = 0;
+  uint16_t discharge_cutoff_dV = 0;
+  uint16_t cell_max_number = 0;
+  uint16_t cell_min_number = 0;
+  uint16_t temp_max_sensor = 0;
+  uint16_t temp_min_sensor = 0;
+};
+
 class PylonHtmlRenderer : public BatteryHtmlRenderer {
  public:
+  PylonHtmlRenderer(PylonExtendedData* d) : data(d) {}
+
   String get_status_html() {
     String content;
-    content += "<h4>Charge cutoff voltage: " + String(datalayer.battery.info.max_design_voltage_dV) + " dV</h4>";
-    content += "<h4>Discharge cutoff voltage: " + String(datalayer.battery.info.min_design_voltage_dV) + " dV</h4>";
+    content += "<h4>BMS charge cutoff voltage: " + String(data->charge_cutoff_dV / 10.0, 1) + " V</h4>";
+    content += "<h4>BMS discharge cutoff voltage: " + String(data->discharge_cutoff_dV / 10.0, 1) + " V</h4>";
+    content += "<h4>Design voltage in use: " + String(datalayer.battery.info.min_design_voltage_dV / 10.0, 1) +
+               " - " + String(datalayer.battery.info.max_design_voltage_dV / 10.0, 1) + " V</h4>";
+    if (data->cell_max_number > 0 || data->cell_min_number > 0) {
+      content += "<h4>Highest cell: #" + String(data->cell_max_number) +
+                 " &nbsp; Lowest cell: #" + String(data->cell_min_number) + "</h4>";
+    }
+    if (data->temp_max_sensor > 0 || data->temp_min_sensor > 0) {
+      content += "<h4>Hottest sensor: #" + String(data->temp_max_sensor) +
+                 " &nbsp; Coldest sensor: #" + String(data->temp_min_sensor) + "</h4>";
+    }
     return content;
   }
+
+ private:
+  PylonExtendedData* data;
 };
 
 #endif

--- a/Software/src/battery/PYLON-HTML.h
+++ b/Software/src/battery/PYLON-HTML.h
@@ -24,15 +24,15 @@ class PylonHtmlRenderer : public BatteryHtmlRenderer {
     String content;
     content += "<h4>BMS charge cutoff voltage: " + String(data->charge_cutoff_dV / 10.0, 1) + " V</h4>";
     content += "<h4>BMS discharge cutoff voltage: " + String(data->discharge_cutoff_dV / 10.0, 1) + " V</h4>";
-    content += "<h4>Design voltage in use: " + String(datalayer.battery.info.min_design_voltage_dV / 10.0, 1) +
-               " - " + String(datalayer.battery.info.max_design_voltage_dV / 10.0, 1) + " V</h4>";
+    content += "<h4>Design voltage in use: " + String(datalayer.battery.info.min_design_voltage_dV / 10.0, 1) + " - " +
+               String(datalayer.battery.info.max_design_voltage_dV / 10.0, 1) + " V</h4>";
     if (data->cell_max_number > 0 || data->cell_min_number > 0) {
-      content += "<h4>Highest cell: #" + String(data->cell_max_number) +
-                 " &nbsp; Lowest cell: #" + String(data->cell_min_number) + "</h4>";
+      content += "<h4>Highest cell: #" + String(data->cell_max_number) + " &nbsp; Lowest cell: #" +
+                 String(data->cell_min_number) + "</h4>";
     }
     if (data->temp_max_sensor > 0 || data->temp_min_sensor > 0) {
-      content += "<h4>Hottest sensor: #" + String(data->temp_max_sensor) +
-                 " &nbsp; Coldest sensor: #" + String(data->temp_min_sensor) + "</h4>";
+      content += "<h4>Hottest sensor: #" + String(data->temp_max_sensor) + " &nbsp; Coldest sensor: #" +
+                 String(data->temp_min_sensor) + "</h4>";
     }
     return content;
   }


### PR DESCRIPTION
## What

Three related fixes for BMS that speak the Pylontech HV CAN protocol but deviate slightly from the reference encoding. All three were found while commissioning a DIY 75S NMC pack with a **GCE HV BMS** driving a Solax X1 Hybrid G4.

1. **Max discharge power reported as ~4294959 kW.** The discharge current limit in frame `0x4211` (bytes 6-7) is decoded as `-(value - 30000)`. The GCE encodes this limit with a *positive* offset (`30000 + I`), like the charge limit, so the result was negative and underflowed the unsigned `max_discharge_current_dA` / `max_discharge_power_W` fields, sending garbage to the inverter. `abs(value - 30000)` yields the correct magnitude for both encodings.

2. **User-configured pack voltage limits had no effect.** `update_values()` wrote the BMS-announced charge/discharge cutoffs (frame `0x4220`) into `max/min_design_voltage_dV` on every cycle, overwriting the values set in `setup()` from the user's webserver settings. The cutoffs now only apply when the user has left the corresponding limit at `0`.

3. **Battery info page was sparse and mislabeled.** The frames already carry the highest/lowest cell index and hottest/coldest sensor index (`0x4231`/`0x4241` bytes 4-7) but they were discarded. The page now shows them, plus the BMS cutoffs in volts and the design voltage range actually in effect.

## Why

Without these, a GCE (and likely other slightly-off Pylontech-protocol BMS) reports an absurd discharge power and ignores user voltage limits, which is unsafe for a DIY pack.

## Testing

Tested on hardware (LilyGo T-2CAN, based on v11.0.0) with a GCE HV 75S BMS + Solax X1 Hybrid G4:
- Max discharge power now reads a sane value (8.5 kW) instead of 4294959 kW.
- Pack min/max design voltage set in the UI is now honored.
- Battery info page shows highest/lowest cell number and sensor indices.

No behavior change for BMS that already followed the reference encoding: `abs()` is a no-op for correctly-signed values, and the cutoff precedence only changes behavior when the user has explicitly set a non-zero limit.