### PR TITLE
Improvement: Make core-task CAN logging non-blocking to prevent task overruns

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -67,6 +67,9 @@ void register_transmitter(Transmitter* transmitter) {
 // Initialization functions
 void init_serial() {
   // Init Serial monitor
+  // Buffered TX so CAN-log bursts are absorbed instead of dropped; also makes
+  // availableForWrite() report ring-buffer space rather than raw FIFO space.
+  Serial.setTxBufferSize(1024);
   Serial.begin(115200);
 #if (HW_LILYGO2CAN || HW_BECOM || HW_WAVESHARE)
   // Wait up to 100ms for Serial to be available. On the ESP32S3 Serial is

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -469,10 +469,9 @@ static void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirec
     static char usb_line[288];  // header + up to 64 CAN-FD data bytes at 3 chars each
     static uint32_t usb_frames_dropped = 0;
     unsigned long currentTime = millis();
-    size_t size =
-        snprintf(usb_line, sizeof(usb_line), "(%lu.%02lu) %s%d %lX [%u] ", currentTime / 1000,
-                 (currentTime % 1000) / 10, (msgDir == MSG_RX) ? "RX" : "TX",
-                 (msgDir == MSG_RX) ? (int)(interface * 2) : (int)(interface * 2) + 1, frame.ID, frame.DLC);
+    size_t size = snprintf(usb_line, sizeof(usb_line), "(%lu.%02lu) %s%d %lX [%u] ", currentTime / 1000,
+                           (currentTime % 1000) / 10, (msgDir == MSG_RX) ? "RX" : "TX",
+                           (msgDir == MSG_RX) ? (int)(interface * 2) : (int)(interface * 2) + 1, frame.ID, frame.DLC);
     for (uint8_t i = 0; i < frame.DLC; i++) {
       size += snprintf(usb_line + size, sizeof(usb_line) - size, (i < frame.DLC - 1) ? "%02X " : "%02X\r\n",
                        frame.data.u8[i]);

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -462,28 +462,39 @@ static void receive_frame_canfd_addon_2() {
 static void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirection msgDir) {
 
   if (datalayer.system.info.CAN_usb_logging_active) {
-    uint8_t i = 0;
-    Serial.print("(");
-    Serial.print(millis() / 1000.0);
-    if (msgDir == MSG_RX) {
-      Serial.print(") RX");
-      Serial.print((int)(interface * 2));
+    // Build the whole line first, then write it in one go - and only if the TX
+    // buffer has room. This path runs in the core task: a blocked/slow USB host
+    // must never stall it (EVENT_TASK_OVERRUN). Frames that don't fit are
+    // counted and reported as a gap marker once the port drains.
+    static char usb_line[288];  // header + up to 64 CAN-FD data bytes at 3 chars each
+    static uint32_t usb_frames_dropped = 0;
+    unsigned long currentTime = millis();
+    size_t size =
+        snprintf(usb_line, sizeof(usb_line), "(%lu.%02lu) %s%d %lX [%u] ", currentTime / 1000,
+                 (currentTime % 1000) / 10, (msgDir == MSG_RX) ? "RX" : "TX",
+                 (msgDir == MSG_RX) ? (int)(interface * 2) : (int)(interface * 2) + 1, frame.ID, frame.DLC);
+    for (uint8_t i = 0; i < frame.DLC; i++) {
+      size += snprintf(usb_line + size, sizeof(usb_line) - size, (i < frame.DLC - 1) ? "%02X " : "%02X\r\n",
+                       frame.data.u8[i]);
+    }
+    if (frame.DLC == 0) {
+      size += snprintf(usb_line + size, sizeof(usb_line) - size, "\r\n");
+    }
+
+    if ((size_t)Serial.availableForWrite() >= size) {
+      if (usb_frames_dropped > 0) {
+        char marker[48];
+        int marker_len =
+            snprintf(marker, sizeof(marker), "[%lu CAN frames not printed]\r\n", (unsigned long)usb_frames_dropped);
+        if ((size_t)Serial.availableForWrite() >= size + (size_t)marker_len) {
+          Serial.write((const uint8_t*)marker, marker_len);
+          usb_frames_dropped = 0;
+        }
+      }
+      Serial.write((const uint8_t*)usb_line, size);
     } else {
-      Serial.print(") TX");
-      Serial.print((int)(interface * 2) + 1);
+      usb_frames_dropped++;
     }
-    Serial.print(" ");
-    Serial.print(frame.ID, HEX);
-    Serial.print(" [");
-    Serial.print(frame.DLC);
-    Serial.print("] ");
-    for (i = 0; i < frame.DLC; i++) {
-      Serial.print(frame.data.u8[i] < 16 ? "0" : "");
-      Serial.print(frame.data.u8[i], HEX);
-      if (i < frame.DLC - 1)
-        Serial.print(" ");
-    }
-    Serial.println("");
   }
 
   if (datalayer.system.info.can_logging_active) {  // If user clicked on CAN Logging page in webserver, start recording

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -51,34 +51,46 @@ void pause_log_writing() {
   logging_paused = true;
 }
 
+// Number of frames lost because the ring buffer was full (SD writer stalled).
+// Reported as a gap marker in the log once the buffer has room again.
+static uint32_t can_frames_dropped = 0;
+
 void add_can_frame_to_buffer(CAN_frame frame, frameDirection msgDir) {
 
   if (!sd_card_active)
     return;
 
   unsigned long currentTime = millis();
-  static char messagestr_buffer[32];
+  // Sized for the worst case: gap marker + header + 64 data bytes (CAN-FD) at 3 chars each
+  static char messagestr_buffer[320];
   size_t size = 0;
-  size = snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size, "(%lu.%03lu) %s %lX [%u] ",
-                  currentTime / 1000, currentTime % 1000, (msgDir == MSG_RX ? "RX0" : "TX1"), frame.ID, frame.DLC);
 
-  if (xRingbufferSend(can_bufferHandle, &messagestr_buffer, size, pdMS_TO_TICKS(2)) != pdTRUE) {
-    logging.println("Failed to send message to can ring buffer!");
+  if (can_frames_dropped > 0) {
+    // Frames were lost while the SD writer was stalled. Record the gap so the
+    // log stays honest, then continue with the current frame in the same send.
+    size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size,
+                     "[%lu CAN frames dropped, SD buffer full]\n", (unsigned long)can_frames_dropped);
+  }
+
+  size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size, "(%lu.%03lu) %s %lX [%u] ",
+                   currentTime / 1000, currentTime % 1000, (msgDir == MSG_RX ? "RX0" : "TX1"), frame.ID, frame.DLC);
+
+  for (uint8_t i = 0; i < frame.DLC; i++) {
+    size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size,
+                     (i < frame.DLC - 1) ? "%02X " : "%02X\n", frame.data.u8[i]);
+  }
+  if (frame.DLC == 0) {  // Frames without payload still need to terminate the line
+    size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size, "\n");
+  }
+
+  // One send per frame, zero timeout: this runs in the core task and must never
+  // block. If the buffer is full the SD card is stalled anyway - waiting here
+  // would not save the frame, it would only delay the 10ms tasks (EVENT_TASK_OVERRUN).
+  if (xRingbufferSend(can_bufferHandle, messagestr_buffer, size, 0) != pdTRUE) {
+    can_frames_dropped++;
     return;
   }
-
-  uint8_t i = 0;
-  for (i = 0; i < frame.DLC; i++) {
-    if (i < frame.DLC - 1)
-      size = snprintf(messagestr_buffer, sizeof(messagestr_buffer), "%02X ", frame.data.u8[i]);
-    else
-      size = snprintf(messagestr_buffer, sizeof(messagestr_buffer), "%02X\n", frame.data.u8[i]);
-
-    if (xRingbufferSend(can_bufferHandle, &messagestr_buffer, size, pdMS_TO_TICKS(2)) != pdTRUE) {
-      logging.println("Failed to send message to can ring buffer!");
-      return;
-    }
-  }
+  can_frames_dropped = 0;
 }
 
 void write_can_frame_to_sdcard() {
@@ -122,10 +134,11 @@ void add_log_to_buffer(const uint8_t* buffer, size_t size) {
   if (!sd_card_active)
     return;
 
-  if (xRingbufferSend(log_bufferHandle, buffer, size, pdMS_TO_TICKS(1)) != pdTRUE) {
-    logging.println("Failed to send message to log ring buffer!");
-    return;
-  }
+  // Zero timeout: called from the logging path of any task, must never block.
+  // NOTE: do not log from the failure path here. logging.println() would call
+  // Logging::write() -> add_log_to_buffer() again while the buffer is still
+  // full, recursing until the stack overflows.
+  xRingbufferSend(log_bufferHandle, buffer, size, 0);
 }
 
 void write_log_to_sdcard() {


### PR DESCRIPTION
### What
This PR makes the CAN logging paths that run in the core task non-blocking:

- **SD CAN logging** (`add_can_frame_to_buffer`): the full log line (timestamp, direction, ID, DLC, all data bytes) is now built into a single buffer and pushed to the ring buffer with **one send and zero timeout**, instead of up to 9 separate sends with a 2 ms timeout each. Frames that don't fit because the SD writer is stalled are counted and reported as a `[N CAN frames dropped, SD buffer full]` marker in the log once the buffer drains.
- **`add_log_to_buffer`**: zero timeout, and the `logging.println()` call removed from the failure path.
- **USB CAN logging** (`print_can_frame`): the line is built with a single `snprintf` and written with **one `Serial.write`, only if `Serial.availableForWrite()` reports enough room**, instead of ~15 individual `Serial.print()` calls. Dropped frames are counted and reported as a `[N CAN frames not printed]` marker once the port drains.
- **`init_serial`**: `Serial.setTxBufferSize(1024)` before `Serial.begin()`, so bursts are absorbed by a TX ring buffer and `availableForWrite()` reports buffer space rather than raw UART FIFO space.

The log output format is byte-compatible with the current one (same spacing, uppercase hex, line endings), so existing parsers keep working. Two minor behavior improvements: log lines are now written atomically (a full buffer can no longer leave a header without its data bytes mid-line), and zero-DLC frames get a proper line termination.

### Why
With CAN logging enabled, the current implementation can block the core task long enough to delay the 10 ms tasks and trigger `EVENT_TASK_OVERRUN` ("Task took too long to complete"):

- **SD path**: 9 ring buffer sends × 2 ms timeout = up to **~18 ms of blocking per frame** whenever the ring buffer is full. SD cards routinely stall for tens to hundreds of ms during wear-leveling, so this happens in normal operation, and on a busy bus the delay compounds across queued frames.
- **USB path**: `Serial.print()` blocks when the TX buffer is full — i.e. whenever the host isn't draining the port or can't keep up with a busy 500 kbit/s bus.
- Blocking doesn't even save the data: if the sink is stalled, waiting in the core task just delays contactor/precharge handling without getting the frame out.

Additionally, `add_log_to_buffer` has a latent crash: its failure path calls `logging.println()`, which goes through `Logging::write()` back into `add_log_to_buffer()` while the ring buffer is still full — **unbounded recursion ending in a stack overflow** whenever the SD writer stalls long enough.

### How
- The philosophy follows what the logging subsystem already does for syslog: the producer side (core task) only ever does a memcpy into a queue and never waits on a sink. Sinks that can't keep up lose data, and the loss is made visible in the log instead of being silently absorbed as core-task latency.
- `add_can_frame_to_buffer` formats into a 320-byte static buffer (sized for a gap marker + CAN-FD 64-byte payload at 3 chars/byte) and issues one `xRingbufferSend(..., 0)`. The buffer is `RINGBUF_TYPE_BYTEBUF` and the SD writer task streams whatever chunk it receives, so single-send-per-line needs no consumer changes. A `static` counter tracks drops; the next successful send prepends the gap marker. `static` is safe because this is only called from the core task.
- The USB path mirrors the same pattern: build line → check `availableForWrite()` → single `Serial.write` or increment drop counter. The 1024-byte TX buffer matters on UART-console boards, where

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
