### PR TITLE
Improvement: Skip unchanged values in NVS settings store to reduce flash writes and prevent task overruns

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -62,8 +62,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveInt(const char* name, int32_t value) {
-    auto oldValue = getInt(name, std::numeric_limits<int32_t>::max());
-    if (value != oldValue) {
+    // isKey() check instead of a sentinel default: saving a value equal to the
+    // sentinel into a missing key must not be skipped.
+    if (!settings.isKey(name) || getInt(name, 0) != value) {
       settings.putInt(name, value);
       settingsUpdated = true;
     }
@@ -74,9 +75,12 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveUInt(const char* name, uint32_t value) {
-    auto oldValue = getUInt(name, std::numeric_limits<uint32_t>::max());
-    settings.putUInt(name, value);
-    settingsUpdated = settingsUpdated || value != oldValue;
+    // isKey() check instead of a sentinel default: saving a value equal to the
+    // sentinel into a missing key must not be skipped.
+    if (!settings.isKey(name) || getUInt(name, 0) != value) {
+      settings.putUInt(name, value);
+      settingsUpdated = true;
+    }
   }
 
   bool settingExists(const char* name) { return settings.isKey(name); }
@@ -93,9 +97,12 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveBool(const char* name, bool value) {
-    auto oldValue = getBool(name, false);
-    settings.putBool(name, value);
-    settingsUpdated = settingsUpdated || value != oldValue;
+    // isKey() check: a stored 'false' must not be mistaken for a missing key,
+    // or the first save of a false value would be skipped and never persisted.
+    if (!settings.isKey(name) || getBool(name, false) != value) {
+      settings.putBool(name, value);
+      settingsUpdated = true;
+    }
   }
 
   String getString(const char* name) { return getString(name, ""); }
@@ -105,9 +112,12 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveString(const char* name, const char* value) {
-    auto oldValue = getString(name, "");
-    settings.putString(name, value);
-    settingsUpdated = settingsUpdated || String(value) != oldValue;
+    // isKey() check: a stored empty string must not be mistaken for a missing
+    // key, or the first save of an empty value would be skipped.
+    if (!settings.isKey(name) || getString(name, "") != String(value)) {
+      settings.putString(name, value);
+      settingsUpdated = true;
+    }
   }
 
   bool were_settings_updated() const { return settingsUpdated; }


### PR DESCRIPTION
### What
This PR makes the NVS settings store (`BatteryEmulatorSettingsStore` in `comm_nvm.h`) skip writes for values that haven't changed:

- `saveUInt()`, `saveBool()` and `saveString()` already read the old value, but only used it to update the `settingsUpdated` flag — the `put*()` call happened **unconditionally**. They now only write when the value actually differs, matching what `saveInt()` already did.
- All change checks (including `saveInt()`) now use an explicit `isKey()` guard instead of a sentinel default value.
- No API or call-site changes; `store_settings()` and everything else works as before. The `settingsUpdated` / `were_settings_updated()` semantics are unchanged (flag set only on real changes) — the write behavior now simply matches the flag.

### Why
Every `Preferences::put*()` is a synchronous NVS flash operation. During any SPI flash write the cache is suspended and code execution stalls on **both** cores — which shows up as `EVENT_TASK_OVERRUN` ("Task took too long to complete") correlated with saving settings from the web UI.

A typical web-UI save changes one or two values, but `store_settings()` writes **every** key, so each save produces a burst of flash writes instead of one or two. NVS is append-structured, so the unconditional rewrites also churn pages faster; a full page triggers NVS garbage collection, which performs a page *erase* — the longest flash stall of all.

Separately, the existing sentinel-based change detection in `saveInt()` has a latent bug: `getInt(name, INT32_MAX)` returns the sentinel for a missing key, so saving a value **equal to the sentinel** into a fresh key compared as "unchanged" and was silently never persisted. The naive way of extending change detection to the other types would have copied that flaw (a stored `false` or empty string is indistinguishable from a missing key when used as its own default).

### How
Each `save*()` method now uses the same pattern:

```cpp
if (!settings.isKey(name) || get*(name, <any default>) != value) {
  settings.put*(name, value);
  settingsUpdated = true;
}
```

- `isKey()` decides "missing key → always write"; only for existing keys is the stored value compared. This makes the default argument irrelevant, eliminating the sentinel-collision class of bugs for all four types (INT32_MAX/UINT32_MAX ints, `false` booleans, empty strings).
- The old value was already being read in every method, so there is no additional NVS read cost — the diff essentially moves the existing comparison from after the write to before it.
- Result: a typical settings save drops from dozens of NVS writes to one or two, and NVS page GC frequency falls proportionally.


1. **The `saveInt()` change is a bug fix, not just refactoring**: `saveInt("X", INT32_MAX)` on a fresh key was silently dropped before this PR. The other methods didn't have the bug only because they didn't skip writes at all.
2. **Skipped rewrites are not a corruption-defense regression**: with skip-on-unchanged, a key already holding the target value no longer gets its NVS entry refreshed. That is intended — NVS entries don't decay, and integrity is handled by NVS's own CRCs at the page level; rewriting identical values was never a corruption defense.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
