### PR TITLE
Improvement: Apply user current caps to low pass filter input

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -172,8 +172,7 @@ static void filter_inverter_limits(void) {
     cap_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
   }
   if (cap_voltage_dV > 10) {
-    uint32_t user_charge_cap_W =
-        ((uint32_t)datalayer.battery.settings.max_user_set_charge_dA * cap_voltage_dV) / 100;
+    uint32_t user_charge_cap_W = ((uint32_t)datalayer.battery.settings.max_user_set_charge_dA * cap_voltage_dV) / 100;
     uint32_t user_discharge_cap_W =
         ((uint32_t)datalayer.battery.settings.max_user_set_discharge_dA * cap_voltage_dV) / 100;
     if (charge_in > user_charge_cap_W) {

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -161,22 +161,44 @@ static void filter_inverter_limits(void) {
   static uint32_t discharge_power_W_filtered = 0;
   static bool power_filter_initialized = false;
 
+  /* Apply user current caps to the filter INPUT, so the ramp time constant acts on the
+     effective range instead of being accelerated by headroom above the cap. Also makes
+     runtime cap increases ramp instead of jump. BYD-Modbus applies the same min() again
+     driver-side, which is now idempotent. */
+  uint32_t charge_in = datalayer.battery.status.max_charge_power_W;
+  uint32_t discharge_in = datalayer.battery.status.max_discharge_power_W;
+  uint16_t cap_voltage_dV = datalayer.battery.status.voltage_dV;
+  if (cap_voltage_dV <= 10) {
+    cap_voltage_dV = datalayer.battery.info.max_design_voltage_dV;
+  }
+  if (cap_voltage_dV > 10) {
+    uint32_t user_charge_cap_W =
+        ((uint32_t)datalayer.battery.settings.max_user_set_charge_dA * cap_voltage_dV) / 100;
+    uint32_t user_discharge_cap_W =
+        ((uint32_t)datalayer.battery.settings.max_user_set_discharge_dA * cap_voltage_dV) / 100;
+    if (charge_in > user_charge_cap_W) {
+      charge_in = user_charge_cap_W;
+    }
+    if (discharge_in > user_discharge_cap_W) {
+      discharge_in = user_discharge_cap_W;
+    }
+  }
+
   if (!power_filter_initialized) {
-    charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
-    discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+    charge_power_W_filtered = charge_in;
+    discharge_power_W_filtered = discharge_in;
     power_filter_initialized = true;
   } else {
-    if (datalayer.battery.status.max_charge_power_W > charge_power_W_filtered) {
-      charge_power_W_filtered = (datalayer.battery.status.max_charge_power_W * 10 + charge_power_W_filtered * 90) / 100;
+    if (charge_in > charge_power_W_filtered) {
+      charge_power_W_filtered = (charge_in * 10 + charge_power_W_filtered * 90) / 100;
     } else {
-      charge_power_W_filtered = datalayer.battery.status.max_charge_power_W;
+      charge_power_W_filtered = charge_in;
     }
 
-    if (datalayer.battery.status.max_discharge_power_W > discharge_power_W_filtered) {
-      discharge_power_W_filtered =
-          (datalayer.battery.status.max_discharge_power_W * 10 + discharge_power_W_filtered * 90) / 100;
+    if (discharge_in > discharge_power_W_filtered) {
+      discharge_power_W_filtered = (discharge_in * 10 + discharge_power_W_filtered * 90) / 100;
     } else {
-      discharge_power_W_filtered = datalayer.battery.status.max_discharge_power_W;
+      discharge_power_W_filtered = discharge_in;
     }
   }
   datalayer.battery.status.max_charge_power_W = charge_power_W_filtered;


### PR DESCRIPTION
Cap the filter input with max_user_set_charge/discharge_dA (converted via pack voltage, design-voltage fallback) before blending, so the ramp time constant acts on the effective range instead of being accelerated by headroom above the cap. Also makes runtime cap increases ramp smoothly. BYD-Modbus driver-side min() becomes idempotent.

### What
This PR applies the user-configured current caps (`max_user_set_charge/discharge_dA`, converted to W via pack voltage) to the *input* of the inverter limits low pass filter, before the blend.

### Why
min() and the exponential filter don't commute: filtering first lets the ramp rate scale with headroom above the cap, so a battery recovering 0->38 kW under a ~10 kW user cap reaches the cap in ~3 s instead of the intended ~22 s — capping the input makes the time constant act on the effective range, and runtime cap increases ramp instead of jumping.

### How
The filter input is clamped to `user_set_dA x voltage` (same design-voltage fallback as the current derivation) before initialization, blend, and snap-down paths; the downstream `_dA` capping and BYD-Modbus's driver-side min() are unchanged and now idempotent.

Note: with the filter enabled, this also makes the user caps take effect for VCU-CAN, which previously passed raw power without them — intentional, but flagging it since it's a behavior change for that driver.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
