### PR TITLE
Fix: incorrect capacity scaling when MinSoc is negative

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -366,8 +366,11 @@ void update_calculated_values(unsigned long currentMillis) {
 
     datalayer.battery.status.reported_soc = scaled_soc;
 
-    // If battery info is valid
-    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
+    // If battery info is valid. Capacity is not scaled when min_percentage is negative, since the
+    // usable window then extends below the battery's real 0%, which would inflate the reported capacity
+    // beyond what is physically stored.
+    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0 &&
+        datalayer.battery.settings.min_percentage >= 0) {
       // Scale total usable capacity
       scaled_total_capacity = (datalayer.battery.info.total_capacity_Wh * delta_pct) / 10000;
       datalayer.battery.info.reported_total_capacity_Wh = scaled_total_capacity;
@@ -383,7 +386,8 @@ void update_calculated_values(unsigned long currentMillis) {
 
     if (battery2) {
       // If battery info is valid
-      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
+      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0 &&
+          datalayer.battery.settings.min_percentage >= 0) {
 
         datalayer.battery2.info.reported_total_capacity_Wh = scaled_total_capacity;
         // Scale remaining capacity based on scaled SOC

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1149,14 +1149,14 @@ String processor(const String& var) {
                  " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
       content += formatPowerValue("Power", powerFloat, "", 1);
 
-      if (datalayer.battery.settings.soc_scaling_active)
+      if (datalayer.battery.settings.soc_scaling_active && datalayer.battery.settings.min_percentage >= 0)
         content += "<h4 style='color: white;'>Scaled total capacity: " +
                    formatPowerValue(datalayer.battery.info.reported_total_capacity_Wh, "h", 1) +
                    " (real: " + formatPowerValue(datalayer.battery.info.total_capacity_Wh, "h", 1) + ")</h4>";
       else
         content += formatPowerValue("Total capacity", datalayer.battery.info.total_capacity_Wh, "h", 1);
 
-      if (datalayer.battery.settings.soc_scaling_active)
+      if (datalayer.battery.settings.soc_scaling_active && datalayer.battery.settings.min_percentage >= 0)
         content += "<h4 style='color: white;'>Scaled remaining capacity: " +
                    formatPowerValue(datalayer.battery.status.reported_remaining_capacity_Wh, "h", 1) +
                    " (real: " + formatPowerValue(datalayer.battery.status.remaining_capacity_Wh, "h", 1) + ")</h4>";


### PR DESCRIPTION
When I use scaling and change MinSoc to e.g. -5, I get a very skewed remaining capacity with the BMW i3 battery. But it can't be correct to scale the battery larger when MinSoc is changed to a negative value — the battery obviously doesn't become larger in capacity, it will still stop at its actual zero point. We use this function to trick inverters that stop at e.g. 5 percent, but that should only allow us to discharge it fully.


When MinSoc (min_percentage) is set to a negative value, the usable SOC window extends below the battery's real 0%. Scaling total/remaining capacity in this case inflated the reported capacity beyond what is physically stored in the battery.

Changes:

Skip capacity scaling in update_calculated_values() for both battery1 and battery2 when min_percentage < 0, so reported_total_capacity_Wh / remaining capacity reflect the real, unscaled values instead of an inflated number.
Update the webserver UI to hide the "Scaled total/remaining capacity (real: ...)" split display when min_percentage is negative, since scaling isn't applied in that case — just show the real capacity values.


