### PR TITLE
NVM: allow max charge/discharge to be set to 0

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -82,14 +82,10 @@ void init_stored_settings() {
   if (temp2 <= 500 && temp2 >= -100) {
     datalayer.battery.settings.min_percentage = temp2 * 10;  // Multiply by 10 for backwards compatibility
   }
-  temp = settings.getUInt("MAXCHARGEAMP", false);
-  if (temp != 0) {
-    datalayer.battery.settings.max_user_set_charge_dA = temp;
-  }
-  temp = settings.getUInt("MAXDISCHARGEAMP", false);
-  if (temp != 0) {
-    datalayer.battery.settings.max_user_set_discharge_dA = temp;
-  }
+  datalayer.battery.settings.max_user_set_charge_dA =
+      settings.getUInt("MAXCHARGEAMP", datalayer.battery.settings.max_user_set_charge_dA);
+  datalayer.battery.settings.max_user_set_discharge_dA =
+      settings.getUInt("MAXDISCHARGEAMP", datalayer.battery.settings.max_user_set_discharge_dA);
   datalayer.battery.settings.soc_scaling_active = settings.getBool("USE_SCALED_SOC", false);
   temp = settings.getUInt("TARGETCHVOLT", false);
   if (temp != 0) {


### PR DESCRIPTION
### What
Currently, if you set max charge or discharge current to 0, it'll revert on restart, since zero limits don't override the defaults.

Now always set to the NVM value, passing through the previous value as default.

You might want to stop charge or discharge (eg, to fully charge a battery over several days), so having your setting revert on reboot is annoying.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
