### PR TITLE
Nissan LEAF: log detected battery generation (ZE0/AZE0/ZE1)

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -222,13 +222,13 @@ void NissanLeafBattery::
     reported_battery_Type = LEAF_battery_Type;
     switch (LEAF_battery_Type) {
       case AZE0_BATTERY:
-        logging.printf("Nissan LEAF battery generation identified: AZE0 (2013-2017)\n");
+        logging.printf("Battery generation: AZE0\n");
         break;
       case ZE1_BATTERY:
-        logging.printf("Nissan LEAF battery generation identified: ZE1 (2018-2023)\n");
+        logging.printf("Battery generation: ZE1\n");
         break;
       default:
-        logging.printf("Nissan LEAF battery generation identified: ZE0 (2011-2013)\n");
+        logging.printf("Nissan LEAF battery detected.\n");
         break;
     }
   }

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -216,6 +216,23 @@ void NissanLeafBattery::
     datalayer_battery->status.balancing_status = new_status;
   }
 
+  // Log the identified battery generation. ZE0 is the default until AZE0/ZE1
+  // specific CAN frames are seen, so an upgraded detection is logged again
+  if (battery_can_alive && (reported_battery_Type != LEAF_battery_Type)) {
+    reported_battery_Type = LEAF_battery_Type;
+    switch (LEAF_battery_Type) {
+      case AZE0_BATTERY:
+        logging.printf("Nissan LEAF battery generation identified: AZE0 (2013-2017)\n");
+        break;
+      case ZE1_BATTERY:
+        logging.printf("Nissan LEAF battery generation identified: ZE1 (2018-2023)\n");
+        break;
+      default:
+        logging.printf("Nissan LEAF battery generation identified: ZE0 (2011-2013)\n");
+        break;
+    }
+  }
+
   // Update webserver datalayer
   if (datalayer_nissan) {
     memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -151,6 +151,7 @@ class NissanLeafBattery : public CanBattery {
   //Nissan LEAF battery parameters from constantly sent CAN
   uint8_t LEAF_battery_Type = ZE0_BATTERY;
   bool battery_can_alive = false;
+  uint8_t reported_battery_Type = 255;         //255 = generation not yet logged
 #define WH_PER_GID 77                          //One GID is this amount of Watt hours
   uint16_t battery_Discharge_Power_Limit = 0;  //Limit in kW
   uint16_t battery_Charge_Power_Limit = 0;     //Limit in kW


### PR DESCRIPTION
### What
This PR adds a log entry reporting the auto-detected Nissan LEAF battery generation once the battery is communicating.

### Why
The LEAF driver detects the generation from CAN frames, but it was only visible on the battery's advanced webserver page — a log line confirms it at startup for diagnostics and support requests.

### How
`update_values()` logs the generation via `logging.printf` once `battery_can_alive` is set, guarded by a one-shot member; since ZE0 is the default until AZE0/ZE1-specific frames arrive, an upgraded detection is logged again.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
