### PR TITLE
Make CPU temperature configurable, with an offset

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -309,9 +309,9 @@ void update_calculated_values(unsigned long currentMillis) {
     float temp;
     uint32_t hex;
   } temp = {.temp = temperatureRead()};
-  if (temp.hex != 0x42555555) {
-    // Ignoring erroneous temperature value that ESP32 sometimes returns
-    datalayer.system.info.CPU_temperature = temp.temp;
+  if (temp.hex != 0x42555555) {  // Ignoring erroneous temperature value that ESP32 sometimes returns
+    //Apply calibration offset to the CPU temperature reading, if set. Some ESP32 chips report wildly inaccurate temperatures.
+    datalayer.system.info.CPU_temperature = temp.temp + (float)datalayer.system.info.CPU_temperature_calibration_offset;
   }
 
   /*Update free heap*/

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -198,6 +198,8 @@ void init_stored_settings() {
   remote_bms_reset = settings.getBool("REMBMSRESET", false);
   use_canfd_as_can = settings.getBool("CANFDASCAN", false);
   use_canfd2_as_can = settings.getBool("CANFD2ASCAN", false);
+  datalayer.system.info.CPU_measurement_enabled = settings.getBool("MEASURECPUTEMP", false);
+  datalayer.system.info.CPU_temperature_calibration_offset = settings.getInt("CPUTEMPOFFSET", 0);
 #ifdef HW_LILYGO2CAN
   user_selected_gpioopt1 = (GPIOOPT1)settings.getUInt("GPIOOPT1", 0);
 #endif

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -287,8 +287,12 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
   char inverter_brand[8] = {0};
 
   size_t logged_can_messages_offset = 0;
-  /** ESP32 main CPU temperature, for displaying on webserver and for safeties */
+  /** ESP32 main CPU temperature, for displaying on webserver */
   float CPU_temperature = 0;
+  /** bool, determines if CPU temperature should be measured */
+  bool CPU_measurement_enabled = false;
+  /** int, determines the CPU temperature calibration offset. Some ESP32 chips report wildly inaccurate temperatures */
+  int CPU_temperature_calibration_offset = 0;
   /** ESP32 free heap amount, for displaying on webserver and for safeties */
   uint32_t CPU_free_heap = 0;
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -527,6 +527,14 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("EXTPRECHARGE") ? "checked" : "";
   }
 
+  if (var == "MEASURECPUTEMP") {
+    return settings.getBool("MEASURECPUTEMP") ? "checked" : "";
+  }
+
+  if (var == "CPUTEMPOFFSET") {
+    return String(settings.getInt("CPUTEMPOFFSET", 0));
+  }
+
   if (var == "MAXPRETIME") {
     return String(settings.getUInt("MAXPRETIME", 15000));
   }
@@ -1384,6 +1392,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    form .if-measurecputemp { display: none; }
+    form[data-measurecputemp="true"] .if-measurecputemp {
+      display: contents;
+    }
+
     form .if-extprecharge { display: none; }
     form[data-extprecharge="true"] .if-extprecharge {
       display: contents;
@@ -1986,6 +1999,14 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
           <label>Normally Open (NO) inverter disconnect contactor: </label>
           <input type='checkbox' name='NOINVDISC' value='on' %NOINVDISC% />
+        </div>
+
+        <label>Measure CPU temperature: </label>
+        <input type='checkbox' name='MEASURECPUTEMP' value='on' %MEASURECPUTEMP%  title="If enabled, the CPU temperature will be displayed on webserver" />
+
+         <div class="if-measurecputemp">
+            <label>CPU temperature calibration offset (°C): </label>
+            <input name='CPUTEMPOFFSET' type='number' value="%CPUTEMPOFFSET%" pattern="-?[0-9]+" title="Unreliable CPU temperature readings can be corrected with an offset. Measure the actual temperature with a separate thermometer and adjust the offset accordingly." />
         </div>
 
         <label for='LEDMODE'>Status LED pattern: </label><select name='LEDMODE' id='LEDMODE'>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -419,12 +419,12 @@ void init_webserver() {
   });
 
   const char* boolSettingNames[] = {
-      "DBLBTR",      "CNTCTRL",       "CNTCTRLDBL",   "PWMCNTCTRL",    "PERBMSRESET", "SDLOGENABLED", "STATICIP",
-      "REMBMSRESET", "EXTPRECHARGE",  "USBENABLED",   "CANLOGUSB",     "WEBENABLED",  "CANFDASCAN",   "CANFD2ASCAN",
-      "CANLOGSD",    "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",     "HADISC",      "MQTTCELLV",    "GTWRHD",
-      "DIGITALHVIL", "PERFPROFILE",   "INTERLOCKREQ", "SOCESTIMATED",  "PYLONOFFSET", "PYLONORDER",   "DEYEBYD",
-      "NCCONTACTOR", "TRIBTR",        "CNTCTRLTRI",   "ESPNOWENABLED", "PRIMOGEN24",  "CTINVERT",     "LOWPASSFILTER",
-      "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",
+      "DBLBTR",      "CNTCTRL",       "CNTCTRLDBL",   "PWMCNTCTRL",     "PERBMSRESET", "SDLOGENABLED", "STATICIP",
+      "REMBMSRESET", "EXTPRECHARGE",  "USBENABLED",   "CANLOGUSB",      "WEBENABLED",  "CANFDASCAN",   "CANFD2ASCAN",
+      "CANLOGSD",    "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",      "HADISC",      "MQTTCELLV",    "GTWRHD",
+      "DIGITALHVIL", "PERFPROFILE",   "INTERLOCKREQ", "SOCESTIMATED",   "PYLONOFFSET", "PYLONORDER",   "DEYEBYD",
+      "NCCONTACTOR", "TRIBTR",        "CNTCTRLTRI",   "ESPNOWENABLED",  "PRIMOGEN24",  "CTINVERT",     "LOWPASSFILTER",
+      "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP",
 #ifndef SMALL_FLASH_DEVICE
       "SYSLOGEN",
 #endif
@@ -533,6 +533,9 @@ void init_webserver() {
                 } else if (p->name() == "CTATTEN") {
                   auto type = static_cast<adc_attenuation_t>(atoi(p->value().c_str()));
                   settings.saveUInt("CTATTEN", (int)type);
+                } else if (p->name() == "CPUTEMPOFFSET") {
+                  // allow negative offsets so save as number
+                  settings.saveInt("CPUTEMPOFFSET", atoi(p->value().c_str()));
                 } else if (p->name() == "SSID") {
                   settings.saveString("SSID", p->value().c_str());
                   ssid = settings.getString("SSID", "").c_str();
@@ -994,7 +997,11 @@ String processor(const String& var) {
 #ifdef HW_WAVESHARE
     content += " Hardware: Waveshare ESP32-S3-RS485-CAN";
 #endif  // HW_WAVESHARE
-    content += " @ " + String(datalayer.system.info.CPU_temperature, 1) + " &deg;C</h4>";
+    if (datalayer.system.info.CPU_measurement_enabled) {
+      content += " @ " + String(datalayer.system.info.CPU_temperature, 1) + " &deg;C</h4>";
+    } else {
+      content += "</h4>";
+    }
     content += "<h4>Uptime: " + get_uptime() + "</h4>";
     if (datalayer.system.info.performance_measurement_active) {
       content +=


### PR DESCRIPTION
### What
This PR makes CPU temperature configurable, with an offset

### Why
CPU temperature is unreliable on ESP32. Disable showing it to user by default

### How
This PR builds on the feedback in #2556

We have a checkbox (disabled by default), that determines if CPU temperature should be shown on Webserver.

We also have a configurable offset, for sensor calibration

<img width="582" height="66" alt="image" src="https://github.com/user-attachments/assets/ccef3a59-201d-4aec-af85-1b1f5c33279e" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
