### PR TITLE
Make USB debug logging non-blocking to prevent task overruns

### DIFF
--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -13,6 +13,34 @@
 
 bool previous_message_was_newline = true;
 
+// ---- USB debug-log sink ----
+// Writes only when the TX ring buffer has room. This path runs in the core task
+// (and others): it must never block on a host that stops draining the port
+// (EVENT_TASK_OVERRUN). Lost output is reported with a marker once the port
+// recovers, and the marker is always flushed before output resumes so the gap
+// is visible at the right place. CAN frame logging has its own equivalent
+// implementation of this pattern in comm_can.cpp.
+// The drop counter is not atomic; concurrent writers can at worst miscount
+// drops slightly, which only affects the marker, never the data path.
+static uint32_t usb_log_chunks_dropped = 0;
+
+static void usb_log_write(const uint8_t* buffer, size_t size) {
+  static const char marker[] = "\n[USB log output dropped, host not draining port]\n";
+  size_t needed = size;
+  if (usb_log_chunks_dropped > 0) {
+    needed += sizeof(marker) - 1;
+  }
+  if ((size_t)Serial.availableForWrite() < needed) {
+    usb_log_chunks_dropped++;
+    return;
+  }
+  if (usb_log_chunks_dropped > 0) {
+    Serial.write((const uint8_t*)marker, sizeof(marker) - 1);
+    usb_log_chunks_dropped = 0;
+  }
+  Serial.write(buffer, size);
+}
+
 #ifndef SMALL_FLASH_DEVICE
 // ---- Remote syslog sink ----
 std::string syslog_ip;
@@ -275,7 +303,7 @@ void Logging::add_timestamp(size_t size) {
   }
 
   if (datalayer.system.info.usb_logging_active) {
-    Serial.write(timestr);
+    usb_log_write((const uint8_t*)timestr, strlen(timestr));
   }
 }
 
@@ -300,7 +328,7 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
   }
 
   if (datalayer.system.info.usb_logging_active) {
-    Serial.write(buffer, size);
+    usb_log_write(buffer, size);
   }
 
 #ifndef SMALL_FLASH_DEVICE
@@ -368,7 +396,7 @@ void Logging::printf(const char* fmt, ...) {
   }
 
   if (datalayer.system.info.usb_logging_active) {
-    Serial.write(message_buffer, size);
+    usb_log_write((const uint8_t*)message_buffer, size);
   }
 
 #ifndef SMALL_FLASH_DEVICE


### PR DESCRIPTION
### What
This PR makes the general USB debug-log path non-blocking: `Logging::write()`, `Logging::printf()` and `add_timestamp()` now route through a shared `usb_log_write()` helper that only writes when `Serial.availableForWrite()` reports room. Dropped output is reported with a `[USB log output dropped, host not draining port]` marker, always flushed before output resumes so the gap appears at the right place.

### Why
These three sites wrote to Serial unconditionally, so with USB logging active and a host that stops draining the port, every `DEBUG_PRINTF` from the core task blocks and raises `EVENT_TASK_OVERRUN`. This is the same bug class already fixed for CAN frame logging (#2624) — after this PR, no logging sink (SD, USB CAN frames, USB debug, web, syslog) can block the core task.

### How
One static helper mirrors the merged CAN-frame pattern: check room for marker + chunk, write both or drop and count — a stalled host now means drop-with-marker instead of block-until-delivered. `Serial.write` locks internally in both `HardwareSerial` and `HWCDC`, so multi-task callers are safe; the non-atomic drop counter can at worst miscount the marker, never corrupt data.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
