### PR TITLE
Fix measure-firmware-size artifact filter

### DIFF
--- a/.github/scripts/render_size_comment.py
+++ b/.github/scripts/render_size_comment.py
@@ -312,7 +312,11 @@ def main() -> int:
             "> No size reports found in either the PR build or the base build.\n"
         )
     else:
-        body = render(base, pr, args.base_branch, args.base_sha, args.head_sha, json.loads(args.artifact_urls))
+        try:
+            artifact_urls = json.loads(args.artifact_urls)
+        except json.JSONDecodeError:
+            artifact_urls = {}
+        body = render(base, pr, args.base_branch, args.base_sha, args.head_sha, artifact_urls)
 
     sys.stdout.buffer.write(body.encode("utf-8"))
     return 0

--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -56,7 +56,6 @@ jobs:
           const { data: runs } = await github.rest.actions.listWorkflowRuns({
             owner, repo,
             workflow_id: 'compile-common-image.yml',
-            event: 'push',
             head_sha: '${{ inputs.base_sha }}',
             per_page: 20,
           });


### PR DESCRIPTION
### What
This PR fixes an issue in the measure-firmware-size action introduced in #2606. The measure step currently fails when the base branch itself does not have artifacts that were created by a push and the artifact JSON map is thus empty. This is the case if you create a PR and then another PR that would merge into the first PR. On the second PR it will currently filter out the artifacts that exists on the first PR because they were not built by a `push` event.

### How

- Remove the push filter, filtering by SHA will still identify the correct artifacts
- Add more graceful handling for invalid JSONs

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
