### PR TITLE
Power taper: default float charge power to 400W for new users

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -186,7 +186,7 @@ void init_stored_settings() {
   charge_taper_soc = settings.getBool("CHGTAPERSOC", false);
   charge_taper_band_pptt = 10000 - (settings.getUInt("CHGTAPERSTART", 95) *
                                     100);  // Stored as start SOC in whole percent, used as band in pptt
-  charge_taper_floor_W = settings.getUInt("CHGTAPERFLOOR", 0);
+  charge_taper_floor_W = settings.getUInt("CHGTAPERFLOOR", 400);
   contactor_control_inverted_logic = settings.getBool("NCCONTACTOR", false);
   precharge_time_ms = settings.getUInt("PRECHGMS", 100);
   contactor_control_enabled_double_battery = settings.getBool("CNTCTRLDBL", false);

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -492,7 +492,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "CHGTAPERFLOOR") {
-    return String(settings.getUInt("CHGTAPERFLOOR", 0));
+    return String(settings.getUInt("CHGTAPERFLOOR", 400));
   }
 
   if (var == "SLOWCANINV") {


### PR DESCRIPTION
### What
Sets the default "Float charge power" to 400W when no value was previously saved.

### Why
400W is a sensible float default - roughly 1A - above typical minimum stable charging power

### How
Both getUInt("CHGTAPERFLOOR", ...) sites default to 400. NVS returns the default only when the key is absent, so any explicitly saved value - including 0, which disables the floor - is preserved. Users who didn't enabled tapering yet will get 400W as default suggestion instead of 0.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
