### PR TITLE
feature: Add general logging to a syslog server to low flash boards

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -224,12 +224,10 @@ void init_stored_settings() {
   datalayer.system.info.web_logging_active = settings.getBool("WEBENABLED", false);
   datalayer.system.info.CAN_SD_logging_active = settings.getBool("CANLOGSD", false);
   datalayer.system.info.SD_logging_active = settings.getBool("SDLOGENABLED", false);
-#ifndef SMALL_FLASH_DEVICE
   datalayer.system.info.syslog_logging_active = settings.getBool("SYSLOGEN", false);
   syslog_ip = settings.getString("SYSLOGIP").c_str();
   syslog_port = settings.getUInt("SYSLOGPORT", 514);
   syslog_facility = settings.getUInt("SYSLOGFAC", 1);
-#endif
   datalayer.battery.status.led_mode = (led_mode_enum)settings.getUInt("LEDMODE", false);
 
   //Some early integrations need manually set allowed charge/discharge power

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -20,7 +20,6 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched);
 static void update_event_level(void);
 static void update_bms_status(void);
 
-#ifndef SMALL_FLASH_DEVICE
 // Map a Battery-Emulator event level to an RFC 5424 syslog severity.
 static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
   switch (lvl) {
@@ -38,7 +37,6 @@ static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
       return 6;
   }
 }
-#endif
 
 /* Initialization function */
 void init_events(void) {

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -2,11 +2,9 @@
 #include "../../datalayer/datalayer.h"
 #include "../sdcard/sdcard.h"
 
-#ifndef SMALL_FLASH_DEVICE
 #include <WiFi.h>
 #include <WiFiUdp.h>
 #include "../wifi/wifi.h"  // custom_hostname, default_hostname()
-#endif
 
 #define MAX_LINE_LENGTH_PRINTF 128
 #define MAX_LENGTH_TIME_STR 14
@@ -41,7 +39,6 @@ static void usb_log_write(const uint8_t* buffer, size_t size) {
   Serial.write(buffer, size);
 }
 
-#ifndef SMALL_FLASH_DEVICE
 // ---- Remote syslog sink ----
 std::string syslog_ip;
 uint16_t syslog_port = 514;
@@ -265,7 +262,6 @@ static void syslog_emit(const uint8_t* buffer, size_t size) {
     }
   }
 }
-#endif
 
 void Logging::add_timestamp(size_t size) {
 
@@ -331,9 +327,7 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
     usb_log_write(buffer, size);
   }
 
-#ifndef SMALL_FLASH_DEVICE
   syslog_emit(buffer, size);
-#endif
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     char* message_string = datalayer.system.info.logged_can_messages;
@@ -399,9 +393,7 @@ void Logging::printf(const char* fmt, ...) {
     usb_log_write((const uint8_t*)message_buffer, size);
   }
 
-#ifndef SMALL_FLASH_DEVICE
   syslog_emit((const uint8_t*)message_buffer, size);
-#endif
 
   if (datalayer.system.info.web_logging_active && !datalayer.system.info.can_logging_active) {
     // Data was already added to buffer, just move offset

--- a/Software/src/devboard/utils/logging.h
+++ b/Software/src/devboard/utils/logging.h
@@ -17,9 +17,7 @@ class Logging : public Print {
   virtual size_t write(const uint8_t* buffer, size_t size);
   virtual size_t write(uint8_t) { return 0; }
   void printf(const char* fmt, ...);
-#ifndef SMALL_FLASH_DEVICE
   void set_next_severity(uint8_t sev);  // syslog severity for the next assembled line
-#endif
   Logging() {}
 };
 
@@ -39,11 +37,7 @@ class Logging : public Print {
       logging.println(str);                                                                     \
     }                                                                                           \
   } while (0)
-#ifndef SMALL_FLASH_DEVICE
 #define LOG_SET_NEXT_SEVERITY(sev) logging.set_next_severity(sev)
-#else
-#define LOG_SET_NEXT_SEVERITY(sev) ((void)0)
-#endif
 
 #else
 // Mock implementation for tests
@@ -128,12 +122,10 @@ class Logging {
 
 extern Logging logging;
 
-#ifndef SMALL_FLASH_DEVICE
 // Remote syslog config (loaded from NVS in comm_nvm.cpp, consumed in logging.cpp)
 extern std::string syslog_ip;
 extern uint16_t syslog_port;
 extern uint8_t syslog_facility;  // 0..23
 void syslog_start(void);         // starts the syslog sender task; safe to call more than once
-#endif
 
 #endif  // __LOGGING_H__

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -647,7 +647,6 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SDLOGENABLED") {
     return settings.getBool("SDLOGENABLED") ? "checked" : "";
   }
-#ifndef SMALL_FLASH_DEVICE
   if (var == "SYSLOGEN") {
     return settings.getBool("SYSLOGEN") ? "checked" : "";
   }
@@ -660,7 +659,6 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SYSLOGFAC") {
     return String(settings.getUInt("SYSLOGFAC", 1));
   }
-#endif
   if (var == "ESPNOWENABLED") {
     return settings.getBool("ESPNOWENABLED") ? "checked" : "";
   }
@@ -1114,7 +1112,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 #define CANFD2ASCAN_SETTING ""
 #endif
 
-#ifndef SMALL_FLASH_DEVICE
 #define SYSLOG_SETTING_HTML \
   R"rawliteral(
         <label>General logging to syslog server: </label>
@@ -1134,9 +1131,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
               title="0=kern, 1=user, 3=daemon, 16-23=local0-7 (default 1)" />
         </div>
   )rawliteral"
-#else
-#define SYSLOG_SETTING_HTML ""
-#endif
 
 #define SETTINGS_HTML_SCRIPTS \
   R"rawliteral(

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -424,10 +424,7 @@ void init_webserver() {
       "CANLOGSD",    "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",      "HADISC",      "MQTTCELLV",    "GTWRHD",
       "DIGITALHVIL", "PERFPROFILE",   "INTERLOCKREQ", "SOCESTIMATED",   "PYLONOFFSET", "PYLONORDER",   "DEYEBYD",
       "NCCONTACTOR", "TRIBTR",        "CNTCTRLTRI",   "ESPNOWENABLED",  "PRIMOGEN24",  "CTINVERT",     "LOWPASSFILTER",
-      "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP",
-#ifndef SMALL_FLASH_DEVICE
-      "SYSLOGEN",
-#endif
+      "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP", "SYSLOGEN",
   };
 
   const char* uintSettingNames[] = {
@@ -438,17 +435,12 @@ void init_webserver() {
       "INVSUNTYPE", "GPIOOPT4",    "CTVNOM",      "CTANOM",        "CTATTEN",       "PYLONBAUD",     "PYLONBRAND",
       "DALYPWRPCT", "DALYPWRDV",   "DALYDVSTART", "DALYPWRDEG",    "DALYPWR0C",     "RAMPDOWNSOC",   "GPIOOPT5",
       "GPIOOPT6",   "INVICNT",     "FOXESSTYPE",  "FOXESSSUBTYPE", "FOXESSMODULES", "CHGTAPERSTART", "CHGTAPERFLOOR",
-#ifndef SMALL_FLASH_DEVICE
       "SYSLOGPORT", "SYSLOGFAC",
-#endif
   };
 
-  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME", "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD", "HTTPUSER",
-                                      "HTTPPASS",   "LOCALIP",  "GATEWAY",    "SUBNET",   "DNS",          "HADISCTOPIC",
-#ifndef SMALL_FLASH_DEVICE
-                                      "SYSLOGIP"
-#endif
-  };
+  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD",
+                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",  "SUBNET",
+                                      "DNS",        "HADISCTOPIC", "SYSLOGIP"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -16,9 +16,7 @@ bool wifiap_enabled = true;
 bool mdns_enabled = true;    //If true, allows battery monitor te be found by .local address
 bool espnow_enabled = true;  //If true, allows battery emulator to send battery status by using ESPNow messages
 uint16_t wifi_channel = 0;
-#ifndef SMALL_FLASH_DEVICE
 extern const char* version_number;
-#endif
 
 std::string custom_hostname;  //If not set, defaults to "battery-emulator-" + last two MAC bytes (see init_WiFi)
 std::string ssid;
@@ -364,9 +362,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 // Event handler for Wi-Fi Got IP
 void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
-#ifndef SMALL_FLASH_DEVICE
   syslog_start();
-#endif
 
   //clear disconnects events if we got a IP
   clear_event(EVENT_WIFI_DISCONNECT);
@@ -374,7 +370,6 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
   logging.print("IP address: ");
   logging.println(WiFi.localIP().toString());
 
-#ifndef SMALL_FLASH_DEVICE
   // One-shot boot notice — fires once per boot, not on every reconnect.
   static bool boot_logged = false;
   if (!boot_logged) {
@@ -382,7 +377,6 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
     LOG_SET_NEXT_SEVERITY(5);  // RFC 5424 severity 5 = Notice
     logging.printf("Bootup complete, running version %s\n", version_number);
   }
-#endif
 
   static bool mdns_started = false;
   if (mdns_enabled && !mdns_started) {


### PR DESCRIPTION
### What
Extends what https://github.com/dalathegreat/Battery-Emulator/pull/2555 added to low flash devices, now that https://github.com/dalathegreat/Battery-Emulator/pull/2571 and other optimizations give us some headroom.

### Why
see https://github.com/dalathegreat/Battery-Emulator/pull/2555

### How
Removing the `SMALL_FLASH_DEVICE` guards.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
