### PR TITLE
Investigate broken CAN-FD on 11.2.dev

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -61,7 +61,6 @@ custom_component_remove =
     espressif/ksz8851snl
 build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_unflags = -fno-lto
 ;build_cxxflags = -fno-rtti
 lib_deps = 
 
@@ -140,7 +139,6 @@ custom_component_remove =
     espressif/ksz8851snl
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_unflags = -fno-lto
 ;build_cxxflags = -fno-rtti
 lib_deps = 
 
@@ -188,7 +186,6 @@ build_flags =
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_unflags = -fno-lto
 ;build_cxxflags = -fno-rtti
 lib_deps = 
 
@@ -233,7 +230,6 @@ build_flags =
     -D ARDUINO_RUNNING_CORE=1       ; Arduino Runs On Core (setup, loop)
     -D ARDUINO_EVENT_RUNNING_CORE=1 ; Events Run On Core
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
-build_unflags = -fno-lto
 ;build_cxxflags = -fno-rtti
 lib_deps =
 
@@ -286,7 +282,6 @@ build_flags =
     -ffunction-sections
     -fdata-sections
     -Wl,--gc-sections
-build_unflags = -fno-lto
 ;build_cxxflags = -fno-rtti
 lib_deps =
 

--- a/sdkconfig.be_size.defaults
+++ b/sdkconfig.be_size.defaults
@@ -88,7 +88,7 @@ CONFIG_MBEDTLS_TLS_CLIENT_ONLY=y
 # Remove assertion checks outright (not just the message strings). Larger flash
 # win than SILENT. Trade-off: a bug that would have cleanly asserted becomes
 # undefined behaviour instead. Switch back to _SILENT if you want the aborts.
-CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
+# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
 # CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT is not set
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### What
This PR Investigates broken CAN-FD on 11.2.dev

### Why
On ESP32-S3's that have CAN-FD add-ons, the boards stop operating randomly or crash with the latest 10.12.dev changes. 

### How
It is suspected that PR #2571 is the reason, so let's unroll it one step at a time.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
