### PR TITLE
Remove checkprogsize rebuild

### DIFF
--- a/.github/scripts/parse_size.py
+++ b/.github/scripts/parse_size.py
@@ -23,7 +23,11 @@ FLASH_RE = re.compile(r"^Flash:.*used\s+(\d+)\s+bytes\s+from\s+(\d+)\s+bytes", r
 
 
 def _parse_usage(regex: re.Pattern[str], text: str) -> MemoryBytes | None:
-    m = regex.search(text)
+    # A `pio run -t checkprogsize` can print the size table more than  once
+    # Keep the LAST match — that is the final, complete size.
+    m = None
+    for m in regex.finditer(text):
+        pass
     if m is None:
         return None
     return MemoryBytes(used=int(m.group(1)), total=int(m.group(2)))

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -72,12 +72,11 @@ jobs:
       run: pip install --upgrade platformio
 
     - name: Build image for ${{ matrix.board_name }}
-      run: pio run -e ${{ matrix.pio_env }}
+      run: pio run -e ${{ matrix.pio_env }} -t checkprogsize 2>&1 | tee checkprogsize.txt
 
     - name: Capture size report for ${{ matrix.board_name }}
       if: matrix.pio_env != 'compiler_warning_check'
       run: |
-        pio run -e ${{ matrix.pio_env }} -t checkprogsize 2>&1 | tee checkprogsize.txt
         cat checkprogsize.txt | python .github/scripts/parse_size.py \
           --pio-env "${{ matrix.pio_env }}" \
           --board-name "${{ matrix.board_name }}" \


### PR DESCRIPTION
### What
After #2571 the `checkprogsize` invocations are now unable to reuse the artifacts from the previous compile step, thus causing a unnecessary 2min rebuild.

### How
By capturing the size in the first bild we can avoid the rebuild.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
