### PR TITLE
Bugfix: SOC based taper 🐛 do not apply float charge power over a zero allowance

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -193,14 +193,18 @@ static void filter_charge_taper_soc(void) {
       }
     }
 
+    uint32_t base_W = charge_W;  // Allowance entering the taper, after the user/remote cap
     charge_W = (charge_W * (uint32_t)(10000 - soc)) / band;
 
-    /* Optional floor: hold a minimum charge power through the tail of the
-       band, dropping to 0W only at 100.00% scaled SOC. Keeps inverters above
-       their minimum stable charging power (avoids standby cycling), provides
-       a steady balancing trickle, and guarantees the charge session
-       terminates instead of asymptotically stalling below full. */
-    if (charge_taper_floor_W > 0 && soc < 10000 && charge_W < charge_taper_floor_W) {
+    /* Optional float charge power: hold a minimum charge power through the
+       tail of the band, dropping to 0W only at 100.00% scaled SOC. Keeps
+       inverters above their minimum stable charging power (avoids standby
+       cycling), provides a steady balancing trickle, and guarantees the
+       charge session terminates instead of asymptotically stalling below
+       full. Only applied when the allowance entering the taper is non-zero,
+       so it never overrides a zero coming from the BMS itself or from the
+       safety layer (cell overvoltage, battery full, pause states). */
+    if (base_W > 0 && charge_taper_floor_W > 0 && soc < 10000 && charge_W < charge_taper_floor_W) {
       charge_W = charge_taper_floor_W;
     }
 


### PR DESCRIPTION
### What
Stops the float charge power from being applied when the charge allowance entering the taper is zero.

### Why
The float could raise `max_charge_power_W` above zero after the BMS or the safety layer had zeroed the allowance (cell overvoltage, battery full, pause states), advertising charge permission to power-based inverters that the pack had not given, while the current field still read 0 A.

### How
The allowance is captured before the linear taper factor is applied, and the float is now gated on it being non-zero - user/remote current caps are unaffected, so an explicit 0 A cap still receives the float as before.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
