### PR TITLE
Improvement: BYD - Change source pack voltage & current from CAN / add insulation resistance

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -424,6 +424,8 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
         battery_voltage_dV = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[5];
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
       }
       break;
     case 0x43A:
@@ -431,6 +433,8 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
         battery_insulation_ohm_per_volt = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2];
         battery_insulation_valid = true;
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
       }
       break;
     case 0x43B:
@@ -477,6 +481,8 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         lastCurrentSampleMillis = millis();
         BMS_SOH = rx_frame.data.u8[4];
         BMS_voltage_available = true;
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
       }
       break;
     case 0x445:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -44,10 +44,10 @@ void BydAttoBattery::set_12D_payload(uint8_t b0, uint8_t b1, uint8_t b2, uint8_t
 void BydAttoBattery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
-  if (battery_voltage > 0) {
-    datalayer_battery->status.voltage_dV = battery_voltage * 10;  //Value from periodic CAN data prioritized
-  } else if (BMS_voltage > 0) {
-    datalayer_battery->status.voltage_dV = BMS_voltage * 10;  //Polled value fallback
+  if (battery_voltage_dV > 0) {
+    datalayer_battery->status.voltage_dV = battery_voltage_dV;  //0x438, 0.1V resolution, prioritized
+  } else if (battery_voltage > 0) {
+    datalayer_battery->status.voltage_dV = battery_voltage * 10;  //0x444 whole-volt fallback
   }
 
   // We assume pack is not crashed, and use periodically transmitted SOC
@@ -55,7 +55,7 @@ void BydAttoBattery::
 
   datalayer_battery->status.soh_pptt = BMS_SOH * 100;
 
-  datalayer_battery->status.current_dA = -BMS_current;
+  datalayer_battery->status.current_dA = -battery_current_dA;
 
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
@@ -223,8 +223,9 @@ void BydAttoBattery::
   if (datalayer_bydatto) {
     datalayer_bydatto->SOC_highprec = battery_highprecision_SOC;
     datalayer_bydatto->SOC_polled = BMS_SOC;
-    datalayer_bydatto->voltage_periodic = battery_voltage;
-    datalayer_bydatto->voltage_polled = BMS_voltage;
+    datalayer_bydatto->pack_voltage_dV = battery_voltage_dV;
+    datalayer_bydatto->insulation_ohm_per_volt = battery_insulation_ohm_per_volt;
+    datalayer_bydatto->insulation_valid = battery_insulation_valid;
     datalayer_bydatto->battery_temperatures[0] = battery_daughterboard_temperatures[0];
     datalayer_bydatto->battery_temperatures[1] = battery_daughterboard_temperatures[1];
     datalayer_bydatto->battery_temperatures[2] = battery_daughterboard_temperatures[2];
@@ -421,9 +422,16 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x438:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        battery_voltage_dV = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[5];
+      }
       break;
     case 0x43A:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        battery_insulation_ohm_per_volt = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2];
+        battery_insulation_valid = true;
+      }
       break;
     case 0x43B:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -463,10 +471,13 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x444:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
-      BMS_SOH = rx_frame.data.u8[4];
-      //battery_temperature_something = rx_frame.data.u8[7] - 40; resides in frame 7
-      BMS_voltage_available = true;
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        battery_voltage = ((rx_frame.data.u8[1] & 0x0F) << 8) | rx_frame.data.u8[0];
+        battery_current_dA = (int16_t)(((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) - 5000);
+        lastCurrentSampleMillis = millis();
+        BMS_SOH = rx_frame.data.u8[4];
+        BMS_voltage_available = true;
+      }
       break;
     case 0x445:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -530,13 +541,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       switch (pid_reply) {
         case POLL_FOR_BATTERY_SOC:
           BMS_SOC = rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_VOLTAGE:
-          BMS_voltage = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_CURRENT:
-          BMS_current = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4]) - 5000;
-          lastCurrentSampleMillis = millis();
           break;
         case POLL_FOR_LOWEST_TEMP_CELL:
           BMS_lowest_cell_temperature = (rx_frame.data.u8[4] - 40);
@@ -743,7 +747,7 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
       // Only act on a current reading taken after the settle wait, so a stale low sample
       // from before the request can't authorise opening under load
       if ((int32_t)(lastCurrentSampleMillis - contactorStateEntryMillis) >= (int32_t)ZERO_CURRENT_MIN_WAIT_MS &&
-          BMS_current > -OPEN_MAX_CURRENT_dA && BMS_current < OPEN_MAX_CURRENT_dA) {
+          battery_current_dA > -OPEN_MAX_CURRENT_dA && battery_current_dA < OPEN_MAX_CURRENT_dA) {
         set_12D_payload(0xA0, 0x28, 0x02, 0x60, 0x04, 0x31);  // Shutdown pattern
         contactorState = CONTACTORS_OPENING;
         contactorStateEntryMillis = currentMillis;
@@ -975,16 +979,6 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case POLL_FOR_BATTERY_SOC:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_SOC & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_SOC & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_VOLTAGE;
-        break;
-      case POLL_FOR_BATTERY_VOLTAGE:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_VOLTAGE & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_VOLTAGE & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_CURRENT;
-        break;
-      case POLL_FOR_BATTERY_CURRENT:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_CURRENT & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_CURRENT & 0x00FF);
         poll_state = POLL_FOR_LOWEST_TEMP_CELL;
         break;
       case POLL_FOR_LOWEST_TEMP_CELL:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -66,8 +66,7 @@ class BydAttoBattery : public CanBattery {
 
   static const int POLL_TIMES_FULL_POWER = 0x0004;  // Using Carscanner name for now.
   static const int POLL_FOR_BATTERY_SOC = 0x0005;
-  static const int POLL_FOR_BATTERY_VOLTAGE = 0x0008;
-  static const int POLL_FOR_BATTERY_CURRENT = 0x0009;
+  // 0x0008 (voltage) and 0x0009 (current) are no longer polled; 0x438 and 0x444 carry them faster
   static const int POLL_MAX_CHARGE_POWER = 0x000A;
   static const int POLL_CHARGE_TIMES = 0x000B;  // Using Carscanner name for now.
   static const int POLL_MAX_DISCHARGE_POWER = 0x000E;
@@ -154,11 +153,12 @@ class BydAttoBattery : public CanBattery {
   uint16_t rampdown_power = 0;
   uint16_t poll_state = POLL_FOR_BATTERY_SOC;
   uint16_t pid_reply = 0;
-  uint16_t battery_voltage = 0;
+  uint16_t battery_voltage = 0;                  // Whole volts from 0x444, used for the 0x441 link voltage
+  uint16_t battery_voltage_dV = 0;               // Deci-volts from 0x438, primary pack voltage
+  uint16_t battery_insulation_ohm_per_volt = 0;  // 0x43A, multiply by pack voltage for Ohms
   uint16_t battery_highprecision_SOC = 0;
   uint16_t battery_estimated_SOC = 0;
   uint16_t BMS_SOC = 0;
-  uint16_t BMS_voltage = 0;
   uint16_t BMS_lowest_cell_voltage_mV = 3300;
   uint16_t BMS_highest_cell_voltage_mV = 3300;
   uint16_t BMS_allowed_charge_power = 0;
@@ -181,7 +181,7 @@ class BydAttoBattery : public CanBattery {
   int16_t battery_highest_temperature = 0;
   int16_t battery_calc_min_temperature = 0;
   int16_t battery_calc_max_temperature = 0;
-  int16_t BMS_current = 0;
+  int16_t battery_current_dA = 0;  // 0x444, deci-amps, negative while charging
   int16_t BMS_lowest_cell_temperature = 0;
   int16_t BMS_highest_cell_temperature = 0;
   int16_t BMS_average_cell_temperature = 0;
@@ -288,6 +288,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t secondsSinceStartup = 0;
 
   bool BMS_voltage_available = false;
+  bool battery_insulation_valid = false;  // Zero is a valid 0x43A fault reading, so track receipt separately
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -119,8 +119,22 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
 
     content += "<h4>SOC measured: " + String(soc_measured) + "&percnt;</h4>";
     content += "<h4>SOC OBD2: " + String(byd_datalayer->SOC_polled) + "&percnt;</h4>";
-    content += "<h4>Voltage periodic: " + String(byd_datalayer->voltage_periodic) + " V</h4>";
-    content += "<h4>Voltage OBD2: " + String(byd_datalayer->voltage_polled) + " V</h4>";
+    content += "<h4>Pack voltage: ";
+    if (byd_datalayer->pack_voltage_dV > 0) {
+      content += String(byd_datalayer->pack_voltage_dV / 10.0f, 1) + " V</h4>";
+    } else {
+      content += "Not received</h4>";
+    }
+    // 0x43A reports Ohm/V, so scale by pack voltage to get absolute resistance
+    content += "<h4>Insulation resistance: ";
+    if (byd_datalayer->insulation_valid) {
+      float insulation_kohm =
+          static_cast<float>(byd_datalayer->insulation_ohm_per_volt) * (dl_bat.status.voltage_dV / 10.0f) / 1000.0f;
+      content += String(insulation_kohm, 1) + " k&Omega; (" + String(byd_datalayer->insulation_ohm_per_volt) +
+                 " &Omega;/V)</h4>";
+    } else {
+      content += "Not received</h4>";
+    }
     if (byd_datalayer->battery_temperatures[0] != 215) {
       content += "<h4>Temperature sensor 1: " + String(byd_datalayer->battery_temperatures[0]) + " &deg;C</h4>";
     }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -126,10 +126,12 @@ struct DATALAYER_INFO_BYDATTO3 {
   uint16_t SOC_highprec;
   /** SOC% polled OBD2 value. Can be locked if pack is crashed */
   uint16_t SOC_polled;
-  /** Voltage raw battery value */
-  uint16_t voltage_periodic;
-  /** Voltage polled OBD2*/
-  uint16_t voltage_polled;
+  /** Pack voltage from 0x438, deci-volts. Zero until the frame is received */
+  uint16_t pack_voltage_dV;
+  /** Insulation resistance from 0x43A, Ohm per volt. Multiply by pack voltage for Ohms. Zero is a valid fault reading */
+  uint16_t insulation_ohm_per_volt;
+  /** True once a checksum-valid 0x43A has been seen */
+  bool insulation_valid;
   uint16_t chargePower;
   uint16_t charge_times;
   uint16_t dischargePower;

--- a/test/can_log_based/can_logs/5_BydAtto3_base.txt
+++ b/test/can_log_based/can_logs/5_BydAtto3_base.txt
@@ -1,5 +1,9 @@
 # voltage
-(0.001) RX0 7ef [8] 00 00 00 08 81 34 ee ee
+(0.001) RX0 438 [8] 55 55 01 D6 47 68 10 BF
+# voltage fallback, current and SOH
+(0.001) RX0 444 [8] A4 01 88 13 63 63 00 F9
+# insulation resistance
+(0.001) RX0 43a [8] 7E 0A 90 1A 00 00 00 CD
 # lowest cell
 (0.002) RX0 7ef [8] 00 00 00 2f 30 ee ee ee
 # highest cell


### PR DESCRIPTION
### What
* Pack voltage from 0x438 (deci-volts) instead of polled DID 0x0008
* Pack current from 0x444 (deci-amps, offset 5000) instead of polled DID 0x0009
* Insulation resistance from 0x43A added to the battery info page
* Poll rotation drops from 22 to 20 DIDs to improve timings.

### Why
The BMS already broadcasts both values, faster and better:

* 0x438 gives 10x the voltage resolution of the whole-volt DID
* 0x444 arrives at ~101 ms vs the ~4.4 s poll cycle — this also gives the contactor open-interlock a fresh current sample instead of a stale one
* Insulation resistance was not being used (ideally would confirm with scan tool to ensure correct scaling).

### How
All three decodes are checksum-gated; the existing computeBydChecksum() applies unchanged to received frames.

Validated against vehicle captures before implementation.

* 0x438 tracks 0x444 within ±0.7 V
* 0x444 current sign confirmed on two charging logs, same encoding as the retired DID
Transmitted 0x441 link voltage deliberately left on 0x444, so the precharge handshake is untouched. New state is per-instance, so dual-battery setups are covered.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
