### PR TITLE
Fake battery: support triple setup, mirror pack voltage, fake balancing

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -431,6 +431,9 @@ void setup_battery() {
         battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,
                                      &datalayer.system.status.battery3_allowed_contactor_closing);
         break;
+      case BatteryType::TestFake:
+        battery3 = new TestFakeBattery(&datalayer.battery3, can_config.battery_triple);
+        break;
       default:
         DEBUG_PRINTF("User tried enabling triple battery on non-supported integration!\n");
         break;

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -10,7 +10,11 @@ void TestFakeBattery::
 
   datalayer_battery->status.soh_pptt = 9900;  // 99.00%
 
-  //datalayer_battery->status.voltage_dV = 3700;  // 370.0V , value editable via webserver
+  // Battery 1's voltage is set by the user via the webserver (set_fake_voltage).
+  // Batteries 2 and 3 mirror it so all instances report the same pack voltage.
+  if (datalayer_battery != &datalayer.battery) {
+    datalayer_battery->status.voltage_dV = datalayer.battery.status.voltage_dV;
+  }
 
   datalayer_battery->status.current_dA = 0;  // 0 A
 
@@ -56,6 +60,12 @@ void TestFakeBattery::setup(void) {  // Performs one time setup at startup
       4040;  // 404.4V, over this, charging is not possible (goes into forced discharge)
   datalayer_battery->info.min_design_voltage_dV = 2450;  // 245.0V under this, discharging further is disabled
   datalayer_battery->info.number_of_cells = 96;
+
+  // Default fake pack voltage for the primary battery; editable via webserver.
+  // Batteries 2 and 3 pick this up through the mirror in update_values().
+  if (datalayer_battery == &datalayer.battery && datalayer_battery->status.voltage_dV == 0) {
+    datalayer_battery->status.voltage_dV = 3700;  // 370.0V
+  }
 
   if (allows_contactor_closing) {
     *allows_contactor_closing = true;

--- a/Software/src/battery/TEST-FAKE-BATTERY.cpp
+++ b/Software/src/battery/TEST-FAKE-BATTERY.cpp
@@ -34,9 +34,19 @@ void TestFakeBattery::
 
   datalayer_battery->status.max_charge_power_W = 5000;  // 5kW
 
-  for (int i = 0; i < 97; ++i) {
+  uint32_t cell_voltage_sum_mV = 0;
+  for (int i = 0; i < 96; ++i) {
     datalayer_battery->status.cell_voltages_mV[i] = 3700 + random(-20, 21);
+    cell_voltage_sum_mV += datalayer_battery->status.cell_voltages_mV[i];
   }
+
+  // Fake balancing: every cell sitting above the pack average gets its resistor switched on
+  uint16_t cell_voltage_average_mV = cell_voltage_sum_mV / 96;
+  for (int i = 0; i < 96; ++i) {
+    datalayer_battery->status.cell_balancing_status[i] =
+        (datalayer_battery->status.cell_voltages_mV[i] > cell_voltage_average_mV);
+  }
+  datalayer_battery->status.balancing_status = BALANCING_STATUS_ACTIVE;
 
   //Fake that we get CAN messages
   datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;


### PR DESCRIPTION
### What
Add TestFake to the triple-battery switch in setup_battery() so battery3 is instantiated and MQTT publishes the third set of entities.

Batteries 2 and 3 mirror battery 1's user-set fake voltage, and the primary now defaults to 370.0V at boot instead of 0V.

Each cycle, any cell above the pack average gets its resistor flagged on. Since the voltages are re-randomised ±20 mV every pass, roughly half the cells light up and the set churns between cycles — good for exercising a dashboard, and it applies to all three instances since it's written through datalayer_battery.

### Why
Upon test-benching https://github.com/dalathegreat/Battery-Emulator/pull/2643, I noticed that enabling the triple option on the Fake battery just produces a log entry `[boot +0.124s] User tried enabling triple battery on non-supported integration!`.

Additionally I noticed the `Event: Too large voltage diff between the batteries. Second battery cannot join the DC-link`, when I tried to adjust the voltage in the settings. Fixing that so the voltage setting propagates correctly to the double and triple options.

Couldn't test to see behavior of the balancing data, all fields were `false` through MQTT.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
