### PR TITLE
Web UI: only offer double/triple battery for integrations that support it

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -336,6 +336,47 @@ Battery* create_battery(BatteryType type) {
   }
 }
 
+// The integrations that can be instantiated a second time on a separate
+// interface. Must match the switch in setup_battery() below.
+bool battery_supports_double(BatteryType type) {
+  switch (type) {
+    case BatteryType::BoltAmpera:
+    case BatteryType::BydAtto3:
+    case BatteryType::NissanLeaf:
+    case BatteryType::BmwI3:
+    case BatteryType::CmfaEv:
+    case BatteryType::CmpSmartCar:
+    case BatteryType::StellantisEcmp:
+    case BatteryType::KiaHyundai64:
+    case BatteryType::MgHsPhev:
+    case BatteryType::Pylon:
+    case BatteryType::SantaFePhev:
+    case BatteryType::RelionBattery:
+    case BatteryType::RenaultZoe1:
+    case BatteryType::RenaultZoe2:
+    case BatteryType::TestFake:
+    case BatteryType::TeslaModel3Y:
+    case BatteryType::TeslaModelSX:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// The integrations that can be instantiated a third time on a separate
+// interface. Must match the switch in setup_battery() below.
+bool battery_supports_triple(BatteryType type) {
+  switch (type) {
+    case BatteryType::NissanLeaf:
+    case BatteryType::CmfaEv:
+    case BatteryType::RelionBattery:
+    case BatteryType::TestFake:
+      return true;
+    default:
+      return false;
+  }
+}
+
 void setup_battery() {
   if (battery) {
     // Let's not create the battery again.
@@ -354,64 +395,67 @@ void setup_battery() {
   }
 
   if (user_selected_second_battery && !battery2) {
-    switch (user_selected_battery_type) {
-      case BatteryType::BoltAmpera:
-        battery2 =
-            new BoltAmperaBattery(&datalayer.battery2, &datalayer_extended.boltampera_2, can_config.battery_double);
-        break;
-      case BatteryType::BydAtto3:
-        battery2 = new BydAttoBattery(&datalayer.battery2, &datalayer_extended.bydAtto3_2, can_config.battery_double);
-        break;
-      case BatteryType::NissanLeaf:
-        battery2 = new NissanLeafBattery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::BmwI3:
-        battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
-                                    can_config.battery_double, esp32hal->WUP_PIN2());
-        break;
-      case BatteryType::CmfaEv:
-        battery2 = new CmfaEvBattery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::CmpSmartCar:
-        battery2 = new CmpSmartCarBattery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::StellantisEcmp:
-        battery2 = new EcmpBattery(&datalayer.battery2, can_config.battery_double);
-        break;
-      case BatteryType::KiaHyundai64:
-        battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,
-                                           &datalayer.system.status.battery2_allowed_contactor_closing,
-                                           can_config.battery_double);
-        break;
-      case BatteryType::MgHsPhev:
-        battery2 = new MgHsPHEVBattery(&datalayer.battery2, can_config.battery_double);
-        break;
-      case BatteryType::Pylon:
-        battery2 = new PylonBattery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::SantaFePhev:
-        battery2 = new SantaFePhevBattery(&datalayer.battery2, can_config.battery_double);
-        break;
-      case BatteryType::RelionBattery:
-        battery2 = new RelionBattery(&datalayer.battery2, can_config.battery_double,
-                                     &datalayer.system.status.battery2_allowed_contactor_closing);
-        break;
-      case BatteryType::RenaultZoe1:
-        battery2 = new RenaultZoeGen1Battery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::RenaultZoe2:
-        battery2 = new RenaultZoeGen2Battery(&datalayer.battery2, nullptr, can_config.battery_double);
-        break;
-      case BatteryType::TestFake:
-        battery2 = new TestFakeBattery(&datalayer.battery2, can_config.battery_double);
-        break;
-      case BatteryType::TeslaModel3Y:
-      case BatteryType::TeslaModelSX:
-        battery2 = new TeslaBattery(&datalayer.battery2, can_config.battery_double);
-        break;
-      default:
-        DEBUG_PRINTF("User tried enabling double battery on non-supported integration!\n");
-        break;
+    if (!battery_supports_double(user_selected_battery_type)) {
+      DEBUG_PRINTF("User tried enabling double battery on non-supported integration!\n");
+    } else {
+      switch (user_selected_battery_type) {
+        case BatteryType::BoltAmpera:
+          battery2 =
+              new BoltAmperaBattery(&datalayer.battery2, &datalayer_extended.boltampera_2, can_config.battery_double);
+          break;
+        case BatteryType::BydAtto3:
+          battery2 = new BydAttoBattery(&datalayer.battery2, &datalayer_extended.bydAtto3_2, can_config.battery_double);
+          break;
+        case BatteryType::NissanLeaf:
+          battery2 = new NissanLeafBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::BmwI3:
+          battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
+                                      can_config.battery_double, esp32hal->WUP_PIN2());
+          break;
+        case BatteryType::CmfaEv:
+          battery2 = new CmfaEvBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::CmpSmartCar:
+          battery2 = new CmpSmartCarBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::StellantisEcmp:
+          battery2 = new EcmpBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        case BatteryType::KiaHyundai64:
+          battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,
+                                             &datalayer.system.status.battery2_allowed_contactor_closing,
+                                             can_config.battery_double);
+          break;
+        case BatteryType::MgHsPhev:
+          battery2 = new MgHsPHEVBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        case BatteryType::Pylon:
+          battery2 = new PylonBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::SantaFePhev:
+          battery2 = new SantaFePhevBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        case BatteryType::RelionBattery:
+          battery2 = new RelionBattery(&datalayer.battery2, can_config.battery_double,
+                                       &datalayer.system.status.battery2_allowed_contactor_closing);
+          break;
+        case BatteryType::RenaultZoe1:
+          battery2 = new RenaultZoeGen1Battery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::RenaultZoe2:
+          battery2 = new RenaultZoeGen2Battery(&datalayer.battery2, nullptr, can_config.battery_double);
+          break;
+        case BatteryType::TestFake:
+          battery2 = new TestFakeBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        case BatteryType::TeslaModel3Y:
+        case BatteryType::TeslaModelSX:
+          battery2 = new TeslaBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        default:
+          break;
+      }
     }
 
     if (battery2) {
@@ -420,23 +464,26 @@ void setup_battery() {
   }
 
   if (user_selected_triple_battery && !battery3) {
-    switch (user_selected_battery_type) {
-      case BatteryType::NissanLeaf:
-        battery3 = new NissanLeafBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
-        break;
-      case BatteryType::CmfaEv:
-        battery3 = new CmfaEvBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
-        break;
-      case BatteryType::RelionBattery:
-        battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,
-                                     &datalayer.system.status.battery3_allowed_contactor_closing);
-        break;
-      case BatteryType::TestFake:
-        battery3 = new TestFakeBattery(&datalayer.battery3, can_config.battery_triple);
-        break;
-      default:
-        DEBUG_PRINTF("User tried enabling triple battery on non-supported integration!\n");
-        break;
+    if (!battery_supports_triple(user_selected_battery_type)) {
+      DEBUG_PRINTF("User tried enabling triple battery on non-supported integration!\n");
+    } else {
+      switch (user_selected_battery_type) {
+        case BatteryType::NissanLeaf:
+          battery3 = new NissanLeafBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
+          break;
+        case BatteryType::CmfaEv:
+          battery3 = new CmfaEvBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
+          break;
+        case BatteryType::RelionBattery:
+          battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,
+                                       &datalayer.system.status.battery3_allowed_contactor_closing);
+          break;
+        case BatteryType::TestFake:
+          battery3 = new TestFakeBattery(&datalayer.battery3, can_config.battery_triple);
+          break;
+        default:
+          break;
+      }
     }
 
     if (battery3) {

--- a/Software/src/battery/BATTERIES.h
+++ b/Software/src/battery/BATTERIES.h
@@ -15,6 +15,14 @@ void setup_shunt();
 void setup_battery(void);
 Battery* create_battery(BatteryType type);
 
+// Returns true if the given battery integration can be instantiated a second
+// resp. third time to run batteries in parallel. These are the single source of
+// truth for double/triple battery support: setup_battery() gates object creation
+// on them, and the web UI uses them to decide whether to offer the checkboxes.
+// Keep them in sync with the switch statements in setup_battery().
+bool battery_supports_double(BatteryType type);
+bool battery_supports_triple(BatteryType type);
+
 extern uint16_t user_selected_max_pack_voltage_dV;
 extern uint16_t user_selected_min_pack_voltage_dV;
 extern uint16_t user_selected_max_cell_voltage_mV;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -228,6 +228,32 @@ const char* name_for_gpioopt6(GPIOOPT6 option) {
 const char* TRUE_CHAR_CODE = "\u2713";   //&#10003";
 const char* FALSE_CHAR_CODE = "\u2715";  //&#10005";
 
+// Builds the CSS rules that reveal the .if-dblcapable / .if-tricapable blocks
+// only for the battery integrations that actually implement parallel batteries.
+// Generated from battery_supports_double()/battery_supports_triple() so the UI
+// can never drift out of sync with what setup_battery() is able to instantiate.
+static String capability_css(const char* className, bool (*supported)(BatteryType)) {
+  String selectors;
+
+  for (auto& type : enum_values<BatteryType>()) {
+    if (!supported(type)) {
+      continue;
+    }
+    if (!selectors.isEmpty()) {
+      selectors += ",";
+    }
+    selectors += "form[data-battery=\"" + String(to_underlying(type)) + "\"] ." + className;
+  }
+
+  String css = "form ." + String(className) + " { display: none; }";
+
+  if (!selectors.isEmpty()) {
+    css += selectors + " { display: contents; }";
+  }
+
+  return css;
+}
+
 String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& settings);
 
 String settings_processor(const String& var, BatteryEmulatorSettingsStore& settings) {
@@ -241,6 +267,10 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
   if (var == "BATTCOMM") {
     return options_for_enum((comm_interface)settings.getUInt("BATTCOMM", (int)comm_interface::CanNative),
                             name_for_comm_interface);
+  }
+  if (var == "BTRCAPCSS") {
+    return capability_css("if-dblcapable", battery_supports_double) +
+           capability_css("if-tricapable", battery_supports_triple);
   }
   if (var == "BATTCHEM") {
     return options_for_enum(
@@ -1355,6 +1385,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
       display: contents;
     }
 
+    /* Integrations that support running two/three batteries in parallel.
+       Rules are generated at runtime from the battery capability predicates. */
+    %BTRCAPCSS%
+
     form .if-dblbtr { display: none; }
     form[data-dblbtr="true"] .if-dblbtr {
       display: contents;
@@ -1715,6 +1749,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         title="Minimum voltage per individual cell in millivolts. Discharge stops if one cell drops to this voltage." />
         </div>
 
+        <div class="if-dblcapable">
         <label>Double battery: </label>
         <input type='checkbox' name='DBLBTR' value='on' %DBLBTR% 
         title="Enable this option if you intend to run two batteries in parallel" />
@@ -1725,6 +1760,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
                 %BATT2COMM%
             </select>
 
+        <div class="if-tricapable">
         <label>Triple battery: </label>
         <input type='checkbox' name='TRIBTR' value='on' %TRIBTR% 
         title="Enable this option if you intend to run three batteries in parallel" />
@@ -1734,6 +1770,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <select name='BATT3COMM'>
             %BATT3COMM%
         </select>
+        </div>
+
+        </div>
+
         </div>
 
         </div>
@@ -1927,8 +1967,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         <div class="if-dblbtr">
             <label>Double-Battery Contactor control via GPIO: </label>
             <input type='checkbox' name='CNTCTRLDBL' value='on' %CNTCTRLDBL% />
-            <label>Triple-Battery Contactor control via GPIO: </label>
-            <input type='checkbox' name='CNTCTRLTRI' value='on' %CNTCTRLTRI% />
+            <div class="if-tribtr">
+                <label>Triple-Battery Contactor control via GPIO: </label>
+                <input type='checkbox' name='CNTCTRLTRI' value='on' %CNTCTRLTRI% />
+            </div>
         </div>
 
         <label>Contactor control via GPIO: </label>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -573,6 +573,17 @@ void init_webserver() {
                 }
               }
 
+              // The double/triple battery checkboxes are hidden in the UI for integrations
+              // that don't implement parallel batteries. Make sure a previously stored
+              // value can't survive a switch to such an integration.
+              auto selectedBatteryType = static_cast<BatteryType>(settings.getUInt("BATTTYPE", (int)BatteryType::None));
+              if (!battery_supports_double(selectedBatteryType) && settings.getBool("DBLBTR", false)) {
+                settings.saveBool("DBLBTR", false);
+              }
+              if (!battery_supports_triple(selectedBatteryType) && settings.getBool("TRIBTR", false)) {
+                settings.saveBool("TRIBTR", false);
+              }
+
               settingsUpdated = settings.were_settings_updated();
               request->redirect("/settings");
             });


### PR DESCRIPTION
### What
This PR hides the "Double battery" and "Triple battery" checkboxes on the settings page for battery integrations that don't implement parallel batteries.
The double/triple contactor GPIO options and the Battery 2/3 interface selectors follow the same gating.
A previously stored double/triple setting is also cleared when the user switches to an integration that can't use it.

### Why
Currently every integration offers both checkboxes, even though only 17 support a second battery and 4 support a third.
Enabling them on an unsupported integration silently does nothing except print "User tried enabling double battery on non-supported integration!" to the debug log.
Worse, the setting stays in NVS after switching battery type, so an invisible enabled flag can linger and confuse later configuration.

### How
The capability lists are extracted out of the two switch statements in `setup_battery()` into `battery_supports_double()` / `battery_supports_triple()`, which now also gate object creation, so there is a single source of truth.
`settings_html.cpp` generates the `.if-dblcapable` / `.if-tricapable` CSS rules from those predicates at runtime, reusing the existing `form[data-battery=N]` + `display: contents` mechanism, so adding a new integration needs no UI edit.
`/saveSettings` clears `DBLBTR` / `TRIBTR` when the saved battery type doesn't support them, since a hidden checkbox still submits its stored state.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
