### PR TITLE
Improvement: BYD-Modbus - report STANDBY until DC bus is live

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -55,6 +55,7 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
     datalayer.system.status.system_status = STANDBY;
     // During balancing sleep, report contactors as open so an old engaged state is not latched.
     datalayer.system.status.contactors_engaged = 0;
+    datalayer.system.status.dc_bus_live = false;
   }
 
   // Map internal balancing state to datalayer balancing_status
@@ -141,6 +142,8 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
       datalayer.system.status.contactors_engaged = 0;
       break;
   }
+  // I3 drives its own DC switch, so DC is live once its contactors report engaged.
+  datalayer.system.status.dc_bus_live = (datalayer.system.status.contactors_engaged == 1);
 }
 
 void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -1,6 +1,7 @@
 #include "BMW-I3-BATTERY.h"
 #include <Arduino.h>
 #include "../communication/can/comm_can.h"
+#include "../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/common_functions.h"  //For CRC table
@@ -55,7 +56,9 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
     datalayer.system.status.system_status = STANDBY;
     // During balancing sleep, report contactors as open so an old engaged state is not latched.
     datalayer.system.status.contactors_engaged = 0;
-    datalayer.system.status.dc_bus_live = false;
+    if (!contactor_control_enabled) {
+      datalayer.system.status.dc_bus_live = false;
+    }
   }
 
   // Map internal balancing state to datalayer balancing_status
@@ -143,7 +146,10 @@ void BmwI3Battery::update_values() {  //This function maps all the values fetche
       break;
   }
   // I3 drives its own DC switch, so DC is live once its contactors report engaged.
-  datalayer.system.status.dc_bus_live = (datalayer.system.status.contactors_engaged == 1);
+  // Guarded so the GPIO contactor state machine stays authoritative when enabled.
+  if (!contactor_control_enabled) {
+    datalayer.system.status.dc_bus_live = (datalayer.system.status.contactors_engaged == 1);
+  }
 }
 
 void BmwI3Battery::handle_incoming_can_frame(CAN_frame rx_frame) {

--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -840,6 +840,10 @@ void BmwIXBattery::transmit_can(unsigned long currentMillis) {
     if (!contactor_control_enabled) {
       HandleBmwIxCloseContactorsRequest(counter_10ms);
       HandleBmwIxOpenContactorsRequest(counter_10ms);
+      // CAN mode: ContactorState tracks completion of the close/open command sequences.
+      // Note this is command-completion, not pack feedback - if the pack ignored the sequence
+      // we report live anyway, which matches pre-dc_bus_live behaviour (never STANDBY-locks).
+      datalayer.system.status.dc_bus_live = (ContactorState.closed && !ContactorState.open);
     }
     counter_10ms++;
 

--- a/Software/src/battery/BMW-SBOX.cpp
+++ b/Software/src/battery/BMW-SBOX.cpp
@@ -95,12 +95,14 @@ void BmwSbox::transmit_can(unsigned long currentMillis) {
 
     if (contactorStatus == SHUTDOWN_REQUESTED) {
       datalayer.shunt.contactors_engaged = false;
+      datalayer.system.status.dc_bus_live = false;
       return;  // A fault scenario latches the contactor control. It is not possible to recover without a powercycle (and investigation why fault occured)
     }
 
     // After that, check if we are OK to start turning on the contactors
     if (contactorStatus == DISCONNECTED) {
       datalayer.shunt.contactors_engaged = false;
+      datalayer.system.status.dc_bus_live = false;
       SBOX_100.data.u8[0] = 0x55;  // All open
 
       if (datalayer.system.status.battery_allows_contactor_closing &&
@@ -150,6 +152,7 @@ void BmwSbox::transmit_can(unsigned long currentMillis) {
           contactorStatus = COMPLETED;
           logging.println("S-BOX Precharge relay released");
           datalayer.shunt.contactors_engaged = true;
+          datalayer.system.status.dc_bus_live = true;
         }
         break;
       case COMPLETED:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -2,6 +2,7 @@
 #include <Arduino.h>  //For millis()
 #include <cstring>    //For unit test
 #include "../communication/can/comm_can.h"
+#include "../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"
 #include "../devboard/utils/events.h"
@@ -178,6 +179,13 @@ void BydAttoBattery::
       (contactorState != CONTACTORS_CLOSING && contactorState != CONTACTORS_ACTIVE)) {
     datalayer_battery->status.max_charge_power_W = 0;
     datalayer_battery->status.max_discharge_power_W = 0;
+  }
+
+  // Pack-internal contactors: DC bus is live once the pack confirms the main contactor
+  // closed (same 0x344 bit7 feedback used to gate power above). Guarded so the GPIO
+  // contactor state machine stays authoritative when enabled.
+  if (!contactor_control_enabled) {
+    datalayer.system.status.dc_bus_live = (contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) != 0;
   }
 
   datalayer_battery->status.total_discharged_battery_Wh = BMS_total_discharged_kwh * 1000;

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>  // For std::min and std::max
 #include <cstring>    //For unit test
 #include "../communication/can/comm_can.h"
+#include "../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For "More battery info" webpage
 #include "../devboard/safety/safety.h"        //For emulator pause status and battery pause
@@ -767,6 +768,12 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (datalayer.battery.status.real_bms_status != BMS_FAULT)
             datalayer.battery.status.real_bms_status = BMS_STANDBY;
           datalayer.system.status.battery_allows_contactor_closing = false;
+      }
+      // Pack-internal contactors: BMS_mode 1/3/4/6 are the HV-active states (same set that
+      // logs "Contactors closed" above). Guarded so the GPIO state machine wins when enabled.
+      if (!contactor_control_enabled) {
+        datalayer.system.status.dc_bus_live =
+            (BMS_mode == 1) || (BMS_mode == 3) || (BMS_mode == 4) || (BMS_mode == 6);
       }
       BMS_HVIL_status = (rx_frame.data.u8[2] & 0x18) >> 3;
       BMS_error_shutdown = (rx_frame.data.u8[2] & 0x20) >> 5;

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -772,8 +772,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       // Pack-internal contactors: BMS_mode 1/3/4/6 are the HV-active states (same set that
       // logs "Contactors closed" above). Guarded so the GPIO state machine wins when enabled.
       if (!contactor_control_enabled) {
-        datalayer.system.status.dc_bus_live =
-            (BMS_mode == 1) || (BMS_mode == 3) || (BMS_mode == 4) || (BMS_mode == 6);
+        datalayer.system.status.dc_bus_live = (BMS_mode == 1) || (BMS_mode == 3) || (BMS_mode == 4) || (BMS_mode == 6);
       }
       BMS_HVIL_status = (rx_frame.data.u8[2] & 0x18) >> 3;
       BMS_error_shutdown = (rx_frame.data.u8[2] & 0x20) >> 5;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -2,6 +2,7 @@
 #include <cstring>  //For unit test
 #include "../battery/BATTERIES.h"
 #include "../communication/can/comm_can.h"
+#include "../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../datalayer/datalayer.h"
 #include "../datalayer/datalayer_extended.h"  //For Advanced Battery Insights webpage
 #include "../devboard/utils/events.h"
@@ -547,6 +548,12 @@ void TeslaBattery::
     set_event_latched(EVENT_CONTACTOR_WELDED, 0);
   } else if (BMS_contactorState != 5) {
     clear_event(EVENT_CONTACTOR_WELDED);
+  }
+
+  // Pack-internal contactors: DC bus is live only when the BMS confirms CLOSED (4).
+  // Guarded so the GPIO contactor state machine stays authoritative when enabled.
+  if (!contactor_control_enabled) {
+    datalayer.system.status.dc_bus_live = (battery_contactor == 4);
   }
 
   if (user_selected_tesla_GTW_chassisType > 1) {  //{{0, "Model S"}, {1, "Model X"}, {2, "Model 3"}, {3, "Model Y"}};

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -170,6 +170,10 @@ void handle_contactors() {
   }
 
   if (contactor_control_enabled) {
+    // DC is only live to the inverter once precharge is fully complete (COMPLETED). Re-evaluated every
+    // call, so any transition (open, fault-latch, precharge) is reflected within one 10 ms tick.
+    datalayer.system.status.dc_bus_live = (contactorStatus == COMPLETED);
+
     // First check if we have any active errors, incase we do, turn off the battery
     if (datalayer.system.status.system_status == FAULT) {
       timeSpentInFaultedMode++;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -380,6 +380,12 @@ struct DATALAYER_SYSTEM_STATUS_TYPE {
   uint8_t CAN_inverter_still_alive = (CAN_STILL_ALIVE - 1);
   /** 0 if starting up, 1 if contactors engaged, 2 if the contactors controlled by battery-emulator is opened */
   uint8_t contactors_engaged = 0;
+  /** True when the DC bus is actually energized towards the inverter (contactors closed and precharge
+   *  complete). Single source of truth for inverter protocols that must not advertise an ACTIVE battery
+   *  against a dead DC bus (e.g. BYD-Modbus / Fronius during the boot-gate + precharge window).
+   *  Each contactor topology sets it authoritatively; defaults true so direct-wired setups that never
+   *  gate the DC bus keep today's behaviour. */
+  bool dc_bus_live = true;
   /** State of automatic precharge sequence */
   PrechargeState precharge_status = AUTO_PRECHARGE_IDLE;
   /** True if the primary battery allows for the contactors to close */

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -384,7 +384,9 @@ struct DATALAYER_SYSTEM_STATUS_TYPE {
    *  complete). Single source of truth for inverter protocols that must not advertise an ACTIVE battery
    *  against a dead DC bus (e.g. BYD-Modbus / Fronius during the boot-gate + precharge window).
    *  Each contactor topology sets it authoritatively; defaults true so direct-wired setups that never
-   *  gate the DC bus keep today's behaviour. */
+   *  gate the DC bus keep today's behaviour. Battery-side setters must be guarded with
+   *  !contactor_control_enabled so the GPIO contactor state machine (which writes every 10 ms when
+   *  enabled) stays the single writer in GPIO setups. */
   bool dc_bus_live = true;
   /** State of automatic precharge sequence */
   PrechargeState precharge_status = AUTO_PRECHARGE_IDLE;

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -79,12 +79,22 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   // Use the smaller value, battery reported value OR user configured value
   max_charge_W = std::min(datalayer.battery.status.max_charge_power_W, user_configured_max_charge_W);
 
-  if (datalayer.system.status.system_status == ACTIVE) {
+  // Don't advertise ACTIVE to the inverter until the DC bus is actually live. During the boot-gate +
+  // precharge window the emulator drives contactors on its own schedule (BYD-Modbus has no inverter
+  // handshake), so a polling Fronius would otherwise see an ACTIVE battery against a dead DC input and
+  // complain. STANDBY is the protocol-native "present but not delivering" resting state to report here.
+  // Only the ACTIVE case is remapped; FAULT/UPDATING/STANDBY pass through unchanged.
+  system_status_enum reported_status = datalayer.system.status.system_status;
+  if (reported_status == ACTIVE && !datalayer.system.status.dc_bus_live) {
+    reported_status = STANDBY;
+  }
+
+  if (reported_status == ACTIVE) {
     mbPV[308] = datalayer.battery.status.voltage_dV;
   } else {
     mbPV[308] = 0;
   }
-  mbPV[300] = datalayer.system.status.system_status;
+  mbPV[300] = reported_status;
   mbPV[302] = 128 + bms_char_dis_status;
   if (datalayer.battery.status.reported_soc < 100) {
     mbPV[303] = 100;  //Force SOC to never go below 1% to avoid overdischarge


### PR DESCRIPTION
### What:
Add datalayer.system.status.dc_bus_live as the single source of truth for "DC actually energized to the inverter", set by each contactor topology (GPIO state machine, BMW-I3 self-managed switch, BMW-SBOX). BYD-Modbus now remaps register 300 from ACTIVE to STANDBY while the bus is not yet live, and gates the voltage register (308) on the reported status. FAULT,
UPDATING and STANDBY pass through unchanged.

### Why:
Fronius GEN24 event log is filled with error message `GEN24-1187 No bat­tery voltage meas­ured but bat­tery is act­ive` each time Battery Emulator is being rebooted. This causes restarting the inverter, stopping PV production, and entering a long "Starting" procedure of several minutes (as required by the grid operator).

<img width="1282" height="592" alt="image" src="https://github.com/user-attachments/assets/5c34d206-5821-438c-bae4-0dedaaad8e4f" />

BydModbusInverter doesn't override controls_contactor(), so the emulator closes contactors on its own schedule (10s boot gate + precharge) with no inverter handshake. Meanwhile system_status defaults to ACTIVE and is served from boot, so a Fronius polling during that window sees an ACTIVE battery against a dead DC input and complains. STANDBY is the protocol-native "present but not delivering" state that resolves the mismatch.

### How:
dc_bus_live defaults true, so direct-wired setups keep today's behaviour; only topologies that actually gate the bus pull it low. The GPIO path sets it from contactorStatus == COMPLETED, BMW-I3 from its own contactors_engaged, BMW-SBOX from shunt.contactors_engaged. BYD-Modbus is the only consumer; the field is designed to generalise to other inverters later. No timing constants changed; reg 300 still first written on the 1s update loop.

BMW-I3 and BMW-SBOX need their own edits precisely because they're the exceptions that bypass handle_contactors(), everyone else uses the state machine in comm_contactorcontrol.cpp.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
