### PR TITLE
Bugfix: Leaf per-battery data on advanced page for double/triple setups

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -407,7 +407,8 @@ void setup_battery() {
           battery2 = new BydAttoBattery(&datalayer.battery2, &datalayer_extended.bydAtto3_2, can_config.battery_double);
           break;
         case BatteryType::NissanLeaf:
-          battery2 = new NissanLeafBattery(&datalayer.battery2, nullptr, can_config.battery_double);
+          battery2 = new NissanLeafBattery(&datalayer.battery2, &datalayer_extended.nissanleaf_2,
+                                           can_config.battery_double);
           break;
         case BatteryType::BmwI3:
           battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
@@ -469,7 +470,8 @@ void setup_battery() {
     } else {
       switch (user_selected_battery_type) {
         case BatteryType::NissanLeaf:
-          battery3 = new NissanLeafBattery(&datalayer.battery3, nullptr, can_config.battery_triple);
+          battery3 = new NissanLeafBattery(&datalayer.battery3, &datalayer_extended.nissanleaf_3,
+                                           can_config.battery_triple);
           break;
         case BatteryType::CmfaEv:
           battery3 = new CmfaEvBattery(&datalayer.battery3, nullptr, can_config.battery_triple);

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -407,8 +407,8 @@ void setup_battery() {
           battery2 = new BydAttoBattery(&datalayer.battery2, &datalayer_extended.bydAtto3_2, can_config.battery_double);
           break;
         case BatteryType::NissanLeaf:
-          battery2 = new NissanLeafBattery(&datalayer.battery2, &datalayer_extended.nissanleaf_2,
-                                           can_config.battery_double);
+          battery2 =
+              new NissanLeafBattery(&datalayer.battery2, &datalayer_extended.nissanleaf_2, can_config.battery_double);
           break;
         case BatteryType::BmwI3:
           battery2 = new BmwI3Battery(&datalayer.battery2, &datalayer.system.status.battery2_allowed_contactor_closing,
@@ -470,8 +470,8 @@ void setup_battery() {
     } else {
       switch (user_selected_battery_type) {
         case BatteryType::NissanLeaf:
-          battery3 = new NissanLeafBattery(&datalayer.battery3, &datalayer_extended.nissanleaf_3,
-                                           can_config.battery_triple);
+          battery3 =
+              new NissanLeafBattery(&datalayer.battery3, &datalayer_extended.nissanleaf_3, can_config.battery_triple);
           break;
         case BatteryType::CmfaEv:
           battery3 = new CmfaEvBattery(&datalayer.battery3, nullptr, can_config.battery_triple);

--- a/Software/src/battery/BMW-I3-HTML.h
+++ b/Software/src/battery/BMW-I3-HTML.h
@@ -14,6 +14,8 @@ class BmwI3HtmlRenderer : public BatteryHtmlRenderer {
  public:
   BmwI3HtmlRenderer(BmwI3Battery& b) : batt(b) {}
 
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html();
 };
 

--- a/Software/src/battery/BOLT-AMPERA-HTML.h
+++ b/Software/src/battery/BOLT-AMPERA-HTML.h
@@ -8,6 +8,8 @@ class BoltAmperaHtmlRenderer : public BatteryHtmlRenderer {
  public:
   BoltAmperaHtmlRenderer(DATALAYER_INFO_BOLTAMPERA* dl) : boltampera_dl(dl) {}
 
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html() {
     String content;
 

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -10,6 +10,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
  public:
   BydAtto3HtmlRenderer(DATALAYER_INFO_BYDATTO3* dl, const String& sfx = "") : byd_datalayer(dl), s(sfx) {}
 
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html() {
     String content;
 

--- a/Software/src/battery/KIA-HYUNDAI-64-HTML.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-HTML.h
@@ -10,6 +10,8 @@ class KiaHyundai64HtmlRenderer : public BatteryHtmlRenderer {
  public:
   KiaHyundai64HtmlRenderer(DATALAYER_INFO_KIAHYUNDAI64* dl) : kia_datalayer(dl) {}
 
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html() {
     String content;
     auto print_hyundai = [&content](DATALAYER_INFO_KIAHYUNDAI64& data) {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -11,7 +11,7 @@ extern bool user_selected_LEAF_interlock_mandatory;
 class NissanLeafBattery : public CanBattery {
  public:
   // Use the default constructor to create the first or single battery.battery_Total_Voltage2
-  NissanLeafBattery() {
+  NissanLeafBattery() : renderer(&datalayer_extended.nissanleaf) {
     datalayer_battery = &datalayer.battery;
     allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
     datalayer_nissan = &datalayer_extended.nissanleaf;
@@ -19,7 +19,7 @@ class NissanLeafBattery : public CanBattery {
   // Use this constructor for the second battery.
   NissanLeafBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_NISSAN_LEAF* extended,
                     CAN_Interface targetCan)
-      : CanBattery(targetCan) {
+      : CanBattery(targetCan), renderer(extended) {
     datalayer_battery = datalayer_ptr;
     allows_contactor_closing = nullptr;
     datalayer_nissan = extended;

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -8,11 +8,18 @@
 
 class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
  public:
+  NissanLeafHtmlRenderer(DATALAYER_INFO_NISSAN_LEAF* dl) : nissan_dl(dl) {}
+
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html() {
     String content;
+    if (!nissan_dl) {
+      return content;
+    }
 
     content += "<h4>LEAF generation: ";
-    switch (datalayer_extended.nissanleaf.LEAF_gen) {
+    switch (nissan_dl->LEAF_gen) {
       case 0:
         content += String("ZE0</h4>");
         break;
@@ -26,47 +33,50 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         content += String("Unknown</h4>");
     }
     char readableSerialNumber[16];  // One extra space for null terminator
-    memcpy(readableSerialNumber, datalayer_extended.nissanleaf.BatterySerialNumber,
-           sizeof(datalayer_extended.nissanleaf.BatterySerialNumber));
+    memcpy(readableSerialNumber, nissan_dl->BatterySerialNumber,
+           sizeof(nissan_dl->BatterySerialNumber));
     readableSerialNumber[15] = '\0';  // Null terminate the string
     content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
     char readablePartNumber[8];  // One extra space for null terminator
-    memcpy(readablePartNumber, datalayer_extended.nissanleaf.BatteryPartNumber,
-           sizeof(datalayer_extended.nissanleaf.BatteryPartNumber));
+    memcpy(readablePartNumber, nissan_dl->BatteryPartNumber,
+           sizeof(nissan_dl->BatteryPartNumber));
     readablePartNumber[7] = '\0';  // Null terminate the string
     content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
     char readableBMSID[9];  // One extra space for null terminator
-    memcpy(readableBMSID, datalayer_extended.nissanleaf.BMSIDcode, sizeof(datalayer_extended.nissanleaf.BMSIDcode));
+    memcpy(readableBMSID, nissan_dl->BMSIDcode, sizeof(nissan_dl->BMSIDcode));
     readableBMSID[8] = '\0';  // Null terminate the string
     content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
-    content += "<h4>GIDS: " + String(datalayer_extended.nissanleaf.GIDS) + "</h4>";
-    content += "<h4>HX: " + String(datalayer_extended.nissanleaf.battery_HX) + "</h4>";
-    content += "<h4>Regen kW: " + String(datalayer_extended.nissanleaf.ChargePowerLimit) + "</h4>";
-    content += "<h4>Charge kW: " + String(datalayer_extended.nissanleaf.MaxPowerForCharger) + "</h4>";
-    content += "<h4>Interlock: " + String(datalayer_extended.nissanleaf.Interlock) + "</h4>";
-    content += "<h4>Insulation: " + String(datalayer_extended.nissanleaf.Insulation) + "</h4>";
-    content += "<h4>Relay cut request: " + String(datalayer_extended.nissanleaf.RelayCutRequest) + "</h4>";
-    content += "<h4>Failsafe status: " + String(datalayer_extended.nissanleaf.FailsafeStatus) + "</h4>";
-    content += "<h4>Fully charged: " + String(datalayer_extended.nissanleaf.Full) + "</h4>";
-    content += "<h4>Battery empty: " + String(datalayer_extended.nissanleaf.Empty) + "</h4>";
-    content += "<h4>Main relay ON: " + String(datalayer_extended.nissanleaf.MainRelayOn) + "</h4>";
-    content += "<h4>Heater present: " + String(datalayer_extended.nissanleaf.HeatExist) + "</h4>";
-    content += "<h4>Heating stopped: " + String(datalayer_extended.nissanleaf.HeatingStop) + "</h4>";
-    content += "<h4>Heating started: " + String(datalayer_extended.nissanleaf.HeatingStart) + "</h4>";
-    content += "<h4>Heating requested: " + String(datalayer_extended.nissanleaf.HeaterSendRequest) + "</h4>";
-    content += "<h4>Temperature 1: " + String(datalayer_extended.nissanleaf.temperature1 / 10.0) + " &deg;C</h4>";
-    content += "<h4>Temperature 2: " + String(datalayer_extended.nissanleaf.temperature2 / 10.0) + " &deg;C</h4>";
-    if (datalayer_extended.nissanleaf.LEAF_gen == 0) {
-      content += "<h4>Temperature 3: " + String(datalayer_extended.nissanleaf.temperature3 / 10.0) + " &deg;C</h4>";
+    content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
+    content += "<h4>HX: " + String(nissan_dl->battery_HX) + "</h4>";
+    content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
+    content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
+    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
+    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + "</h4>";
+    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
+    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
+    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
+    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
+    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
+    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
+    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
+    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
+    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
+    content += "<h4>Temperature 1: " + String(nissan_dl->temperature1 / 10.0) + " &deg;C</h4>";
+    content += "<h4>Temperature 2: " + String(nissan_dl->temperature2 / 10.0) + " &deg;C</h4>";
+    if (nissan_dl->LEAF_gen == 0) {
+      content += "<h4>Temperature 3: " + String(nissan_dl->temperature3 / 10.0) + " &deg;C</h4>";
     }
-    content += "<h4>Temperature 4: " + String(datalayer_extended.nissanleaf.temperature4 / 10.0) + " &deg;C</h4>";
-    content += "<h4>CryptoChallenge: " + String(datalayer_extended.nissanleaf.CryptoChallenge) + "</h4>";
-    content += "<h4>SolvedChallenge: " + String(datalayer_extended.nissanleaf.SolvedChallengeMSB) +
-               String(datalayer_extended.nissanleaf.SolvedChallengeLSB) + "</h4>";
-    content += "<h4>Challenge failed: " + String(datalayer_extended.nissanleaf.challengeFailed) + "</h4>";
+    content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
+    content += "<h4>CryptoChallenge: " + String(nissan_dl->CryptoChallenge) + "</h4>";
+    content += "<h4>SolvedChallenge: " + String(nissan_dl->SolvedChallengeMSB) +
+               String(nissan_dl->SolvedChallengeLSB) + "</h4>";
+    content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
 
     return content;
   }
+
+ private:
+  DATALAYER_INFO_NISSAN_LEAF* nissan_dl;
 };
 
 #endif

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -33,13 +33,11 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         content += String("Unknown</h4>");
     }
     char readableSerialNumber[16];  // One extra space for null terminator
-    memcpy(readableSerialNumber, nissan_dl->BatterySerialNumber,
-           sizeof(nissan_dl->BatterySerialNumber));
+    memcpy(readableSerialNumber, nissan_dl->BatterySerialNumber, sizeof(nissan_dl->BatterySerialNumber));
     readableSerialNumber[15] = '\0';  // Null terminate the string
     content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
     char readablePartNumber[8];  // One extra space for null terminator
-    memcpy(readablePartNumber, nissan_dl->BatteryPartNumber,
-           sizeof(nissan_dl->BatteryPartNumber));
+    memcpy(readablePartNumber, nissan_dl->BatteryPartNumber, sizeof(nissan_dl->BatteryPartNumber));
     readablePartNumber[7] = '\0';  // Null terminate the string
     content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
     char readableBMSID[9];  // One extra space for null terminator
@@ -68,8 +66,8 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     }
     content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
     content += "<h4>CryptoChallenge: " + String(nissan_dl->CryptoChallenge) + "</h4>";
-    content += "<h4>SolvedChallenge: " + String(nissan_dl->SolvedChallengeMSB) +
-               String(nissan_dl->SolvedChallengeLSB) + "</h4>";
+    content += "<h4>SolvedChallenge: " + String(nissan_dl->SolvedChallengeMSB) + String(nissan_dl->SolvedChallengeLSB) +
+               "</h4>";
     content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
 
     return content;

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -1056,7 +1056,11 @@ class DataLayerExtended {
       DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64_2;
     };
     DATALAYER_INFO_TESLA tesla;
-    DATALAYER_INFO_NISSAN_LEAF nissanleaf;
+    struct {
+      DATALAYER_INFO_NISSAN_LEAF nissanleaf;
+      DATALAYER_INFO_NISSAN_LEAF nissanleaf_2;
+      DATALAYER_INFO_NISSAN_LEAF nissanleaf_3;
+    };
     DATALAYER_INFO_MEB meb;
     DATALAYER_INFO_VOLVO_HYBRID VolvoHybrid;
     DATALAYER_INFO_ZOE zoe;

--- a/Software/src/devboard/webserver/BatteryHtmlRenderer.h
+++ b/Software/src/devboard/webserver/BatteryHtmlRenderer.h
@@ -13,6 +13,14 @@ class BatteryHtmlRenderer {
  public:
   virtual String get_status_html() = 0;
 
+  // Returns true when this renderer reads the data of its own battery instance
+  // (e.g. via a datalayer pointer supplied at construction), rather than the
+  // hardcoded main-battery globals. The advanced battery page only renders
+  // status HTML for battery 2/3 when this returns true; otherwise it shows a
+  // "limited to the Main Battery" notice. Override and return true after
+  // reworking a battery integration for double/triple support.
+  virtual bool renders_own_battery_data() { return false; }
+
   static String render_dtc_section_html(DATALAYER_BATTERY_DTC_TYPE& dtc, const char* json_filename,
                                         bool standard_code_string) {
     String content;
@@ -277,6 +285,8 @@ class BatteryHtmlRenderer {
 class BatteryDefaultRenderer : public BatteryHtmlRenderer {
  public:
   String get_status_html() { return String("No extra information available for this battery type"); }
+  // Static text, valid for any battery instance.
+  bool renders_own_battery_data() { return true; }
 };
 
 #endif

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -111,6 +111,20 @@ String advanced_battery_processor(const String& var) {
       }
     };
 
+    // Renders battery specific status for battery 2/3. Only renderers that
+    // read per-instance data (renders_own_battery_data) are used; legacy
+    // renderers hardcode the main battery datalayer and would show battery 1
+    // values here, so a notice is shown instead until they are reworked.
+    auto render_secondary_battery_status = [&content](Battery* batt) {
+      BatteryHtmlRenderer& renderer = batt->get_status_renderer();
+      if (renderer.renders_own_battery_data()) {
+        content += renderer.get_status_html();
+      } else {
+        content +=
+            "<h4 style='color: #f39c12;'>⚠️ Advanced detailed info is currently limited to the Main Battery.</h4>";
+      }
+    };
+
     if (battery) {
       content += battery->get_status_renderer().get_status_html();
       render_command_buttons(battery, 0);
@@ -119,13 +133,14 @@ String advanced_battery_processor(const String& var) {
     if (battery2) {
       content += "<hr>";
       content += "<h4>Values from battery 2</h4>";
-      content += battery2->get_status_renderer().get_status_html();
+      render_secondary_battery_status(battery2);
       render_command_buttons(battery2, 1);
     }
 
     if (battery3) {
+      content += "<hr>";
       content += "<h4>Values from battery 3</h4>";
-      content += "<h4 style='color: #f39c12;'>⚠️ Advanced detailed info is currently limited to the Main Battery.</h4>";
+      render_secondary_battery_status(battery3);
       render_command_buttons(battery3, 2);
     }
 


### PR DESCRIPTION
### What
This PR fixes issues https://github.com/dalathegreat/Battery-Emulator/issues/1840 and https://github.com/dalathegreat/Battery-Emulator/issues/899, the "More battery info" page for double/triple Nissan Leaf setups: battery 2 previously displayed battery 1's values, and battery 3 showed no data at all. Each Leaf now shows its own real data (Insulation, GIDS, HX, temperatures, serial number, etc.).

### Why
The Leaf HTML renderer read the hardcoded global `datalayer_extended.nissanleaf`, and batteries 2/3 were constructed with a `nullptr` extended pointer, so their driver writes were silently discarded. This made the page misleading for multi-battery users and left no per-battery Insulation reading.

### How
Adds `nissanleaf_2`/`nissanleaf_3` structs to the `DataLayerExtended` union (zero RAM growth — 3×72 B fits under the 752 B Tesla member), passes them in `BATTERIES.cpp`, and constructs `NissanLeafHtmlRenderer` with the per-instance pointer. A new `renders_own_battery_data()` flag on `BatteryHtmlRenderer` gates battery 2/3 rendering: reworked renderers (Leaf, BMW-i3, Bolt, BYD Atto 3, KIA-64) show real data, legacy ones show the "limited to Main Battery" notice instead of wrong values. Future integrations follow the same three steps and flip the flag.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
