### PR TITLE
Improvement: Add generic MQTT autodiscovered Insulation Resistance sensor

### DIFF
--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -683,6 +683,8 @@ void BmwPhevBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (rx_frame.DLC == 8 && rx_frame.data.u8[2] == 0x62 && rx_frame.data.u8[3] == 0xD6 &&
               rx_frame.data.u8[4] == 0xD9) {                                     // Isolation Reading 2
             iso_safety_kohm = (rx_frame.data.u8[5] << 8 | rx_frame.data.u8[6]);  //STAT_R_ISO_ROH_01_WERT
+            datalayer.battery.status.insulation_resistance_kOhm = iso_safety_kohm;
+            datalayer.battery.status.insulation_resistance_available = true;
             iso_safety_kohm_quality =
                 (rx_frame.data.u8[7]);  //STAT_R_ISO_ROH_QAL_01_INFO Quality of measurement 0-21 (higher better)
           }

--- a/Software/src/battery/BMW-PHEV-BATTERY.h
+++ b/Software/src/battery/BMW-PHEV-BATTERY.h
@@ -14,6 +14,7 @@ class BmwPhevBattery : public CanBattery {
   static constexpr const char* Name = "BMW PHEV Battery";
 
   bool supports_reset_DTC() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void reset_DTC() { datalayer_extended.bmwphev.UserRequestDTCreset = true; }
 
   bool supports_reset_BMS() { return true; }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -227,6 +227,13 @@ void BydAttoBattery::
     datalayer_battery->status.temperature_max_dC = BMS_highest_cell_temperature * 10;
   }
 
+  if (battery_insulation_valid) {
+    // BMS reports insulation in Ohm per Volt of pack voltage. Convert to kOhm.
+    datalayer_battery->status.insulation_resistance_kOhm =
+        (uint16_t)(((uint32_t)battery_insulation_ohm_per_volt * datalayer_battery->status.voltage_dV) / 10000u);
+    datalayer_battery->status.insulation_resistance_available = true;
+  }
+
   // Update webserver datalayer
   if (datalayer_bydatto) {
     datalayer_bydatto->SOC_highprec = battery_highprecision_SOC;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -42,6 +42,7 @@ class BydAttoBattery : public CanBattery {
   bool supports_read_DTC() { return true; }
   void read_DTC() { datalayer_bydatto->UserRequestDTCreadout = true; }
   bool supports_reset_DTC() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void reset_DTC() { datalayer_bydatto->UserRequestDTCreset = true; }
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -151,6 +151,10 @@ class Battery {
   // Battery reports total_charged_battery_Wh and total_discharged_battery_Wh
   virtual bool supports_charged_energy() { return false; }
 
+  // Battery reports insulation/isolation resistance via
+  // datalayer status insulation_resistance_kOhm
+  virtual bool supports_insulation_resistance() { return false; }
+
   virtual BatteryHtmlRenderer& get_status_renderer() { return defaultRenderer; }
 
  private:

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -230,6 +230,8 @@ void CmpSmartCarBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       l3_fault = rx_frame.data.u8[4] & 0x3F;
       master_warning = (rx_frame.data.u8[4] & 0xC0) >> 6;
       insulation_resistance_kOhm = ((rx_frame.data.u8[5] << 8) | (rx_frame.data.u8[6]));
+      datalayer_battery->status.insulation_resistance_kOhm = insulation_resistance_kOhm;
+      datalayer_battery->status.insulation_resistance_available = true;
       //counter_325 = (rx_frame.data.u8[7] & 0x0F);
       break;
     case 0x334:  // Cellvoltages

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.h
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.h
@@ -27,6 +27,7 @@ class CmpSmartCarBattery : public CanBattery {
   static constexpr const char* Name = "Stellantis CMP Smart Car Battery";
 
   bool supports_charged_energy() { return true; }
+  bool supports_insulation_resistance() { return true; }
 
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { datalayer_extended.stellantisCMPsmart.UserRequestDTCreset = true; }

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -500,6 +500,8 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       battery_insulationResistanceKOhm =
           (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];  //Byte 2, bit 7, length 16 (0-60000 kOhm)
+      datalayer_battery->status.insulation_resistance_kOhm = battery_insulationResistanceKOhm;
+      datalayer_battery->status.insulation_resistance_available = true;
       break;
     case 0x6D1:
       break;

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -28,6 +28,7 @@ class EcmpBattery : public CanBattery {
   static constexpr const char* Name = "Stellantis ECMP battery";
 
   bool supports_clear_isolation() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void clear_isolation() { UserRequestIsolationReset = true; }
 
   bool supports_factory_mode_method() { return true; }

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.cpp
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.cpp
@@ -286,6 +286,8 @@ void HyundaiIoniq28Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case 0x28:                         //Eighth datarow in PID group
           if (incoming_poll_group == 1) {  //28 7F FF 7F FF 03 E8 00
             isolation_resistance = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
+            datalayer_battery->status.insulation_resistance_kOhm = isolation_resistance;
+            datalayer_battery->status.insulation_resistance_available = true;
           }
           break;
       }

--- a/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
+++ b/Software/src/battery/HYUNDAI-IONIQ-28-BATTERY.h
@@ -27,6 +27,7 @@ class HyundaiIoniq28Battery : public CanBattery {
   uint8_t get_battery_management_mode() const;
 
   bool supports_reset_DTC() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void reset_DTC() { UserRequestDTCreset = true; }
 
  private:

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.cpp
@@ -455,6 +455,8 @@ void KiaHyundai64Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (pid_reply == POLL_GROUP_1) {
             inverterVoltage = (inverterVoltageFrameHigh << 8) + rx_frame.data.u8[1];
             isolation_resistance_kOhm = ((rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7]);
+            datalayer_battery->status.insulation_resistance_kOhm = isolation_resistance_kOhm;
+            datalayer_battery->status.insulation_resistance_available = true;
           }
           break;
         default:

--- a/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
+++ b/Software/src/battery/KIA-HYUNDAI-64-BATTERY.h
@@ -34,6 +34,7 @@ class KiaHyundai64Battery : public CanBattery {
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
   bool supports_reset_DTC() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void reset_DTC() { UserRequestDTCreset = true; }
 
  private:

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -411,6 +411,8 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       max_charge_percent = ((rx_frame.data.u8[7] << 3) | rx_frame.data.u8[6] >> 5);                  //*0.05
       min_charge_percent = ((rx_frame.data.u8[4] << 3) | rx_frame.data.u8[3] >> 5);                  //*0.05
       isolation_resistance_kOhm = (((rx_frame.data.u8[3] & 0x1F) << 7) | rx_frame.data.u8[2] >> 1);  //*5
+      datalayer_battery->status.insulation_resistance_kOhm = isolation_resistance_kOhm * 5;
+      datalayer_battery->status.insulation_resistance_available = true;
       break;
     case BMS_25:  // BMS 500ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -23,6 +23,7 @@ class MebBattery : public CanBattery, public IsoTp {
   virtual void update_values();
   virtual void transmit_can(unsigned long currentMillis);
   bool supports_real_BMS_status() { return true; }
+  bool supports_insulation_resistance() { return true; }
   bool supports_charged_energy() { return true; }
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { datalayer_extended.meb.UserRequestDTCreset = true; }

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -410,6 +410,8 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
         if (rx_frame.data.u8[0] == 0x23) {  // Fourth frame
           battery_insulation = (uint16_t)((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
+          datalayer_battery->status.insulation_resistance_kOhm = battery_insulation;
+          datalayer_battery->status.insulation_resistance_available = true;
         }
 
         if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -410,8 +410,10 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
         if (rx_frame.data.u8[0] == 0x23) {  // Fourth frame
           battery_insulation = (uint16_t)((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-          datalayer_battery->status.insulation_resistance_kOhm = battery_insulation;
-          datalayer_battery->status.insulation_resistance_available = true;
+          if (battery_insulation > 0) {
+            datalayer_battery->status.insulation_resistance_kOhm = battery_insulation;
+            datalayer_battery->status.insulation_resistance_available = true;
+          }
         }
 
         if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -36,6 +36,7 @@ class NissanLeafBattery : public CanBattery {
   void reset_SOH() { UserRequestSOHreset = true; }
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { UserRequestDTCreset = true; }
+  bool supports_insulation_resistance() { return true; }
 
   bool soc_plausible() {
     // When pack voltage is close to max, and SOC% is still low (<65.0%), SOC is not plausible

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -1307,6 +1307,8 @@ void TeslaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       BMS_isolationResistance =
           ((rx_frame.data.u8[3] & (0x1FU)) << 5) |
           ((rx_frame.data.u8[2] >> 3) & (0x1FU));  //19|10@1+ (10,0) [0|0] "kOhm"/to datalayer_extended
+      datalayer_battery->status.insulation_resistance_kOhm = BMS_isolationResistance * 10;
+      datalayer_battery->status.insulation_resistance_available = true;
       //BMS_chargeRequest = ((rx_frame.data.u8[3] >> 5) & (0x01U));
       BMS_chargeRequest = static_cast<bool>(extract_signal_value(rx_frame.data.u8, 29, 1));
       BMS_keepWarmRequest = ((rx_frame.data.u8[3] >> 6) & (0x01U));

--- a/Software/src/battery/TESLA-BATTERY.h
+++ b/Software/src/battery/TESLA-BATTERY.h
@@ -34,6 +34,7 @@ class TeslaBattery : public CanBattery {
   virtual void transmit_can(unsigned long currentMillis);
 
   bool supports_clear_isolation() { return true; }
+  bool supports_insulation_resistance() { return true; }
   void clear_isolation() { datalayer_battery->settings.user_requests_tesla_isolation_clear = true; }
 
   bool supports_reset_BMS() { return true; }

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -101,6 +101,11 @@ struct DATALAYER_BATTERY_STATUS_TYPE {
   uint16_t reported_soc;
   /** A counter that increases incase a CAN CRC read error occurs */
   uint16_t CAN_error_counter;
+  /** Insulation/isolation resistance between the HV pack and chassis, in kOhm.
+   * Not available for all battery types. Only valid once
+   * insulation_resistance_available has been set by the battery integration.
+   */
+  uint16_t insulation_resistance_kOhm = 0;
 
   /** int16_t */
   /** Maximum temperature currently measured in the pack, in d°C. 150 = 15.0 °C */
@@ -126,6 +131,11 @@ struct DATALAYER_BATTERY_STATUS_TYPE {
   led_mode_enum led_mode = CLASSIC;
   /** Balancing status */
   balancing_status_enum balancing_status = BALANCING_STATUS_UNKNOWN;
+
+  /** True once the battery integration has decoded a valid
+   * insulation_resistance_kOhm sample. Not available for all battery types.
+   */
+  bool insulation_resistance_available = false;
 
   /** All cell voltages currently measured in the pack, in mV.
    * Use with battery.info.number_of_cells to get valid data.

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -134,6 +134,9 @@ static bool supports_tesla_dcdc_metrics(Battery* b) {
 static bool supports_byd_autocal_metrics(Battery* b) {
   return b != nullptr && user_selected_battery_type == BatteryType::BydAtto3;
 }
+static bool supports_insulation(Battery* b) {
+  return b != nullptr && b->supports_insulation_resistance();
+}
 
 static const SensorConfig batterySensorConfigTemplate[] = {
     {"SOC", "SOC (Scaled)", "%", "battery", always},
@@ -154,6 +157,7 @@ static const SensorConfig batterySensorConfigTemplate[] = {
     {"max_charge_power", "Max Charge Power", "W", "power", always},
     {"charged_energy", "Battery Charged Energy", "Wh", "energy", supports_charged},
     {"discharged_energy", "Battery Discharged Energy", "Wh", "energy", supports_charged},
+    {"insulation_resistance", "Insulation Resistance", "kΩ", "", supports_insulation},
     {"balancing_active_cells", "Balancing Cells", "", "", always},
     {"balancing_status", "Balancing Status", "", "", always},
     {"charging_state", "Charging State", "", "", always},
@@ -309,6 +313,11 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
   doc["remaining_capacity"] = ((float)battery_data.status.reported_remaining_capacity_Wh);
   doc["max_discharge_power"] = ((float)battery_data.status.max_discharge_power_W);
   doc["max_charge_power"] = ((float)battery_data.status.max_charge_power_W);
+  // Omit until the integration has decoded a valid sample so HA shows "unknown"
+  // instead of a false 0 kOhm at boot.
+  if (battery_data.status.insulation_resistance_available) {
+    doc["insulation_resistance"] = battery_data.status.insulation_resistance_kOhm;
+  }
 
   if (battery_supports_charged) {
     // Note: reads the charged/discharged totals of THIS battery. The previous implementation
@@ -361,6 +370,9 @@ static const char* sensor_discovery_icon(const char* entity_id, const char* devi
     }
     if (strcmp(entity_id, "bms_status") == 0) {
       return "mdi:information-box-outline";
+    }
+    if (strcmp(entity_id, "insulation_resistance") == 0) {
+      return "mdi:resistor";
     }
     if (strcmp(entity_id, "charging_state") == 0) {
       return "mdi:home-battery";
@@ -433,6 +445,13 @@ static bool publish_sensor_discovery(const SensorConfig& config, const char* id_
   // records long-term statistics for it.
   if (strcmp(config.entity_id, "balancing_active_cells") == 0) {
     doc["state_class"] = "measurement";
+  }
+  // "insulation_resistance" is a numeric value with no device_class, so it also misses the
+  // state_class assignment above. Mark it as a measurement and display it as a whole
+  // number of kOhm.
+  if (strcmp(config.entity_id, "insulation_resistance") == 0) {
+    doc["state_class"] = "measurement";
+    doc["suggested_display_precision"] = 0;
   }
   // "energy" device_class is only valid with state_class total / total_increasing, never
   // "measurement" — HA rejects the combination. The capacity sensors represent a current


### PR DESCRIPTION
### What
Adds insulation_resistance_kOhm + availability flag to the generic battery status datalayer and a supports_insulation_resistance() capability on the Battery base class. Publishes a HA autodiscovered sensor ("Insulation Resistance" in kΩ, state_class measurement, precision 0, mdi:resistor) per battery instance, including battery 2/3 in double/triple setups. 

<img width="510" height="49" alt="image" src="https://github.com/user-attachments/assets/207fcb4d-fd96-415c-bb91-22486d459c0d" />

Wired up in: Nissan Leaf, BYD Atto 3, eCMP, CMP Smart Car, Kia/Hyundai 64, Hyundai Ioniq 28, MEB, Tesla 3Y/SX, BMW PHEV.

### Why
Insulation resistance is a key early indicator of HV pack health (moisture ingress, degrading waterproofing), but until now it was only visible by manually opening the More Battery Info page. Exposing it over MQTT allows long-term trending, dashboards and alerting in various third patry systems. For stationary storage this is even more important to be actively monitored than when was in the car originally, as an improper insulation resistance may cause tragic accidents.

Storing it in the per-instance generic datalayer (instead of the extended structs) is deliberate: extended data is shared or null for battery 2/3, so this is the only path that reports correct per-battery values in multi-battery systems. Bonus: CMP Smart Car already decoded this value from CAN but never used it anywhere.

### How
- datalayer.h: adds insulation_resistance_kOhm (uint16) and an insulation_resistance_available flag to DATALAYER_BATTERY_STATUS_TYPE.
- Battery.h: new supports_insulation_resistance() virtual (default false), following the supports_charged_energy() pattern; the existing _2/_3 config cloning in create_battery_sensor_configs() picks it up as-is.
- mqtt.cpp: sensor template row, explicit state_class/precision (no device_class), icon mapping, and value published only once a valid sample exists  HA shows "unknown" instead of a false 0 at boot.
- Drivers write value + flag at their decode site via datalayer_battery, converting to kΩ where needed (Tesla ×10, MEB ×5, BYD Ω/V × pack V).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
