### PR TITLE
Sungrow: SBR cleanup and updates

### DIFF
--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -85,6 +85,17 @@ bool SungrowInverter::setup() {
   SUNGROW_707.data.u8[5] = (battery_config.nameplate_wh >> 8);      // Nameplate capacity (high)
   SUNGROW_707.data.u8[6] = battery_config.module_count;             // Num of modules
 
+  // 0x70F mux 0 b4-7 - max continuous power (W) = nominal voltage x 30 A. Per the SBR datasheet each
+  //                    module is 64 V nominal and the pack is 30 A continuous, so 1920 W per module
+  //                    (SBR096 = 5760, SBR160 = 9600, SBR224 = 13440). On a real battery this is a
+  //                    static rating - invariant across SoC and season - so it belongs here, not in
+  //                    update_values(). The live limits are reported separately in 0x701.
+  uint16_t max_power_w = 1920 * battery_config.module_count;
+  SUNGROW_70F_00.data.u8[4] = (max_power_w & 0x00FF);
+  SUNGROW_70F_00.data.u8[5] = (max_power_w >> 8);
+  SUNGROW_70F_00.data.u8[6] = (max_power_w & 0x00FF);
+  SUNGROW_70F_00.data.u8[7] = (max_power_w >> 8);
+
   // Cell type for each active module
   // 0x42 = IEC
   // 0x44 = Non-IEC

--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -69,8 +69,21 @@ uint16_t modbus_crc(const uint8_t* data, uint8_t length) {
 }  // namespace
 
 bool SungrowInverter::setup() {
+  // Where to find a frame's bytes (convention):
+  //   - header .data{} initialiser -> bytes constant for every SBR (frame declaration + fixed payload)
+  //   - setup() (here)             -> bytes fixed for this run: battery_config-derived + version constants
+  //   - update_values()            -> per-cycle telemetry rebuilt from live datalayer values
+  //   - map_can_frame_to_variable() -> 0x1E0 Modbus reply, built on demand when the inverter polls
+
   // Stored value is model (0-6), get_config_for_model handles default
   battery_config = get_config_for_model(user_selected_inverter_sungrow_type);
+
+  // 0x707 - nameplate capacity + module count from battery_config (b4-6). Every other byte is constant
+  //         (firmware version in b0-3, b1-2 and b7 = 0) and set in the header .data{} initialiser.
+  // NOTE: must come after battery_config is assigned above, or it reads the default {9600, 3}.
+  SUNGROW_707.data.u8[4] = (battery_config.nameplate_wh & 0x00FF);  // Nameplate capacity (low)
+  SUNGROW_707.data.u8[5] = (battery_config.nameplate_wh >> 8);      // Nameplate capacity (high)
+  SUNGROW_707.data.u8[6] = battery_config.module_count;             // Num of modules
 
   // Cell type for each active module
   // 0x42 = IEC
@@ -131,21 +144,12 @@ bool SungrowInverter::setup() {
 }
 
 void SungrowInverter::update_values() {
+  // Per-cycle telemetry only. Static / config-only frames are built once in setup() (see the
+  // convention note there); some constant frames live entirely in the header .data{} initialiser.
   current_dA = datalayer.battery.status.reported_current_dA;
 
-  // Actual SoC
-  SUNGROW_400.data.u8[1] = (datalayer.battery.status.real_soc & 0x00FF);
-  SUNGROW_400.data.u8[2] = (datalayer.battery.status.real_soc >> 8);
-  // Magic number
-  SUNGROW_400.data.u8[3] = 0x01;
-
-  // BMS init message
-  SUNGROW_500.data.u8[0] = 0x01;                                           // Magic number
-  SUNGROW_500.data.u8[1] = 0x01;                                           // Magic number
-  SUNGROW_500.data.u8[2] = 0x03;                                           // Magic number
-  SUNGROW_500.data.u8[3] = 0xFF;                                           // Magic number
-  SUNGROW_500.data.u8[5] = 0x01;                                           // Magic number
-  SUNGROW_500.data.u8[7] = (datalayer.battery.status.reported_soc / 100);  // SoC as a int
+  // 0x500 - BMS init message: b0-6 are static unknown values -> header .data{}. Only b7 (live SoC) here.
+  SUNGROW_500.data.u8[7] = (datalayer.battery.status.reported_soc / 100);  // Battery SoC, integer %
 
   // Max voltage (eg 400.0V = 4000 , 16bits long)
   SUNGROW_701.data.u8[0] = (datalayer.battery.info.max_design_voltage_dV & 0x00FF);
@@ -190,7 +194,7 @@ void SungrowInverter::update_values() {
   SUNGROW_703.data.u8[6] = ((datalayer.battery.status.total_discharged_battery_Wh >> 16) & 0x00FF);
   SUNGROW_703.data.u8[7] = ((datalayer.battery.status.total_discharged_battery_Wh >> 24) & 0x00FF);
 
-  //Vbat (eg 400.0V = 4000 , 16bits long)
+  // Vbat (eg 400.0V = 4000 , 16bits long)
   SUNGROW_704.data.u8[0] = (datalayer.battery.status.voltage_dV & 0x00FF);
   SUNGROW_704.data.u8[1] = (datalayer.battery.status.voltage_dV >> 8);
   // Current
@@ -203,18 +207,13 @@ void SungrowInverter::update_values() {
   SUNGROW_704.data.u8[6] = (datalayer.battery.status.temperature_max_dC & 0xFF);
   SUNGROW_704.data.u8[7] = ((datalayer.battery.status.temperature_max_dC >> 8) & 0xFF);
 
-  // Battery status: 0=Unplugged, 1=Standby, 2=Run
-  SUNGROW_705.data.u8[0] = 0x02;                                   // Always "Run"
-  SUNGROW_705.data.u8[1] = 0x00;                                   // Magic number
-  SUNGROW_705.data.u8[2] = 0x01;                                   // Magic number
+  // 0x705 - b0-2 and b7 (padding) are static -> header .data{}. Model id (b3-4) + voltage (b5-6) below.
   uint16_t battery_model_id = 8420 + battery_config.module_count;  // SBR064=8422, SBR096=8423, etc.
   SUNGROW_705.data.u8[3] = (battery_model_id & 0xFF);
   SUNGROW_705.data.u8[4] = (battery_model_id >> 8);
-  //Vbat, again (eg 400.0V = 4000 , 16bits long)
+  // Vbat, again (eg 400.0V = 4000 , 16bits long)
   SUNGROW_705.data.u8[5] = (datalayer.battery.status.voltage_dV & 0x00FF);
   SUNGROW_705.data.u8[6] = (datalayer.battery.status.voltage_dV >> 8);
-  // Padding?
-  SUNGROW_705.data.u8[7] = 0x00;  // Magic number
 
   // Temperature Max (signed int16_t in 0.1°C units)
   SUNGROW_706.data.u8[0] = (datalayer.battery.status.temperature_max_dC & 0xFF);
@@ -229,39 +228,6 @@ void SungrowInverter::update_values() {
   SUNGROW_706.data.u8[6] = (datalayer.battery.status.cell_min_voltage_mV & 0x00FF);
   SUNGROW_706.data.u8[7] = (datalayer.battery.status.cell_min_voltage_mV >> 8);
 
-  // Battery Configuration
-  SUNGROW_707.data.u8[0] = 0x26;                                    // Magic number
-  SUNGROW_707.data.u8[1] = 0x00;                                    // Magic number
-  SUNGROW_707.data.u8[2] = 0x00;                                    // Magic number
-  SUNGROW_707.data.u8[3] = 0x01;                                    // Magic number. Num of stacks?
-  SUNGROW_707.data.u8[4] = (battery_config.nameplate_wh & 0x00FF);  // Nameplate capacity
-  SUNGROW_707.data.u8[5] = (battery_config.nameplate_wh >> 8);      // Nameplate capacity
-  SUNGROW_707.data.u8[6] = battery_config.module_count;             // Num of modules
-  SUNGROW_707.data.u8[7] = 0x00;                                    // Padding?
-
-  // ---- 0x70F: two muxes (b0 = 0x00..0x07, b1 = 0x00) ----
-  SUNGROW_70F_00.data.u8[2] = 0x88;  // Magic number
-  SUNGROW_70F_00.data.u8[3] = 0x13;  // Magic number
-  SUNGROW_70F_00.data.u8[4] = 0x80;  // Magic number
-  SUNGROW_70F_00.data.u8[5] = 0x16;  // Magic number
-  SUNGROW_70F_00.data.u8[6] = 0x80;  // Magic number
-  SUNGROW_70F_00.data.u8[7] = 0x16;  // Magic number
-  // Charge counter??
-  SUNGROW_70F_02.data.u8[2] = 0x70;  // Magic number
-  SUNGROW_70F_02.data.u8[3] = 0x20;  // Magic number
-  // Unknown
-  SUNGROW_70F_02.data.u8[6] = 0x92;  // Magic number
-  SUNGROW_70F_02.data.u8[7] = 0x09;  // Magic number
-  // Discharge counter??
-  SUNGROW_70F_03.data.u8[2] = 0xFD;
-  SUNGROW_70F_03.data.u8[3] = 0x1D;
-  // Unknown
-  SUNGROW_70F_03.data.u8[6] = 0xCE;
-  SUNGROW_70F_03.data.u8[7] = 0x26;
-  // Unknown
-  SUNGROW_70F_04.data.u8[2] = 0x0C;
-  SUNGROW_70F_04.data.u8[3] = 0x06;
-
   // Populate 0x70F_05/06/07 with module SOC based on module_count
   // 0x70F_05: modules 1-3, 0x70F_06: modules 4-6, 0x70F_07: modules 7-8
   {
@@ -274,31 +240,15 @@ void SungrowInverter::update_values() {
     }
   }
 
-  // 0x713 - Battery Cell Temperature Overview
-  // Cell position with minimum temperature (cell/module addressing)
-  SUNGROW_713.data.u8[0] = 0x02;  // Cell location with minimum temperature
-  SUNGROW_713.data.u8[1] = 0x01;  // Module location with minimum temperature
-  // Minimum cell temperature (signed int16_t in 0.1°C units)
+  // 0x713 - Cell/module locations are static (header). Min/max cell temperatures here (int16_t, 0.1C):
   SUNGROW_713.data.u8[2] = (datalayer.battery.status.temperature_min_dC & 0xFF);
   SUNGROW_713.data.u8[3] = ((datalayer.battery.status.temperature_min_dC >> 8) & 0xFF);
-  // Cell position with maximum temperature (cell/module addressing)
-  SUNGROW_713.data.u8[4] = 0x01;  // Cell location with maximum temperature
-  SUNGROW_713.data.u8[5] = 0x02;  // Module location with maximum temperature
-  // Maximum cell temperature (signed int16_t in 0.1°C units)
   SUNGROW_713.data.u8[6] = (datalayer.battery.status.temperature_max_dC & 0xFF);
   SUNGROW_713.data.u8[7] = ((datalayer.battery.status.temperature_max_dC >> 8) & 0xFF);
 
-  // 0x714 - Battery Cell Voltage Overview
-  // Cell position with maximum voltage (cell/module addressing)
-  SUNGROW_714.data.u8[0] = 0x05;  // Cell location with minimum voltage
-  SUNGROW_714.data.u8[1] = 0x01;  // Module location with minimum voltage
-  // Maximum cell voltage (0.1 mV units = cell_max_voltage_mV * 10)
+  // 0x714 - Cell/module locations are static (header, max-first). Max/min cell voltages here (0.1 mV = mV*10):
   SUNGROW_714.data.u8[2] = ((datalayer.battery.status.cell_max_voltage_mV * 10) & 0x00FF);
   SUNGROW_714.data.u8[3] = ((datalayer.battery.status.cell_max_voltage_mV * 10) >> 8);
-  // Cell position with minimum voltage (cell/module addressing)
-  SUNGROW_714.data.u8[4] = 0x11;  // Cell location with maximum voltage
-  SUNGROW_714.data.u8[5] = 0x02;  // Module location with maximum voltage
-  // Minimum cell voltage (0.1 mV units = cell_min_voltage_mV * 10)
   SUNGROW_714.data.u8[6] = ((datalayer.battery.status.cell_min_voltage_mV * 10) & 0x00FF);
   SUNGROW_714.data.u8[7] = ((datalayer.battery.status.cell_min_voltage_mV * 10) >> 8);
 
@@ -320,11 +270,9 @@ void SungrowInverter::update_values() {
     }
   }
 
-  // 0x719 - Status and Module Fault???
-  // Possibly relates to Modbus register 3_10789 and 3_10790
-  SUNGROW_719.data.u8[0] = 0x02;
+  // 0x719 is a static unknown value -> now in the header .data{}.
 
-  //Copy 7## content to 0## messages
+  // Copy 7## content to 0## messages
   // SUNGROW_000 all bytes 0x00
   memcpy(SUNGROW_001.data.u8, SUNGROW_701.data.u8, 8);
   memcpy(SUNGROW_002.data.u8, SUNGROW_702.data.u8, 8);
@@ -637,9 +585,9 @@ void SungrowInverter::transmit_can(unsigned long currentMillis) {
     if ((int32_t)(currentMillis - previousMillis1s) >= INTERVAL_1_S) {
       previousMillis1s = currentMillis;
 
-      // Head messages
+      // Head messages (.30): 0x402, 0x500, 0x401
+      transmit_can_frame(&SUNGROW_402);
       transmit_can_frame(&SUNGROW_500);
-      transmit_can_frame(&SUNGROW_400);
       transmit_can_frame(&SUNGROW_401);
 
       // Init specific messages
@@ -676,9 +624,9 @@ void SungrowInverter::transmit_can(unsigned long currentMillis) {
 
     switch (batch_send_index) {
       case 0:
-        // Head messages
+        // Head messages (.30): 0x402, 0x500, 0x401
+        transmit_can_frame(&SUNGROW_402);
         transmit_can_frame(&SUNGROW_500);
-        transmit_can_frame(&SUNGROW_400);
         transmit_can_frame(&SUNGROW_401);
         break;
 

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -401,21 +401,27 @@ class SungrowInverter : public CanInverterProtocol {
                            .DLC = 8,
                            .ID = 0x70E,
                            .data = {0x07, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  // 0x70F (MUX). Muxes 00/02/03/04 = static unknown values (kept visible below); 05/06/07 = per-module
-  //             SoC, set in update_values(). Byte 0 = mux selector, byte 1 = 0.
+  // 0x70F (MUX). Byte 0 = mux selector, byte 1 = 0. Mux 00 b4-7 = max continuous power (static
+  //             rating), filled in setup() from battery_config; mux 05/06/07 = per-module SoC, set
+  //             in update_values(). The remaining unknown bytes below are frozen snapshots from a
+  //             real-battery capture - kept visible so they aren't mistaken for decoded or live
+  //             values. "Cold-drift cluster" = the 16-bit unknowns at b2-3 of muxes 02/03/04: on a
+  //             real pack all three drift slowly *together* and read higher in the cold. Ruled out
+  //             as power/current limits (those derate in cold), and as SoC and SoH.
   CAN_frame SUNGROW_70F_00 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
                               .data = {0x00,          // Mux selector
                                        0x00,          // Always 0
-                                       0x88, 0x13,    // Unknown (static)
-                                       0x80, 0x16,    // Unknown per-module value 1 (static)
-                                       0x80, 0x16}};  // Unknown per-module value 2 (static)
+                                       0x88, 0x13,    // Unknown, fixed 5000 (static)
+                                       0x00, 0x00,    // Max continuous power W, live - set in setup()
+                                       0x00, 0x00}};  // Max continuous power W, rating - set in setup()
   CAN_frame SUNGROW_70F_01 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
+                              // Mux selector + padding: whole payload is 0 on a real pack
                               .data = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame SUNGROW_70F_02 = {.FD = false,
                               .ext_ID = false,
@@ -423,26 +429,27 @@ class SungrowInverter : public CanInverterProtocol {
                               .ID = 0x70F,
                               .data = {0x02,          // Mux selector
                                        0x00,          // Always 0
-                                       0x70, 0x20,    // Unknown (static)
-                                       0x00, 0x00,    // (zero)
-                                       0x92, 0x09}};  // Unknown (static)
+                                       0x70, 0x20,    // Unknown 16-bit (cold-drift cluster)
+                                       0x00, 0x00,    // Padding (always 0)
+                                       0x92, 0x09}};  // Unknown 16-bit, near-constant (~5760)
   CAN_frame SUNGROW_70F_03 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
                               .data = {0x03,          // Mux selector
                                        0x00,          // Always 0
-                                       0xFD, 0x1D,    // Unknown (static)
-                                       0x00, 0x00,    // (zero)
-                                       0xCE, 0x26}};  // Unknown (static, ~SoC/SoH %)
+                                       0xFD, 0x1D,    // Unknown 16-bit (cold-drift cluster)
+                                       0x00, 0x00,    // Padding (always 0)
+                                       0xCE, 0x26}};  // Unknown ~9980 (x0.01 = 99.8 %); not SoC, not SoH
   CAN_frame SUNGROW_70F_04 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
-                              .data = {0x04,                      // Mux selector
-                                       0x00,                      // Always 0
-                                       0x0C, 0x06,                // Unknown (static, charge value + padding)
-                                       0x00, 0x00, 0x00, 0x00}};  // (zero)
+                              .data = {0x04,              // Mux selector
+                                       0x00,              // Always 0
+                                       0x0C, 0x06,        // Unknown 16-bit (cold-drift cluster), not charge
+                                       0x00, 0x00, 0x00,  // Padding (always 0)
+                                       0x00}};            // Charge state: 0 = Normal, 2 = Stop Charge
   CAN_frame SUNGROW_70F_05 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -221,21 +221,30 @@ class SungrowInverter : public CanInverterProtocol {
                            .DLC = 8,
                            .ID = 0x01E,
                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame SUNGROW_400 = {.FD = false,
-                           .ext_ID = false,
-                           .DLC = 8,
-                           .ID = 0x400,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame SUNGROW_401 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x401,
                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  // 0x402 - static .30 head frame (SBRBCU-S_22011.01.30). On the real bus it REPLACES 0x400 (both 0x400
+  //         and 0x1F0 stop when 0x402 starts). Payload is constant, byte 2 = 0x55. The emulator targets
+  //         .30, so this is sent every cycle in the head group (SoC is carried by 0x500/0x702).
+  CAN_frame SUNGROW_402 = {.FD = false,
+                           .ext_ID = false,
+                           .DLC = 8,
+                           .ID = 0x402,
+                           .data = {0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  // 0x1F0 - firmware-update channel (fw .27-era; on the real bus 23 Jan-13 Jun 2026, dropped on .30).
+  //         Irregular cadence, not steady telemetry - not emulated (no frame defined or transmitted).
+  // 0x500 - BMS init message. b0-6 = static unknown values (kept visible below); b7 = SoC (set in update_values).
   CAN_frame SUNGROW_500 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x500,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                           .data = {0x01,                    // Unknown (500_Unknown_0)
+                                    0x01, 0x03,              // Unknown (500_Unknown_1; b2 old guess: module count)
+                                    0xFF, 0x00, 0x01, 0x00,  // Unknown (500_Unknown_2)
+                                    0x00}};                  // Battery SoC integer % - set in update_values()
   CAN_frame SUNGROW_501 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
@@ -311,15 +320,17 @@ class SungrowInverter : public CanInverterProtocol {
                                     0x00, 0x00,    // Battery current
                                     0x00, 0x00,    // Another related battery voltage
                                     0x00, 0x00}};  // Battery temperature
-  // 0x705 - TODO
+  // 0x705 - Battery Status
   CAN_frame SUNGROW_705 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x705,
-                           .data = {0x00, 0x00,        // Status??
-                                    0x00, 0x00, 0x00,  // ????
-                                    0x00, 0x00,        // Yet another battery voltage
-                                    0x00}};            // Padding??
+                           .data = {0x02,        // Battery status: 0=Unplugged, 1=Standby, 2=Run (always Run)
+                                    0x00,        // Always 0 (705_Always_0)
+                                    0x01,        // Always 1 (705_Always_1)
+                                    0x00, 0x00,  // Battery model id - set in update_values() from module_count
+                                    0x00, 0x00,  // Battery voltage - set in update_values()
+                                    0x00}};      // Padding (705_Padding)
   // 0x706 - Battery Cell Status
   CAN_frame SUNGROW_706 = {.FD = false,
                            .ext_ID = false,
@@ -327,14 +338,19 @@ class SungrowInverter : public CanInverterProtocol {
                            .ID = 0x706,
                            .data = {0x00, 0x00,    // Cell MAX temperature
                                     0x00, 0x00,    // Cell MIN temperature
-                                    0x00, 0x00,    // Cell MIN voltage
-                                    0x00, 0x00}};  // Cell MAX voltage
-  // 0x707 - TODO
+                                    0x00, 0x00,    // Cell MAX voltage
+                                    0x00, 0x00}};  // Cell MIN voltage
+  // 0x707 - Battery Configuration
   CAN_frame SUNGROW_707 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x707,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                           .data = {0x30,        // BMS firmware patch (BCD .30)
+                                    0x00, 0x00,  // Always 0
+                                    0x01,        // BMS firmware minor (BCD .1)
+                                    0x00, 0x00,  // Nameplate capacity Wh - filled in setup() from battery_config
+                                    0x00,        // Module count - filled in setup() from battery_config
+                                    0x00}};      // Always 0
   // 0x708 - Battery Serial Number (MUX)
   CAN_frame SUNGROW_708_00 = {.FD = false,
                               .ext_ID = false,
@@ -385,12 +401,17 @@ class SungrowInverter : public CanInverterProtocol {
                            .DLC = 8,
                            .ID = 0x70E,
                            .data = {0x07, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  // 0x70F (MUX)
+  // 0x70F (MUX). Muxes 00/02/03/04 = static unknown values (kept visible below); 05/06/07 = per-module
+  //             SoC, set in update_values(). Byte 0 = mux selector, byte 1 = 0.
   CAN_frame SUNGROW_70F_00 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
-                              .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x00,          // Mux selector
+                                       0x00,          // Always 0
+                                       0x88, 0x13,    // Unknown (static)
+                                       0x80, 0x16,    // Unknown per-module value 1 (static)
+                                       0x80, 0x16}};  // Unknown per-module value 2 (static)
   CAN_frame SUNGROW_70F_01 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
@@ -400,17 +421,28 @@ class SungrowInverter : public CanInverterProtocol {
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
-                              .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x02,          // Mux selector
+                                       0x00,          // Always 0
+                                       0x70, 0x20,    // Unknown (static)
+                                       0x00, 0x00,    // (zero)
+                                       0x92, 0x09}};  // Unknown (static)
   CAN_frame SUNGROW_70F_03 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
-                              .data = {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x03,          // Mux selector
+                                       0x00,          // Always 0
+                                       0xFD, 0x1D,    // Unknown (static)
+                                       0x00, 0x00,    // (zero)
+                                       0xCE, 0x26}};  // Unknown (static, ~SoC/SoH %)
   CAN_frame SUNGROW_70F_04 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
                               .ID = 0x70F,
-                              .data = {0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                              .data = {0x04,                      // Mux selector
+                                       0x00,                      // Always 0
+                                       0x0C, 0x06,                // Unknown (static, charge value + padding)
+                                       0x00, 0x00, 0x00, 0x00}};  // (zero)
   CAN_frame SUNGROW_70F_05 = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
@@ -426,28 +458,31 @@ class SungrowInverter : public CanInverterProtocol {
                               .DLC = 8,
                               .ID = 0x70F,
                               .data = {0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  // 0x713 - Battery Cell Temperature Overview
+  // 0x713 - Battery Cell Temperature Overview. Cell/module locations are arbitrary static placeholders
+  //         (not the real min/max cell position); temperatures (b2-3, b6-7) set in update_values().
   CAN_frame SUNGROW_713 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x713,
-                           .data = {0x00,          // Cell location with minimum temperature
-                                    0x00,          // Module location with minimum temperature
-                                    0x00, 0x00,    // Cell MIN temperature
-                                    0x00,          // Cell location with maximum temperature
-                                    0x00,          // Module location with maximum temperature
-                                    0x00, 0x00}};  // Cell MAX temperature
-  // 0x714 - Battery Cell Voltage Overview
+                           .data = {0x02,          // Cell location, min temp (arbitrary)
+                                    0x01,          // Module location, min temp (arbitrary)
+                                    0x00, 0x00,    // Cell MIN temperature - set in update_values()
+                                    0x01,          // Cell location, max temp (arbitrary)
+                                    0x02,          // Module location, max temp (arbitrary)
+                                    0x00, 0x00}};  // Cell MAX temperature - set in update_values()
+  // 0x714 - Battery Cell Voltage Overview. Max-first: b0-3 = max cell, b4-7 = min cell (opposite of the
+  //         min-first 0x713/0x715/0x716; confirmed on a real SBR - b2-3 always > b6-7). Cell/module
+  //         locations are arbitrary static placeholders; voltages (b2-3, b6-7) set in update_values().
   CAN_frame SUNGROW_714 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x714,
-                           .data = {0x00,          // Cell location with minimum voltage
-                                    0x00,          // Module location with minimum voltage
-                                    0x00, 0x00,    // Cell MIN voltage
-                                    0x00,          // Cell location with maximum voltage
-                                    0x00,          // Module location with maximum voltage
-                                    0x00, 0x00}};  // Cell MAX voltage
+                           .data = {0x05,          // Cell location, max voltage (arbitrary)
+                                    0x01,          // Module location, max voltage (arbitrary)
+                                    0x00, 0x00,    // Cell MAX voltage - set in update_values()
+                                    0x11,          // Cell location, min voltage (arbitrary)
+                                    0x02,          // Module location, min voltage (arbitrary)
+                                    0x00, 0x00}};  // Cell MIN voltage - set in update_values()
   // 0x715 - Module 1+2 Cell Voltage Overview
   CAN_frame SUNGROW_715 = {.FD = false,
                            .ext_ID = false,
@@ -489,7 +524,8 @@ class SungrowInverter : public CanInverterProtocol {
                            .ext_ID = false,
                            .DLC = 8,
                            .ID = 0x719,
-                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+                           .data = {0x02,                                        // Unknown (static, possibly status)
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};  // (zero)
   // 0x71A - Module Cell Type (set in setup)
   CAN_frame SUNGROW_71A = {.FD = false,
                            .ext_ID = false,


### PR DESCRIPTION
### What
This PR updates the Sungrow SBRXXX battery emulator to the **`.30` BMS firmware** frame set, corrects mislabelled and undecoded frame comments, and moves each frame's constant/config bytes into the header initialisers so `update_values()` carries only live telemetry.

### Why
Real Sungrow SBR batteries have moved to BMS firmware `.30` (`SBRBCU-S_22011.01.30`), which changes the CAN frame set: `0x400` (and the irregular `0x1F0` firmware-update channel) stop, and a static `0x402` appears in their place. An inverter that has taken the firmware update expects the `.30` frames, so the emulator has to match. While in the file, several comments were vague ("Magic number") or actively wrong — the `0x706`/`0x714` min/max cell-voltage labels were reversed — and many constant/config bytes were rewritten every cycle, obscuring which bytes are actually dynamic.

### How
- **`.30` frame set:** the `0x707` firmware-patch byte is now `0x30`; a static `0x402` (`00 00 55 …`) replaces `0x400`, which is removed entirely. SoC still reaches the inverter via `0x500`/`0x702`. `0x1F0` is documented only (not emulated).
- **Comment / label fixes:** vague comments are replaced with the decoded field meaning, and the reversed min/max labels in `0x706`/`0x714` are corrected. `0x714` is genuinely max-first (bytes 2–3 > bytes 6–7), which the emulator already emitted correctly — only the comments were wrong. Confirmed against a real `.30` SBR capture.
- **Frame-data reorganisation:** constant, model-derived and static-but-unknown bytes are moved from `update_values()` into the header `.data{}` initialisers (`0x500`, `0x705`, `0x707`, `0x70F`, `0x713`/`0x714`, `0x719`); `update_values()` now writes only per-cycle telemetry. Payloads are byte-for-byte unchanged (transmit-identical, verified on-bus against a real `.30` battery). A short convention note in `setup()` records where each frame's bytes come from (header / `setup()` / `update_values()` / Modbus reply).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)

