### PR TITLE
Basic support for Stark LED RGB addon

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -1,6 +1,7 @@
 #include "comm_contactorcontrol.h"
 #include "../../devboard/hal/hal.h"
 #include "../../devboard/safety/safety.h"
+#include "../../devboard/utils/led_handler.h"
 #include "../../inverter/INVERTERS.h"
 #ifndef UNIT_TEST
 #include "driver/gpio.h"  // gpio_hold_en / gpio_hold_dis / gpio_deep_sleep_hold_en
@@ -93,14 +94,19 @@ bool init_contactors() {
       // Set all pins OFF (0% PWM)
       ledcWrite(posPin, PWM_OFF_DUTY);
       ledcWrite(negPin, PWM_OFF_DUTY);
+      set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
+      set_indicator_led(IndicatorLed::CONTACTOR_NEG, false);
     } else {  //Normal CONTACTOR_CONTROL
       pinMode(posPin, OUTPUT);
       set(posPin, OFF);
+      set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
       pinMode(negPin, OUTPUT);
       set(negPin, OFF);
+      set_indicator_led(IndicatorLed::CONTACTOR_NEG, false);
     }  // Precharge never has PWM regardless of setting
     pinMode(precPin, OUTPUT);
     set(precPin, OFF);
+    set_indicator_led(IndicatorLed::PRECHARGE, false);
   }
 
   if (contactor_control_enabled_double_battery) {
@@ -134,6 +140,7 @@ bool init_contactors() {
     }
     pinMode(pin, OUTPUT);
     digitalWrite(pin, HIGH);
+    set_indicator_led(IndicatorLed::BMS_POWER, true);
   }
 
   return true;
@@ -190,6 +197,9 @@ void handle_contactors() {
       set(prechargePin, OFF);
       set(negPin, OFF, PWM_OFF_DUTY);
       set(posPin, OFF, PWM_OFF_DUTY);
+      set_indicator_led(IndicatorLed::PRECHARGE, false);
+      set_indicator_led(IndicatorLed::CONTACTOR_NEG, false);
+      set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
       set_event(EVENT_ERROR_OPEN_CONTACTOR, 0);
       datalayer.system.status.contactors_engaged = 2;
       return;  // A fault scenario latches the contactor control. It is not possible to recover without a powercycle (and investigation why fault occured)
@@ -200,6 +210,9 @@ void handle_contactors() {
       set(prechargePin, OFF);
       set(negPin, OFF, PWM_OFF_DUTY);
       set(posPin, OFF, PWM_OFF_DUTY);
+      set_indicator_led(IndicatorLed::PRECHARGE, false);
+      set_indicator_led(IndicatorLed::CONTACTOR_NEG, false);
+      set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
       datalayer.system.status.contactors_engaged = 0;
 
       if (datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active) {
@@ -229,6 +242,7 @@ void handle_contactors() {
     switch (contactorStatus) {
       case START_PRECHARGE:
         set(negPin, ON, PWM_ON_DUTY);
+        set_indicator_led(IndicatorLed::CONTACTOR_NEG, true);
         dbg_contactors("NEGATIVE");
         prechargeStartTime = currentTime;
         contactorStatus = PRECHARGE;
@@ -238,6 +252,7 @@ void handle_contactors() {
       case PRECHARGE:
         if (currentTime - prechargeStartTime >= NEGATIVE_CONTACTOR_TIME_MS) {
           set(prechargePin, ON);
+          set_indicator_led(IndicatorLed::PRECHARGE, true);
           dbg_contactors("PRECHARGE");
           negativeStartTime = currentTime;
           contactorStatus = POSITIVE;
@@ -248,6 +263,7 @@ void handle_contactors() {
       case POSITIVE:
         if (currentTime - negativeStartTime >= precharge_time_ms) {
           set(posPin, ON, PWM_ON_DUTY);
+          set_indicator_led(IndicatorLed::CONTACTOR_POS, true);
           dbg_contactors("POSITIVE");
           prechargeCompletedTime = currentTime;
           contactorStatus = PRECHARGE_OFF;
@@ -260,6 +276,7 @@ void handle_contactors() {
           set(prechargePin, OFF);
           set(negPin, ON, pwm_hold_duty);
           set(posPin, ON, pwm_hold_duty);
+          set_indicator_led(IndicatorLed::PRECHARGE, false);
           dbg_contactors("PRECHARGE_OFF");
           contactorStatus = COMPLETED;
           datalayer.system.status.contactors_engaged = 1;
@@ -304,10 +321,12 @@ Feature is only used if user has enabled PERIODIC_BMS_RESET */
 
 void bms_power_off() {
   digitalWrite(esp32hal->BMS_POWER(), LOW);
+  set_indicator_led(IndicatorLed::BMS_POWER, false);
 }
 
 void bms_power_on() {
   digitalWrite(esp32hal->BMS_POWER(), HIGH);
+  set_indicator_led(IndicatorLed::BMS_POWER, true);
 }
 
 void handle_BMSpower() {

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -197,6 +197,9 @@ class Esp32Hal {
   // LED
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_NC; }
   virtual uint8_t LED_MAX_BRIGHTNESS() { return 40; }
+  // Number of LEDs chained off LED_PIN(). Pixel 0 is always the STATUS LED; boards that replace
+  // additional hardwired indicator LEDs with RGB LEDs on the same chain report more than 1 here.
+  virtual uint8_t LED_COUNT() { return 1; }
 
 #ifndef SMALL_FLASH_DEVICE
   // i2c display

--- a/Software/src/devboard/hal/hw_stark.h
+++ b/Software/src/devboard/hal/hw_stark.h
@@ -92,7 +92,12 @@ class StarkHal : public Esp32Hal {
 
   // LED
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_4; }
-  virtual uint8_t LED_MAX_BRIGHTNESS() { return 40; }
+  virtual uint8_t LED_MAX_BRIGHTNESS() { return 20; }
+  // LEDs 1-4 (PRECHARGE, CONTACTOR NEG, CONTACTOR POS, BMS POWER) are chained off the STATUS LED
+  // (pixel 0). On boards with the older plain hardwired LEDs there's no physical RGB LED at those
+  // positions, so this extra chain data has nowhere to go and is simply a no-op; on boards with
+  // the RGB LED PCB it lights them. No user-facing option needed either way.
+  virtual uint8_t LED_COUNT() { return 5; }
 
   // Equipment stop pin
   virtual gpio_num_t EQUIPMENT_STOP_PIN() { return GPIO_NUM_2; }

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -9,6 +9,15 @@
 #define COLOR_RED(x) (((uint32_t)x << 16) | ((uint32_t)0 << 8) | 0)
 #define COLOR_BLUE(x) (((uint32_t)0 << 16) | ((uint32_t)0 << 8) | x)
 
+// Scales a full-brightness 24-bit color's R/G/B channels by `brightness` (0-255).
+static uint32_t scale_color(uint32_t color, uint8_t brightness) {
+  uint8_t r = (uint8_t)(color >> 16), g = (uint8_t)(color >> 8), b = (uint8_t)color;
+  r = (uint16_t)r * brightness / 255;
+  g = (uint16_t)g * brightness / 255;
+  b = (uint16_t)b * brightness / 255;
+  return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+}
+
 #define BPM_TO_MS(x) ((60000 / (x)))  // 60 * 1000 = 60000
 
 #define HEARTBEAT_BASE 150      // 0.15 * 1000
@@ -23,6 +32,8 @@ static bool led_override_active = false;
 static uint32_t led_override_color = 0;
 static uint16_t led_override_period_ms = 0;
 
+static bool indicator_led_state[4] = {false, false, false, false};
+
 void set_led_override(bool active, uint32_t color, uint16_t period_ms) {
   if (led == nullptr) {
     return;  // no LED (GPIO unset or used for an OLED) — nothing to drive
@@ -30,6 +41,10 @@ void set_led_override(bool active, uint32_t color, uint16_t period_ms) {
   led_override_active = active;
   led_override_color = color;
   led_override_period_ms = period_ms;
+}
+
+void set_indicator_led(IndicatorLed indicator, bool on) {
+  indicator_led_state[static_cast<uint8_t>(indicator)] = on;
 }
 
 uint16_t map_int(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max) {
@@ -48,7 +63,7 @@ bool led_init(void) {
     return false;
   }
 
-  led = new LED(datalayer.battery.status.led_mode, led_pin, esp32hal->LED_MAX_BRIGHTNESS());
+  led = new LED(datalayer.battery.status.led_mode, led_pin, esp32hal->LED_MAX_BRIGHTNESS(), esp32hal->LED_COUNT());
 
   return true;
 }
@@ -99,19 +114,31 @@ void LED::exe(void) {
   }
 
   // Set color
+  uint32_t status_hue = 0;  // full-brightness hue, reused below for the indicator LEDs
   switch (get_emulator_status()) {
     case EMULATOR_STATUS::STATUS_OK:
+      status_hue = COLOR_GREEN(0xFF);
       pixels.setPixelColor(COLOR_GREEN(brightness));  // Green pulsing LED
       break;
     case EMULATOR_STATUS::STATUS_WARNING:
+      status_hue = COLOR_YELLOW(0xFF);
       pixels.setPixelColor(COLOR_YELLOW(brightness));  // Yellow pulsing LED
       break;
     case EMULATOR_STATUS::STATUS_ERROR:
+      status_hue = COLOR_RED(0xFF);
       pixels.setPixelColor(COLOR_RED(esp32hal->LED_MAX_BRIGHTNESS()));  // Red LED full brightness
       break;
     case EMULATOR_STATUS::STATUS_UPDATING:
+      status_hue = COLOR_BLUE(0xFF);
       pixels.setPixelColor(COLOR_BLUE(brightness));  // Blue pulsing LED
       break;
+  }
+
+  // Indicator LEDs 1-4 mirror the STATUS LED's color, at a fixed (non-animated) brightness
+  // (no-op past the end of the chain on boards without RGB indicator LEDs).
+  uint32_t indicator_color = scale_color(status_hue, max_brightness);
+  for (uint8_t i = 0; i < 4; i++) {
+    pixels.setPixelColor(i + 1, indicator_led_state[i] ? indicator_color : 0);
   }
 
   pixels.show();  // This sends the updated pixel color to the hardware.

--- a/Software/src/devboard/utils/led_handler.cpp
+++ b/Software/src/devboard/utils/led_handler.cpp
@@ -134,11 +134,14 @@ void LED::exe(void) {
       break;
   }
 
-  // Indicator LEDs 1-4 mirror the STATUS LED's color, at a fixed (non-animated) brightness
-  // (no-op past the end of the chain on boards without RGB indicator LEDs).
-  uint32_t indicator_color = scale_color(status_hue, max_brightness);
-  for (uint8_t i = 0; i < 4; i++) {
-    pixels.setPixelColor(i + 1, indicator_led_state[i] ? indicator_color : 0);
+  // Indicator LEDs 1-4 mirror the STATUS LED's color, at a fixed (non-animated) brightness.
+  // Skipped entirely on boards with no RGB indicator LEDs (num_leds == 1), rather than relying
+  // on Adafruit_NeoPixel::setPixelColor()'s bounds check to make it a no-op.
+  if (num_leds > 1) {
+    uint32_t indicator_color = scale_color(status_hue, max_brightness);
+    for (uint8_t i = 0; i < 4; i++) {
+      pixels.setPixelColor(i + 1, indicator_led_state[i] ? indicator_color : 0);
+    }
   }
 
   pixels.show();  // This sends the updated pixel color to the hardware.

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -13,10 +13,14 @@ enum class IndicatorLed : uint8_t { PRECHARGE = 0, CONTACTOR_NEG = 1, CONTACTOR_
 class LED {
  public:
   LED(gpio_num_t pin, uint8_t maxBrightness, uint8_t numLeds = 1)
-      : pixels(pin, numLeds), max_brightness(maxBrightness), brightness(maxBrightness), mode(led_mode_enum::CLASSIC) {}
+      : pixels(pin, numLeds),
+        max_brightness(maxBrightness),
+        brightness(maxBrightness),
+        mode(led_mode_enum::CLASSIC),
+        num_leds(numLeds) {}
 
   LED(led_mode_enum mode, gpio_num_t pin, uint8_t maxBrightness, uint8_t numLeds = 1)
-      : pixels(pin, numLeds), max_brightness(maxBrightness), brightness(maxBrightness), mode(mode) {}
+      : pixels(pin, numLeds), max_brightness(maxBrightness), brightness(maxBrightness), mode(mode), num_leds(numLeds) {}
 
   void exe(void);
 
@@ -25,6 +29,7 @@ class LED {
   uint8_t max_brightness;
   uint8_t brightness;
   led_mode_enum mode;
+  uint8_t num_leds;  // 1 = STATUS only; >1 = STATUS + RGB indicator LEDs are present
 
   void classic_run(void);
   void flow_run(void);

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -6,13 +6,17 @@
 
 static const uint32_t LED_COLOR_WHITE = 0xFFFFFF;  // R=G=B=255
 
+// Indicator LEDs 1-4 in the chain, for boards that can replace their hardwired 12V-output LEDs
+// with RGB LEDs (pixel 0 is always the STATUS LED and is unaffected by this).
+enum class IndicatorLed : uint8_t { PRECHARGE = 0, CONTACTOR_NEG = 1, CONTACTOR_POS = 2, BMS_POWER = 3 };
+
 class LED {
  public:
-  LED(gpio_num_t pin, uint8_t maxBrightness)
-      : pixels(pin), max_brightness(maxBrightness), brightness(maxBrightness), mode(led_mode_enum::CLASSIC) {}
+  LED(gpio_num_t pin, uint8_t maxBrightness, uint8_t numLeds = 1)
+      : pixels(pin, numLeds), max_brightness(maxBrightness), brightness(maxBrightness), mode(led_mode_enum::CLASSIC) {}
 
-  LED(led_mode_enum mode, gpio_num_t pin, uint8_t maxBrightness)
-      : pixels(pin), max_brightness(maxBrightness), brightness(maxBrightness), mode(mode) {}
+  LED(led_mode_enum mode, gpio_num_t pin, uint8_t maxBrightness, uint8_t numLeds = 1)
+      : pixels(pin, numLeds), max_brightness(maxBrightness), brightness(maxBrightness), mode(mode) {}
 
   void exe(void);
 
@@ -37,5 +41,9 @@ void led_exe(void);
 // `period_ms`. Pass active=false to release and resume normal battery-state behavior.
 // No-op when no LED is present (GPIO unset, or configured as an OLED instead).
 void set_led_override(bool active, uint32_t color, uint16_t period_ms);
+
+// Mirrors on/off state onto an RGB indicator LED, for boards where an indicator position is an
+// RGB LED instead of a plain hardwired GPIO LED. No-op on boards without RGB indicator LEDs.
+void set_indicator_led(IndicatorLed indicator, bool on);
 
 #endif  // LED_H_

--- a/Software/src/devboard/utils/led_handler.h
+++ b/Software/src/devboard/utils/led_handler.h
@@ -1,6 +1,7 @@
 #ifndef LED_H_
 #define LED_H_
 
+#include <soc/gpio_num.h>
 #include "../../devboard/utils/types.h"
 #include "../../lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h"
 

--- a/Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
+++ b/Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
@@ -1,22 +1,26 @@
-/*Based on the Adafruit Neopixel library, which has been heavily modified to support only 1x RGB/GRB LED for lowest possible CPU usage*/
+/*Based on the Adafruit Neopixel library, which has been heavily modified to support a small chain of RGB/GRB LEDs (default 1) for lowest possible CPU usage*/
 
 #include "Adafruit_NeoPixel.h"
 
-extern "C" void espShow(uint16_t pin, uint8_t *pixels, uint8_t numBytes);
+extern "C" void espShow(uint16_t pin, uint8_t* pixels, uint8_t numBytes);
 
-Adafruit_NeoPixel::Adafruit_NeoPixel(int16_t p) : pixels(NULL) {
+Adafruit_NeoPixel::Adafruit_NeoPixel(int16_t p, uint16_t n) : pixels(NULL) {
+  numLEDs = n;
+  numBytes = 3 * n;
   updateLength();
   setPin(p);
 }
 
 void Adafruit_NeoPixel::updateLength(void) {
   free(pixels);
-  pixels = (uint8_t *)malloc(numBytes);
-  if (pixels) memset(pixels, 0, numBytes);
+  pixels = (uint8_t*)malloc(numBytes);
+  if (pixels)
+    memset(pixels, 0, numBytes);
 }
 
 void Adafruit_NeoPixel::setPin(int16_t p) {
-  if (pin >= 0) pinMode(pin, INPUT);
+  if (pin >= 0)
+    pinMode(pin, INPUT);
   pin = p;
   if ((p >= 0)) {
     pinMode(p, OUTPUT);
@@ -31,27 +35,34 @@ void Adafruit_NeoPixel::setColorOrder(uint32_t o) {
 #endif
 
 void Adafruit_NeoPixel::show(void) {
-  if (!pixels) return;
+  if (!pixels)
+    return;
   espShow(pin, pixels, numBytes);
 }
 
 void Adafruit_NeoPixel::setPixelColor(uint32_t c) {
-  uint8_t *p = pixels;
+  setPixelColor(0, c);
+}
+
+void Adafruit_NeoPixel::setPixelColor(uint16_t index, uint32_t c) {
+  if (!pixels || index >= numLEDs) {
+    return;
+  }
+  uint8_t* p = &pixels[index * 3];
   uint8_t r = (uint8_t)(c >> 16), g = (uint8_t)(c >> 8), b = (uint8_t)c;
 #ifdef HW_LILYGO2CAN
-  if (color_order == GRB) {  // GRB color order 
+  if (color_order == GRB) {  // GRB color order
     p[rOffset] = g;
     p[gOffset] = r;
     p[bOffset] = b;
-  } else {                   // default RGB color order  
+  } else {  // default RGB color order
     p[rOffset] = r;
     p[gOffset] = g;
     p[bOffset] = b;
   }
 #else
-    p[rOffset] = r;
-    p[gOffset] = g;
-    p[bOffset] = b;
+  p[rOffset] = r;
+  p[gOffset] = g;
+  p[bOffset] = b;
 #endif
 }
-

--- a/Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h
+++ b/Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.h
@@ -38,7 +38,10 @@
 
 #include <Arduino.h>
 
-enum led_color_order { RGB, GRB }; // Default lilygo_330 color order RGB; WS2812D-F5 color order GRB (RED and GREEN swapped)
+enum led_color_order {
+  RGB,
+  GRB
+};  // Default lilygo_330 color order RGB; WS2812D-F5 color order GRB (RED and GREEN swapped)
 
 /*!
     @brief  Class that stores state and functions for interacting with
@@ -46,31 +49,32 @@ enum led_color_order { RGB, GRB }; // Default lilygo_330 color order RGB; WS2812
 */
 class Adafruit_NeoPixel {
 
-public:
-  // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(int16_t pin = -1);
+ public:
+  // Constructor: pin number, number of LEDs in the chain (default 1)
+  Adafruit_NeoPixel(int16_t pin = -1, uint16_t n = 1);
   Adafruit_NeoPixel(void);
 
   void show(void);
   void setPin(int16_t p);
   void setPixelColor(uint32_t c);
+  void setPixelColor(uint16_t index, uint32_t c);
   void updateLength(void);
-#ifdef HW_LILYGO2CAN  
+#ifdef HW_LILYGO2CAN
   void setColorOrder(uint32_t o);
 #endif
 
-private:
-
-protected:
-  uint8_t numBytes = 3;  ///< Size of 'pixels' buffer below
-  int16_t pin;        ///< Output pin number (-1 if not yet set)
-  uint8_t *pixels;    ///< Holds LED color values (3 or 4 bytes each)
-  uint8_t rOffset = 0b01;    ///< Red index within each 3- or 4-byte pixel
-  uint8_t gOffset = 0b00;    ///< Index of green byte
-  uint8_t bOffset = 0b10;    ///< Index of blue byte
+ private:
+ protected:
+  uint16_t numLEDs = 1;    ///< Number of LEDs in the chain
+  uint8_t numBytes = 3;    ///< Size of 'pixels' buffer below
+  int16_t pin;             ///< Output pin number (-1 if not yet set)
+  uint8_t* pixels;         ///< Holds LED color values (3 or 4 bytes each)
+  uint8_t rOffset = 0b01;  ///< Red index within each 3- or 4-byte pixel
+  uint8_t gOffset = 0b00;  ///< Index of green byte
+  uint8_t bOffset = 0b10;  ///< Index of blue byte
 #ifdef HW_LILYGO2CAN
-  uint32_t color_order = RGB;    ///< Holds LED Color order (RGB,GRB supported)
+  uint32_t color_order = RGB;  ///< Holds LED Color order (RGB,GRB supported)
 #endif
 };
 
-#endif // ADAFRUIT_NEOPIXEL_H
+#endif  // ADAFRUIT_NEOPIXEL_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,9 @@ add_executable(tests
     ../Software/src/devboard/utils/types.cpp
     ../Software/src/devboard/utils/events.cpp
     ../Software/src/devboard/utils/common_functions.cpp
+    ../Software/src/devboard/utils/led_handler.cpp
+    ../Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
+    emul/neopixel_show.cpp
     ../Software/src/datalayer/datalayer.cpp
     ../Software/src/datalayer/datalayer_extended.cpp
     ../Software/src/lib/uds_isotp/isotp.cpp

--- a/test/emul/neopixel_show.cpp
+++ b/test/emul/neopixel_show.cpp
@@ -1,0 +1,10 @@
+#include <cstdint>
+
+// Test-only stand-in for esp.c's real RMT-peripheral transmit function. Unit tests build for the
+// host (not ESP-IDF), so there's no RMT driver to link against; nothing here needs to inspect
+// actual pixel data, just satisfy the linker for Adafruit_NeoPixel::show().
+extern "C" void espShow(uint16_t pin, uint8_t* pixels, uint8_t numBytes) {
+  (void)pin;
+  (void)pixels;
+  (void)numBytes;
+}


### PR DESCRIPTION
This PR aims to add basic support for the upcoming Stark LED RGB addon swapping the four plain LEDs on the daughter board for RGB LEDs. At this point all LEDs reflect the colour of the STATUS LED. Future support could implement color selection and various animations.