### PR TITLE
Fix inverter CAN alive-event handling in update_machineryprotection

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -286,7 +286,7 @@ void update_machineryprotection() {
 
     //Check if we have ever seen the Battery
     if (!battery_detected) {
-      if (datalayer.battery.status.CAN_battery_still_alive == CAN_STILL_ALIVE) {
+      if (datalayer.battery.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
         battery_detected = true;
         set_event(EVENT_CAN_BATTERY_DETECTED, 1);
       }
@@ -312,7 +312,9 @@ void update_machineryprotection() {
 
     //Check if we have ever seen the inverter
     if (!inverter_detected) {
-      if (datalayer.system.status.CAN_inverter_still_alive == CAN_STILL_ALIVE) {
+      // >= not ==: some drivers refresh the counter above CAN_STILL_ALIVE for a
+      // longer timeout (SMA x3, Sofar x2), which would never match equality
+      if (datalayer.system.status.CAN_inverter_still_alive >= CAN_STILL_ALIVE) {
         inverter_detected = true;
         set_event(EVENT_CAN_INVERTER_DETECTED, 1);
       }
@@ -325,6 +327,9 @@ void update_machineryprotection() {
         set_event(EVENT_CAN_INVERTER_MISSING, can_config.inverter);
       }
     } else {
+      // Inverter frames received recently - clear any previously raised missing-event
+      // regardless of which timeout mode is active
+      clear_event(EVENT_CAN_INVERTER_MISSING);
       // If the inverter is a slow starter, only decrement the counter every 2 seconds to give it more time to start up before we report it as missing
       if (user_selected_inverter_long_CAN_timeout) {
         static uint8_t slow_start_counter = 0;
@@ -335,7 +340,6 @@ void update_machineryprotection() {
         }
       } else {  //Normal 60s timeout for regular inverters
         datalayer.system.status.CAN_inverter_still_alive--;
-        clear_event(EVENT_CAN_INVERTER_MISSING);
       }
     }
   }
@@ -343,7 +347,7 @@ void update_machineryprotection() {
   if (charger) {
     // Check if we have ever seen the charger
     if (!charger_detected) {
-      if (datalayer.charger.CAN_charger_still_alive == CAN_STILL_ALIVE) {
+      if (datalayer.charger.CAN_charger_still_alive >= CAN_STILL_ALIVE) {
         charger_detected = true;
         set_event(EVENT_CAN_CHARGER_DETECTED, 1);
       }
@@ -371,7 +375,7 @@ void update_machineryprotection() {
 
     // Check if we have ever seen the Battery 2
     if (!battery2_detected) {
-      if (datalayer.battery2.status.CAN_battery_still_alive == CAN_STILL_ALIVE) {
+      if (datalayer.battery2.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
         battery2_detected = true;
         set_event(EVENT_CAN_BATTERY2_DETECTED, 1);
       }
@@ -439,7 +443,7 @@ void update_machineryprotection() {
 
     // Check if we have ever seen the Battery 3
     if (!battery3_detected) {
-      if (datalayer.battery3.status.CAN_battery_still_alive == CAN_STILL_ALIVE) {
+      if (datalayer.battery3.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
         battery3_detected = true;
         set_event(EVENT_CAN_BATTERY3_DETECTED, 1);
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(tests
     tests.cpp
     voltage_sync_tests.cpp
     bms_reset_tests.cpp
+    inverter_alive_tests.cpp
     battery/NissanLeafTest.cpp 
     battery/still_alive_tests.cpp
     can_log_based/canlog_safety_tests.cpp

--- a/test/inverter_alive_tests.cpp
+++ b/test/inverter_alive_tests.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/safety/safety.h"
+#include "../Software/src/devboard/utils/events.h"
+#include "../Software/src/inverter/INVERTERS.h"
+
+// Tests for the inverter CAN aliveness handling in update_machineryprotection().
+//
+// NOTE on ordering: safety.cpp keeps a file-static inverter_detected latch with no
+// reset, so the detection test below must run before any other test in this suite
+// refreshes the counter to >= CAN_STILL_ALIVE. Google Test runs tests within a
+// suite in definition order (as long as shuffling is not enabled), so keep the
+// detection test first in this file.
+
+namespace {
+
+void setup_can_inverter_test() {
+  datalayer = DataLayer();
+  reset_all_events();
+  init_hal();
+  // Avoid tripping the low-heap check (CPU_free_heap defaults to 0)
+  datalayer.system.info.CPU_free_heap = 200000;
+  if (!inverter) {
+    // BydCan: a plain CAN inverter without the SMA startup grace window,
+    // so EVENT_CAN_INVERTER_MISSING is raised without needing to advance millis()
+    user_selected_inverter_protocol = InverterProtocolType::BydCan;
+    setup_inverter();
+  }
+  ASSERT_NE(inverter, nullptr);
+}
+
+}  // namespace
+
+// Some drivers deliberately refresh the aliveness counter above CAN_STILL_ALIVE to
+// get a longer timeout (SMA x3, Sofar x2). Detection must still fire for them:
+// with the previous equality check the detected-event never fired in normal
+// operation, and instead fired mid-outage when the decrementing counter happened
+// to pass exactly CAN_STILL_ALIVE.
+TEST(InverterAliveTests, DetectionFiresWithMultipliedRefreshValue) {
+  setup_can_inverter_test();
+
+  // Mimic an SMA-style RX handler refresh
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;
+  update_machineryprotection();
+
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_INVERTER_DETECTED)->occurences, 1)
+      << "Inverter detection must fire on the first refresh even when the driver "
+         "refreshes the counter above CAN_STILL_ALIVE";
+}
+
+// Regression test: with the long-CAN-timeout option enabled, a missing-inverter
+// event must still clear once the inverter starts sending frames again. The
+// clear_event() call was previously only present in the normal-timeout branch,
+// so the ERROR-level event (and the resulting FAULT state) survived recovery
+// until reboot.
+TEST(InverterAliveTests, MissingEventClearsOnRecoveryWithLongTimeout) {
+  setup_can_inverter_test();
+  user_selected_inverter_long_CAN_timeout = true;
+
+  // Inverter silent: counter has drained to zero -> event raised
+  datalayer.system.status.CAN_inverter_still_alive = 0;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_INVERTER_MISSING)->state, EVENT_STATE_ACTIVE);
+
+  // Inverter frames arrive again: RX handler refreshes the counter
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_INVERTER_MISSING)->state, EVENT_STATE_INACTIVE)
+      << "Missing-inverter event must clear on recovery with the long timeout enabled";
+
+  user_selected_inverter_long_CAN_timeout = false;
+}
+
+// Control case: same recovery with the normal timeout (worked before the fix,
+// must keep working)
+TEST(InverterAliveTests, MissingEventClearsOnRecoveryWithNormalTimeout) {
+  setup_can_inverter_test();
+  user_selected_inverter_long_CAN_timeout = false;
+
+  datalayer.system.status.CAN_inverter_still_alive = 0;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_INVERTER_MISSING)->state, EVENT_STATE_ACTIVE);
+
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_INVERTER_MISSING)->state, EVENT_STATE_INACTIVE);
+}
+
+// The long-timeout decrement runs at half rate (every 2nd call); make sure the
+// hoisted clear_event did not change that behavior.
+TEST(InverterAliveTests, LongTimeoutStillDecrementsAtHalfRate) {
+  setup_can_inverter_test();
+  user_selected_inverter_long_CAN_timeout = true;
+
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
+  // 6 calls at half rate -> the counter must drop by at most 3
+  for (int i = 0; i < 6; i++) {
+    update_machineryprotection();
+  }
+  EXPECT_GE(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE - 3);
+  EXPECT_LT(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE);
+
+  user_selected_inverter_long_CAN_timeout = false;
+}


### PR DESCRIPTION
Two related fixes to the CAN aliveness logic in `safety.cpp`, plus regression tests.

### 1. `EVENT_CAN_INVERTER_MISSING` never cleared with the long CAN timeout option

When the "long inverter CAN timeout" option was added (e5aa5b94), the original decrement + `clear_event()` pair was moved into the normal-timeout `else` branch, and the new long-timeout branch re-implemented only the decrement — so with the option **enabled**, the missing-inverter event is never cleared once raised.

Since the event is ERROR level, this is severe: `system_status` goes to FAULT, power limits are zeroed every cycle, and after 10 s of FAULT the contactor control latches `SHUTDOWN_REQUESTED` — so a single inverter CAN dropout longer than the timeout permanently stops the system until power cycle, **even after the inverter recovers**. This inverts the intent of the option, which exists to be *more* tolerant of slow-starting inverters.

**Fix:** hoist `clear_event(EVENT_CAN_INVERTER_MISSING)` above the timeout-mode branch, mirroring the battery path a few lines up. The half-rate decrement behavior of the long-timeout mode is unchanged (covered by a test).

### 2. Detected-events never fire for drivers that refresh the counter above `CAN_STILL_ALIVE`

The "component detected" checks compare with `== CAN_STILL_ALIVE`, but some inverter drivers deliberately refresh the counter above that value to get a longer timeout: the SMA family uses `CAN_STILL_ALIVE * 3`, Sofar uses `* 2`. (Those drivers predate the detection events: bdc8c986 vs 35314c7d.)

For those inverters:
- `EVENT_CAN_INVERTER_DETECTED` never fires in normal operation, and
- it instead fires **mid-outage**, when the decrementing counter happens to pass exactly 60 — logging "Successfully communicating with inverter!" while the inverter has been silent for two minutes.

**Fix:** compare with `>=` instead of `==` at all five detection sites (battery 1/2/3, inverter, charger). This is correct in all paths: detection latches on the first refresh, and the boot value is deliberately `CAN_STILL_ALIVE - 1` so a never-seen component stays undetected. Battery and charger drivers have no multipliers today, so those three changes are prophylactic — they protect against the same drift if a battery driver ever gets a longer timeout the same way.

### Tests

`test/inverter_alive_tests.cpp` (new, registered in the test CMakeLists):

- `DetectionFiresWithMultipliedRefreshValue` — fails without fix 2
- `MissingEventClearsOnRecoveryWithLongTimeout` — fails without fix 1
- `MissingEventClearsOnRecoveryWithNormalTimeout` — control, passes before and after
- `LongTimeoutStillDecrementsAtHalfRate` — guards the unchanged half-rate decrement

Note: the detection test must run before the others in the suite because `inverter_detected` is a file-static latch with no reset (documented in the test file; default definition order handles it).

