### PR TITLE
Bugfix: missing newline on truncated log lines

### DIFF
--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -382,8 +382,24 @@ void Logging::printf(const char* fmt, ...) {
 
   va_list args;
   va_start(args, fmt);
-  int size = min(MAX_LINE_LENGTH_PRINTF - 1, vsnprintf(message_buffer, MAX_LINE_LENGTH_PRINTF, fmt, args));
+  int needed = vsnprintf(message_buffer, MAX_LINE_LENGTH_PRINTF, fmt, args);
   va_end(args);
+
+  // Nothing usable was produced (encoding error, or an empty message)
+  if (needed <= 0) {
+    return;
+  }
+
+  int size = min(MAX_LINE_LENGTH_PRINTF - 1, needed);
+
+  /* vsnprintf returns the length the line WOULD have had, so a larger value means the output
+     was truncated and any trailing newline went with it. Terminate the line ourselves. Without
+     this previous_message_was_newline stays false, and the next message - which may be logged
+     hours later - is appended to this line instead of starting a new one with its own
+     timestamp. */
+  if (needed >= MAX_LINE_LENGTH_PRINTF) {
+    message_buffer[size - 1] = '\n';
+  }
 
   if (datalayer.system.info.SD_logging_active) {
     add_log_to_buffer((uint8_t*)message_buffer, size);


### PR DESCRIPTION
### What
This PR terminates truncated log lines with a newline in `Logging::printf`, and returns early when `vsnprintf` produces nothing usable.

### Why
A line longer than `MAX_LINE_LENGTH_PRINTF` loses its trailing newline, so the next message - possibly logged hours later - is appended to it without its own timestamp. Affects all logging platforms.

### How
`vsnprintf` returns the length the line would have had, so a value at or above the buffer size means truncation; in that case the last character is replaced with a newline. A non-positive result now returns early instead of reading `message_buffer[-1]`, matching the `size == 0` check the `write()` path already has.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
