### PR TITLE
Deduplicate CAN aliveness checks and fix shared corrupted-CAN warning being cleared by healthy batteries

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -38,6 +38,26 @@ bool inverter_detected = false;
 battery_pause_status emulator_pause_status = NORMAL;
 //battery pause status end
 
+// Shared CAN-aliveness handling for battery 1/2/3 and the charger: latch the
+// detected-event on the first counter refresh, raise the missing-event when the
+// counter runs out, decrement and clear it otherwise. The inverter has its own
+// logic (long-timeout option, startup grace) and is handled separately.
+static void check_can_component_alive(uint8_t& still_alive_counter, bool& detected, EVENTS_ENUM_TYPE detected_event,
+                                      EVENTS_ENUM_TYPE missing_event, uint8_t missing_event_data) {
+  if (!detected) {
+    if (still_alive_counter >= CAN_STILL_ALIVE) {
+      detected = true;
+      set_event(detected_event, 1);
+    }
+  }
+  if (!still_alive_counter) {
+    set_event(missing_event, missing_event_data);
+  } else {
+    --still_alive_counter;
+    clear_event(missing_event);
+  }
+}
+
 void update_machineryprotection() {
   //Check if we start to get low on memory
   static uint8_t hysteresisHeapSeconds = 0;
@@ -284,28 +304,10 @@ void update_machineryprotection() {
       }
     }
 
-    //Check if we have ever seen the Battery
-    if (!battery_detected) {
-      if (datalayer.battery.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
-        battery_detected = true;
-        set_event(EVENT_CAN_BATTERY_DETECTED, 1);
-      }
-    }
-
-    // Check if the BMS is still sending CAN messages. If we go 60s without messages we raise an error
-    if (!datalayer.battery.status.CAN_battery_still_alive) {
-      set_event(EVENT_CAN_BATTERY_MISSING, can_config.battery);
-    } else {
-      datalayer.battery.status.CAN_battery_still_alive--;
-      clear_event(EVENT_CAN_BATTERY_MISSING);
-    }
-
-    // Too many malformed CAN messages recieved!
-    if (datalayer.battery.status.CAN_error_counter > MAX_CAN_FAILURES) {
-      set_event(EVENT_CAN_CORRUPTED_WARNING, can_config.battery);
-    } else {
-      clear_event(EVENT_CAN_CORRUPTED_WARNING);
-    }
+    // Check that the BMS has been seen and is still sending CAN messages.
+    // If we go 60s without messages we raise an error
+    check_can_component_alive(datalayer.battery.status.CAN_battery_still_alive, battery_detected,
+                              EVENT_CAN_BATTERY_DETECTED, EVENT_CAN_BATTERY_MISSING, can_config.battery);
   }
 
   if (inverter && inverter->interface_type() == InverterInterfaceType::Can) {
@@ -345,22 +347,11 @@ void update_machineryprotection() {
   }
 
   if (charger) {
-    // Check if we have ever seen the charger
-    if (!charger_detected) {
-      if (datalayer.charger.CAN_charger_still_alive >= CAN_STILL_ALIVE) {
-        charger_detected = true;
-        set_event(EVENT_CAN_CHARGER_DETECTED, 1);
-      }
-    }
-
     // Assuming chargers are all CAN here.
-    // Check if the charger is still sending CAN messages. If we go 60s without messages we raise a warning
-    if (!datalayer.charger.CAN_charger_still_alive) {
-      set_event(EVENT_CAN_CHARGER_MISSING, charger->interface());
-    } else {
-      datalayer.charger.CAN_charger_still_alive--;
-      clear_event(EVENT_CAN_CHARGER_MISSING);
-    }
+    // Check that the charger has been seen and is still sending CAN messages.
+    // If we go 60s without messages we raise a warning
+    check_can_component_alive(datalayer.charger.CAN_charger_still_alive, charger_detected, EVENT_CAN_CHARGER_DETECTED,
+                              EVENT_CAN_CHARGER_MISSING, charger->interface());
   }
 
   // Additional Double-Battery safeties are checked here
@@ -373,27 +364,9 @@ void update_machineryprotection() {
       datalayer.battery2.status.max_charge_power_W = 0;
     }
 
-    // Check if we have ever seen the Battery 2
-    if (!battery2_detected) {
-      if (datalayer.battery2.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
-        battery2_detected = true;
-        set_event(EVENT_CAN_BATTERY2_DETECTED, 1);
-      }
-    }
-
-    if (!datalayer.battery2.status.CAN_battery_still_alive) {
-      set_event(EVENT_CAN_BATTERY2_MISSING, can_config.battery_double);
-    } else {
-      datalayer.battery2.status.CAN_battery_still_alive--;
-      clear_event(EVENT_CAN_BATTERY2_MISSING);
-    }
-
-    // Too many malformed CAN messages recieved!
-    if (datalayer.battery2.status.CAN_error_counter > MAX_CAN_FAILURES) {
-      set_event(EVENT_CAN_CORRUPTED_WARNING, can_config.battery_double);
-    } else {
-      clear_event(EVENT_CAN_CORRUPTED_WARNING);
-    }
+    // Check that the Battery 2 BMS has been seen and is still sending CAN messages
+    check_can_component_alive(datalayer.battery2.status.CAN_battery_still_alive, battery2_detected,
+                              EVENT_CAN_BATTERY2_DETECTED, EVENT_CAN_BATTERY2_MISSING, can_config.battery_double);
 
     // Cell overvoltage, critical latching error without automatic reset. Requires user action.
     if (datalayer.battery2.status.cell_max_voltage_mV >= datalayer.battery2.info.max_cell_voltage_mV) {
@@ -441,27 +414,9 @@ void update_machineryprotection() {
       datalayer.battery3.status.max_charge_power_W = 0;
     }
 
-    // Check if we have ever seen the Battery 3
-    if (!battery3_detected) {
-      if (datalayer.battery3.status.CAN_battery_still_alive >= CAN_STILL_ALIVE) {
-        battery3_detected = true;
-        set_event(EVENT_CAN_BATTERY3_DETECTED, 1);
-      }
-    }
-
-    if (!datalayer.battery3.status.CAN_battery_still_alive) {
-      set_event(EVENT_CAN_BATTERY3_MISSING, can_config.battery_triple);
-    } else {
-      datalayer.battery3.status.CAN_battery_still_alive--;
-      clear_event(EVENT_CAN_BATTERY3_MISSING);
-    }
-
-    // Too many malformed CAN messages recieved!
-    if (datalayer.battery3.status.CAN_error_counter > MAX_CAN_FAILURES) {
-      set_event(EVENT_CAN_CORRUPTED_WARNING, can_config.battery_triple);
-    } else {
-      clear_event(EVENT_CAN_CORRUPTED_WARNING);
-    }
+    // Check that the Battery 3 BMS has been seen and is still sending CAN messages
+    check_can_component_alive(datalayer.battery3.status.CAN_battery_still_alive, battery3_detected,
+                              EVENT_CAN_BATTERY3_DETECTED, EVENT_CAN_BATTERY3_MISSING, can_config.battery_triple);
 
     // Cell overvoltage, critical latching error without automatic reset. Requires user action.
     if (datalayer.battery3.status.cell_max_voltage_mV >= datalayer.battery3.info.max_cell_voltage_mV) {
@@ -497,6 +452,28 @@ void update_machineryprotection() {
         clear_event(EVENT_SOH_DIFFERENCE);
       }
     }
+  }
+
+  // Too many malformed CAN messages received! EVENT_CAN_CORRUPTED_WARNING is shared by
+  // all batteries; evaluate them together so one battery's clean state can no longer
+  // clear another battery's active warning. Event data = first offending channel.
+  bool can_corrupted = false;
+  uint8_t corrupted_channel = can_config.battery;
+  if (battery && datalayer.battery.status.CAN_error_counter > MAX_CAN_FAILURES) {
+    can_corrupted = true;
+  }
+  if (battery2 && !can_corrupted && datalayer.battery2.status.CAN_error_counter > MAX_CAN_FAILURES) {
+    can_corrupted = true;
+    corrupted_channel = can_config.battery_double;
+  }
+  if (battery3 && !can_corrupted && datalayer.battery3.status.CAN_error_counter > MAX_CAN_FAILURES) {
+    can_corrupted = true;
+    corrupted_channel = can_config.battery_triple;
+  }
+  if (can_corrupted) {
+    set_event(EVENT_CAN_CORRUPTED_WARNING, corrupted_channel);
+  } else {
+    clear_event(EVENT_CAN_CORRUPTED_WARNING);
   }
 
   //Safeties verified, Zero charge/discharge ampere values incase any safety wrote the W to 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(tests
     voltage_sync_tests.cpp
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
+    battery_alive_tests.cpp
     battery/NissanLeafTest.cpp 
     battery/still_alive_tests.cpp
     can_log_based/canlog_safety_tests.cpp

--- a/test/battery_alive_tests.cpp
+++ b/test/battery_alive_tests.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/battery/BATTERIES.h"
+#include "../Software/src/charger/CHARGERS.h"
+#include "../Software/src/charger/CanCharger.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/safety/safety.h"
+#include "../Software/src/devboard/utils/events.h"
+
+// Tests for the shared CAN-aliveness handling of battery 1/2/3 and the charger
+// in update_machineryprotection(), and for the aggregated corrupted-CAN warning
+// (EVENT_CAN_CORRUPTED_WARNING is one event shared by all batteries).
+
+// Defined in safety.cpp; not exposed via safety.h like the battery latches are.
+extern bool charger_detected;
+
+namespace {
+
+class BatteryAliveTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer = DataLayer();
+    reset_all_events();
+    init_hal();
+    // Avoid tripping the low-heap check (CPU_free_heap defaults to 0)
+    datalayer.system.info.CPU_free_heap = 200000;
+    if (!battery2) {
+      // BMW i3 supports double battery, so one setup creates both instances
+      user_selected_battery_type = BatteryType::BmwI3;
+      user_selected_second_battery = true;
+      setup_battery();
+    }
+    if (!charger) {
+      user_selected_charger_type = ChargerType::ChevyVolt;
+      setup_charger();
+    }
+    ASSERT_NE(battery, nullptr);
+    ASSERT_NE(battery2, nullptr);
+    ASSERT_NE(charger, nullptr);
+    // The detection latches are globals with no reset inside safety.cpp;
+    // set them explicitly so tests are order-independent.
+    battery_detected = true;
+    battery2_detected = true;
+    battery3_detected = true;
+    charger_detected = true;
+  }
+};
+
+}  // namespace
+
+// The key regression: one battery's corruption warning must not be cleared by
+// another battery's clean state. Before the aggregation, the per-battery
+// set/clear blocks ran in sequence and the last one to run won, so a healthy
+// battery 2 silently cleared battery 1's active warning every cycle.
+TEST_F(BatteryAliveTest, CorruptedWarningNotMaskedByHealthySecondBattery) {
+  datalayer.battery.status.CAN_error_counter = MAX_CAN_FAILURES + 1;
+  datalayer.battery2.status.CAN_error_counter = 0;
+
+  update_machineryprotection();
+
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_CORRUPTED_WARNING)->state, EVENT_STATE_ACTIVE)
+      << "Battery 2's clean CAN state must not clear battery 1's corruption warning";
+}
+
+TEST_F(BatteryAliveTest, SecondBatteryCorruptionRaisesWarning) {
+  datalayer.battery.status.CAN_error_counter = 0;
+  datalayer.battery2.status.CAN_error_counter = MAX_CAN_FAILURES + 1;
+
+  update_machineryprotection();
+
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_CORRUPTED_WARNING)->state, EVENT_STATE_ACTIVE);
+}
+
+TEST_F(BatteryAliveTest, CorruptedWarningClearsWhenAllBatteriesHealthy) {
+  datalayer.battery.status.CAN_error_counter = MAX_CAN_FAILURES + 1;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_CORRUPTED_WARNING)->state, EVENT_STATE_ACTIVE);
+
+  datalayer.battery.status.CAN_error_counter = 0;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_CORRUPTED_WARNING)->state, EVENT_STATE_INACTIVE);
+}
+
+// Detection must latch on >= CAN_STILL_ALIVE, not equality: some drivers refresh
+// the counter to a multiple for a longer timeout (SMA x3, Sofar x2 on the
+// inverter side today; the battery/charger checks are kept equivalent).
+TEST_F(BatteryAliveTest, BatteryDetectionFiresWithMultipliedRefreshValue) {
+  battery_detected = false;
+  datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE * 3;
+
+  update_machineryprotection();
+
+  EXPECT_TRUE(battery_detected);
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_BATTERY_DETECTED)->occurences, 1);
+}
+
+TEST_F(BatteryAliveTest, BatteryMissingSetsAtZeroAndClearsOnRefresh) {
+  datalayer.battery.status.CAN_battery_still_alive = 0;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_BATTERY_MISSING)->state, EVENT_STATE_ACTIVE);
+
+  datalayer.battery.status.CAN_battery_still_alive = 10;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_BATTERY_MISSING)->state, EVENT_STATE_INACTIVE);
+  EXPECT_EQ(datalayer.battery.status.CAN_battery_still_alive, 9) << "Counter must decrement on every cycle";
+}
+
+TEST_F(BatteryAliveTest, SecondBatteryMissingSetsAtZeroAndClearsOnRefresh) {
+  datalayer.battery2.status.CAN_battery_still_alive = 0;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_BATTERY2_MISSING)->state, EVENT_STATE_ACTIVE);
+
+  datalayer.battery2.status.CAN_battery_still_alive = 10;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_BATTERY2_MISSING)->state, EVENT_STATE_INACTIVE);
+  EXPECT_EQ(datalayer.battery2.status.CAN_battery_still_alive, 9);
+}
+
+TEST_F(BatteryAliveTest, ChargerMissingSetsAtZeroAndClearsOnRefresh) {
+  datalayer.charger.CAN_charger_still_alive = 0;
+  update_machineryprotection();
+  ASSERT_EQ(get_event_pointer(EVENT_CAN_CHARGER_MISSING)->state, EVENT_STATE_ACTIVE);
+
+  datalayer.charger.CAN_charger_still_alive = 10;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_CHARGER_MISSING)->state, EVENT_STATE_INACTIVE);
+  EXPECT_EQ(datalayer.charger.CAN_charger_still_alive, 9);
+}
+
+TEST_F(BatteryAliveTest, ChargerDetectionFiresOnRefresh) {
+  charger_detected = false;
+  datalayer.charger.CAN_charger_still_alive = CAN_STILL_ALIVE;
+
+  update_machineryprotection();
+
+  EXPECT_TRUE(charger_detected);
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_CHARGER_DETECTED)->occurences, 1);
+}


### PR DESCRIPTION
### The bug: one battery's corruption warning is masked by another battery's health

`EVENT_CAN_CORRUPTED_WARNING` is a single event shared by all batteries, but each battery block in `update_machineryprotection()` set **or cleared** it independently — so the last block to run wins. With a double/triple battery setup, a healthy battery 2 (or 3) silently clears battery 1's active corruption warning every cycle: battery 1 can be receiving a stream of malformed CAN frames and the event log shows nothing.

Fixed by evaluating all configured batteries together after the battery blocks: the warning is active while **any** battery's `CAN_error_counter` exceeds `MAX_CAN_FAILURES`, and clears only when all are healthy. Event data is now the first offending channel (previously: last writer's channel — a strictly-better tiebreak, listed here as the only intentional semantic change).

The new regression test `CorruptedWarningNotMaskedByHealthySecondBattery` fails on current main and passes with this change.

### The cleanup the fix falls out of

The CAN aliveness handling (detected-event latch on first counter refresh, missing-event at counter zero, decrement + clear otherwise) was copy-pasted four times: battery 1, battery 2, battery 3, charger. This is the same copy-paste drift that produced the bugs fixed in #2677 — and this corruption-warning bug is another instance of it.

The four blocks are replaced by one helper:

```cpp
static void check_can_component_alive(uint8_t& still_alive_counter, bool& detected, EVENTS_ENUM_TYPE detected_event,
                                      EVENTS_ENUM_TYPE missing_event, uint8_t missing_event_data);
```

**The inverter block is deliberately not converted** — it has the long-timeout option and startup-grace special cases the others don't, and stays exactly as #2677 left it.

Everything else is behavior-preserving: same detection latch semantics (`>=`, matching #2677), same event data arguments (charger keeps `charger->interface()`), same guards around each call site.

### Tests

`test/battery_alive_tests.cpp` (new, registered in the test CMakeLists):

- `CorruptedWarningNotMaskedByHealthySecondBattery` — the masking regression, fails on current main
- `SecondBatteryCorruptionRaisesWarning`, `CorruptedWarningClearsWhenAllBatteriesHealthy` — aggregation behavior
- Detection at multiplied refresh values, missing-at-zero / clear-and-decrement-on-refresh for battery 1, battery 2, and charger paths — all pass before and after (behavior preservation)

Full suite: 99/99 pass. Firmware compiles clean under the `-Werror` warning-check environment.
