### PR TITLE
BYD vehicle: Add P1A4800 DTC-description

### DIFF
--- a/web_data/dtc/byd_atto3_dtc.json
+++ b/web_data/dtc/byd_atto3_dtc.json
@@ -436,6 +436,7 @@
   {"dtc": "P1A3F00", "l_dsc": "Pre-charging Contactor Loop Check Fault"},
   {"dtc": "P1A4100", "l_dsc": "Main Contactor Sintering Fault"},
   {"dtc": "P1A4200", "l_dsc": "Negative Contactor Sintering"},
+  {"dtc": "P1A4800", "l_dsc": " Main Motor Cover Open Failure / Main motor opened housing fault"},
   {"dtc": "P1A5600", "l_dsc": "12V Supply Input of Battery Management System Too Low"},
   {"dtc": "P1A5B00", "l_dsc": "Contactor Disconnected Due to Dual-circuit Power Supply Fault"},
   {"dtc": "P1A6000", "l_dsc": "High Voltage Interlock 1 Fault"},


### PR DESCRIPTION
What
This PR adds 1 more DTC to BYD vehicle implementation

Why
Aid reverse engineering, more DTCs decoded

How does it do it?
Source: Internet


