### PR TITLE
BYD vehicle: Add U012100 DTC-description

### DIFF
--- a/web_data/dtc/byd_atto3_dtc.json
+++ b/web_data/dtc/byd_atto3_dtc.json
@@ -591,6 +591,7 @@
   {"dtc": "U011181", "l_dsc": "Message Data of BMC Abnormal"},
   {"dtc": "U011182", "l_dsc": "Cycle Counter of BMC Abnormal"},
   {"dtc": "U011187", "l_dsc": "Communication with Battery Management System (BMS) Failed"},
+  {"dtc": "U012100", "l_dsc": "Lost Communication With ABS Module"},
   {"dtc": "U012187", "l_dsc": "Communication with ABS Failed"},
   {"dtc": "U014081", "l_dsc": "Message Data of BCM Abnormal"},
   {"dtc": "U014087", "l_dsc": "Communication with BCM Failed"},


### PR DESCRIPTION
What
This PR adds 1 more DTC to BYD vehicle implementation

Why
Aid reverse engineering, more DTCs decoded

How
Source: Internet

