### PR TITLE
Sync settings-page defaults with boot defaults (6 mismatches)

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -264,7 +264,7 @@ void init_stored_settings() {
   static_dns = settings.getString("DNS").c_str();
 
   mqtt_server = settings.getString("MQTTSERVER").c_str();
-  mqtt_port = settings.getUInt("MQTTPORT", 0);
+  mqtt_port = settings.getUInt("MQTTPORT", 1883);
   mqtt_user = settings.getString("MQTTUSER").c_str();
   mqtt_password = settings.getString("MQTTPASSWORD").c_str();
 

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -276,9 +276,8 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
            capability_css("if-tricapable", battery_supports_triple);
   }
   if (var == "BATTCHEM") {
-    return options_for_enum(
-        (battery_chemistry_enum)settings.getUInt("BATTCHEM", (int)battery_chemistry_enum::Autodetect),
-        name_for_chemistry);
+    return options_for_enum((battery_chemistry_enum)settings.getUInt("BATTCHEM", (int)battery_chemistry_enum::NCA),
+                            name_for_chemistry);
   }
   if (var == "INVTYPE") {
     return options_for_enum_with_none(
@@ -310,8 +309,8 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
 
   if (var == "CTATTEN") {
     return options_for_enum_with_none(
-        (adc_attenuation_enum)settings.getUInt("CTATTEN", (int)adc_attenuation_enum::ADC_0db), name_for_adc_attenuation,
-        adc_attenuation_enum::ADC_0db);
+        (adc_attenuation_enum)settings.getUInt("CTATTEN", (int)adc_attenuation_enum::ADC_11db),
+        name_for_adc_attenuation, adc_attenuation_enum::ADC_0db);
   }
 
   if (var == "EQSTOP") {
@@ -360,7 +359,7 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
   }
 
   if (var == "SUNGROW_MODEL") {
-    return options_from_map(settings.getUInt("INVSUNTYPE", 1), sungrow_models);  // Default: SBR096
+    return options_from_map(settings.getUInt("INVSUNTYPE", 0), sungrow_models);  // Default: SBR064, as boot assumes
   }
 
   if (var == "PYLON_MODEL") {
@@ -634,11 +633,11 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "CHGPOWER") {
-    return String(settings.getUInt("CHGPOWER", 0));
+    return String(settings.getUInt("CHGPOWER", 1000));
   }
 
   if (var == "DCHGPOWER") {
-    return String(settings.getUInt("DCHGPOWER", 0));
+    return String(settings.getUInt("DCHGPOWER", 1000));
   }
 
   if (var == "LOCALIP") {


### PR DESCRIPTION
For a setting whose NVS key was never saved, the settings page renders one default while the firmware boots with another: the operator believes X is active while the firmware runs Y — and saving the form as-displayed silently **persists** the wrong value. Concrete case: a device with never-saved `CHGPOWER` runs a 1000 W charger override while the page shows 0; one save of the settings form turns the working 1000 W into 0 without the user ever touching that field.

Six keys are affected (verified as the complete set by two independent passes over `comm_nvm.cpp` vs the settings processors):

| Key | Boot default | Page displayed | Fix |
|---|---|---|---|
| `CHGPOWER` | 1000 W | 0 | render → **1000** |
| `DCHGPOWER` | 1000 W | 0 | render → **1000** |
| `BATTCHEM` | NCA (1) | Autodetect (0) | render → **NCA** |
| `CTATTEN` | ADC_11db (3) | ADC_0db (0) | render → **ADC_11db** |
| `INVSUNTYPE` | SBR064 (0) | SBR096 (1) | render → **SBR064** |
| `MQTTPORT` | 0 | 1883 | **boot → 1883** |

**Five are display fixes** — the render literal changes to what boot has always applied, so device behavior is untouched; the page just stops lying. For `CHGPOWER`/`DCHGPOWER` the direction was verified against the consumers: `override_charge_power_W` feeds `max_charge_power_W` directly (ENNOID, iMiEV, …), so 0 means *zero watts*, not "no override" — aligning boot to the displayed 0 instead would have disabled charging on never-saved devices.

**One is a boot fix**, where the stored default was the broken half: `MQTTPORT` 0 → 1883. Port 0 is never valid, 1883 is the MQTT standard and what the page has always shown. This is benign: MQTT is disabled by default, and anyone who enabled it via the form saved the pre-filled 1883 along with it.

**One question left open deliberately:** `BATTCHEM` arguably *should* default to Autodetect — but that changes chemistry resolution (and with it cell-voltage limits) for never-saved packs, which is safety-adjacent. This PR keeps the historical boot value (NCA) on both surfaces; if Autodetect is the intended default, that's a deliberate two-literal follow-up.

After this change, render default == boot default for every key, so the accept-then-lose scenario is closed for all six. Longer term, single-sourcing each default (per-setting descriptor, fits naturally with the settings work in #1544) makes this bug class structurally impossible — this PR is just the sync, kept frontend-agnostic on purpose.

No test coverage exists for these paths (webserver isn't in the host test build); verification is the green `-Werror` build, a ~zero size-CI delta (literal-for-literal), and the full host suite still passing (99/99).
