### PR TITLE
Bugfix: MQTT, value_template include default handling for missing keys

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -422,9 +422,8 @@ static bool publish_sensor_discovery(const SensorConfig& config, const char* id_
   char value_template[96];
   snprintf(entity_id, sizeof(entity_id), "%s%s", config.entity_id, id_suffix);
   snprintf(name_buf, sizeof(name_buf), "%s%s", config.name, name_suffix);
-  // The state topics are per-battery, so the value_template key is the base id for every
-  // battery — no "_2"/"_3" key variants exist anymore.
-  snprintf(value_template, sizeof(value_template), "{{ value_json.%s }}", config.entity_id);
+  // The state topics are per-battery, so the value_template key is the base id for every battery
+  snprintf(value_template, sizeof(value_template), "{{ value_json.%s | default(none) }}", config.entity_id);
 
   JsonDocument& doc = shared_doc;
   doc["name"] = name_buf;


### PR DESCRIPTION
### What
Fix for https://github.com/dalathegreat/Battery-Emulator/issues/1387 

### Why
When BE boots up, connects to MQTT broker and publishes the initial topics, Home Assistant logs these warnings:
```
Template variable warning: 'dict object' has no attribute 'insulation_resistance' when rendering '{{ value_json.insulation_resistance }}'
Template variable warning: 'dict object' has no attribute 'cell_min_voltage' when rendering '{{ value_json.cell_min_voltage }}'
Template variable warning: 'dict object' has no attribute 'cell_voltage_delta' when rendering '{{ value_json.cell_voltage_delta }}'
Template variable warning: 'dict object' has no attribute 'cell_max_voltage' when rendering '{{ value_json.cell_max_voltage }}'
```

### How
Set a default to `none` for the topics not having yet a value, this populates HA entities correctly with "Unknown" state.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
