### PR TITLE
Ford: Add more CAN sending to reduce DTCs

### DIFF
--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -546,29 +546,18 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
       FORD_25B.data.u8[2] = 0x09;
     }
 
-    transmit_can_frame(&FORD_25B);
+    transmit_can_frame(&FORD_25B);  //Contactor control
 
-    //TEST
     //transmit_can_frame(&FORD_217);  //Confirmed does NOT help reduce amount of DTCs
     //transmit_can_frame(&FORD_442);  //Confirmed does NOT help reduce amount of DTCs
-    //Full vehicle emulation, not required
-    /*
-    
-    //
-    */
+    //transmit_can_frame(&FORD_48F);  //Confirmed does NOT help reduce amount of DTCs
   }
 
   // Send 30ms CAN Message
   if (currentMillis - previousMillis30 >= INTERVAL_30_MS) {
     previousMillis30 = currentMillis;
 
-    //TEST
-    //transmit_can_frame(&FORD_77);  //Confirmed does NOT help reduce amount of DTCs
-    //transmit_can_frame(&FORD_47);  //Confirmed does NOT help reduce amount of DTCs
-    //transmit_can_frame(&FORD_48);  //Confirmed does NOT help reduce amount of DTCs
-    //Full vehicle emulation, not required
     /*
-
     counter_30ms = (counter_30ms + 1) % 16;  // cycles 0-15
 
     // Byte 2: upper nibble = 0xF, lower nibble = (0xF - counter_10ms) % 16
@@ -601,22 +590,23 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     // Byte 7: counts down by 2 each step, maintaining byte6 + byte7 = 0x7F
     FORD_200.data.u8[7] = 0x7F - (counter_8_30ms * 2);
 
-    //
-    //transmit_can_frame(&FORD_7D); Not needed for contactor closing
-    //transmit_can_frame(&FORD_167); Not needed for contactor closing
-    // //Only sent in AC charging logs! Not needed for contactor closing
-    //transmit_can_frame(&FORD_204); Not needed for contactor closing
-    //transmit_can_frame(&FORD_4B0); Not needed for contactor closing
-    //
-    //transmit_can_frame(&FORD_230); Not needed for contactor closing
-    //transmit_can_frame(&FORD_415); Not needed for contactor closing
-    //transmit_can_frame(&FORD_4C);  Not needed for contactor closing
-    //transmit_can_frame(&FORD_7E); Not needed for contactor closing
-    //transmit_can_frame(&FORD_48); Not needed for contactor closing
-    //transmit_can_frame(&FORD_165); Not needed for contactor closing
-    //transmit_can_frame(&FORD_7F); Not needed for contactor closing
-    transmit_can_frame(&FORD_200);
     */
+
+    //transmit_can_frame(&FORD_77); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_47); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_48); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_7D); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_200); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_204); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_415); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_4B0); //Confirmed does NOT help reduce amount of DTCs
+
+    transmit_can_frame(&FORD_167);  //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
+    transmit_can_frame(&FORD_230);  //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
+    transmit_can_frame(&FORD_7F);   //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
+    transmit_can_frame(&FORD_165);  //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
+    transmit_can_frame(&FORD_7E);   //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
+    transmit_can_frame(&FORD_4C);   //Some code here removes one DTC (P1A42 Propulsion System Status Signal Performance)
   }
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
@@ -635,31 +625,17 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     //FORD_5A.data.u8
     //transmit_can_frame(&FORD_5A);
 
-    //TEST
-    //transmit_can_frame(&FORD_12F); //Confirmed does NOT help reduce amount of DTCs
-    //transmit_can_frame(&FORD_203);  //Confirmed does NOT help reduce amount of DTCs
-    //WAVE3
-    transmit_can_frame(&FORD_332);
-    transmit_can_frame(&FORD_333);
-    transmit_can_frame(&FORD_42B);
-    transmit_can_frame(&FORD_2EC);
-    transmit_can_frame(&FORD_156);
-    transmit_can_frame(&FORD_166);
-    transmit_can_frame(&FORD_175);
-    transmit_can_frame(&FORD_178);
-    //Full vehicle emulation, not required
-    /*
-
-
-
-
-
-
-
-
-    transmit_can_frame(
-        &FORD_176);  //This message actually has checksum/counter, but it seems to close contactors without those
-*/
+    //transmit_can_frame(&FORD_12F);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_203);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_332);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_333);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_42B);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_2EC);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_156);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_166);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_175);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_178);//Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_176);//Confirmed does NOT help reduce amount of DTCs
   }
 
   // Send 250ms CAN Message
@@ -683,11 +659,9 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   // Send 1s CAN Message
   if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
     previousMillis1000 = currentMillis;
-    //Full vehicle emulation, not required
-    /*
-    transmit_can_frame(&FORD_3C3);
-    transmit_can_frame(&FORD_581);
-    */
+
+    //transmit_can_frame(&FORD_3C3); //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_581); //Confirmed does NOT help reduce amount of DTCs
   }
 }
 

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -548,10 +548,13 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     transmit_can_frame(&FORD_25B);
 
+    //TEST
+    transmit_can_frame(&FORD_217);  //TEST
+    transmit_can_frame(&FORD_442);  //TEST
     //Full vehicle emulation, not required
     /*
-    //transmit_can_frame(&FORD_217); Not needed for contactor closing
-    //transmit_can_frame(&FORD_442); Not needed for contactor closing
+    
+    //
     */
   }
 
@@ -560,8 +563,9 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     previousMillis30 = currentMillis;
 
     //TEST
-    transmit_can_frame(&FORD_77);  //Static, content never changes (TEST)
-
+    //transmit_can_frame(&FORD_77);  //Confirmed does NOT help reduce amount of DTCs
+    transmit_can_frame(&FORD_47);  //TEST
+    transmit_can_frame(&FORD_48);  //TEST
     //Full vehicle emulation, not required
     /*
 
@@ -600,10 +604,10 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     //
     //transmit_can_frame(&FORD_7D); Not needed for contactor closing
     //transmit_can_frame(&FORD_167); Not needed for contactor closing
-    //transmit_can_frame(&FORD_48F);  //Only sent in AC charging logs! Not needed for contactor closing
+    // //Only sent in AC charging logs! Not needed for contactor closing
     //transmit_can_frame(&FORD_204); Not needed for contactor closing
     //transmit_can_frame(&FORD_4B0); Not needed for contactor closing
-    //transmit_can_frame(&FORD_47); Not needed for contactor closing
+    //
     //transmit_can_frame(&FORD_230); Not needed for contactor closing
     //transmit_can_frame(&FORD_415); Not needed for contactor closing
     //transmit_can_frame(&FORD_4C);  Not needed for contactor closing
@@ -617,9 +621,9 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
     previousMillis50 = currentMillis;
-    transmit_can_frame(&FORD_42C);  //Static, content never changes (TEST)
-    transmit_can_frame(&FORD_42F);  //Static, content never changes (TEST)
-    transmit_can_frame(&FORD_43D);  //Static, content never changes (TEST)
+    //transmit_can_frame(&FORD_42C);  //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_42F);  //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_43D);  //Confirmed does NOT help reduce amount of DTCs
   }
 
   // Send 100ms CAN Message
@@ -628,8 +632,12 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     transmit_can_frame(&FORD_185);  // Required to close contactors
 
+    //FORD_5A.data.u8
+
     //TEST
-    transmit_can_frame(&FORD_12F);
+    //transmit_can_frame(&FORD_12F); //Confirmed does NOT help reduce amount of DTCs
+    transmit_can_frame(&FORD_203);  //TEST
+    //transmit_can_frame(&FORD_5A);
 
     //Full vehicle emulation, not required
     /*
@@ -639,12 +647,10 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&FORD_42B);
     transmit_can_frame(&FORD_2EC);
     transmit_can_frame(&FORD_156);
-    transmit_can_frame(
-        &FORD_5A);  //This message actually has checksum/counter, but it seems to close contactors without those
     transmit_can_frame(&FORD_166);
     transmit_can_frame(&FORD_175);
     transmit_can_frame(&FORD_178);
-    transmit_can_frame(&FORD_203);  //MANDATORY FOR CONTACTOR OPERATION
+
     transmit_can_frame(
         &FORD_176);  //This message actually has checksum/counter, but it seems to close contactors without those
 */

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -549,8 +549,8 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&FORD_25B);
 
     //TEST
-    transmit_can_frame(&FORD_217);  //TEST
-    transmit_can_frame(&FORD_442);  //TEST
+    //transmit_can_frame(&FORD_217);  //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_442);  //Confirmed does NOT help reduce amount of DTCs
     //Full vehicle emulation, not required
     /*
     
@@ -564,8 +564,8 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     //TEST
     //transmit_can_frame(&FORD_77);  //Confirmed does NOT help reduce amount of DTCs
-    transmit_can_frame(&FORD_47);  //TEST
-    transmit_can_frame(&FORD_48);  //TEST
+    //transmit_can_frame(&FORD_47);  //Confirmed does NOT help reduce amount of DTCs
+    //transmit_can_frame(&FORD_48);  //Confirmed does NOT help reduce amount of DTCs
     //Full vehicle emulation, not required
     /*
 
@@ -633,15 +633,12 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&FORD_185);  // Required to close contactors
 
     //FORD_5A.data.u8
+    //transmit_can_frame(&FORD_5A);
 
     //TEST
     //transmit_can_frame(&FORD_12F); //Confirmed does NOT help reduce amount of DTCs
-    transmit_can_frame(&FORD_203);  //TEST
-    //transmit_can_frame(&FORD_5A);
-
-    //Full vehicle emulation, not required
-    /*
-
+    //transmit_can_frame(&FORD_203);  //Confirmed does NOT help reduce amount of DTCs
+    //WAVE3
     transmit_can_frame(&FORD_332);
     transmit_can_frame(&FORD_333);
     transmit_can_frame(&FORD_42B);
@@ -650,6 +647,15 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&FORD_166);
     transmit_can_frame(&FORD_175);
     transmit_can_frame(&FORD_178);
+    //Full vehicle emulation, not required
+    /*
+
+
+
+
+
+
+
 
     transmit_can_frame(
         &FORD_176);  //This message actually has checksum/counter, but it seems to close contactors without those

--- a/Software/src/battery/FORD-MACH-E-BATTERY.cpp
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.cpp
@@ -559,6 +559,9 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis30 >= INTERVAL_30_MS) {
     previousMillis30 = currentMillis;
 
+    //TEST
+    transmit_can_frame(&FORD_77);  //Static, content never changes (TEST)
+
     //Full vehicle emulation, not required
     /*
 
@@ -594,7 +597,7 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
     // Byte 7: counts down by 2 each step, maintaining byte6 + byte7 = 0x7F
     FORD_200.data.u8[7] = 0x7F - (counter_8_30ms * 2);
 
-    //transmit_can_frame(&FORD_77); Not needed for contactor closing
+    //
     //transmit_can_frame(&FORD_7D); Not needed for contactor closing
     //transmit_can_frame(&FORD_167); Not needed for contactor closing
     //transmit_can_frame(&FORD_48F);  //Only sent in AC charging logs! Not needed for contactor closing
@@ -614,9 +617,9 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
   // Send 50ms CAN Message
   if (currentMillis - previousMillis50 >= INTERVAL_50_MS) {
     previousMillis50 = currentMillis;
-    //transmit_can_frame(&FORD_42C); Not needed for contactor closing
-    //transmit_can_frame(&FORD_42F); Not needed for contactor closing
-    //transmit_can_frame(&FORD_43D);
+    transmit_can_frame(&FORD_42C);  //Static, content never changes (TEST)
+    transmit_can_frame(&FORD_42F);  //Static, content never changes (TEST)
+    transmit_can_frame(&FORD_43D);  //Static, content never changes (TEST)
   }
 
   // Send 100ms CAN Message
@@ -625,10 +628,12 @@ void FordMachEBattery::transmit_can(unsigned long currentMillis) {
 
     transmit_can_frame(&FORD_185);  // Required to close contactors
 
+    //TEST
+    transmit_can_frame(&FORD_12F);
+
     //Full vehicle emulation, not required
     /*
-    transmit_can_frame(
-        &FORD_12F);  //This message actually has checksum/counter, but it seems to close contactors without those
+
     transmit_can_frame(&FORD_332);
     transmit_can_frame(&FORD_333);
     transmit_can_frame(&FORD_42B);

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -296,6 +296,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .ID = 0x185,
                         .data = {0x03, 0x4E, 0x75, 0x32, 0x00, 0x80, 0x00, 0x00}};
   //Message test to reduce active codes
+  /*
   CAN_frame FORD_43D = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
@@ -321,29 +322,45 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                        .DLC = 8,
                        .ID = 0x077,
                        .data = {0x00, 0x00, 0x08, 0x00, 0xFF, 0xF7, 0xEA, 0x02}};
-
-  //Messages to emulate full vehicle
-  /*
-  CAN_frame FORD_47 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x047,
-                       .data = {0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_48 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x048,
-                       .data = {0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_4C = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x04C,
-                       .data = {0x70, 0xAA, 0xBF, 0xDE, 0xCC, 0xEC, 0x00, 0x00}};
+                       */
+  CAN_frame FORD_203 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x203,
+                        .data = {0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame FORD_5A = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
                        .ID = 0x05A,
                        .data = {0x00, 0x00, 0x00, 0x0B, 0xF2, 0x90, 0x10, 0x00}};
+  CAN_frame FORD_47 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x047,
+                       .data = {0x44, 0x34, 0xD2, 0xBE, 0xC0, 0xFB, 0x00, 0x00}};
+  CAN_frame FORD_48 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x048,
+                       .data = {0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_217 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x217,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_442 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x442,
+                        .data = {0x4E, 0x20, 0x38, 0x71, 0xBA, 0x00, 0x00, 0x40}};
+  //Messages to emulate full vehicle
+  /*
+
+  CAN_frame FORD_4C = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x04C,
+                       .data = {0x70, 0xAA, 0xBF, 0xDE, 0xCC, 0xEC, 0x00, 0x00}};
 
   CAN_frame FORD_7D = {.FD = false,
                        .ext_ID = false,
@@ -401,21 +418,13 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x200,
                         .data = {0x00, 0x00, 0x80, 0x00, 0x80, 0x00, 0x00, 0x70}};
-  CAN_frame FORD_203 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x203,
-                        .data = {0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
   CAN_frame FORD_204 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x204,
                         .data = {0xD4, 0x00, 0x7D, 0x00, 0x00, 0xF7, 0x00, 0x00}};
-  CAN_frame FORD_217 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x217,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
   CAN_frame FORD_230 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
@@ -455,11 +464,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
 
 
 
-  CAN_frame FORD_442 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x442,
-                        .data = {0x4E, 0x20, 0x78, 0x7E, 0x7C, 0x00, 0x00, 0x40}};
+
   CAN_frame FORD_48F = {.FD = false,  //Only sent in active charging logs (OBC?)
                         .ext_ID = false,
                         .DLC = 8,

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -295,6 +295,33 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x185,
                         .data = {0x03, 0x4E, 0x75, 0x32, 0x00, 0x80, 0x00, 0x00}};
+  //Message test to reduce active codes
+  CAN_frame FORD_43D = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x43D,  //Data from AC charge log
+                        .data = {0x40, 0x10, 0xDC, 0x13, 0x07, 0x86, 0x02, 0xB5}};
+  CAN_frame FORD_42F = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x42F,  //Data from AC charge log
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_42C = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x42C,  //Data from AC charge log
+                        .data = {0x80, 0x02, 0x00, 0x00, 0x19, 0xB0, 0x00, 0x00}};
+  CAN_frame FORD_12F = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x12F,
+                        .data = {0x0A, 0xF8, 0x3F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+  CAN_frame FORD_77 = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x077,
+                       .data = {0x00, 0x00, 0x08, 0x00, 0xFF, 0xF7, 0xEA, 0x02}};
+
   //Messages to emulate full vehicle
   /*
   CAN_frame FORD_47 = {.FD = false,
@@ -317,11 +344,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                        .DLC = 8,
                        .ID = 0x05A,
                        .data = {0x00, 0x00, 0x00, 0x0B, 0xF2, 0x90, 0x10, 0x00}};
-  CAN_frame FORD_77 = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x077,
-                       .data = {0x00, 0x00, 0x0F, 0xFE, 0xFF, 0xFF, 0xFB, 0xFE}};
+
   CAN_frame FORD_7D = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
@@ -372,11 +395,6 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x175,
                         .data = {0x01, 0xB6, 0x02, 0x00, 0x4E, 0x46, 0xC6, 0x17}};
-  CAN_frame FORD_12F = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x12F,
-                        .data = {0x0A, 0xF8, 0x3F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
 
   CAN_frame FORD_200 = {.FD = false,
                         .ext_ID = false,
@@ -434,21 +452,9 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x42B,
                         .data = {0xCB, 0xBE, 0x00, 0x02, 0x00, 0x00, 0xCE, 0x00}};
-  CAN_frame FORD_42C = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x42C,
-                        .data = {0x80, 0x02, 0x00, 0x00, 0x19, 0xA0, 0x00, 0x00}};
-  CAN_frame FORD_42F = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x42F,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_43D = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x43D,
-                        .data = {0x00, 0x00, 0xDC, 0x00, 0x00, 0x77, 0x00, 0x00}};
+
+
+
   CAN_frame FORD_442 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -322,7 +322,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                        .DLC = 8,
                        .ID = 0x077,
                        .data = {0x00, 0x00, 0x08, 0x00, 0xFF, 0xF7, 0xEA, 0x02}};
-                       */
+                       
   CAN_frame FORD_203 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
@@ -353,6 +353,49 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x442,
                         .data = {0x4E, 0x20, 0x38, 0x71, 0xBA, 0x00, 0x00, 0x40}};
+                        */
+  //Wave3
+  CAN_frame FORD_332 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x332,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00}};
+  CAN_frame FORD_333 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x333,
+                        .data = {0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_42B = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x42B,
+                        .data = {0xCB, 0xBE, 0x00, 0x02, 0x00, 0x00, 0xCE, 0x00}};
+  CAN_frame FORD_2EC = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x2EC,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x01, 0x60, 0x00, 0x00}};
+  CAN_frame FORD_156 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x156,
+                        .data = {0x4B, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_166 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x166,
+                        .data = {0x00, 0x00, 0x00, 0x01, 0x5C, 0x89, 0x00, 0x00}};
+  CAN_frame FORD_175 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x175,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_178 = {.FD = false,  //Static content
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x175,
+                        .data = {0x01, 0xB6, 0x02, 0x00, 0x46, 0x3C, 0xC6, 0x17}};
+  //Wave4
   //Messages to emulate full vehicle
   /*
 
@@ -377,41 +420,25 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                        .DLC = 8,
                        .ID = 0x07F,
                        .data = {0x00, 0x00, 0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_156 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x156,
-                        .data = {0x4B, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}};
+
   CAN_frame FORD_165 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x165,
                         .data = {0x10, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_166 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x166,
-                        .data = {0x00, 0x00, 0x00, 0x01, 0x5C, 0x89, 0x00, 0x00}};
+
   CAN_frame FORD_167 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x167,
                         .data = {0x00, 0x80, 0x00, 0x11, 0xFF, 0xE0, 0x00, 0x00}};
-  CAN_frame FORD_175 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x175,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
   CAN_frame FORD_176 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x176,
                         .data = {0x00, 0x0E, 0xF0, 0x10, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_178 = {.FD = false,  //Static content
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x175,
-                        .data = {0x01, 0xB6, 0x02, 0x00, 0x4E, 0x46, 0xC6, 0x17}};
+
 
   CAN_frame FORD_200 = {.FD = false,
                         .ext_ID = false,
@@ -431,21 +458,8 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .ID = 0x230,
                         .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}};
 
-  CAN_frame FORD_2EC = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x2EC,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00}};
-  CAN_frame FORD_332 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x332,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FORD_333 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x333,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+
   CAN_frame FORD_3C3 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
@@ -456,11 +470,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x415,
                         .data = {0x00, 0x00, 0xC0, 0xFC, 0x0F, 0xFE, 0xEF, 0xFE}};
-  CAN_frame FORD_42B = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x42B,
-                        .data = {0xCB, 0xBE, 0x00, 0x02, 0x00, 0x00, 0xCE, 0x00}};
+
 
 
 

--- a/Software/src/battery/FORD-MACH-E-BATTERY.h
+++ b/Software/src/battery/FORD-MACH-E-BATTERY.h
@@ -71,11 +71,7 @@ class FordMachEBattery : public CanBattery {
   uint16_t minimum_cellvoltage_mV = 3700;
   uint16_t charge_current_allowed = 0;
   uint16_t discharge_current_allowed = 0;
-
-  uint8_t counter_30ms = 0;
-  uint8_t counter_8_30ms = 0;
   uint16_t pid_reply = 0;
-
   uint16_t polled_12V = 12000;
 
   uint8_t display_soc = 0;
@@ -353,7 +349,7 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x442,
                         .data = {0x4E, 0x20, 0x38, 0x71, 0xBA, 0x00, 0x00, 0x40}};
-                        */
+
   //Wave3
   CAN_frame FORD_332 = {.FD = false,
                         .ext_ID = false,
@@ -395,102 +391,85 @@ static const uint16_t PID_UNKNOWN_37 = 0xF449;
                         .DLC = 8,
                         .ID = 0x175,
                         .data = {0x01, 0xB6, 0x02, 0x00, 0x46, 0x3C, 0xC6, 0x17}};
-  //Wave4
-  //Messages to emulate full vehicle
-  /*
-
+    CAN_frame FORD_7D = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x07D,
+                       .data = {0x00, 0x00, 0xF0, 0xF0, 0x00, 0x3F, 0xEF, 0xFE}};
+  CAN_frame FORD_204 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x204,
+                        .data = {0xD4, 0x00, 0x7D, 0x00, 0x00, 0xF7, 0x00, 0x00}};
+  CAN_frame FORD_4B0 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x4B0,
+                        .data = {0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0xF0}};
+  CAN_frame FORD_415 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x415,
+                        .data = {0x00, 0x00, 0xC0, 0xFC, 0x0F, 0xFE, 0xEF, 0xFE}};
+  CAN_frame FORD_200 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x200,
+                        .data = {0x00, 0x00, 0x80, 0x00, 0x80, 0x00, 0x00, 0x70}};
+                        */
+  CAN_frame FORD_167 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x167,
+                        .data = {0x03, 0x80, 0x00, 0x11, 0xFF, 0xE0, 0x00, 0x00}};
+  CAN_frame FORD_230 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x230,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}};
+  CAN_frame FORD_7F = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x07F,
+                       .data = {0x00, 0x00, 0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_165 = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x165,
+                        .data = {0x10, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  CAN_frame FORD_7E = {.FD = false,
+                       .ext_ID = false,
+                       .DLC = 8,
+                       .ID = 0x07E,
+                       .data = {0x00, 0x00, 0x3E, 0x80, 0x00, 0x04, 0x00, 0x00}};
   CAN_frame FORD_4C = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
                        .ID = 0x04C,
                        .data = {0x70, 0xAA, 0xBF, 0xDE, 0xCC, 0xEC, 0x00, 0x00}};
 
-  CAN_frame FORD_7D = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x07D,
-                       .data = {0x00, 0x00, 0xF0, 0xF0, 0x00, 0x3F, 0xEF, 0xFE}};
-  CAN_frame FORD_7E = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x07E,
-                       .data = {0x00, 0x00, 0x3E, 0x80, 0x00, 0x04, 0x00, 0x00}};
-  CAN_frame FORD_7F = {.FD = false,
-                       .ext_ID = false,
-                       .DLC = 8,
-                       .ID = 0x07F,
-                       .data = {0x00, 0x00, 0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00}};
-
-  CAN_frame FORD_165 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x165,
-                        .data = {0x10, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-
-  CAN_frame FORD_167 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x167,
-                        .data = {0x00, 0x80, 0x00, 0x11, 0xFF, 0xE0, 0x00, 0x00}};
-
+  /*
   CAN_frame FORD_176 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x176,
                         .data = {0x00, 0x0E, 0xF0, 0x10, 0x00, 0x00, 0x00, 0x00}};
-
-
-  CAN_frame FORD_200 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x200,
-                        .data = {0x00, 0x00, 0x80, 0x00, 0x80, 0x00, 0x00, 0x70}};
-
-  CAN_frame FORD_204 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x204,
-                        .data = {0xD4, 0x00, 0x7D, 0x00, 0x00, 0xF7, 0x00, 0x00}};
-
-  CAN_frame FORD_230 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x230,
-                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}};
-
-
-
   CAN_frame FORD_3C3 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x3C3,
                         .data = {0x5C, 0xC8, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00}};
-  CAN_frame FORD_415 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x415,
-                        .data = {0x00, 0x00, 0xC0, 0xFC, 0x0F, 0xFE, 0xEF, 0xFE}};
-
-
-
-
-
   CAN_frame FORD_48F = {.FD = false,  //Only sent in active charging logs (OBC?)
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x48F,
                         .data = {0x30, 0x4E, 0x20, 0x80, 0x00, 0x00, 0x80, 0x00}};
-  CAN_frame FORD_4B0 = {.FD = false,
-                        .ext_ID = false,
-                        .DLC = 8,
-                        .ID = 0x4B0,
-                        .data = {0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0xF0}};
   CAN_frame FORD_581 = {.FD = false,
                         .ext_ID = false,
                         .DLC = 8,
                         .ID = 0x4B0,
                         .data = {0x81, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-                        */
+*/
 };
 
 #endif


### PR DESCRIPTION
### What
This PR sends more CAN messages towards Ford integration

### Why
The DTC P1A42 (Propulsion System Status Signal Performance) gets removed when this PR is run

### How
We send more CAN messages

Before: 8 codes active
<img width="967" height="547" alt="image" src="https://github.com/user-attachments/assets/9a478148-d649-416f-a9f1-8d89104e60de" />

After: 7 codes active 
<img width="965" height="485" alt="image" src="https://github.com/user-attachments/assets/78eb8c40-bee5-4ff8-bc17-f0e3833f837e" />



> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
