### PR TITLE
Improvement: BYD - source cell min/max from 0x446 broadcast, drop redundant UDS polls

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -505,6 +505,12 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x446:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      // Broadcast cell extrema summary (~1Hz), fresher than the UDS round-robin. b0/b4 = 1-based
+      // min/max cell number; min/max mV are 12-bit little-endian in b1:b2 / b5:b6.
+      BMS_min_cell_voltage_number = rx_frame.data.u8[0];
+      BMS_lowest_cell_voltage_mV = rx_frame.data.u8[1] | ((rx_frame.data.u8[2] & 0x0F) << 8);
+      BMS_max_cell_voltage_number = rx_frame.data.u8[4];
+      BMS_highest_cell_voltage_mV = rx_frame.data.u8[5] | ((rx_frame.data.u8[6] & 0x0F) << 8);
       break;
     case 0x447:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -572,12 +578,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case POLL_FOR_BATTERY_PACK_AVG_TEMP:
           BMS_average_cell_temperature = (rx_frame.data.u8[4] - 40);
           break;
-        case POLL_FOR_BATTERY_CELL_MV_MAX:
-          BMS_highest_cell_voltage_mV = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_BATTERY_CELL_MV_MIN:
-          BMS_lowest_cell_voltage_mV = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
         case POLL_FOR_ORIGINAL_CALIBRATION:
           BMS_capacity_original_calibration = (rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6];
           BMC_SOC_original_calibration = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
@@ -610,14 +610,8 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case POLL_TIMES_FULL_POWER:
           BMS_times_full_power = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case POLL_MIN_CELL_VOLTAGE_NUMBER:
-          BMS_min_cell_voltage_number = rx_frame.data.u8[4];
-          break;
         case POLL_MIN_TEMP_MODULE_NUMBER:
           BMS_min_temp_module_number = rx_frame.data.u8[4];
-          break;
-        case POLL_MAX_CELL_VOLTAGE_NUMBER:
-          BMS_max_cell_voltage_number = rx_frame.data.u8[4];
           break;
         case POLL_MAX_TEMP_MODULE_NUMBER:
           BMS_max_temp_module_number = rx_frame.data.u8[4];
@@ -1015,16 +1009,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case POLL_FOR_BATTERY_PACK_AVG_TEMP:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_PACK_AVG_TEMP & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_PACK_AVG_TEMP & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_CELL_MV_MAX;
-        break;
-      case POLL_FOR_BATTERY_CELL_MV_MAX:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_CELL_MV_MAX & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_CELL_MV_MAX & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_CELL_MV_MIN;
-        break;
-      case POLL_FOR_BATTERY_CELL_MV_MIN:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_CELL_MV_MIN & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_CELL_MV_MIN & 0x00FF);
+        // Cell min/max voltage now come from the 0x446 broadcast, not this poll.
         poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
         break;
       case POLL_FOR_ORIGINAL_CALIBRATION:
@@ -1075,21 +1060,12 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case POLL_TIMES_FULL_POWER:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TIMES_FULL_POWER & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TIMES_FULL_POWER & 0x00FF);
-        poll_state = POLL_MIN_CELL_VOLTAGE_NUMBER;
-        break;
-      case POLL_MIN_CELL_VOLTAGE_NUMBER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MIN_CELL_VOLTAGE_NUMBER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MIN_CELL_VOLTAGE_NUMBER & 0x00FF);
+        // Cell min/max numbers now come from the 0x446 broadcast, not this poll.
         poll_state = POLL_MIN_TEMP_MODULE_NUMBER;
         break;
       case POLL_MIN_TEMP_MODULE_NUMBER:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MIN_TEMP_MODULE_NUMBER & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MIN_TEMP_MODULE_NUMBER & 0x00FF);
-        poll_state = POLL_MAX_CELL_VOLTAGE_NUMBER;
-        break;
-      case POLL_MAX_CELL_VOLTAGE_NUMBER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MAX_CELL_VOLTAGE_NUMBER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MAX_CELL_VOLTAGE_NUMBER & 0x00FF);
         poll_state = POLL_MAX_TEMP_MODULE_NUMBER;
         break;
       case POLL_MAX_TEMP_MODULE_NUMBER:

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -75,10 +75,7 @@ class BydAttoBattery : public CanBattery {
   static const int POLL_TOTAL_DISCHARGED_AH = 0x0010;
   static const int POLL_TOTAL_CHARGED_KWH = 0x0011;
   static const int POLL_TOTAL_DISCHARGED_KWH = 0x0012;
-  static const int POLL_MIN_CELL_VOLTAGE_NUMBER = 0x002A;
-  static const int POLL_FOR_BATTERY_CELL_MV_MIN = 0x002B;
-  static const int POLL_MAX_CELL_VOLTAGE_NUMBER = 0x002C;
-  static const int POLL_FOR_BATTERY_CELL_MV_MAX = 0x002D;
+  // 0x002A-0x002D (cell min/max number + voltage) are sourced from the 0x446 broadcast, not polled.
   static const int POLL_MIN_TEMP_MODULE_NUMBER = 0x002E;
   static const int POLL_FOR_LOWEST_TEMP_CELL = 0x002F;
   static const int POLL_MAX_TEMP_MODULE_NUMBER = 0x0030;

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -134,6 +134,9 @@ static bool supports_tesla_dcdc_metrics(Battery* b) {
 static bool supports_byd_autocal_metrics(Battery* b) {
   return b != nullptr && user_selected_battery_type == BatteryType::BydAtto3;
 }
+static bool supports_byd_metrics(Battery* b) {
+  return b != nullptr && user_selected_battery_type == BatteryType::BydAtto3;
+}
 static bool supports_insulation(Battery* b) {
   return b != nullptr && b->supports_insulation_resistance();
 }
@@ -167,7 +170,9 @@ static const SensorConfig batterySensorConfigTemplate[] = {
     {"autocal_taper", "BYD Auto-cal: In Taper", "", "", supports_byd_autocal_metrics},
     {"autocal_dwell_s", "BYD Auto-cal: Dwell Time", "s", "duration", supports_byd_autocal_metrics},
     {"autocal_cooldown_ready", "BYD Auto-cal: Cooldown Ready", "", "", supports_byd_autocal_metrics},
-    {"autocal_soc_drift", "BYD Auto-cal: SOC Drift", "%", "battery", supports_byd_autocal_metrics}};
+    {"autocal_soc_drift", "BYD Auto-cal: SOC Drift", "%", "battery", supports_byd_autocal_metrics},
+    {"min_cell_number", "Min Cell Number", "", "", supports_byd_metrics},
+    {"max_cell_number", "Max Cell Number", "", "", supports_byd_metrics}};
 
 static const SensorConfig globalSensorConfigTemplate[] = {
     {"bms_status", "BMS Status", "", "", always},
@@ -355,6 +360,12 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
     doc["autocal_dwell_s"] = byd.autocal_dwell_accumulated_ms / 1000u;
     doc["autocal_cooldown_ready"] = byd.autocal_crit_cooldown_ready;
     doc["autocal_soc_drift"] = byd.autocal_drift_percent;
+  }
+  if (supports_byd_metrics(::battery)) {
+    const DATALAYER_INFO_BYDATTO3& byd =
+        (battery_index == 2) ? datalayer_extended.bydAtto3_2 : datalayer_extended.bydAtto3;
+    doc["min_cell_number"] = byd.BMS_min_cell_voltage_number;
+    doc["max_cell_number"] = byd.BMS_max_cell_voltage_number;
   }
 }
 


### PR DESCRIPTION
### What
Source BYD Atto 3 min/max cell voltage and cell numbers from the 0x446 broadcast instead of UDS polling, and drop the now-redundant 0x002A–0x002D polls. Adds MQTT min/max cell number sensors.

### Why
0x446 already broadcasts the cell extrema at ~1Hz; polling the same values was ~5× slower and used four rotation slots. Broadcast-sourcing refreshes cell min/max faster and speeds up every other polled value too. Exposing the cell numbers over MQTT lets a weak cell be tracked over time.

### How
Decode 0x446 (b0/b4 = 1-based min/max cell number, min/max mV 12-bit LE in b1:b2 / b5:b6) into the existing cell min/max fields, so all readers are fed unchanged, just fresher. Remove the four UDS poll cases, re-thread the poll rotation over them, drop the unused constants. Add the two MQTT sensors.

Tested on my own Atto 3 pack: 0x446 min/max voltages and cell numbers matched the 0x43D full sweep.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
