### PR TITLE
Make absolute millis() comparisons wrap-safe (49.7-day rollover)

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -321,8 +321,12 @@ void update_calculated_values(unsigned long currentMillis) {
   /*Update free heap*/
   datalayer.system.info.CPU_free_heap = ESP.getFreeHeap();
 
-  /* Check is remote set limits have timed out */
-  if (currentMillis > datalayer.battery.settings.remote_set_timestamp + datalayer.battery.settings.remote_set_timeout) {
+  /* Check is remote set limits have timed out. Wrap-safe subtraction: the naive
+     "currentMillis > timestamp + timeout" comparison both overflows near the 49.7-day
+     millis() wrap (fresh limits expire immediately) and inverts after it (stale limits
+     persist up to another 49.7 days) */
+  if ((currentMillis - datalayer.battery.settings.remote_set_timestamp) >
+      datalayer.battery.settings.remote_set_timeout) {
     datalayer.battery.settings.remote_settings_limit_charge = false;
     datalayer.battery.settings.remote_settings_limit_discharge = false;
     datalayer.battery.settings.max_remote_set_charge_dA = 0;

--- a/Software/src/battery/BMW-I3-BATTERY.cpp
+++ b/Software/src/battery/BMW-I3-BATTERY.cpp
@@ -44,9 +44,9 @@ void BmwI3Battery::end_balancing() {
 void BmwI3Battery::update_values() {  //This function maps all the values fetched via CAN to the battery datalayer
   if (datalayer.system.info.equipment_stop_active == true || UserRequestBalancing == STARTING ||
       UserRequestBalancing == EXECUTING) {
-    digitalWrite(wakeup_pin, LOW);  // Turn off wakeup pin
-  } else if (millis() > INTERVAL_1_S) {
-    digitalWrite(wakeup_pin, HIGH);  // Wake up the battery
+    digitalWrite(wakeup_pin, LOW);         // Turn off wakeup pin
+  } else if (millis64() > INTERVAL_1_S) {  // millis64: plain millis() wraps after 49.7 days
+    digitalWrite(wakeup_pin, HIGH);        // Wake up the battery
   }
 
   // When balancing mode has stopped CAN, keep the alive counter refreshed

--- a/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
+++ b/Software/src/battery/CMP-SMART-CAR-BATTERY.cpp
@@ -8,8 +8,8 @@
 
 void CmpSmartCarBattery::update_values() {
   if (datalayer.system.info.equipment_stop_active == true) {
-    digitalWrite(esp32hal->WUP_PIN1(), LOW);  // Turn off wakeup pin
-  } else if (millis() > INTERVAL_1_S) {
+    digitalWrite(esp32hal->WUP_PIN1(), LOW);   // Turn off wakeup pin
+  } else if (millis64() > INTERVAL_1_S) {      // millis64: plain millis() wraps after 49.7 days
     digitalWrite(esp32hal->WUP_PIN1(), HIGH);  // Wake up the battery
   }
 

--- a/Software/src/battery/KIA-E-GMP-BATTERY.cpp
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.cpp
@@ -153,7 +153,7 @@ void KiaEGmpBattery::update_values() {
 
   datalayer.battery.status.cell_min_voltage_mV = CellVoltMin_mV;
 
-  if ((millis() > INTERVAL_60_S) && !set_voltage_limits) {
+  if ((millis64() > INTERVAL_60_S) && !set_voltage_limits) {  // millis64: plain millis() wraps after 49.7 days
     set_voltage_limits = true;
     set_voltage_minmax_limits();  // Count cells, and set voltage limits accordingly
   }

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -325,7 +325,9 @@ void update_machineryprotection() {
     // Check if the inverter is still sending CAN messages. If we go 60s without messages we raise a warning
     if (!datalayer.system.status.CAN_inverter_still_alive) {
       // Inverters that are slow to boot get a startup grace window before we fault.
-      if (!inverter->needs_can_startup_grace() || millis() > INVERTER_STARTUP_GRACE_MS) {
+      // millis64: with plain millis() this comparison goes false again for 5 minutes
+      // after the 49.7-day wrap, re-suppressing detection of a new inverter-comms loss
+      if (!inverter->needs_can_startup_grace() || millis64() > INVERTER_STARTUP_GRACE_MS) {
         set_event(EVENT_CAN_INVERTER_MISSING, can_config.inverter);
       }
     } else {


### PR DESCRIPTION
`millis()` wraps at 2³² ms ≈ 49.7 days. Five sites compare it as an absolute since-boot value instead of using wrap-safe arithmetic. Per-site effect at the wrap, honestly graded:

| Site | Effect at the 49.7-day wrap |
|---|---|
| `BMW-I3-BATTERY.cpp` wakeup gating | None in practice — the GPIO output latch holds HIGH through the 1 s post-wrap window; worst case is a ≤1 s delayed HIGH-restore if equipment-stop/balancing ends inside exactly that window. Hygiene fix. |
| `CMP-SMART-CAR-BATTERY.cpp` wakeup gating | Same pattern, same (non-)effect. Hygiene fix. |
| `KIA-E-GMP-BATTERY.cpp` voltage-limit one-shot | Benign — the one-shot latch was set long before the wrap. Hygiene fix. |
| `safety.cpp` inverter startup grace | **Real, modest** — for inverters using the startup grace window (SMA family), a *new* inverter-comms loss beginning right after the wrap is detected up to 5 minutes late, because the grace window re-arms. An already-raised event is not cleared by this. |
| `Software.cpp` remote-limit expiry | **Real, both directions** — `timestamp + timeout` overflows near the wrap, so freshly set remote limits expire immediately; and once `currentMillis` wraps, stale limits can persist up to another 49.7 days. |

### Fix

- Since-boot gates use the in-tree monotonic `millis64()` (the event system already uses it) — one-line changes, identical semantics before the wrap.
- The remote-limit expiry uses wrap-safe unsigned subtraction (`currentMillis - timestamp > timeout`) — no 64-bit math needed, and boot state (`timestamp = 0`) behaves as today.

### Relation to #2390

Found while investigating #2390 — but deliberately **not** claimed as a fix for it. As noted in the issue discussion, the emulator holds the pack awake far beyond an ECU's designed ignition-cycle uptime, and a 32-bit millisecond counter wrapping *inside the SME itself* matches the ~50-day fingerprint and the power-cycle recovery exactly — which no emulator-side change can prevent. This PR removes the emulator's own instances of the same bug class.

### Testing

Full host suite green; firmware compiles clean under the `-Werror` warning-check environment.

A 32-bit wrap regression test isn't possible in the host suite, and not just because the emulated `millis()` returns 64-bit `unsigned long`: truncating the emulated clock to `uint32_t` was tried and makes things worse. Production code stores timestamps in `unsigned long` variables and computes deltas at that width — uniformly 32-bit on the target, uniformly 64-bit on the host. A 32-bit clock feeding 64-bit delta arithmetic breaks code that is provably correct on the target (`bms_reset_tests` fails falsely, since `20000 - 0xFFFFFFF5` no longer reduces mod 2^32). Notably, that test already starts its clock at 2^64−10 on purpose — the suite exercises the same wrap-safe-subtraction idiom at the host's own wrap boundary, which is the consistent analog of what the target does at 2^32. The suite therefore serves as a no-regression check for the subtraction idiom and normal semantics; the 32-bit-specific sites rely on review.
