### PR TITLE
Make core time arithmetic width-deterministic (uint32_t)

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -41,10 +41,12 @@
 // The current software version, shown on webserver
 const char* version_number = "12.1.dev";
 
-// Interval timers
-volatile unsigned long currentMillis = 0;
-unsigned long previousMillis10ms = 0;
-unsigned long previousMillisUpdateVal = 0;
+// Interval timers. Time values are uint32_t on purpose: that is the width
+// millis() actually has on the target, so the wrap arithmetic is identical on
+// every platform (including the 64-bit host test build).
+volatile uint32_t currentMillis = 0;
+uint32_t previousMillis10ms = 0;
+uint32_t previousMillisUpdateVal = 0;
 // Task time measurement for debugging
 MyTimer core_task_timer_10s(INTERVAL_10_S);
 uint64_t start_time_10ms = 0;
@@ -307,7 +309,7 @@ static void filter_inverter_limits(void) {
   }
 }
 
-void update_calculated_values(unsigned long currentMillis) {
+void update_calculated_values(uint32_t currentMillis) {
   /* Update CPU temperature*/
   union {
     float temp;
@@ -321,17 +323,8 @@ void update_calculated_values(unsigned long currentMillis) {
   /*Update free heap*/
   datalayer.system.info.CPU_free_heap = ESP.getFreeHeap();
 
-  /* Check is remote set limits have timed out. Wrap-safe subtraction: the naive
-     "currentMillis > timestamp + timeout" comparison both overflows near the 49.7-day
-     millis() wrap (fresh limits expire immediately) and inverts after it (stale limits
-     persist up to another 49.7 days) */
-  if ((currentMillis - datalayer.battery.settings.remote_set_timestamp) >
-      datalayer.battery.settings.remote_set_timeout) {
-    datalayer.battery.settings.remote_settings_limit_charge = false;
-    datalayer.battery.settings.remote_settings_limit_discharge = false;
-    datalayer.battery.settings.max_remote_set_charge_dA = 0;
-    datalayer.battery.settings.max_remote_set_discharge_dA = 0;
-  }
+  /* Check if remote set limits have timed out */
+  update_remote_limit_expiry(currentMillis);
 
   /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
      If unavailable (some drivers report 0 before battery comms are up), fall back to the design

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -41,16 +41,16 @@ uint16_t pwm_hold_duty = 250;
 #define PWM_OFF_DUTY 0  //No need to have this userconfigurable
 #define PWM_Positive_Channel 0
 #define PWM_Negative_Channel 1
-static unsigned long prechargeStartTime = 0;
-unsigned long negativeStartTime = 0;
-unsigned long prechargeCompletedTime = 0;
-unsigned long timeSpentInFaultedMode = 0;
-unsigned long currentTime = 0;
-unsigned long lastPowerRemovalTime = 0;
+static uint32_t prechargeStartTime = 0;
+uint32_t negativeStartTime = 0;
+uint32_t prechargeCompletedTime = 0;
+uint32_t timeSpentInFaultedMode = 0;
+uint32_t currentTime = 0;
+uint32_t lastPowerRemovalTime = 0;
 bool periodicResetDeferred = false;   //True while a due periodic reset is waiting for SOC to recover
 bool balancingPeriodSkipped = false;  //True once balancing has cost the reset a period
-unsigned long bmsPowerOnTime = 0;
-const unsigned long bmsWarmupDuration = 3000;
+uint32_t bmsPowerOnTime = 0;
+const uint32_t bmsWarmupDuration = 3000;
 #define BMS_RESET_DEFER_SOC_PPTT 1500  // 15.00%, below this the low-SOC guard defers the periodic reset
 
 void set(uint8_t pin, bool direction, uint32_t pwm_freq = 0xFFFF) {
@@ -337,12 +337,12 @@ void bms_power_on() {
 
 // Configured period between two automatic resets. Guarded to 24h in case the stored
 // value is missing or nonsensical, see load_settings().
-static unsigned long bms_reset_interval_ms() {
+static uint32_t bms_reset_interval_ms() {
   uint32_t hours = periodic_bms_reset_interval_h;
   if (hours == 0) {
     hours = 24;
   }
-  return (unsigned long)hours * 60UL * 60UL * 1000UL;
+  return (uint32_t)hours * 60UL * 60UL * 1000UL;
 }
 
 /* The two guards behave differently on purpose, so the decision is three-way rather than

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -151,9 +151,9 @@ struct DATALAYER_BATTERY_STATUS_TYPE {
 struct DATALAYER_BATTERY_SETTINGS_TYPE {
 
   /** Last time a remote set command was received to enable timeout of settings */
-  unsigned long remote_set_timestamp = 0;
+  uint32_t remote_set_timestamp = 0;
   /** Timeout time for remote limits */
-  unsigned long remote_set_timeout = 0;
+  uint32_t remote_set_timeout = 0;
   /* Forced balancing max time & start timestamp */
   uint32_t balancing_max_time_ms = 3600000;  //1h default, (60min*60sec*1000ms)
   uint32_t balancing_start_time_ms = 0;      //For keeping track when balancing started

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -58,6 +58,20 @@ static void check_can_component_alive(uint8_t& still_alive_counter, bool& detect
   }
 }
 
+/* Expire remote-set limits. Wrap-safe subtraction: the naive
+   "currentMillis > timestamp + timeout" comparison both overflows near the 49.7-day
+   millis() wrap (fresh limits expire immediately) and inverts after it (stale limits
+   persist up to another 49.7 days) */
+void update_remote_limit_expiry(uint32_t currentMillis) {
+  if ((currentMillis - datalayer.battery.settings.remote_set_timestamp) >
+      datalayer.battery.settings.remote_set_timeout) {
+    datalayer.battery.settings.remote_settings_limit_charge = false;
+    datalayer.battery.settings.remote_settings_limit_discharge = false;
+    datalayer.battery.settings.max_remote_set_charge_dA = 0;
+    datalayer.battery.settings.max_remote_set_discharge_dA = 0;
+  }
+}
+
 void update_machineryprotection() {
   //Check if we start to get low on memory
   static uint8_t hysteresisHeapSeconds = 0;

--- a/Software/src/devboard/safety/safety.h
+++ b/Software/src/devboard/safety/safety.h
@@ -24,6 +24,7 @@ extern bool battery3_detected;
 extern void store_settings_equipment_stop();
 
 void update_machineryprotection();
+void update_remote_limit_expiry(uint32_t currentMillis);
 void graceful_restart();
 void update_restart_progress();
 

--- a/Software/src/devboard/utils/timer.cpp
+++ b/Software/src/devboard/utils/timer.cpp
@@ -1,11 +1,11 @@
 #include "timer.h"
 
-MyTimer::MyTimer(unsigned long interval) : interval(interval) {
+MyTimer::MyTimer(uint32_t interval) : interval(interval) {
   previous_millis = millis();
 }
 
 bool MyTimer::elapsed(void) {
-  unsigned long current_millis = millis();
+  uint32_t current_millis = millis();
   if (current_millis - previous_millis >= interval) {
     previous_millis = current_millis;
     return true;
@@ -17,7 +17,7 @@ void MyTimer::reset(void) {
   previous_millis = millis();
 }
 
-void MyTimer::set_interval(unsigned long interval) {
+void MyTimer::set_interval(uint32_t interval) {
   this->interval = interval;
   reset();
 }

--- a/Software/src/devboard/utils/timer.h
+++ b/Software/src/devboard/utils/timer.h
@@ -11,14 +11,14 @@ class MyTimer {
   MyTimer() : interval(0), previous_millis(0) {}
 
   /** interval in ms */
-  MyTimer(unsigned long interval);
+  MyTimer(uint32_t interval);
   /** Returns true and resets the timer if it has elapsed */
   bool elapsed(void);
   void reset(void);
-  void set_interval(unsigned long interval);
+  void set_interval(uint32_t interval);
 
-  unsigned long interval;
-  unsigned long previous_millis;
+  uint32_t interval;
+  uint32_t previous_millis;
 
  private:
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(tests
     voltage_sync_tests.cpp
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
+    millis_wrap_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp 

--- a/test/bms_reset_tests.cpp
+++ b/test/bms_reset_tests.cpp
@@ -13,7 +13,7 @@ const unsigned long bmsWarmupDuration = 3000;
 // contactors are powered directly by BE, so the reset doesn't need to wait for
 // zero current before cutting the BMS power.
 TEST(BmsResetTests, BmsResetSequenceDirectSuccess) {
-  set_millis64(0xffffffffffffffff - 10);  // Test overflow handling
+  set_millis64(0x100000000ULL - 10);  // Start just below the 32-bit millis() wrap to test overflow handling
   remote_bms_reset = true;
   contactor_control_enabled = true;
   datalayer.battery.settings.user_set_bms_reset_duration_ms = 30000;  // 30 seconds
@@ -77,7 +77,7 @@ TEST(BmsResetTests, BmsResetSequenceDirectSuccess) {
 // contactors are powered by the BMS, so the reset needs to wait for zero
 // current before cutting power to avoid arcing.
 TEST(BmsResetTests, BmsResetSequenceWaitSuccess) {
-  set_millis64(0xffffffffffffffff - 10);
+  set_millis64(0x100000000ULL - 10);  // Start just below the 32-bit millis() wrap
   remote_bms_reset = true;
   contactor_control_enabled = false;
   datalayer.battery.settings.user_set_bms_reset_duration_ms = 30000;  // 30 seconds
@@ -158,7 +158,7 @@ TEST(BmsResetTests, BmsResetSequenceWaitSuccess) {
 
 // Bring the reset scheduling state into the test so we can decide when the
 // configured interval has elapsed instead of having to simulate a full day.
-extern unsigned long lastPowerRemovalTime;
+extern uint32_t lastPowerRemovalTime;
 extern bool periodicResetDeferred;
 extern bool balancingPeriodSkipped;
 

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -131,7 +131,9 @@ inline void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 unsigned long micros();
 // Can be previously declared as a macro in stupid eModbus
 #undef millis
-unsigned long millis();
+// uint32_t, deliberately: on the target unsigned long IS 32 bits wide, so this
+// is the truthful width of the millis() contract (wrap at 2^32 ms included).
+uint32_t millis();
 void set_millis64(uint64_t time);
 
 void delay(unsigned long ms);

--- a/test/emul/time.cpp
+++ b/test/emul/time.cpp
@@ -2,8 +2,11 @@
 
 uint64_t current_time = 0;
 
-unsigned long millis() {
-  return static_cast<unsigned long>(current_time);
+uint32_t millis() {
+  // Match the ESP32: millis() is 32 bits wide and wraps at 2^32 ms (49.7 days).
+  // Production time variables are uint32_t, so the host runs exactly the
+  // arithmetic the target runs, wrap included.
+  return static_cast<uint32_t>(current_time);
 }
 
 uint64_t get_timestamp(unsigned long millis) {

--- a/test/millis_wrap_tests.cpp
+++ b/test/millis_wrap_tests.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <Arduino.h>  // Emul: set_millis64() to control the test clock
+
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/safety/safety.h"
+#include "../Software/src/devboard/utils/events.h"
+#include "../Software/src/inverter/INVERTERS.h"
+
+// Regression tests for millis() 32-bit wrap handling (2^32 ms = 49.7 days).
+// The emulated millis() truncates to 32 bits like the ESP32 does, and
+// production time variables are uint32_t, so the host runs exactly the
+// arithmetic the target runs - setting the 64-bit test clock past 2^32 makes
+// millis() read small values again while millis64() keeps counting.
+
+TEST(MillisWrapTest, EmulatedClockTruncatesLikeTheTarget) {
+  set_millis64(0x100000000ULL + 1000);
+  EXPECT_EQ(millis(), 1000UL);
+  EXPECT_EQ(millis64(), 0x100000000ULL + 1000);
+  set_millis64(0);
+}
+
+// The SMA-family startup grace window is a since-boot gate: with a plain
+// millis() comparison it would re-arm for 5 minutes after every wrap,
+// suppressing detection of a new inverter-comms loss as if the system had
+// just booted.
+TEST(MillisWrapTest, InverterStartupGraceDoesNotRearmAfterWrap) {
+  datalayer = DataLayer();
+  reset_all_events();
+  init_hal();
+  // Avoid tripping the low-heap check (CPU_free_heap defaults to 0)
+  datalayer.system.info.CPU_free_heap = 200000;
+  if (!inverter) {
+    user_selected_inverter_protocol = InverterProtocolType::SmaBydH;
+    setup_inverter();
+  }
+  ASSERT_NE(inverter, nullptr);
+  ASSERT_TRUE(inverter->needs_can_startup_grace());
+
+  set_millis64(0x100000000ULL + 1000);
+  datalayer.system.status.CAN_inverter_still_alive = 0;
+
+  update_machineryprotection();
+
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_INVERTER_MISSING)->state, EVENT_STATE_ACTIVE)
+      << "The startup grace window must not re-arm after the millis() wrap";
+  set_millis64(0);
+}
+
+// Remote-limit expiry across the wrap, both failure directions of the old
+// "currentMillis > timestamp + timeout" comparison:
+// (a) a limit set just before the wrap must not expire immediately - the sum
+//     overflows to a small number, so any pre-wrap check tripped it, and
+// (b) a limit whose timeout genuinely elapsed across the wrap must still
+//     expire - post-wrap currentMillis is small, so the inverted comparison
+//     kept stale limits alive.
+TEST(MillisWrapTest, RemoteLimitExpiryIsWrapSafe) {
+  datalayer = DataLayer();
+
+  // (a) Set 16 ms before the wrap; timestamp + timeout overflows to ~59984
+  datalayer.battery.settings.remote_set_timestamp = 0xFFFFFFF0u;
+  datalayer.battery.settings.remote_set_timeout = 60000;
+  datalayer.battery.settings.remote_settings_limit_charge = true;
+  datalayer.battery.settings.remote_settings_limit_discharge = true;
+  datalayer.battery.settings.max_remote_set_charge_dA = 100;
+  datalayer.battery.settings.max_remote_set_discharge_dA = 100;
+
+  // 8 ms later, still before the wrap: must survive
+  update_remote_limit_expiry(0xFFFFFFF8u);
+  EXPECT_TRUE(datalayer.battery.settings.remote_settings_limit_charge)
+      << "A fresh remote limit must not expire because timestamp + timeout overflowed";
+  // 1 s after the wrap (~1 s elapsed): must still survive
+  update_remote_limit_expiry(1000);
+  EXPECT_TRUE(datalayer.battery.settings.remote_settings_limit_charge)
+      << "A fresh remote limit must not expire just because the clock wrapped";
+  // 70 s after the wrap: the 60 s timeout has genuinely elapsed
+  update_remote_limit_expiry(70000);
+  EXPECT_FALSE(datalayer.battery.settings.remote_settings_limit_charge);
+
+  // (b) Set ~65 s before the wrap; the sum does NOT overflow (~4294961760),
+  // so after the wrap the naive comparison never becomes true again
+  datalayer.battery.settings.remote_set_timestamp = 0xFFFF0000u;
+  datalayer.battery.settings.remote_set_timeout = 60000;
+  datalayer.battery.settings.remote_settings_limit_charge = true;
+  datalayer.battery.settings.remote_settings_limit_discharge = true;
+  datalayer.battery.settings.max_remote_set_charge_dA = 100;
+  datalayer.battery.settings.max_remote_set_discharge_dA = 100;
+
+  // 70 s after the wrap: ~135 s elapsed, far past the 60 s timeout
+  update_remote_limit_expiry(70000);
+  EXPECT_FALSE(datalayer.battery.settings.remote_settings_limit_charge)
+      << "A stale remote limit must not persist across the wrap";
+  EXPECT_FALSE(datalayer.battery.settings.remote_settings_limit_discharge);
+  EXPECT_EQ(datalayer.battery.settings.max_remote_set_charge_dA, 0);
+  EXPECT_EQ(datalayer.battery.settings.max_remote_set_discharge_dA, 0);
+}


### PR DESCRIPTION
`millis()` is 32 bits wide on the target: the wrap at 2^32 ms IS the semantics of every timestamp comparison. Declaring time values as `unsigned long` makes that width platform-dependent — correct on the ESP32 where `unsigned long` is 32-bit, silently different on the 64-bit host test build, where the wrap never occurs. Consequence (discussed on #2707): wrap behavior was untestable, and the host suite exercised different arithmetic than the target runs.

This narrows the **core** time-carrying variables to `uint32_t`: `Software.cpp` interval timers and the `update_calculated_values()` parameter, the precharge/BMS-reset state-machine timestamps in `comm_contactorcontrol.cpp`, the datalayer `remote_set_timestamp`/`remote_set_timeout`, and `MyTimer`. The remote-limit expiry check moves into `update_remote_limit_expiry()` in safety.cpp so the host suite can reach it (behavior unchanged).

With production widths deterministic, the emulated `millis()` now returns a truncating `uint32_t` — the host runs exactly the arithmetic the target runs, wrap included. The BMS-reset overflow tests move from the host's 2^64 boundary to the target's real 2^32 boundary, and new wrap regression tests cover the two real bugs fixed in #2707 (SMA startup-grace re-arm; remote-limit expiry, both overflow directions) — each verified to fail against the pre-#2707 logic.

Driver-level `unsigned long` (including the `transmit_can(unsigned long)` signatures, 83 sites) is deliberately untouched — that mechanical sweep is proposed separately to keep this reviewable.

Testing: full host suite green (103 tests), `-Werror` warning-check build green, size CI expected ~neutral.
