### PR TITLE
FoxESS battery: refresh CAN keep-alive and stop overwriting BMS-reported voltage limits

### DIFF
--- a/Software/src/battery/FOXESS-BATTERY.cpp
+++ b/Software/src/battery/FOXESS-BATTERY.cpp
@@ -23,64 +23,81 @@ void FoxessBattery::
 
   datalayer.battery.status.max_charge_power_W = ((datalayer.battery.status.voltage_dV * max_charge_power_dA) / 100);
 
+  // The HS-series pack table. Sole source for number_of_cells; the design
+  // voltage limits from it apply only until the BMS reports its own limits in
+  // 0x1872 (BMS_Limits) - packs outside this table (e.g. EP-series) would
+  // otherwise trip false BATTERY_OVERVOLTAGE against table values.
+  uint8_t cells = 0;
+  uint16_t table_max_design_voltage_dV = 0;
+  uint16_t table_min_design_voltage_dV = 0;
   switch (NUMBER_OF_PACKS) {
     case 1:  //HS2.6 (48V invalid combo for most HV inverters)
-      datalayer.battery.info.number_of_cells = 16;
-      datalayer.battery.info.max_design_voltage_dV = 584;
-      datalayer.battery.info.min_design_voltage_dV = 400;
+      cells = 16;
+      table_max_design_voltage_dV = 584;
+      table_min_design_voltage_dV = 400;
       break;
     case 2:  //HS5.2
-      datalayer.battery.info.number_of_cells = 32;
-      datalayer.battery.info.max_design_voltage_dV = 1168;
-      datalayer.battery.info.min_design_voltage_dV = 800;
+      cells = 32;
+      table_max_design_voltage_dV = 1168;
+      table_min_design_voltage_dV = 800;
       break;
     case 3:  //HS7.8
-      datalayer.battery.info.number_of_cells = 48;
-      datalayer.battery.info.max_design_voltage_dV = 1752;
-      datalayer.battery.info.min_design_voltage_dV = 1200;
+      cells = 48;
+      table_max_design_voltage_dV = 1752;
+      table_min_design_voltage_dV = 1200;
       break;
     case 4:  //HS10.4
-      datalayer.battery.info.number_of_cells = 64;
-      datalayer.battery.info.max_design_voltage_dV = 2336;
-      datalayer.battery.info.min_design_voltage_dV = 1600;
+      cells = 64;
+      table_max_design_voltage_dV = 2336;
+      table_min_design_voltage_dV = 1600;
       break;
     case 5:  //HS13
-      datalayer.battery.info.number_of_cells = 80;
-      datalayer.battery.info.max_design_voltage_dV = 2920;
-      datalayer.battery.info.min_design_voltage_dV = 2000;
+      cells = 80;
+      table_max_design_voltage_dV = 2920;
+      table_min_design_voltage_dV = 2000;
       break;
     case 6:  //HS15.6
-      datalayer.battery.info.number_of_cells = 96;
-      datalayer.battery.info.max_design_voltage_dV = 3504;
-      datalayer.battery.info.min_design_voltage_dV = 2400;
+      cells = 96;
+      table_max_design_voltage_dV = 3504;
+      table_min_design_voltage_dV = 2400;
       break;
     case 7:  //HS18.2
-      datalayer.battery.info.number_of_cells = 112;
-      datalayer.battery.info.max_design_voltage_dV = 4088;
-      datalayer.battery.info.min_design_voltage_dV = 2800;
+      cells = 112;
+      table_max_design_voltage_dV = 4088;
+      table_min_design_voltage_dV = 2800;
       break;
     case 8:  //HS20.8
-      datalayer.battery.info.number_of_cells = 128;
-      datalayer.battery.info.max_design_voltage_dV = 4672;
-      datalayer.battery.info.min_design_voltage_dV = 3200;
+      cells = 128;
+      table_max_design_voltage_dV = 4672;
+      table_min_design_voltage_dV = 3200;
       break;
     default:
       //Data not available yet
       break;
+  }
+  if (cells != 0) {
+    datalayer.battery.info.number_of_cells = cells;
+    if (!bms_limits_received) {
+      datalayer.battery.info.max_design_voltage_dV = table_max_design_voltage_dV;
+      datalayer.battery.info.min_design_voltage_dV = table_min_design_voltage_dV;
+    }
   }
 }
 
 void FoxessBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   switch (rx_frame.ID) {
     case 0x1872:  //BMS_Limits
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       datalayer.battery.info.max_design_voltage_dV = (uint16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
       datalayer.battery.info.min_design_voltage_dV = (uint16_t)(rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);
+      bms_limits_received = true;
       if (!charging_disabled) {
         max_charge_power_dA = (uint16_t)(rx_frame.data.u8[5] << 8 | rx_frame.data.u8[4]);
       }
       max_discharge_power_dA = (uint16_t)(rx_frame.data.u8[7] << 8 | rx_frame.data.u8[6]);
       break;
     case 0x1873:  //BMS_PackData
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       datalayer.battery.status.voltage_dV = (uint16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
       datalayer.battery.status.current_dA =
           (int16_t)(rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);  //TODO: Direction right way?
@@ -88,12 +105,14 @@ void FoxessBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer.battery.status.remaining_capacity_Wh = ((rx_frame.data.u8[7] << 8 | rx_frame.data.u8[6]) * 10);
       break;
     case 0x1874:  //BMS_CellData
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       datalayer.battery.status.temperature_max_dC = (int16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
       datalayer.battery.status.temperature_min_dC = (int16_t)(rx_frame.data.u8[3] << 8 | rx_frame.data.u8[2]);
       cut_mv_max = (uint16_t)(rx_frame.data.u8[5] << 8 | rx_frame.data.u8[4]);
       cut_mv_min = (uint16_t)(rx_frame.data.u8[7] << 8 | rx_frame.data.u8[6]);
       break;
     case 0x1875:  //BMS_Status
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       temperature_average = (int16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
       STATUS_OPERATIONAL_PACKS = (uint8_t)rx_frame.data.u8[2];
       NUMBER_OF_PACKS = (uint8_t)rx_frame.data.u8[3];
@@ -101,6 +120,7 @@ void FoxessBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       cycle_count = (uint16_t)(rx_frame.data.u8[7] << 8 | rx_frame.data.u8[6]);
       break;
     case 0x1876:  //BMS_PackTemps
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       // 0x1876 b0 bit 0 appears to be 1 when at maxsoc and BMS says charge is not allowed -
       // when at 0 indicates charge is possible - additional note there is something more to it than this,
       // it's not as straight forward - needs more testing to find what sets/unsets bit0 of byte0
@@ -115,16 +135,19 @@ void FoxessBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer.battery.status.cell_min_voltage_mV = (uint16_t)(rx_frame.data.u8[7] << 8 | rx_frame.data.u8[6]);
       break;
     case 0x1877:  //BMS_ErrorsBrand
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       pack_error = (uint8_t)(rx_frame.data.u8[0]);
       firmware_pack_minor = (uint8_t)(rx_frame.data.u8[6] & 0x0F);
       firmware_pack_major = (uint8_t)((rx_frame.data.u8[6] & 0xF0) >> 4);
       break;
     case 0x1878:  //BMS_PackStats
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       max_ac_voltage = (uint16_t)(rx_frame.data.u8[1] << 8 | rx_frame.data.u8[0]);
       total_watt_hours = (uint32_t)(rx_frame.data.u8[7] << 24 | rx_frame.data.u8[6] << 16 | rx_frame.data.u8[5] << 8 |
                                     rx_frame.data.u8[4]);
       break;
     case 0x1879:  //BMS_PackState
+      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       b0_idle = (bool)(rx_frame.data.u8[1] & 0x01);
       b1_ok_discharge = (bool)((rx_frame.data.u8[1] & 0x02) >> 1);
       b2_ok_charge = (bool)((rx_frame.data.u8[1] & 0x04) >> 2);

--- a/Software/src/battery/FOXESS-BATTERY.h
+++ b/Software/src/battery/FOXESS-BATTERY.h
@@ -78,6 +78,9 @@ class FoxessBattery : public CanBattery {
   uint8_t STATUS_OPERATIONAL_PACKS =
       0;  //0x1875 b2 contains status for operational packs (responding) in binary so 01111111 is pack 8 not operational, 11101101 is pack 5 & 2 not operational
   uint8_t NUMBER_OF_PACKS = 0;  //1-8
+  // True once 0x1872 (BMS_Limits) has been seen: the BMS-reported design
+  // voltage limits are then authoritative over the HS-series pack table
+  bool bms_limits_received = false;
   uint8_t contactor_status = 0;
   uint8_t statemachine_polling = 0;
   bool charging_disabled = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,7 +73,8 @@ add_executable(tests
     inverter_alive_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
-    battery/NissanLeafTest.cpp 
+    battery/NissanLeafTest.cpp
+    battery/foxess_tests.cpp 
     battery/still_alive_tests.cpp
     can_log_based/canlog_safety_tests.cpp
     utils/utils.cpp

--- a/test/battery/foxess_tests.cpp
+++ b/test/battery/foxess_tests.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include "../../Software/src/battery/FOXESS-BATTERY.h"
+#include "../../Software/src/datalayer/datalayer.h"
+#include "../../Software/src/devboard/hal/hal.h"
+#include "../../Software/src/devboard/utils/events.h"
+
+// Regression tests for the FoxESS driver fixes from #1664:
+// 1. The driver never refreshed CAN_battery_still_alive, so
+//    EVENT_CAN_BATTERY_MISSING fired 60 s after boot regardless of traffic.
+// 2. update_values() re-applied the hardcoded HS-series voltage table every
+//    cycle, overwriting the limits the BMS itself reports in 0x1872 - packs
+//    outside the HS table (EP-series) tripped false BATTERY_OVERVOLTAGE.
+
+class FoxessTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer = DataLayer();
+    reset_all_events();
+    init_hal();
+    battery = new FoxessBattery();
+  }
+
+  void TearDown() override { delete battery; }
+
+  FoxessBattery* battery = nullptr;
+};
+
+TEST_F(FoxessTest, RecognizedFrameRefreshesStillAliveCounter) {
+  datalayer.battery.status.CAN_battery_still_alive = 0;
+
+  // 0x1873 BMS_PackData - part of the BMS's periodic broadcast
+  CAN_frame frame = {
+      .ID = 0x1873,
+      .data = {.u8 = {0x84, 0x0F, 0x00, 0x00, 0x50, 0x00, 0xE8, 0x03}},
+  };
+  battery->handle_incoming_can_frame(frame);
+
+  EXPECT_EQ(datalayer.battery.status.CAN_battery_still_alive, CAN_STILL_ALIVE)
+      << "Periodic BMS traffic must refresh the aliveness counter";
+}
+
+TEST_F(FoxessTest, BmsReportedLimitsSurviveUpdateValues) {
+  // 0x1875 BMS_Status: byte 3 = NUMBER_OF_PACKS = 6 (HS15.6 in the table)
+  CAN_frame status_frame = {
+      .ID = 0x1875,
+      .data = {.u8 = {0x00, 0x00, 0x06, 0x06, 0x01, 0x00, 0x00, 0x00}},
+  };
+  battery->handle_incoming_can_frame(status_frame);
+
+  // Before any 0x1872: the table is the (fallback) source
+  battery->update_values();
+  EXPECT_EQ(datalayer.battery.info.max_design_voltage_dV, 3504);
+  EXPECT_EQ(datalayer.battery.info.min_design_voltage_dV, 2400);
+
+  // 0x1872 BMS_Limits: max 398.0 V (3980 = 0x0F8C), min 296.8 V (2968 = 0x0B98)
+  // - an EP-series pack outside the HS table
+  CAN_frame limits_frame = {
+      .ID = 0x1872,
+      .data = {.u8 = {0x8C, 0x0F, 0x98, 0x0B, 0x64, 0x00, 0x64, 0x00}},
+  };
+  battery->handle_incoming_can_frame(limits_frame);
+
+  battery->update_values();
+  EXPECT_EQ(datalayer.battery.info.max_design_voltage_dV, 3980)
+      << "BMS-reported limits must not be overwritten by the HS-series table";
+  EXPECT_EQ(datalayer.battery.info.min_design_voltage_dV, 2968);
+  // The table remains the only source for the cell count
+  EXPECT_EQ(datalayer.battery.info.number_of_cells, 96);
+}


### PR DESCRIPTION
Two defects in the FoxESS battery driver, found investigating #1664. Both affect every FoxESS battery user, not just EP-series packs.

### 1. The driver never refreshes the CAN keep-alive counter

`FOXESS-BATTERY.cpp` was the only battery driver with no `CAN_battery_still_alive` refresh anywhere in its receive handler. Consequence: `EVENT_CAN_BATTERY_MISSING` (ERROR level) fires 60 seconds after boot regardless of live traffic → `system_status` goes to FAULT → charge/discharge limits are forced to 0 → the contactor never closes and the inverter sees a dead battery.

Fixed by refreshing the counter in the eight periodic `0x187x` status cases — recognized traffic only, so the existing still-alive test contract (bogus frames must not renew the counter) holds.

### 2. `update_values()` overwrites the BMS-reported voltage limits every cycle

The `0x1872` (BMS_Limits) handler correctly writes the BMS-reported `max/min_design_voltage_dV` — and then `update_values()` re-applies the hardcoded HS-series pack table on the next cycle, clobbering them. The table always wins. Any pack outside the HS table trips a false `EVENT_BATTERY_OVERVOLTAGE` that zeroes charge power: the reporter's EP11 sits at ~398 V against the HS15.6 table's 350.4 V max.

Fixed by making the `0x1872` limits authoritative once received. The table remains the fallback before the first `0x1872` arrives and stays the only source for `number_of_cells`. The `0x1872` power-limit fields are untouched (working today).

### Relation to #1664

These two account for the reporter's "impossible" `CAN_Battery_Missing` and `Battery_Overvoltage` errors. This fixes the BE-side defects in #1664; whether the EP11 then closes contactors on the standard poll sequence remains open (may need EP-specific work), but these fixes are prerequisite to finding out and benefit all FoxESS users.

### Testing

New regression tests (`test/battery/foxess_tests.cpp`): the keep-alive test and the 0x1872-authority test both **fail against the unfixed driver** (verified) and pass with the fix; the limits test also pins the pre-0x1872 table fallback. Full suite 102/102 green; firmware compiles clean under the `-Werror` warning-check environment.
