### PR TITLE
Equipment stop: wait for zero current before opening contactors (bounded)

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -35,7 +35,7 @@ const uint8_t OFF = 0;
 #define PRECHARGE_COMPLETED_TIME_MS \
   1000  // After successful precharge, resistor is turned off after this delay (and contactors are economized if PWM enabled)
 #define ESTOP_OPEN_TIMEOUT_MS \
-  10000  // Equipment stop: max time to wait for the pause to reach zero current before opening contactors anyway
+  7000  // Equipment stop: max time to wait for the pause to reach zero current before opening contactors anyway
 uint16_t pwm_frequency = 20000;
 uint16_t pwm_hold_duty = 250;
 #define PWM_ON_DUTY 1023

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -34,6 +34,8 @@ const uint8_t OFF = 0;
   500  // Time after negative contactor is turned on, to start precharge (not actual precharge time!)
 #define PRECHARGE_COMPLETED_TIME_MS \
   1000  // After successful precharge, resistor is turned off after this delay (and contactors are economized if PWM enabled)
+#define ESTOP_OPEN_TIMEOUT_MS \
+  10000  // Equipment stop: max time to wait for the pause to reach zero current before opening contactors anyway
 uint16_t pwm_frequency = 20000;
 uint16_t pwm_hold_duty = 250;
 #define PWM_ON_DUTY 1023
@@ -47,6 +49,7 @@ unsigned long prechargeCompletedTime = 0;
 unsigned long timeSpentInFaultedMode = 0;
 unsigned long currentTime = 0;
 unsigned long lastPowerRemovalTime = 0;
+static unsigned long estop_open_wait_start_ms = 0;
 bool periodicResetDeferred = false;   //True while a due periodic reset is waiting for SOC to recover
 bool balancingPeriodSkipped = false;  //True once balancing has cost the reset a period
 unsigned long bmsPowerOnTime = 0;
@@ -225,11 +228,34 @@ void handle_contactors() {
       }
     }
 
-    // In case the inverter requests contactors to open, set the state accordingly
+    // In case the inverter or the equipment stop requests contactors to open, jump to Disconnected (recoverable)
     if (contactorStatus == COMPLETED) {
-      //Incase inverter (or estop) requests contactors to open, make state machine jump to Disconnected state (recoverable)
-      if (!datalayer.system.status.inverter_allows_contactor_closing || datalayer.system.info.equipment_stop_active) {
+      if (!datalayer.system.status.inverter_allows_contactor_closing) {
+        // Inverter-commanded opening stays immediate: the inverter has already
+        // stopped power transfer before revoking its permission
         contactorStatus = DISCONNECTED;
+      } else if (datalayer.system.info.equipment_stop_active) {
+        // Equipment stop: every e-stop entry point also issues a battery pause,
+        // so hold the contactors until the pause state machine reports PAUSED
+        // (current below 1.8 A) - opening under load risks arcing/welding.
+        // Bounded: after ESTOP_OPEN_TIMEOUT_MS we open anyway and raise an
+        // event, mirroring the BMS-reset give-up behavior.
+        unsigned long now = millis();
+        if (estop_open_wait_start_ms == 0) {
+          estop_open_wait_start_ms = now;
+        }
+        bool paused = (emulator_pause_status == PAUSED);
+        bool timed_out = (now - estop_open_wait_start_ms) > ESTOP_OPEN_TIMEOUT_MS;
+        if (paused || timed_out) {
+          if (timed_out) {
+            logging.printf("Contactors: Equipment stop wait timed out, opening under load\n");
+            set_event(EVENT_ERROR_OPEN_CONTACTOR, 1);
+          }
+          estop_open_wait_start_ms = 0;
+          contactorStatus = DISCONNECTED;
+        }
+      } else {
+        estop_open_wait_start_ms = 0;
       }
       // Skip running the state machine below if it has already completed
       return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(tests
     voltage_sync_tests.cpp
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
+    estop_graceful_open_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp 

--- a/test/estop_graceful_open_tests.cpp
+++ b/test/estop_graceful_open_tests.cpp
@@ -56,9 +56,9 @@ TEST_F(EstopGracefulOpenTest, EstopHoldsContactorsUntilTimeoutWhenCurrentFlows) 
   EXPECT_EQ(contactorStatus, COMPLETED) << "Still within the timeout window";
   EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_INACTIVE);
 
-  set_millis64(100000 + 11000);
+  set_millis64(100000 + 8000);
   handle_contactors();
-  EXPECT_EQ(contactorStatus, DISCONNECTED) << "The wait is bounded: open anyway after the timeout";
+  EXPECT_EQ(contactorStatus, DISCONNECTED) << "The wait is bounded: open anyway after the 7 s timeout";
   EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_ACTIVE)
       << "A forced open under load must be visible in the event log";
   EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->data, 1);

--- a/test/estop_graceful_open_tests.cpp
+++ b/test/estop_graceful_open_tests.cpp
@@ -1,0 +1,100 @@
+#include <gtest/gtest.h>
+
+#include <Arduino.h>  // Emul: set_millis64() to control the test clock
+
+#include "../Software/src/communication/contactorcontrol/comm_contactorcontrol.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/safety/safety.h"
+#include "../Software/src/devboard/utils/events.h"
+
+// Mirrors the file-scope contactor FSM in comm_contactorcontrol.cpp so the
+// tests can place it in a known state. Must match the definition there.
+enum State { DISCONNECTED, START_PRECHARGE, PRECHARGE, POSITIVE, PRECHARGE_OFF, COMPLETED, SHUTDOWN_REQUESTED };
+extern State contactorStatus;
+
+// Regression tests for #1750: equipment stop used to jump COMPLETED ->
+// DISCONNECTED in the same 10 ms tick that zeroed the power limits - faster
+// than any inverter can ramp down, so the contactors opened under load.
+// The e-stop path now waits for the pause state machine to report PAUSED
+// (current below 1.8 A) or a bounded timeout before opening.
+
+class EstopGracefulOpenTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer = DataLayer();
+    reset_all_events();
+    init_hal();
+    set_millis64(100000);
+    contactor_control_enabled = true;
+    contactorStatus = COMPLETED;
+    emulator_pause_status = NORMAL;
+    battery_detected = true;
+    datalayer.system.status.system_status = ACTIVE;
+    datalayer.system.status.inverter_allows_contactor_closing = true;
+    datalayer.system.info.equipment_stop_active = false;
+  }
+
+  void TearDown() override {
+    contactor_control_enabled = false;
+    contactorStatus = DISCONNECTED;
+    emulator_pause_status = NORMAL;
+    datalayer.system.info.equipment_stop_active = false;
+    set_millis64(0);
+  }
+};
+
+TEST_F(EstopGracefulOpenTest, EstopHoldsContactorsUntilTimeoutWhenCurrentFlows) {
+  datalayer.system.info.equipment_stop_active = true;
+  // Pause was requested but current is still flowing: not PAUSED yet
+
+  handle_contactors();
+  EXPECT_EQ(contactorStatus, COMPLETED) << "Contactors must not open under load in the same tick";
+
+  set_millis64(100000 + 5000);
+  handle_contactors();
+  EXPECT_EQ(contactorStatus, COMPLETED) << "Still within the timeout window";
+  EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_INACTIVE);
+
+  set_millis64(100000 + 11000);
+  handle_contactors();
+  EXPECT_EQ(contactorStatus, DISCONNECTED) << "The wait is bounded: open anyway after the timeout";
+  EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_ACTIVE)
+      << "A forced open under load must be visible in the event log";
+  EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->data, 1);
+}
+
+TEST_F(EstopGracefulOpenTest, EstopOpensPromptlyOncePaused) {
+  datalayer.system.info.equipment_stop_active = true;
+  emulator_pause_status = PAUSED;
+
+  handle_contactors();
+
+  EXPECT_EQ(contactorStatus, DISCONNECTED) << "Zero current reached: open without waiting for the timeout";
+  EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_INACTIVE)
+      << "A graceful open is not an error";
+}
+
+TEST_F(EstopGracefulOpenTest, EstopOpensWhenPauseCompletesMidWait) {
+  datalayer.system.info.equipment_stop_active = true;
+
+  handle_contactors();
+  EXPECT_EQ(contactorStatus, COMPLETED);
+
+  // The inverter ramps down and the pause FSM reaches PAUSED within the window
+  set_millis64(100000 + 3000);
+  emulator_pause_status = PAUSED;
+  handle_contactors();
+
+  EXPECT_EQ(contactorStatus, DISCONNECTED);
+  EXPECT_EQ(get_event_pointer(EVENT_ERROR_OPEN_CONTACTOR)->state, EVENT_STATE_INACTIVE);
+}
+
+TEST_F(EstopGracefulOpenTest, InverterCommandedOpeningStaysImmediate) {
+  datalayer.system.status.inverter_allows_contactor_closing = false;
+
+  handle_contactors();
+
+  EXPECT_EQ(contactorStatus, DISCONNECTED)
+      << "Inverter-commanded opening keeps today's immediate behavior - the inverter has already stopped power";
+}


### PR DESCRIPTION
Today, equipment stop zeroes the power limits and drops all contactor outputs **in the same 10 ms tick** — faster than any inverter can ramp down, so the contactors open under load (arc/weld risk, the exact scenario described in #1750).

The graceful machinery already exists — v11 applied it everywhere except this path: the pause state machine only reports PAUSED below 1.8 A, the BMS reset waits for zero current with a 10 s give-up ("so we don't weld the contactors"), and graceful restart waits for PAUSED. This PR applies the same pattern to the e-stop path.

### Behavior

- **Equipment stop** now holds the contactors in COMPLETED until the pause state machine reports PAUSED (current < 1.8 A) **or** a 7 s timeout (10 s originally; lowered per review - equipment stop doubles as an emergency stop in practice). Every e-stop entry point (button, MQTT, web) already issues the battery pause, so the PAUSED condition is reached without extra wiring in normal cases.
- **On timeout** it opens anyway and raises `EVENT_ERROR_OPEN_CONTACTOR` (data = 1), so a forced open under load is visible in the event log.
- **Inverter-commanded opening** keeps today's immediate behavior — the inverter has already stopped power transfer before revoking its permission.
- **The latched FAULT shutdown path is untouched** — genuine faults still open immediately.

Fixes #1750 (offer made in the issue).

### Testing

Four new host tests: hold-under-load until the bounded timeout (+ event raised), prompt open when already paused, open as soon as the pause completes mid-wait, and a regression guard that the inverter path stays immediate. The two hold-behavior tests fail against the unfixed code (verified). Full suite 104/104 green; firmware compiles clean under the `-Werror` warning-check environment.
