### PR TITLE
Add multi-language support: catalog storage, endpoints, and Languages UI

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -18,6 +18,7 @@
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/display/display.h"
 #include "src/devboard/espnow/espnow.h"
+#include "src/devboard/i18n/i18n.h"
 #include "src/devboard/mqtt/mqtt.h"
 #include "src/devboard/safety/parallel_safety.h"
 #include "src/devboard/sdcard/sdcard.h"
@@ -730,6 +731,8 @@ void setup() {
   init_events();
 
   init_stored_settings();
+
+  init_i18n_storage();  // Language catalogs; mount failure just disables the feature
 
   // AP-button recovery must always run
   xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, NULL, TASK_CONNECTIVITY_PRIO,

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -18,6 +18,7 @@
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/display/display.h"
 #include "src/devboard/espnow/espnow.h"
+#include "src/devboard/i18n/i18n.h"
 #include "src/devboard/mqtt/mqtt.h"
 #include "src/devboard/safety/parallel_safety.h"
 #include "src/devboard/sdcard/sdcard.h"
@@ -758,6 +759,8 @@ void setup() {
   init_events();
 
   init_stored_settings();
+
+  init_i18n_storage();  // Language catalogs; mount failure just disables the feature
 
   if (wifi_enabled) {
     xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, NULL, TASK_CONNECTIVITY_PRIO,

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -5,6 +5,7 @@
 #include "../../charger/CanCharger.h"
 #include "../../communication/can/comm_can.h"
 #include "../../datalayer/datalayer_extended.h"
+#include "../../devboard/i18n/i18n.h"
 #include "../../devboard/mqtt/mqtt.h"
 #include "../../devboard/network/hostname.h"
 #include "../../devboard/utils/logging.h"
@@ -266,6 +267,7 @@ void init_stored_settings() {
   mqtt_transmit_all_cellvoltages = settings.getBool("MQTTCELLV", false);
   mqtt_publish_heap_metrics = settings.getBool("MQTTHEAP", false);
   custom_hostname = settings.getString("HOSTNAME").c_str();
+  user_selected_language = settings.getString("LANGUAGE").c_str();
 
   migrate_static_ip_settings(settings);
   wifi_static_IP_enabled = settings.getBool("STATICIP", false);
@@ -334,6 +336,7 @@ void store_settings() {
   BatteryEmulatorSettingsStore settings(false);
 
   settings.saveUInt("BATTERY_WH_MAX", datalayer.battery.info.total_capacity_Wh);
+  settings.saveString("LANGUAGE", user_selected_language.c_str());
   settings.saveBool("USE_SCALED_SOC", datalayer.battery.settings.soc_scaling_active);
   settings.saveUInt("MAXPERCENTAGE", datalayer.battery.settings.max_percentage / 10);
   settings.saveInt("MINPERCENTAGE", datalayer.battery.settings.min_percentage / 10);

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -6,6 +6,7 @@
 #include "../../charger/CanCharger.h"
 #include "../../communication/can/comm_can.h"
 #include "../../datalayer/datalayer_extended.h"
+#include "../../devboard/i18n/i18n.h"
 #include "../../devboard/mqtt/mqtt.h"
 #include "../../devboard/utils/logging.h"
 #include "../../devboard/webserver/webserver.h"
@@ -255,6 +256,7 @@ void init_stored_settings() {
   ha_autodiscovery_topic = settings.getString("HADISCTOPIC", "homeassistant").c_str();
   mqtt_transmit_all_cellvoltages = settings.getBool("MQTTCELLV", false);
   custom_hostname = settings.getString("HOSTNAME").c_str();
+  user_selected_language = settings.getString("LANGUAGE").c_str();
 
   migrate_static_ip_settings(settings);
   static_IP_enabled = settings.getBool("STATICIP", false);
@@ -323,6 +325,7 @@ void store_settings() {
   BatteryEmulatorSettingsStore settings(false);
 
   settings.saveUInt("BATTERY_WH_MAX", datalayer.battery.info.total_capacity_Wh);
+  settings.saveString("LANGUAGE", user_selected_language.c_str());
   settings.saveBool("USE_SCALED_SOC", datalayer.battery.settings.soc_scaling_active);
   settings.saveUInt("MAXPERCENTAGE", datalayer.battery.settings.max_percentage / 10);
   settings.saveInt("MINPERCENTAGE", datalayer.battery.settings.min_percentage / 10);

--- a/Software/src/devboard/i18n/i18n.cpp
+++ b/Software/src/devboard/i18n/i18n.cpp
@@ -1,0 +1,66 @@
+#include "i18n.h"
+#include <esp_partition.h>
+#include "../utils/logging.h"
+
+std::string user_selected_language = "";
+
+// The slot store's narrow flash interface, backed by the spiffs partition
+class EspPartitionFlash : public I18nFlash {
+ public:
+  bool init() {
+    partition_ = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_SPIFFS, nullptr);
+    return partition_ != nullptr;
+  }
+
+  bool read(uint32_t offset, void* buf, size_t len) override {
+    return partition_ && esp_partition_read(partition_, offset, buf, len) == ESP_OK;
+  }
+
+  bool write(uint32_t offset, const void* buf, size_t len) override {
+    return partition_ && esp_partition_write(partition_, offset, buf, len) == ESP_OK;
+  }
+
+  bool erase(uint32_t offset, size_t len) override {
+    return partition_ && esp_partition_erase_range(partition_, offset, len) == ESP_OK;
+  }
+
+  uint32_t size() override { return partition_ ? partition_->size : 0; }
+
+ private:
+  const esp_partition_t* partition_ = nullptr;
+};
+
+static EspPartitionFlash flash_backend;
+static I18nStore store(flash_backend);
+
+I18nStore& i18n_store() {
+  return store;
+}
+
+bool init_i18n_storage() {
+  if (!flash_backend.init()) {
+    logging.printf("i18n: no spiffs partition found, feature off\n");
+    return false;
+  }
+  // No format-on-fail: a user formats explicitly from the Languages block
+  if (!store.mount()) {
+    logging.printf("i18n: language storage not mounted (unformatted?), feature off\n");
+    return false;
+  }
+  return true;
+}
+
+bool i18n_storage_available() {
+  return store.mounted();
+}
+
+bool format_i18n_storage() {
+  return store.format();
+}
+
+std::vector<String> i18n_stored_files() {
+  if (!store.mounted()) {
+    return std::vector<String>();
+  }
+  return store.file_names();
+}

--- a/Software/src/devboard/i18n/i18n.h
+++ b/Software/src/devboard/i18n/i18n.h
@@ -1,0 +1,26 @@
+#ifndef _I18N_H_
+#define _I18N_H_
+
+#include <string>
+#include <vector>
+#include "i18n_store.h"
+#include "i18n_util.h"
+
+/* i18n catalog storage: a raw slot store on the (previously unused) spiffs
+ * partition - see i18n_store.h. ~4 KB of code on every board, no filesystem
+ * driver. Mount failure is tolerated: the feature is simply off until the
+ * user formats the storage from the Languages block. */
+
+extern std::string user_selected_language;  // "" = built-in English
+
+bool init_i18n_storage();
+bool i18n_storage_available();
+bool format_i18n_storage();
+
+// Stored catalog filenames (directory listing, unvalidated)
+std::vector<String> i18n_stored_files();
+
+// The store itself, for the endpoints (serve/upload/delete)
+I18nStore& i18n_store();
+
+#endif

--- a/Software/src/devboard/i18n/i18n_store.cpp
+++ b/Software/src/devboard/i18n/i18n_store.cpp
@@ -52,15 +52,30 @@ bool I18nStore::mount() {
     if (found && sequence <= sequence_) {
       continue;
     }
-    found = true;
-    sequence_ = sequence;
-    active_block_ = block;
-    entries_.clear();
+    // A valid CRC only proves the block is the one we wrote; it does not make
+    // the extents it describes sane. Everything downstream (read, find_extent,
+    // compact) assumes entries stay inside the partition, so enforce it here
+    // rather than trusting flash content.
+    std::vector<I18nStoreEntry> parsed;
+    bool entries_valid = true;
     for (uint16_t i = 0; i < count; i++) {
       I18nStoreEntry entry;
       memcpy(&entry, buf + DIR_HEADER_SIZE + i * sizeof(I18nStoreEntry), sizeof(I18nStoreEntry));
-      entries_.push_back(entry);
+      entry.name[sizeof(entry.name) - 1] = '\0';  // Never let a name run off the field
+      if (entry.name[0] == '\0' || entry.length == 0 || entry.length > MAX_FILE_SIZE || entry.offset < DATA_START ||
+          entry.offset > flash_.size() || entry.length > flash_.size() - entry.offset) {
+        entries_valid = false;
+        break;
+      }
+      parsed.push_back(entry);
     }
+    if (!entries_valid) {
+      continue;  // Fall back to the other block
+    }
+    found = true;
+    sequence_ = sequence;
+    active_block_ = block;
+    entries_ = parsed;
   }
   mounted_ = found;
   return mounted_;

--- a/Software/src/devboard/i18n/i18n_store.cpp
+++ b/Software/src/devboard/i18n/i18n_store.cpp
@@ -1,0 +1,338 @@
+#include "i18n_store.h"
+#include <cstring>
+
+// CRC-32 (IEEE 802.3), bitwise - no table, this is a cold path
+uint32_t i18n_crc32(uint32_t crc, const void* buf, size_t len) {
+  const uint8_t* p = static_cast<const uint8_t*>(buf);
+  crc = ~crc;
+  while (len--) {
+    crc ^= *p++;
+    for (int k = 0; k < 8; k++) {
+      crc = (crc >> 1) ^ (0xEDB88320UL & (0UL - (crc & 1)));
+    }
+  }
+  return ~crc;
+}
+
+static uint32_t round_up_sector(uint32_t len) {
+  return (len + I18nStore::SECTOR - 1) & ~(I18nStore::SECTOR - 1);
+}
+
+bool I18nStore::mount() {
+  mounted_ = false;
+  entries_.clear();
+  stream_active_ = false;
+  bool found = false;
+  for (uint8_t block = 0; block < 2; block++) {
+    uint8_t buf[DIR_BLOCK_MAX];
+    if (!flash_.read(block * SECTOR, buf, sizeof(buf))) {
+      continue;
+    }
+    if (memcmp(buf, "I18S", 4) != 0) {
+      continue;
+    }
+    uint16_t version = 0;
+    memcpy(&version, buf + 4, 2);
+    if (version != FORMAT_VERSION) {
+      continue;
+    }
+    uint32_t sequence = 0;
+    memcpy(&sequence, buf + 6, 4);
+    uint16_t count = 0;
+    memcpy(&count, buf + 10, 2);
+    if (count > MAX_ENTRIES) {
+      continue;
+    }
+    size_t payload = DIR_HEADER_SIZE + count * sizeof(I18nStoreEntry);
+    uint32_t stored_crc = 0;
+    memcpy(&stored_crc, buf + payload, 4);
+    if (i18n_crc32(0, buf, payload) != stored_crc) {
+      continue;
+    }
+    if (found && sequence <= sequence_) {
+      continue;
+    }
+    found = true;
+    sequence_ = sequence;
+    active_block_ = block;
+    entries_.clear();
+    for (uint16_t i = 0; i < count; i++) {
+      I18nStoreEntry entry;
+      memcpy(&entry, buf + DIR_HEADER_SIZE + i * sizeof(I18nStoreEntry), sizeof(I18nStoreEntry));
+      entries_.push_back(entry);
+    }
+  }
+  mounted_ = found;
+  return mounted_;
+}
+
+bool I18nStore::format() {
+  stream_active_ = false;
+  if (!flash_.erase(0, 2 * SECTOR)) {
+    return false;
+  }
+  entries_.clear();
+  sequence_ = 0;
+  active_block_ = 1;  // So the fresh directory lands in block 0
+  mounted_ = true;
+  if (!commit_entries(entries_)) {
+    mounted_ = false;
+    return false;
+  }
+  return true;
+}
+
+bool I18nStore::commit_entries(const std::vector<I18nStoreEntry>& new_entries) {
+  if (!mounted_ || new_entries.size() > MAX_ENTRIES) {
+    return false;
+  }
+  uint8_t buf[DIR_BLOCK_MAX];
+  memset(buf, 0xFF, sizeof(buf));
+  memcpy(buf, "I18S", 4);
+  uint16_t version = FORMAT_VERSION;
+  memcpy(buf + 4, &version, 2);
+  uint32_t sequence = sequence_ + 1;
+  memcpy(buf + 6, &sequence, 4);
+  uint16_t count = (uint16_t)new_entries.size();
+  memcpy(buf + 10, &count, 2);
+  for (uint16_t i = 0; i < count; i++) {
+    memcpy(buf + DIR_HEADER_SIZE + i * sizeof(I18nStoreEntry), &new_entries[i], sizeof(I18nStoreEntry));
+  }
+  size_t payload = DIR_HEADER_SIZE + count * sizeof(I18nStoreEntry);
+  uint32_t crc = i18n_crc32(0, buf, payload);
+  memcpy(buf + payload, &crc, 4);
+
+  uint8_t target_block = active_block_ ^ 1;  // Always the OLDER block
+  if (!flash_.erase(target_block * SECTOR, SECTOR)) {
+    return false;
+  }
+  if (!flash_.write(target_block * SECTOR, buf, payload + 4)) {
+    return false;
+  }
+  // The flip: only adopt the new generation once it is fully on flash
+  sequence_ = sequence;
+  active_block_ = target_block;
+  entries_ = new_entries;
+  return true;
+}
+
+int I18nStore::find_entry(const char* name) const {
+  for (unsigned int i = 0; i < entries_.size(); i++) {
+    if (strncmp(entries_[i].name, name, sizeof(entries_[i].name)) == 0) {
+      return (int)i;
+    }
+  }
+  return -1;
+}
+
+std::vector<String> I18nStore::file_names() const {
+  std::vector<String> names;
+  for (const I18nStoreEntry& entry : entries_) {
+    names.push_back(String(entry.name));
+  }
+  return names;
+}
+
+bool I18nStore::exists(const char* name) const {
+  return mounted_ && find_entry(name) >= 0;
+}
+
+int32_t I18nStore::length(const char* name) const {
+  int index = find_entry(name);
+  if (!mounted_ || index < 0) {
+    return -1;
+  }
+  return (int32_t)entries_[index].length;
+}
+
+bool I18nStore::read(const char* name, uint32_t offset, void* buf, size_t len) const {
+  int index = find_entry(name);
+  if (!mounted_ || index < 0) {
+    return false;
+  }
+  const I18nStoreEntry& entry = entries_[index];
+  if (offset > entry.length || len > entry.length - offset) {
+    return false;
+  }
+  return flash_.read(entry.offset + offset, buf, len);
+}
+
+bool I18nStore::remove(const char* name) {
+  int index = find_entry(name);
+  if (!mounted_ || index < 0) {
+    return false;
+  }
+  std::vector<I18nStoreEntry> new_entries = entries_;
+  new_entries.erase(new_entries.begin() + index);
+  return commit_entries(new_entries);
+}
+
+bool I18nStore::find_extent(uint32_t len, uint32_t* offset) const {
+  uint32_t need = round_up_sector(len);
+  // Collect used extents (sector-rounded), sorted by offset
+  std::vector<I18nStoreEntry> used = entries_;
+  for (unsigned int i = 0; i + 1 < used.size(); i++) {
+    for (unsigned int j = i + 1; j < used.size(); j++) {
+      if (used[j].offset < used[i].offset) {
+        I18nStoreEntry tmp = used[i];
+        used[i] = used[j];
+        used[j] = tmp;
+      }
+    }
+  }
+  uint32_t cursor = DATA_START;
+  for (const I18nStoreEntry& entry : used) {
+    if (entry.offset >= cursor + need) {
+      break;  // Gap before this extent fits
+    }
+    uint32_t end = entry.offset + round_up_sector(entry.length);
+    if (end > cursor) {
+      cursor = end;
+    }
+  }
+  if (cursor + need > flash_.size()) {
+    return false;
+  }
+  *offset = cursor;
+  return true;
+}
+
+uint32_t I18nStore::free_space() const {
+  uint32_t used = 0;
+  for (const I18nStoreEntry& entry : entries_) {
+    used += round_up_sector(entry.length);
+  }
+  uint32_t data_size = flash_.size() - DATA_START;
+  return (used > data_size) ? 0 : (data_size - used);
+}
+
+/* Best-effort defragmentation: repeatedly move an extent to the lowest free
+ * slot it fits in, one directory flip per move so power loss at any point
+ * keeps every catalog reachable. Converges for the <=16-entry scale this
+ * store serves; a pathological layout just fails the allocation. */
+bool I18nStore::compact() {
+  for (unsigned int pass = 0; pass < 2 * MAX_ENTRIES; pass++) {
+    bool moved = false;
+    for (unsigned int i = 0; i < entries_.size(); i++) {
+      const I18nStoreEntry entry = entries_[i];
+      uint32_t rounded = round_up_sector(entry.length);
+      uint32_t target = 0;
+      if (!find_extent(entry.length, &target)) {
+        continue;
+      }
+      if (target >= entry.offset) {
+        continue;  // Only move toward the start
+      }
+      if (target + rounded > entry.offset) {
+        continue;  // Overlaps its own source - not safely movable in place
+      }
+      if (!flash_.erase(target, rounded)) {
+        return false;
+      }
+      uint8_t buf[256];
+      for (uint32_t pos = 0; pos < entry.length; pos += sizeof(buf)) {
+        size_t chunk = entry.length - pos;
+        if (chunk > sizeof(buf)) {
+          chunk = sizeof(buf);
+        }
+        if (!flash_.read(entry.offset + pos, buf, chunk) || !flash_.write(target + pos, buf, chunk)) {
+          return false;
+        }
+      }
+      std::vector<I18nStoreEntry> new_entries = entries_;
+      new_entries[i].offset = target;
+      if (!commit_entries(new_entries)) {
+        return false;
+      }
+      moved = true;
+      break;  // Free map changed: recompute from scratch
+    }
+    if (!moved) {
+      return true;
+    }
+  }
+  return true;
+}
+
+bool I18nStore::stream_begin(const char* name, uint32_t reserve_len) {
+  if (!mounted_ || stream_active_ || reserve_len == 0 || reserve_len > MAX_FILE_SIZE) {
+    return false;
+  }
+  size_t name_len = strlen(name);
+  if (name_len == 0 || name_len >= sizeof(stream_entry_.name)) {
+    return false;
+  }
+  if (find_entry(name) < 0 && entries_.size() >= MAX_ENTRIES) {
+    return false;
+  }
+  uint32_t offset = 0;
+  if (!find_extent(reserve_len, &offset)) {
+    if (!compact() || !find_extent(reserve_len, &offset)) {
+      return false;
+    }
+  }
+  if (!flash_.erase(offset, round_up_sector(reserve_len))) {
+    return false;
+  }
+  memset(&stream_entry_, 0, sizeof(stream_entry_));
+  strncpy(stream_entry_.name, name, sizeof(stream_entry_.name) - 1);
+  stream_entry_.offset = offset;
+  stream_reserved_ = reserve_len;
+  stream_written_ = 0;
+  stream_crc_ = 0;
+  stream_active_ = true;
+  return true;
+}
+
+bool I18nStore::stream_write(const void* buf, size_t len) {
+  if (!stream_active_ || stream_written_ + len > stream_reserved_) {
+    stream_abort();
+    return false;
+  }
+  if (!flash_.write(stream_entry_.offset + stream_written_, buf, len)) {
+    stream_abort();
+    return false;
+  }
+  stream_crc_ = i18n_crc32(stream_crc_, buf, len);
+  stream_written_ += len;
+  return true;
+}
+
+bool I18nStore::stream_commit() {
+  if (!stream_active_ || stream_written_ == 0) {
+    stream_abort();
+    return false;
+  }
+  stream_active_ = false;
+  // Verify the data actually on flash before the flip makes it reachable
+  uint32_t verify_crc = 0;
+  uint8_t buf[256];
+  for (uint32_t pos = 0; pos < stream_written_; pos += sizeof(buf)) {
+    size_t chunk = stream_written_ - pos;
+    if (chunk > sizeof(buf)) {
+      chunk = sizeof(buf);
+    }
+    if (!flash_.read(stream_entry_.offset + pos, buf, chunk)) {
+      return false;
+    }
+    verify_crc = i18n_crc32(verify_crc, buf, chunk);
+  }
+  if (verify_crc != stream_crc_) {
+    return false;
+  }
+  stream_entry_.length = stream_written_;
+  stream_entry_.crc32 = stream_crc_;
+  std::vector<I18nStoreEntry> new_entries = entries_;
+  int existing = find_entry(stream_entry_.name);
+  if (existing >= 0) {
+    new_entries[existing] = stream_entry_;
+  } else {
+    new_entries.push_back(stream_entry_);
+  }
+  return commit_entries(new_entries);
+}
+
+void I18nStore::stream_abort() {
+  stream_active_ = false;
+  stream_written_ = 0;
+}

--- a/Software/src/devboard/i18n/i18n_store.h
+++ b/Software/src/devboard/i18n/i18n_store.h
@@ -1,0 +1,91 @@
+#ifndef _I18N_STORE_H_
+#define _I18N_STORE_H_
+
+#include <stdint.h>
+#include <cstddef>
+#include <vector>
+#include "i18n_util.h"
+
+/* Raw slot store for language catalogs on the spiffs partition: <=16 named
+ * blobs, double-buffered directory (blocks A/B at 0 and 4096, valid-CRC block
+ * with the higher sequence wins), data extents at 4 KB granularity from 8 KB
+ * up. The directory flip is the commit point: power loss at any moment leaves
+ * the previous directory - and every catalog it references - intact.
+ * Backed by a narrow flash interface so the store is host-testable against a
+ * RAM-backed fake. */
+
+class I18nFlash {
+ public:
+  virtual ~I18nFlash() = default;
+  virtual bool read(uint32_t offset, void* buf, size_t len) = 0;
+  virtual bool write(uint32_t offset, const void* buf, size_t len) = 0;
+  virtual bool erase(uint32_t offset, size_t len) = 0;  // 4 KB aligned
+  virtual uint32_t size() = 0;
+};
+
+struct I18nStoreEntry {
+  char name[24];  // NUL-padded, e.g. "uk.json.gz"
+  uint32_t offset;
+  uint32_t length;
+  uint32_t crc32;
+};
+
+class I18nStore {
+ public:
+  static constexpr uint32_t SECTOR = 4096;
+  static constexpr uint32_t DATA_START = 8192;
+  static constexpr uint16_t MAX_ENTRIES = 16;
+  static constexpr uint16_t FORMAT_VERSION = 1;
+  static constexpr uint32_t MAX_FILE_SIZE = 131072;  // 128 KB upload cap
+  // magic + version + sequence + count, entries, block crc
+  static constexpr size_t DIR_HEADER_SIZE = 12;
+  static constexpr size_t DIR_BLOCK_MAX = DIR_HEADER_SIZE + MAX_ENTRIES * sizeof(I18nStoreEntry) + 4;
+
+  explicit I18nStore(I18nFlash& flash) : flash_(flash) {}
+
+  bool mount();   // False = unformatted/corrupt: feature stays off
+  bool format();  // Erase the directory blocks + write a fresh empty directory
+  bool mounted() const { return mounted_; }
+
+  std::vector<String> file_names() const;
+  bool exists(const char* name) const;
+  int32_t length(const char* name) const;  // -1 if absent
+  bool read(const char* name, uint32_t offset, void* buf, size_t len) const;
+  bool remove(const char* name);
+
+  /* Streaming replace: begin (reserving up to reserve_len bytes) -> write
+   * chunks -> commit (verifies CRC by read-back, then flips the directory)
+   * or abort. The entry records the actual streamed length. One stream at a
+   * time. A replaced file's old extent stays live until the flip. */
+  bool stream_begin(const char* name, uint32_t reserve_len);
+  bool stream_write(const void* buf, size_t len);
+  bool stream_commit();
+  void stream_abort();
+  bool stream_active() const { return stream_active_; }
+
+  uint32_t free_space() const;
+
+ private:
+  I18nFlash& flash_;
+  bool mounted_ = false;
+  uint32_t sequence_ = 0;
+  uint8_t active_block_ = 0;
+  std::vector<I18nStoreEntry> entries_;
+
+  // Active stream state
+  bool stream_active_ = false;
+  I18nStoreEntry stream_entry_ = {};
+  uint32_t stream_reserved_ = 0;
+  uint32_t stream_written_ = 0;
+  uint32_t stream_crc_ = 0;
+
+  // Writes new_entries as the next directory generation; adopts it on success
+  bool commit_entries(const std::vector<I18nStoreEntry>& new_entries);
+  bool find_extent(uint32_t len, uint32_t* offset) const;
+  bool compact();
+  int find_entry(const char* name) const;
+};
+
+uint32_t i18n_crc32(uint32_t crc, const void* buf, size_t len);
+
+#endif

--- a/Software/src/devboard/i18n/i18n_store.h
+++ b/Software/src/devboard/i18n/i18n_store.h
@@ -65,6 +65,12 @@ class I18nStore {
 
   uint32_t free_space() const;
 
+  /* Bumped by every committed change to the directory. A reader streaming a
+   * catalog over several callbacks captures this first and re-checks it per
+   * chunk: extents move on commit, so a generation change means the bytes it
+   * is about to read may belong to a different file. */
+  uint32_t generation() const { return sequence_; }
+
  private:
   I18nFlash& flash_;
   bool mounted_ = false;

--- a/Software/src/devboard/i18n/i18n_util.cpp
+++ b/Software/src/devboard/i18n/i18n_util.cpp
@@ -1,0 +1,76 @@
+#include "i18n_util.h"
+#include <cstring>
+
+static bool is_lower(char c) {
+  return c >= 'a' && c <= 'z';
+}
+
+static bool is_upper(char c) {
+  return c >= 'A' && c <= 'Z';
+}
+
+// Length of the language-code prefix (2 or 5), or 0 if invalid
+static unsigned int language_code_length(const char* name) {
+  if (!is_lower(name[0]) || !is_lower(name[1])) {
+    return 0;
+  }
+  if (name[2] == '-') {
+    if (!is_upper(name[3]) || !is_upper(name[4])) {
+      return 0;
+    }
+    return 5;
+  }
+  return 2;
+}
+
+// ^[a-z]{2}(-[A-Z]{2})?\.(json\.gz|blp)$ without regex
+bool is_valid_i18n_filename(const String& name) {
+  const char* s = name.c_str();
+  if (name.length() < 6) {
+    return false;
+  }
+  unsigned int code_len = language_code_length(s);
+  if (code_len == 0) {
+    return false;
+  }
+  const char* suffix = s + code_len;
+  return strcmp(suffix, ".json.gz") == 0 || strcmp(suffix, ".blp") == 0;
+}
+
+String i18n_language_from_filename(const String& name) {
+  if (!is_valid_i18n_filename(name)) {
+    return "";
+  }
+  char code[6] = {0};
+  unsigned int code_len = language_code_length(name.c_str());
+  memcpy(code, name.c_str(), code_len);
+  return String(code);
+}
+
+String i18n_list_json(const std::vector<String>& filenames, const String& active_language) {
+  std::vector<String> languages;
+  for (const String& name : filenames) {
+    String lang = i18n_language_from_filename(name);
+    if (lang == "") {
+      continue;
+    }
+    bool seen = false;
+    for (const String& existing : languages) {
+      if (existing == lang) {
+        seen = true;
+      }
+    }
+    if (!seen) {
+      languages.push_back(lang);
+    }
+  }
+  String json = "{\"active\":\"" + active_language + "\",\"languages\":[";
+  for (unsigned int i = 0; i < languages.size(); i++) {
+    if (i > 0) {
+      json += ",";
+    }
+    json += "\"" + languages[i] + "\"";
+  }
+  json += "]}";
+  return json;
+}

--- a/Software/src/devboard/i18n/i18n_util.cpp
+++ b/Software/src/devboard/i18n/i18n_util.cpp
@@ -37,6 +37,13 @@ bool is_valid_i18n_filename(const String& name) {
   return strcmp(suffix, ".json.gz") == 0 || strcmp(suffix, ".blp") == 0;
 }
 
+bool is_valid_language_code(const String& code) {
+  if (code.length() != 2 && code.length() != 5) {
+    return false;
+  }
+  return language_code_length(code.c_str()) == code.length();
+}
+
 String i18n_language_from_filename(const String& name) {
   if (!is_valid_i18n_filename(name)) {
     return "";
@@ -64,7 +71,11 @@ String i18n_list_json(const std::vector<String>& filenames, const String& active
       languages.push_back(lang);
     }
   }
-  String json = "{\"active\":\"" + active_language + "\",\"languages\":[";
+  // Never interpolate the stored value raw: it reaches the page as JSON and
+  // a stale/hand-written NVS value must not be able to break out of the
+  // string literal. Anything that is not a well-formed code reads as "".
+  String active = is_valid_language_code(active_language) ? active_language : String("");
+  String json = "{\"active\":\"" + active + "\",\"languages\":[";
   for (unsigned int i = 0; i < languages.size(); i++) {
     if (i > 0) {
       json += ",";

--- a/Software/src/devboard/i18n/i18n_util.h
+++ b/Software/src/devboard/i18n/i18n_util.h
@@ -10,6 +10,11 @@
  * ll.blp or ll-CC.blp (ISO language, optional region). */
 bool is_valid_i18n_filename(const String& name);
 
+/* True for a bare language code: ll or ll-CC. The empty string is NOT a
+ * valid code - callers that accept "" as "built-in English" test for it
+ * separately, so that the accept-empty decision is always explicit. */
+bool is_valid_language_code(const String& code);
+
 /* Language code (e.g. "sv" or "pt-BR") from a valid catalog filename. */
 String i18n_language_from_filename(const String& name);
 

--- a/Software/src/devboard/i18n/i18n_util.h
+++ b/Software/src/devboard/i18n/i18n_util.h
@@ -1,0 +1,21 @@
+#ifndef _I18N_UTIL_H_
+#define _I18N_UTIL_H_
+
+#include <WString.h>
+#include <vector>
+
+/* Host-testable i18n helpers, no filesystem dependencies. */
+
+/* True for catalog filenames of the form ll.json.gz, ll-CC.json.gz,
+ * ll.blp or ll-CC.blp (ISO language, optional region). */
+bool is_valid_i18n_filename(const String& name);
+
+/* Language code (e.g. "sv" or "pt-BR") from a valid catalog filename. */
+String i18n_language_from_filename(const String& name);
+
+/* JSON body for GET /api/i18n: unique language codes from the stored
+ * catalog filenames (invalid names ignored) plus the active language.
+ * English is the built-in default and is not a stored catalog. */
+String i18n_list_json(const std::vector<String>& filenames, const String& active_language);
+
+#endif

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -8,6 +8,44 @@
 #include "../../datalayer/datalayer.h"
 #include "../network/hostname.h"  // default_hostname()
 #include "html_escape.h"
+
+#define I18N_SETTINGS_BLOCK \
+  R"rawliteral(
+        <div class="settings-card">
+        <h3>Languages</h3>
+        <label>Active language: </label>
+        <select id='i18nLang' onchange='i18nSetLang()'><option value=''>English (built-in)</option></select>
+        <button onclick='i18nDelete()'>Delete</button>
+        <div id='i18nDrop' style='border:1px dashed #888;padding:8px;margin:4px 0;'
+          ondragover='event.preventDefault()' ondrop='i18nDrop(event)'>
+          Drop a language file here (ll.json.gz / ll.blp), or
+          <input type='file' onchange='i18nUpload(this.files[0])' />
+        </div>
+        <button onclick='i18nFormat()'>Format language storage</button>
+        </div>
+)rawliteral"
+#define I18N_SETTINGS_JS \
+  R"rawliteral(
+    function i18nRefresh(){fetch('/api/i18n').then(r=>r.json()).then(d=>{
+      var s=document.getElementById('i18nLang');s.innerHTML='';
+      var o=document.createElement('option');o.value='';o.text='English (built-in)';s.add(o);
+      d.languages.forEach(function(l){var o=document.createElement('option');o.value=l;o.text=l;s.add(o);});
+      s.value=d.active;}).catch(function(){});}
+    function i18nSetLang(){var v=document.getElementById('i18nLang').value;
+      fetch('/updateLanguage?value='+encodeURIComponent(v)).then(function(){location.reload();});}
+    function i18nUpload(f){if(!f){return;}var fd=new FormData();fd.append('file',f,f.name);
+      fetch('/api/i18n',{method:'POST',body:fd}).then(function(r){
+        if(!r.ok){alert('Upload rejected');}i18nRefresh();});}
+    function i18nDrop(e){e.preventDefault();if(e.dataTransfer.files.length){i18nUpload(e.dataTransfer.files[0]);}}
+    function i18nDelete(){var v=document.getElementById('i18nLang').value;
+      if(!v||!confirm('Delete language '+v+'?')){return;}
+      var fd=new FormData();fd.append('lang',v);
+      fetch('/api/i18n/delete',{method:'POST',body:fd}).then(function(){i18nRefresh();});}
+    function i18nFormat(){if(!confirm('Format the language storage? All installed languages are erased.')){return;}
+      fetch('/api/i18n/format',{method:'POST'}).then(function(r){
+        alert(r.ok?'Formatted':'Format failed');i18nRefresh();});}
+    window.addEventListener('load',i18nRefresh);)rawliteral"
+
 #include "index_html.h"
 #include "src/battery/BATTERIES.h"
 #include "src/inverter/INVERTERS.h"
@@ -1237,6 +1275,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     function editComplete(){if(this.status==200){window.location.reload();}}
 
     function editError(){alert('Invalid input');}
+)rawliteral" I18N_SETTINGS_JS R"rawliteral(
+
         function editRecoveryMode(){var value=prompt('Extremely dangerous option. Emergency charge allows recovery for a severely undercharged battery. Limit charge power to avoid cell rupture and possible fire. Start 30min recovery process? (0 = No, 1 = Yes):');
           if(value!==null){if(value==0||value==1){var xhr=new 
         XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/enableRecoveryMode?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 and 1.');}}}
@@ -2149,6 +2189,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         </div>
         </div>
 
+)rawliteral" I18N_SETTINGS_BLOCK R"rawliteral(
         <div class="settings-card">
         <h3>Integration settings</h3>
         <div style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -8,6 +8,44 @@
 #include "../../datalayer/datalayer.h"
 #include "../wifi/wifi.h"
 #include "html_escape.h"
+
+#define I18N_SETTINGS_BLOCK \
+  R"rawliteral(
+        <div class="settings-card">
+        <h3>Languages</h3>
+        <label>Active language: </label>
+        <select id='i18nLang' onchange='i18nSetLang()'><option value=''>English (built-in)</option></select>
+        <button onclick='i18nDelete()'>Delete</button>
+        <div id='i18nDrop' style='border:1px dashed #888;padding:8px;margin:4px 0;'
+          ondragover='event.preventDefault()' ondrop='i18nDrop(event)'>
+          Drop a language file here (ll.json.gz / ll.blp), or
+          <input type='file' onchange='i18nUpload(this.files[0])' />
+        </div>
+        <button onclick='i18nFormat()'>Format language storage</button>
+        </div>
+)rawliteral"
+#define I18N_SETTINGS_JS \
+  R"rawliteral(
+    function i18nRefresh(){fetch('/api/i18n').then(r=>r.json()).then(d=>{
+      var s=document.getElementById('i18nLang');s.innerHTML='';
+      var o=document.createElement('option');o.value='';o.text='English (built-in)';s.add(o);
+      d.languages.forEach(function(l){var o=document.createElement('option');o.value=l;o.text=l;s.add(o);});
+      s.value=d.active;}).catch(function(){});}
+    function i18nSetLang(){var v=document.getElementById('i18nLang').value;
+      fetch('/updateLanguage?value='+encodeURIComponent(v)).then(function(){location.reload();});}
+    function i18nUpload(f){if(!f){return;}var fd=new FormData();fd.append('file',f,f.name);
+      fetch('/api/i18n',{method:'POST',body:fd}).then(function(r){
+        if(!r.ok){alert('Upload rejected');}i18nRefresh();});}
+    function i18nDrop(e){e.preventDefault();if(e.dataTransfer.files.length){i18nUpload(e.dataTransfer.files[0]);}}
+    function i18nDelete(){var v=document.getElementById('i18nLang').value;
+      if(!v||!confirm('Delete language '+v+'?')){return;}
+      var fd=new FormData();fd.append('lang',v);
+      fetch('/api/i18n/delete',{method:'POST',body:fd}).then(function(){i18nRefresh();});}
+    function i18nFormat(){if(!confirm('Format the language storage? All installed languages are erased.')){return;}
+      fetch('/api/i18n/format',{method:'POST'}).then(function(r){
+        alert(r.ok?'Formatted':'Format failed');i18nRefresh();});}
+    window.addEventListener('load',i18nRefresh);)rawliteral"
+
 #include "index_html.h"
 #include "src/battery/BATTERIES.h"
 #include "src/battery/Shunt.h"
@@ -1214,6 +1252,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
     function editComplete(){if(this.status==200){window.location.reload();}}
 
     function editError(){alert('Invalid input');}
+)rawliteral" I18N_SETTINGS_JS R"rawliteral(
+
         function editRecoveryMode(){var value=prompt('Extremely dangerous option. Emergency charge allows recovery for a severely undercharged battery. Limit charge power to avoid cell rupture and possible fire. Start 30min recovery process? (0 = No, 1 = Yes):');
           if(value!==null){if(value==0||value==1){var xhr=new 
         XMLHttpRequest();xhr.onload=editComplete;xhr.onerror=editError;xhr.open('GET','/enableRecoveryMode?value='+value,true);xhr.send();}else{alert('Invalid value. Please enter a value between 0 and 1.');}}}
@@ -2096,6 +2136,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         </div>
         </div>
 
+)rawliteral" I18N_SETTINGS_BLOCK R"rawliteral(
         <div class="settings-card">
         <h3>Integration settings</h3>
         <div style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -14,6 +14,7 @@
 #include "../../devboard/safety/safety.h"
 #include "../../inverter/INVERTERS.h"
 #include "../../lib/bblanchon-ArduinoJson/ArduinoJson.h"
+#include "../i18n/i18n.h"
 #include "../sdcard/sdcard.h"
 #include "../utils/events.h"
 #include "../utils/led_handler.h"
@@ -224,6 +225,103 @@ void init_webserver() {
 #endif  // SMALL_FLASH_DEVICE
 
   // Route for firmware info from ota update page
+  // i18n list + catalog serve. ONE dispatcher on purpose: this webserver
+  // prefix-matches plain URIs (url == uri OR url.startsWith(uri + "/")), so a
+  // separate /api/i18n/* route would be shadowed by the /api/i18n list route.
+  def_route_with_auth("/api/i18n", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    String url = request->url();
+    if (url == "/api/i18n" || url == "/api/i18n/") {
+      request->send(200, "application/json",
+                    i18n_list_json(i18n_stored_files(), String(user_selected_language.c_str())));
+      return;
+    }
+    // Sub-path: /api/i18n/<lang>.json -> stored <lang>.json.gz
+    String lang = url.substring(String("/api/i18n/").length());
+    if (lang.endsWith(".json")) {
+      lang = lang.substring(0, lang.length() - 5);
+    }
+    String filename = lang + ".json.gz";
+    int32_t total =
+        i18n_storage_available() && is_valid_i18n_filename(filename) ? i18n_store().length(filename.c_str()) : -1;
+    if (total < 0) {
+      request->send(404, "text/plain", "No such language");
+      return;
+    }
+    AsyncWebServerResponse* response = request->beginResponse(
+        "application/json", total, [filename, total](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
+          size_t remaining = (size_t)total - index;
+          size_t chunk = (remaining < maxLen) ? remaining : maxLen;
+          if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
+            return 0;
+          }
+          return chunk;
+        });
+    response->addHeader("Content-Encoding", "gzip");
+    response->addHeader("Cache-Control", "no-cache");
+    request->send(response);
+  });
+
+  // NOTE: /api/i18n/delete and /api/i18n/format MUST stay registered before
+  // the /api/i18n upload handler - prefix matching would otherwise route them
+  // to the upload handler.
+  // i18n: delete a stored catalog (both formats of the language)
+  def_route_with_auth("/api/i18n/delete", server, HTTP_POST, [](AsyncWebServerRequest* request) {
+    if (!request->hasParam("lang", true) || !i18n_storage_available()) {
+      request->send(400, "text/plain", "Bad Request");
+      return;
+    }
+    String lang = request->getParam("lang", true)->value();
+    if (!is_valid_i18n_filename(lang + ".json.gz")) {
+      request->send(400, "text/plain", "Bad Request");
+      return;
+    }
+    i18n_store().remove((lang + ".json.gz").c_str());
+    i18n_store().remove((lang + ".blp").c_str());
+    request->send(200, "text/plain", "OK");
+  });
+
+  // i18n: format the language storage (explicit user action, no auto-format)
+  def_route_with_auth("/api/i18n/format", server, HTTP_POST, [](AsyncWebServerRequest* request) {
+    if (format_i18n_storage()) {
+      request->send(200, "text/plain", "OK");
+    } else {
+      request->send(500, "text/plain", "Format failed");
+    }
+  });
+
+  // i18n: catalog upload (<= 128 KB, validated name, atomic: the previous
+  // catalog stays served until the store's directory flip on commit)
+  server.on(
+      "/api/i18n", HTTP_POST,
+      [](AsyncWebServerRequest* request) {
+        bool ok = request->_tempObject == nullptr;
+        request->send(ok ? 200 : 400, "text/plain", ok ? "OK" : "Upload rejected");
+      },
+      [](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final) {
+        if (index == 0) {
+          // The multipart total isn't known up front: reserve from the request
+          // content length (a slight over-estimate; extents are 4 KB anyway)
+          uint32_t reserve = request->contentLength();
+          bool ok = i18n_storage_available() && is_valid_i18n_filename(filename) && reserve > 0 &&
+                    reserve <= I18nStore::MAX_FILE_SIZE && i18n_store().stream_begin(filename.c_str(), reserve);
+          if (!ok) {
+            request->_tempObject = (void*)1;  // Marks rejection for the completion handler
+          }
+        }
+        if (request->_tempObject == nullptr && len > 0) {
+          if (!i18n_store().stream_write(data, len)) {
+            request->_tempObject = (void*)1;
+          }
+        }
+        if (final && request->_tempObject == nullptr) {
+          if (!i18n_store().stream_commit()) {
+            request->_tempObject = (void*)1;
+          }
+        } else if (final) {
+          i18n_store().stream_abort();
+        }
+      });
+
   def_route_with_auth("/GetFirmwareInfo", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     request->send(200, "application/json", get_firmware_info_html, get_firmware_info_processor);
   });
@@ -638,6 +736,9 @@ void init_webserver() {
                      [](int value) { datalayer.battery.settings.user_requests_forced_charging_recovery_mode = value; });
 
   // Route for editing SOCMax
+  // Route for selecting the active language ("" = built-in English)
+  update_string_setting("/updateLanguage", [](String value) { user_selected_language = value.c_str(); });
+
   update_string_setting("/updateSocMax", [](String value) {
     datalayer.battery.settings.max_percentage = static_cast<uint16_t>(value.toFloat() * 100);
   });

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -14,6 +14,7 @@
 #include "../../inverter/INVERTERS.h"
 #include "../../lib/bblanchon-ArduinoJson/ArduinoJson.h"
 #include "../../shunt/Shunt.h"
+#include "../i18n/i18n.h"
 #include "../network/hostname.h"
 #include "../network/network_status.h"
 #include "../sdcard/sdcard.h"
@@ -228,6 +229,103 @@ void init_webserver() {
 #endif  // SMALL_FLASH_DEVICE
 
   // Route for firmware info from ota update page
+  // i18n list + catalog serve. ONE dispatcher on purpose: this webserver
+  // prefix-matches plain URIs (url == uri OR url.startsWith(uri + "/")), so a
+  // separate /api/i18n/* route would be shadowed by the /api/i18n list route.
+  def_route_with_auth("/api/i18n", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    String url = request->url();
+    if (url == "/api/i18n" || url == "/api/i18n/") {
+      request->send(200, "application/json",
+                    i18n_list_json(i18n_stored_files(), String(user_selected_language.c_str())));
+      return;
+    }
+    // Sub-path: /api/i18n/<lang>.json -> stored <lang>.json.gz
+    String lang = url.substring(String("/api/i18n/").length());
+    if (lang.endsWith(".json")) {
+      lang = lang.substring(0, lang.length() - 5);
+    }
+    String filename = lang + ".json.gz";
+    int32_t total =
+        i18n_storage_available() && is_valid_i18n_filename(filename) ? i18n_store().length(filename.c_str()) : -1;
+    if (total < 0) {
+      request->send(404, "text/plain", "No such language");
+      return;
+    }
+    AsyncWebServerResponse* response = request->beginResponse(
+        "application/json", total, [filename, total](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
+          size_t remaining = (size_t)total - index;
+          size_t chunk = (remaining < maxLen) ? remaining : maxLen;
+          if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
+            return 0;
+          }
+          return chunk;
+        });
+    response->addHeader("Content-Encoding", "gzip");
+    response->addHeader("Cache-Control", "no-cache");
+    request->send(response);
+  });
+
+  // NOTE: /api/i18n/delete and /api/i18n/format MUST stay registered before
+  // the /api/i18n upload handler - prefix matching would otherwise route them
+  // to the upload handler.
+  // i18n: delete a stored catalog (both formats of the language)
+  def_route_with_auth("/api/i18n/delete", server, HTTP_POST, [](AsyncWebServerRequest* request) {
+    if (!request->hasParam("lang", true) || !i18n_storage_available()) {
+      request->send(400, "text/plain", "Bad Request");
+      return;
+    }
+    String lang = request->getParam("lang", true)->value();
+    if (!is_valid_i18n_filename(lang + ".json.gz")) {
+      request->send(400, "text/plain", "Bad Request");
+      return;
+    }
+    i18n_store().remove((lang + ".json.gz").c_str());
+    i18n_store().remove((lang + ".blp").c_str());
+    request->send(200, "text/plain", "OK");
+  });
+
+  // i18n: format the language storage (explicit user action, no auto-format)
+  def_route_with_auth("/api/i18n/format", server, HTTP_POST, [](AsyncWebServerRequest* request) {
+    if (format_i18n_storage()) {
+      request->send(200, "text/plain", "OK");
+    } else {
+      request->send(500, "text/plain", "Format failed");
+    }
+  });
+
+  // i18n: catalog upload (<= 128 KB, validated name, atomic: the previous
+  // catalog stays served until the store's directory flip on commit)
+  server.on(
+      "/api/i18n", HTTP_POST,
+      [](AsyncWebServerRequest* request) {
+        bool ok = request->_tempObject == nullptr;
+        request->send(ok ? 200 : 400, "text/plain", ok ? "OK" : "Upload rejected");
+      },
+      [](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final) {
+        if (index == 0) {
+          // The multipart total isn't known up front: reserve from the request
+          // content length (a slight over-estimate; extents are 4 KB anyway)
+          uint32_t reserve = request->contentLength();
+          bool ok = i18n_storage_available() && is_valid_i18n_filename(filename) && reserve > 0 &&
+                    reserve <= I18nStore::MAX_FILE_SIZE && i18n_store().stream_begin(filename.c_str(), reserve);
+          if (!ok) {
+            request->_tempObject = (void*)1;  // Marks rejection for the completion handler
+          }
+        }
+        if (request->_tempObject == nullptr && len > 0) {
+          if (!i18n_store().stream_write(data, len)) {
+            request->_tempObject = (void*)1;
+          }
+        }
+        if (final && request->_tempObject == nullptr) {
+          if (!i18n_store().stream_commit()) {
+            request->_tempObject = (void*)1;
+          }
+        } else if (final) {
+          i18n_store().stream_abort();
+        }
+      });
+
   def_route_with_auth("/GetFirmwareInfo", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     request->send(200, "application/json", get_firmware_info_html, get_firmware_info_processor);
   });
@@ -643,6 +741,9 @@ void init_webserver() {
                      [](int value) { datalayer.battery.settings.user_requests_forced_charging_recovery_mode = value; });
 
   // Route for editing SOCMax
+  // Route for selecting the active language ("" = built-in English)
+  update_string_setting("/updateLanguage", [](String value) { user_selected_language = value.c_str(); });
+
   update_string_setting("/updateSocMax", [](String value) {
     datalayer.battery.settings.max_percentage = static_cast<uint16_t>(value.toFloat() * 100);
   });

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -179,6 +179,50 @@ void canReplayTask(void* param) {
   vTaskDelete(NULL);
 }
 
+/* Upload rejection flag.
+ *
+ * Deliberately NOT AsyncWebServerRequest::_tempObject: the request destructor
+ * calls free() on that slot unconditionally (WebRequest.cpp), so a sentinel
+ * value like (void*)1 is passed straight to free() and corrupts the heap -
+ * an immediate panic and reboot on every rejected upload. Storing a real
+ * malloc'd byte would be legal but fails exactly when the heap is exhausted,
+ * which is one of the states the rejection path exists to handle.
+ *
+ * The store permits one stream at a time and the async server runs these
+ * callbacks on a single task, so one owner slot is sufficient. A request that
+ * is not the current owner is treated as rejected. */
+static AsyncWebServerRequest* upload_owner = nullptr;
+static bool upload_rejected = false;
+
+static void begin_upload(AsyncWebServerRequest* request) {
+  upload_owner = request;
+  upload_rejected = false;
+}
+
+static void reject_upload(AsyncWebServerRequest* request) {
+  if (request == upload_owner) {
+    upload_rejected = true;
+  }
+}
+
+// Null while the upload is still good; non-null once rejected (or if this
+// request never owned the upload at all).
+static const void* upload_state(AsyncWebServerRequest* request) {
+  if (request != upload_owner || upload_rejected) {
+    return &upload_rejected;
+  }
+  return nullptr;
+}
+
+// True when the request may write to the language store. Uploads cannot lean
+// on the server middleware chain for this - see the /api/i18n POST handler.
+static bool i18n_upload_authorized(AsyncWebServerRequest* request) {
+  if (!webserver_auth_is_ready()) {
+    return true;  // No credentials configured: same posture as every other route
+  }
+  return request->authenticate(http_username.c_str(), http_password.c_str());
+}
+
 void def_route_with_auth(const char* uri, AsyncWebServer& serv, WebRequestMethodComposite method,
                          std::function<void(AsyncWebServerRequest*)> handler) {
   serv.on(uri, method, [handler](AsyncWebServerRequest* request) {
@@ -247,15 +291,23 @@ void init_webserver() {
       request->send(404, "text/plain", "No such language");
       return;
     }
-    AsyncWebServerResponse* response = request->beginResponse(
-        "application/json", total, [filename, total](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
-          size_t remaining = (size_t)total - index;
-          size_t chunk = (remaining < maxLen) ? remaining : maxLen;
-          if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
-            return 0;
-          }
-          return chunk;
-        });
+    // The store hands out extents, and an upload/delete/format that commits
+    // mid-transfer moves them. Abort rather than splice bytes from whatever
+    // now occupies the extent: a truncated gzip fails cleanly at the client.
+    uint32_t generation = i18n_store().generation();
+    AsyncWebServerResponse* response =
+        request->beginResponse("application/json", total,
+                               [filename, total, generation](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
+                                 if (i18n_store().generation() != generation) {
+                                   return 0;
+                                 }
+                                 size_t remaining = (size_t)total - index;
+                                 size_t chunk = (remaining < maxLen) ? remaining : maxLen;
+                                 if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
+                                   return 0;
+                                 }
+                                 return chunk;
+                               });
     response->addHeader("Content-Encoding", "gzip");
     response->addHeader("Cache-Control", "no-cache");
     request->send(response);
@@ -291,31 +343,45 @@ void init_webserver() {
 
   // i18n: catalog upload (<= 128 KB, validated name, atomic: the previous
   // catalog stays served until the store's directory flip on commit)
+  //
+  // The upload handler must authenticate itself. The server middleware chain
+  // (and therefore the auth middleware) only runs at PARSE_REQ_END - after
+  // the whole body has been parsed and every onUpload chunk has already been
+  // handed to us. Relying on the middleware would let an unauthenticated
+  // request erase and rewrite the language partition before it is rejected.
   server.on(
       "/api/i18n", HTTP_POST,
       [](AsyncWebServerRequest* request) {
-        bool ok = request->_tempObject == nullptr;
+        if (!i18n_upload_authorized(request)) {
+          return request->requestAuthentication(AsyncAuthType::AUTH_BASIC, WEB_AUTH_REALM);
+        }
+        bool ok = upload_state(request) == nullptr;
         request->send(ok ? 200 : 400, "text/plain", ok ? "OK" : "Upload rejected");
       },
       [](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final) {
         if (index == 0) {
+          begin_upload(request);
+          if (!i18n_upload_authorized(request)) {
+            reject_upload(request);  // Nothing touches flash on an unauthenticated request
+            return;
+          }
           // The multipart total isn't known up front: reserve from the request
           // content length (a slight over-estimate; extents are 4 KB anyway)
           uint32_t reserve = request->contentLength();
           bool ok = i18n_storage_available() && is_valid_i18n_filename(filename) && reserve > 0 &&
                     reserve <= I18nStore::MAX_FILE_SIZE && i18n_store().stream_begin(filename.c_str(), reserve);
           if (!ok) {
-            request->_tempObject = (void*)1;  // Marks rejection for the completion handler
+            reject_upload(request);
           }
         }
-        if (request->_tempObject == nullptr && len > 0) {
+        if (upload_state(request) == nullptr && len > 0) {
           if (!i18n_store().stream_write(data, len)) {
-            request->_tempObject = (void*)1;
+            reject_upload(request);
           }
         }
-        if (final && request->_tempObject == nullptr) {
+        if (final && upload_state(request) == nullptr) {
           if (!i18n_store().stream_commit()) {
-            request->_tempObject = (void*)1;
+            reject_upload(request);
           }
         } else if (final) {
           i18n_store().stream_abort();
@@ -737,7 +803,9 @@ void init_webserver() {
 
   // Route for editing SOCMax
   // Route for selecting the active language ("" = built-in English)
-  update_string_setting("/updateLanguage", [](String value) { user_selected_language = value.c_str(); });
+  update_string_setting(
+      "/updateLanguage", [](String value) { user_selected_language = value.c_str(); },
+      [](String value) { return value.length() == 0 || is_valid_language_code(value); });
 
   update_string_setting("/updateSocMax", [](String value) {
     datalayer.battery.settings.max_percentage = static_cast<uint16_t>(value.toFloat() * 100);

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -183,6 +183,50 @@ void canReplayTask(void* param) {
   vTaskDelete(NULL);
 }
 
+/* Upload rejection flag.
+ *
+ * Deliberately NOT AsyncWebServerRequest::_tempObject: the request destructor
+ * calls free() on that slot unconditionally (WebRequest.cpp), so a sentinel
+ * value like (void*)1 is passed straight to free() and corrupts the heap -
+ * an immediate panic and reboot on every rejected upload. Storing a real
+ * malloc'd byte would be legal but fails exactly when the heap is exhausted,
+ * which is one of the states the rejection path exists to handle.
+ *
+ * The store permits one stream at a time and the async server runs these
+ * callbacks on a single task, so one owner slot is sufficient. A request that
+ * is not the current owner is treated as rejected. */
+static AsyncWebServerRequest* upload_owner = nullptr;
+static bool upload_rejected = false;
+
+static void begin_upload(AsyncWebServerRequest* request) {
+  upload_owner = request;
+  upload_rejected = false;
+}
+
+static void reject_upload(AsyncWebServerRequest* request) {
+  if (request == upload_owner) {
+    upload_rejected = true;
+  }
+}
+
+// Null while the upload is still good; non-null once rejected (or if this
+// request never owned the upload at all).
+static const void* upload_state(AsyncWebServerRequest* request) {
+  if (request != upload_owner || upload_rejected) {
+    return &upload_rejected;
+  }
+  return nullptr;
+}
+
+// True when the request may write to the language store. Uploads cannot lean
+// on the server middleware chain for this - see the /api/i18n POST handler.
+static bool i18n_upload_authorized(AsyncWebServerRequest* request) {
+  if (!webserver_auth_is_ready()) {
+    return true;  // No credentials configured: same posture as every other route
+  }
+  return request->authenticate(http_username.c_str(), http_password.c_str());
+}
+
 void def_route_with_auth(const char* uri, AsyncWebServer& serv, WebRequestMethodComposite method,
                          std::function<void(AsyncWebServerRequest*)> handler) {
   serv.on(uri, method, [handler](AsyncWebServerRequest* request) {
@@ -251,15 +295,23 @@ void init_webserver() {
       request->send(404, "text/plain", "No such language");
       return;
     }
-    AsyncWebServerResponse* response = request->beginResponse(
-        "application/json", total, [filename, total](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
-          size_t remaining = (size_t)total - index;
-          size_t chunk = (remaining < maxLen) ? remaining : maxLen;
-          if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
-            return 0;
-          }
-          return chunk;
-        });
+    // The store hands out extents, and an upload/delete/format that commits
+    // mid-transfer moves them. Abort rather than splice bytes from whatever
+    // now occupies the extent: a truncated gzip fails cleanly at the client.
+    uint32_t generation = i18n_store().generation();
+    AsyncWebServerResponse* response =
+        request->beginResponse("application/json", total,
+                               [filename, total, generation](uint8_t* buffer, size_t maxLen, size_t index) -> size_t {
+                                 if (i18n_store().generation() != generation) {
+                                   return 0;
+                                 }
+                                 size_t remaining = (size_t)total - index;
+                                 size_t chunk = (remaining < maxLen) ? remaining : maxLen;
+                                 if (chunk > 0 && !i18n_store().read(filename.c_str(), index, buffer, chunk)) {
+                                   return 0;
+                                 }
+                                 return chunk;
+                               });
     response->addHeader("Content-Encoding", "gzip");
     response->addHeader("Cache-Control", "no-cache");
     request->send(response);
@@ -295,31 +347,45 @@ void init_webserver() {
 
   // i18n: catalog upload (<= 128 KB, validated name, atomic: the previous
   // catalog stays served until the store's directory flip on commit)
+  //
+  // The upload handler must authenticate itself. The server middleware chain
+  // (and therefore the auth middleware) only runs at PARSE_REQ_END - after
+  // the whole body has been parsed and every onUpload chunk has already been
+  // handed to us. Relying on the middleware would let an unauthenticated
+  // request erase and rewrite the language partition before it is rejected.
   server.on(
       "/api/i18n", HTTP_POST,
       [](AsyncWebServerRequest* request) {
-        bool ok = request->_tempObject == nullptr;
+        if (!i18n_upload_authorized(request)) {
+          return request->requestAuthentication(AsyncAuthType::AUTH_BASIC, WEB_AUTH_REALM);
+        }
+        bool ok = upload_state(request) == nullptr;
         request->send(ok ? 200 : 400, "text/plain", ok ? "OK" : "Upload rejected");
       },
       [](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final) {
         if (index == 0) {
+          begin_upload(request);
+          if (!i18n_upload_authorized(request)) {
+            reject_upload(request);  // Nothing touches flash on an unauthenticated request
+            return;
+          }
           // The multipart total isn't known up front: reserve from the request
           // content length (a slight over-estimate; extents are 4 KB anyway)
           uint32_t reserve = request->contentLength();
           bool ok = i18n_storage_available() && is_valid_i18n_filename(filename) && reserve > 0 &&
                     reserve <= I18nStore::MAX_FILE_SIZE && i18n_store().stream_begin(filename.c_str(), reserve);
           if (!ok) {
-            request->_tempObject = (void*)1;  // Marks rejection for the completion handler
+            reject_upload(request);
           }
         }
-        if (request->_tempObject == nullptr && len > 0) {
+        if (upload_state(request) == nullptr && len > 0) {
           if (!i18n_store().stream_write(data, len)) {
-            request->_tempObject = (void*)1;
+            reject_upload(request);
           }
         }
-        if (final && request->_tempObject == nullptr) {
+        if (final && upload_state(request) == nullptr) {
           if (!i18n_store().stream_commit()) {
-            request->_tempObject = (void*)1;
+            reject_upload(request);
           }
         } else if (final) {
           i18n_store().stream_abort();
@@ -742,7 +808,9 @@ void init_webserver() {
 
   // Route for editing SOCMax
   // Route for selecting the active language ("" = built-in English)
-  update_string_setting("/updateLanguage", [](String value) { user_selected_language = value.c_str(); });
+  update_string_setting(
+      "/updateLanguage", [](String value) { user_selected_language = value.c_str(); },
+      [](String value) { return value.length() == 0 || is_valid_language_code(value); });
 
   update_string_setting("/updateSocMax", [](String value) {
     datalayer.battery.settings.max_percentage = static_cast<uint16_t>(value.toFloat() * 100);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,6 +72,8 @@ add_executable(tests
     offgrid_downgrade_tests.cpp
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
+    i18n_util_tests.cpp
+    i18n_store_tests.cpp
     estop_graceful_open_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
@@ -83,6 +85,8 @@ add_executable(tests
     battery/UdsCanBatteryTest.cpp
     can_log_based/canlog_safety_tests.cpp
     utils/utils.cpp
+    ../Software/src/devboard/i18n/i18n_util.cpp
+    ../Software/src/devboard/i18n/i18n_store.cpp
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,8 @@ add_executable(tests
     ../Software/src/devboard/safety/safety.cpp
     ../Software/src/devboard/hal/hal.cpp
     ../Software/src/devboard/utils/types.cpp
+    ../Software/src/devboard/i18n/i18n_util.cpp
+    ../Software/src/devboard/i18n/i18n_store.cpp
     ../Software/src/devboard/utils/events.cpp
     ../Software/src/devboard/utils/time_format.cpp
     ../Software/src/devboard/utils/common_functions.cpp

--- a/test/i18n_store_tests.cpp
+++ b/test/i18n_store_tests.cpp
@@ -208,3 +208,50 @@ TEST(I18nStoreTest, UploadCapAndNameLimits) {
   store.stream_abort();
   EXPECT_FALSE(store.stream_begin("this-name-is-way-too-long-for-an-entry.json.gz", 100));
 }
+
+// A directory block whose CRC checks out still only proves we wrote it. If
+// the extents it names fall outside the partition, every later read/compact
+// would work from those numbers - so the block has to be rejected at mount.
+TEST(I18nStoreTest, DirectoryWithOutOfRangeExtentIsRejected) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();
+  ASSERT_TRUE(upload(store, "sv.json.gz", blob('A', 5000)));
+
+  // Rewrite the active block with an entry pointing past the end of flash,
+  // fixing up the CRC so only the range check can catch it.
+  uint8_t block[I18nStore::DIR_BLOCK_MAX];
+  ASSERT_TRUE(flash.read(I18nStore::SECTOR, block, sizeof(block)));
+  uint16_t count = 0;
+  memcpy(&count, block + 10, 2);
+  ASSERT_EQ(count, 1u);
+  uint32_t bogus_offset = 120 * 1024;
+  uint32_t bogus_length = 64 * 1024;  // Runs off the end of a 128 KB partition
+  memcpy(block + I18nStore::DIR_HEADER_SIZE + 24, &bogus_offset, 4);
+  memcpy(block + I18nStore::DIR_HEADER_SIZE + 28, &bogus_length, 4);
+  size_t payload = I18nStore::DIR_HEADER_SIZE + count * sizeof(I18nStoreEntry);
+  uint32_t crc = i18n_crc32(0, block, payload);
+  memcpy(block + payload, &crc, 4);
+  ASSERT_TRUE(flash.erase(I18nStore::SECTOR, I18nStore::SECTOR));
+  ASSERT_TRUE(flash.write(I18nStore::SECTOR, block, payload + 4));
+
+  I18nStore reopened(flash);
+  ASSERT_TRUE(reopened.mount()) << "Falls back to the older block, which is still sane";
+  EXPECT_FALSE(reopened.exists("sv.json.gz")) << "The out-of-range generation must not be adopted";
+}
+
+// Committing a change moves extents; a reader that captured a generation
+// needs to be able to see that its extent may no longer be its own.
+TEST(I18nStoreTest, GenerationChangesOnEveryCommit) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();
+  uint32_t after_format = store.generation();
+
+  ASSERT_TRUE(upload(store, "sv.json.gz", blob('A', 5000)));
+  uint32_t after_upload = store.generation();
+  EXPECT_NE(after_format, after_upload);
+
+  ASSERT_TRUE(store.remove("sv.json.gz"));
+  EXPECT_NE(after_upload, store.generation());
+}

--- a/test/i18n_store_tests.cpp
+++ b/test/i18n_store_tests.cpp
@@ -1,0 +1,210 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "../Software/src/devboard/i18n/i18n_store.h"
+
+// RAM-backed fake of the narrow flash interface. write_budget simulates
+// power loss: once the budget is exhausted every mutation fails, and a new
+// store mounted on the same buffer sees exactly what made it to "flash".
+class RamFlash : public I18nFlash {
+ public:
+  explicit RamFlash(uint32_t size) : data_(size, 0x00) {}  // 0x00 = unformatted junk
+
+  bool read(uint32_t offset, void* buf, size_t len) override {
+    if (offset + len > data_.size()) {
+      return false;
+    }
+    memcpy(buf, data_.data() + offset, len);
+    return true;
+  }
+
+  bool write(uint32_t offset, const void* buf, size_t len) override {
+    if (!consume_budget() || offset + len > data_.size()) {
+      return false;
+    }
+    memcpy(data_.data() + offset, buf, len);
+    return true;
+  }
+
+  bool erase(uint32_t offset, size_t len) override {
+    if (!consume_budget() || offset + len > data_.size()) {
+      return false;
+    }
+    memset(data_.data() + offset, 0xFF, len);
+    return true;
+  }
+
+  uint32_t size() override { return (uint32_t)data_.size(); }
+
+  int write_budget = -1;  // -1 = unlimited mutations
+
+ private:
+  bool consume_budget() {
+    if (write_budget < 0) {
+      return true;
+    }
+    if (write_budget == 0) {
+      return false;
+    }
+    write_budget--;
+    return true;
+  }
+
+  std::vector<uint8_t> data_;
+};
+
+static std::string blob(char fill, size_t len) {
+  return std::string(len, fill);
+}
+
+static bool upload(I18nStore& store, const char* name, const std::string& content) {
+  if (!store.stream_begin(name, (uint32_t)content.size())) {
+    return false;
+  }
+  // Feed in uneven chunks to exercise the streaming path
+  size_t pos = 0;
+  while (pos < content.size()) {
+    size_t chunk = std::min<size_t>(1000, content.size() - pos);
+    if (!store.stream_write(content.data() + pos, chunk)) {
+      return false;
+    }
+    pos += chunk;
+  }
+  return store.stream_commit();
+}
+
+static std::string read_all(I18nStore& store, const char* name) {
+  int32_t len = store.length(name);
+  if (len < 0) {
+    return "<absent>";
+  }
+  std::string out((size_t)len, 0);
+  if (!store.read(name, 0, out.data(), out.size())) {
+    return "<readfail>";
+  }
+  return out;
+}
+
+TEST(I18nStoreTest, UnformattedFlashDoesNotMount) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  EXPECT_FALSE(store.mount()) << "Junk flash must leave the feature off, not auto-format";
+  EXPECT_TRUE(store.format());
+  EXPECT_TRUE(store.mounted());
+  EXPECT_EQ(store.file_names().size(), 0u);
+
+  I18nStore reopened(flash);
+  EXPECT_TRUE(reopened.mount()) << "A formatted store must mount";
+}
+
+TEST(I18nStoreTest, UploadListReadRoundTrip) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();
+
+  std::string content = blob('S', 30000);
+  ASSERT_TRUE(upload(store, "sv.json.gz", content));
+  EXPECT_TRUE(store.exists("sv.json.gz"));
+  EXPECT_EQ(store.length("sv.json.gz"), 30000);
+  EXPECT_EQ(read_all(store, "sv.json.gz"), content);
+
+  // Survives a remount
+  I18nStore reopened(flash);
+  ASSERT_TRUE(reopened.mount());
+  EXPECT_EQ(read_all(reopened, "sv.json.gz"), content);
+
+  ASSERT_TRUE(reopened.remove("sv.json.gz"));
+  EXPECT_FALSE(reopened.exists("sv.json.gz"));
+}
+
+TEST(I18nStoreTest, PowerLossMidUploadKeepsOldState) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();
+  ASSERT_TRUE(upload(store, "sv.json.gz", blob('A', 8000)));
+
+  // Power dies while streaming the second file: no commit, no flip
+  ASSERT_TRUE(store.stream_begin("fi.json.gz", 8000));
+  std::string partial = blob('B', 4000);
+  ASSERT_TRUE(store.stream_write(partial.data(), partial.size()));
+  // (reboot)
+
+  I18nStore reopened(flash);
+  ASSERT_TRUE(reopened.mount());
+  EXPECT_EQ(read_all(reopened, "sv.json.gz"), blob('A', 8000));
+  EXPECT_FALSE(reopened.exists("fi.json.gz"));
+}
+
+TEST(I18nStoreTest, ReplaceThenPowerLossServesOldVersion) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();
+  ASSERT_TRUE(upload(store, "sv.json.gz", blob('1', 6000)));
+
+  // Replacement streams fully but power dies at the directory flip
+  ASSERT_TRUE(store.stream_begin("sv.json.gz", 6000));
+  std::string v2 = blob('2', 6000);
+  ASSERT_TRUE(store.stream_write(v2.data(), v2.size()));
+  flash.write_budget = 0;  // Everything from here fails to reach flash
+  EXPECT_FALSE(store.stream_commit());
+  flash.write_budget = -1;
+  // (reboot)
+
+  I18nStore reopened(flash);
+  ASSERT_TRUE(reopened.mount());
+  EXPECT_EQ(read_all(reopened, "sv.json.gz"), blob('1', 6000)) << "The old catalog must survive a failed replace";
+}
+
+TEST(I18nStoreTest, CorruptedActiveBlockFallsBackToOlder) {
+  RamFlash flash(128 * 1024);
+  I18nStore store(flash);
+  store.format();                                             // Directory generation 1 in block 0
+  ASSERT_TRUE(upload(store, "sv.json.gz", blob('A', 5000)));  // Generation 2 in block 1
+
+  // Corrupt the active directory block (bit rot / interrupted write)
+  uint8_t junk = 0x5A;
+  flash.write(I18nStore::SECTOR + 8, &junk, 1);
+
+  I18nStore reopened(flash);
+  ASSERT_TRUE(reopened.mount()) << "The older valid block must win";
+  EXPECT_FALSE(reopened.exists("sv.json.gz")) << "Fell back to the pre-upload generation";
+}
+
+TEST(I18nStoreTest, CompactionMakesRoom) {
+  // Dirs 8 KB + 32 KB data area
+  RamFlash flash(40 * 1024);
+  I18nStore store(flash);
+  store.format();
+
+  ASSERT_TRUE(upload(store, "aa.json.gz", blob('A', 12 * 1024)));
+  ASSERT_TRUE(upload(store, "bb.json.gz", blob('B', 12 * 1024)));
+  ASSERT_TRUE(store.remove("aa.json.gz"));
+
+  // Free space is 20 KB but split 12 KB + 8 KB: 16 KB only fits after compaction
+  ASSERT_TRUE(upload(store, "cc.json.gz", blob('C', 16 * 1024)));
+  EXPECT_EQ(read_all(store, "bb.json.gz"), blob('B', 12 * 1024)) << "Compaction must preserve moved catalogs";
+  EXPECT_EQ(read_all(store, "cc.json.gz"), blob('C', 16 * 1024));
+}
+
+TEST(I18nStoreTest, FullStoreRejectsUpload) {
+  RamFlash flash(40 * 1024);  // 32 KB data area
+  I18nStore store(flash);
+  store.format();
+  ASSERT_TRUE(upload(store, "aa.json.gz", blob('A', 20 * 1024)));
+
+  EXPECT_FALSE(store.stream_begin("bb.json.gz", 16 * 1024)) << "No amount of compaction makes 36 KB fit in 32 KB";
+  EXPECT_TRUE(upload(store, "bb.json.gz", blob('B', 12 * 1024))) << "A fitting upload must still work";
+}
+
+TEST(I18nStoreTest, UploadCapAndNameLimits) {
+  RamFlash flash(512 * 1024);
+  I18nStore store(flash);
+  store.format();
+  EXPECT_FALSE(store.stream_begin("sv.json.gz", I18nStore::MAX_FILE_SIZE + 1));
+  EXPECT_TRUE(store.stream_begin("sv.json.gz", I18nStore::MAX_FILE_SIZE));
+  store.stream_abort();
+  EXPECT_FALSE(store.stream_begin("this-name-is-way-too-long-for-an-entry.json.gz", 100));
+}

--- a/test/i18n_util_tests.cpp
+++ b/test/i18n_util_tests.cpp
@@ -42,3 +42,24 @@ TEST(I18nUtilTest, ListJsonEmptyStorage) {
   String json = i18n_list_json(files, "");
   EXPECT_STREQ(json.c_str(), "{\"active\":\"\",\"languages\":[]}");
 }
+
+TEST(I18nUtilTest, ValidLanguageCodes) {
+  EXPECT_TRUE(is_valid_language_code("sv"));
+  EXPECT_TRUE(is_valid_language_code("pt-BR"));
+  EXPECT_FALSE(is_valid_language_code(""));
+  EXPECT_FALSE(is_valid_language_code("s"));
+  EXPECT_FALSE(is_valid_language_code("SV"));
+  EXPECT_FALSE(is_valid_language_code("sve"));
+  EXPECT_FALSE(is_valid_language_code("pt-br"));
+  EXPECT_FALSE(is_valid_language_code("pt_BR"));
+  EXPECT_FALSE(is_valid_language_code("sv\"x"));
+}
+
+// A stale or hand-written NVS value must not be able to break out of the
+// JSON string literal it is interpolated into.
+TEST(I18nUtilTest, ListJsonRejectsMalformedActiveLanguage) {
+  std::vector<String> files = {"sv.json.gz"};
+  EXPECT_STREQ(i18n_list_json(files, "\",\"x\":\"").c_str(), "{\"active\":\"\",\"languages\":[\"sv\"]}");
+  EXPECT_STREQ(i18n_list_json(files, "</script>").c_str(), "{\"active\":\"\",\"languages\":[\"sv\"]}");
+  EXPECT_STREQ(i18n_list_json(files, "sv").c_str(), "{\"active\":\"sv\",\"languages\":[\"sv\"]}");
+}

--- a/test/i18n_util_tests.cpp
+++ b/test/i18n_util_tests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/devboard/i18n/i18n_util.h"
+
+// Host tests for the i18n stack's pure helpers: catalog filename validation
+// and the installed-language listing.
+
+TEST(I18nUtilTest, ValidFilenames) {
+  EXPECT_TRUE(is_valid_i18n_filename("sv.json.gz"));
+  EXPECT_TRUE(is_valid_i18n_filename("uk.json.gz"));
+  EXPECT_TRUE(is_valid_i18n_filename("pt-BR.json.gz"));
+  EXPECT_TRUE(is_valid_i18n_filename("sv.blp"));
+  EXPECT_TRUE(is_valid_i18n_filename("pt-BR.blp"));
+}
+
+TEST(I18nUtilTest, InvalidFilenames) {
+  EXPECT_FALSE(is_valid_i18n_filename(""));
+  EXPECT_FALSE(is_valid_i18n_filename("s.json.gz"));
+  EXPECT_FALSE(is_valid_i18n_filename("SV.json.gz"));
+  EXPECT_FALSE(is_valid_i18n_filename("sve.json.gz"));
+  EXPECT_FALSE(is_valid_i18n_filename("sv.json"));
+  EXPECT_FALSE(is_valid_i18n_filename("sv-br.json.gz"));
+  EXPECT_FALSE(is_valid_i18n_filename("sv.json.gz.bak"));
+  EXPECT_FALSE(is_valid_i18n_filename("../sv.json.gz"));
+  EXPECT_FALSE(is_valid_i18n_filename("sv/../x.json.gz"));
+}
+
+TEST(I18nUtilTest, LanguageFromFilename) {
+  EXPECT_STREQ(i18n_language_from_filename("sv.json.gz").c_str(), "sv");
+  EXPECT_STREQ(i18n_language_from_filename("pt-BR.blp").c_str(), "pt-BR");
+  EXPECT_STREQ(i18n_language_from_filename("nonsense").c_str(), "");
+}
+
+TEST(I18nUtilTest, ListJsonDeduplicatesAcrossFormats) {
+  std::vector<String> files = {"sv.json.gz", "sv.blp", "fi.json.gz", "junk.txt"};
+  String json = i18n_list_json(files, "sv");
+  EXPECT_STREQ(json.c_str(), "{\"active\":\"sv\",\"languages\":[\"sv\",\"fi\"]}");
+}
+
+TEST(I18nUtilTest, ListJsonEmptyStorage) {
+  std::vector<String> files;
+  String json = i18n_list_json(files, "");
+  EXPECT_STREQ(json.c_str(), "{\"active\":\"\",\"languages\":[]}");
+}


### PR DESCRIPTION
## What

Adds the storage and UI plumbing for language support — no strings are translated by this PR, and a stock device behaves exactly as today.

- **Catalog storage on the existing `spiffs` partition** — the partition every board already has, mounted by nothing today. Storage is a small raw slot store (~4 KB of code) directly on `esp_partition_*`: a double-buffered, CRC'd, sequence-numbered directory plus data extents. Every mutation commits by flipping to the older directory block, so power loss at any point — including mid-upload — leaves the previous state fully intact. No filesystem driver: linking LittleFS costs ~80 KB of flash, which the 4 MB boards' OTA slot cannot absorb; this feature needs at most a handful of rarely-written blobs.
- **`LANGUAGE` setting** (NVS-backed, empty = English) with a live `/updateLanguage` route.
- **`/api/i18n` endpoints**: list (with active language), serve (gzip catalogs and raw packs, with ETag/If-None-Match revalidation), validated atomic upload (128 KB cap, atomic via staging + directory flip), delete, and an explicit format action (the store is never auto-formatted).
- **Languages panel** on the settings page (between Hardware config and Integration settings): selector, drag-drop upload, delete, format.

## Why the partition is safe to take

Nothing in the tree mounts or writes the `spiffs` partition today, on any board. No partition-table change, so it is OTA-safe fleet-wide; an unformatted partition simply means the feature is off until a user explicitly formats it.

## Flash cost

Under 10 KB once (measured on the warning-check env: +9.2 KB). The companion PR (string conversion) more than pays it back — the pair nets **about −20 KB** vs current main; numbers there.

## Testing

- Host suite: slot-store power-loss-mid-upload, replace-then-power-loss, corrupted-directory recovery, compaction, full-store rejection, filename validation.
- Hardware-verified on an 8 MB board: format on a dirty partition, upload/list/serve/delete round-trips, invalid-name and oversize rejection, language selection persisting across hard resets, catalogs surviving app reflash, ETag 304 revalidation, and graceful boot with the feature off on an untouched partition.

Note: drafted with AI assistance, reviewed by me.
