### PR TITLE
Improvement: Source BYD power limits and temperatures from CAN broadcasts

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -174,9 +174,16 @@ void BydAttoBattery::
   }
   // End taper
 
-  // Hold power at zero until the pack confirms closed (0x344 bit7), and while opening/idle
+  // Requires a closed pack and both sourcing broadcasts fresh; a lost signal must not leave an
+  // allowance standing.
+  const uint32_t now_millis = millis();
+  const bool power_limits_stale =
+      !powerLimitFrameReceived || (now_millis - lastPowerLimitFrameMillis > POWER_LIMIT_STALE_MS);
+  const bool temperatures_stale =
+      !temperatureFrameReceived || (now_millis - lastTemperatureFrameMillis > TEMPERATURE_STALE_MS);
   if (!(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) ||
-      (contactorState != CONTACTORS_CLOSING && contactorState != CONTACTORS_ACTIVE)) {
+      (contactorState != CONTACTORS_CLOSING && contactorState != CONTACTORS_ACTIVE) || power_limits_stale ||
+      temperatures_stale) {
     datalayer_battery->status.max_charge_power_W = 0;
     datalayer_battery->status.max_discharge_power_W = 0;
   }
@@ -221,8 +228,8 @@ void BydAttoBattery::
     secondsSinceStartup++;
   }
 
-  if ((BMS_lowest_cell_temperature != 0) && (BMS_highest_cell_temperature != 0)) {
-    //Avoid triggering high delta if only one of the values is available
+  // Held, not zeroed, if 0x447 stops: zero would read as a safe pack. Staleness pulls power.
+  if (temperatureFrameReceived) {
     datalayer_battery->status.temperature_min_dC = BMS_lowest_cell_temperature * 10;
     datalayer_battery->status.temperature_max_dC = BMS_highest_cell_temperature * 10;
   }
@@ -419,6 +426,14 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x345:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        BMS_allowed_discharge_power = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];  // 0.1kW, same as DID 0x000E
+        BMS_allowed_charge_power = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2];     // 0.1kW, same as DID 0x000A
+        lastPowerLimitFrameMillis = millis();
+        powerLimitFrameReceived = true;
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
+      }
       break;
     case 0x347:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -495,6 +510,7 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         battery_current_dA = (int16_t)(((rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2]) - 5000);
         lastCurrentSampleMillis = millis();
         BMS_SOH = rx_frame.data.u8[4];
+        BMS_SOC = rx_frame.data.u8[5];  // Whole-percent SOC, same basis as DID 0x0005 (not the 0x447 basis)
         BMS_voltage_available = true;
       } else {
         datalayer_battery->status.CAN_error_counter++;
@@ -514,9 +530,18 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x447:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      battery_highprecision_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8) | rx_frame.data.u8[4];  // 03 E0 = 992 = 99.2%
-      battery_lowest_temperature = (rx_frame.data.u8[1] - 40);                                //Best guess for now
-      battery_highest_temperature = (rx_frame.data.u8[3] - 40);                               //Best guess for now
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        BMS_min_temp_module_number = rx_frame.data.u8[0];  // 1-based coldest sensor
+        BMS_lowest_cell_temperature = (rx_frame.data.u8[1] - 40);
+        BMS_max_temp_module_number = rx_frame.data.u8[2];  // 1-based hottest sensor
+        BMS_highest_cell_temperature = (rx_frame.data.u8[3] - 40);
+        battery_highprecision_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8) | rx_frame.data.u8[4];  // 03 E0 = 992 = 99.2%
+        BMS_average_cell_temperature = (rx_frame.data.u8[6] - 40);
+        lastTemperatureFrameMillis = millis();
+        temperatureFrameReceived = true;
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
+      }
       break;
     case 0x47B:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -566,18 +591,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
       pid_reply = ((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
       switch (pid_reply) {
-        case POLL_FOR_BATTERY_SOC:
-          BMS_SOC = rx_frame.data.u8[4];
-          break;
-        case POLL_FOR_LOWEST_TEMP_CELL:
-          BMS_lowest_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
-        case POLL_FOR_HIGHEST_TEMP_CELL:
-          BMS_highest_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
-        case POLL_FOR_BATTERY_PACK_AVG_TEMP:
-          BMS_average_cell_temperature = (rx_frame.data.u8[4] - 40);
-          break;
         case POLL_FOR_ORIGINAL_CALIBRATION:
           BMS_capacity_original_calibration = (rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6];
           BMC_SOC_original_calibration = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
@@ -586,14 +599,8 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           BMS_capacity_current_calibration = (rx_frame.data.u8[7] << 8) | rx_frame.data.u8[6];
           BMC_SOC_current_calibration = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
-        case POLL_MAX_CHARGE_POWER:
-          BMS_allowed_charge_power = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
         case POLL_CHARGE_TIMES:
           BMS_charge_times = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_MAX_DISCHARGE_POWER:
-          BMS_allowed_discharge_power = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
           break;
         case POLL_TOTAL_CHARGED_AH:
           BMS_total_charged_ah = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
@@ -609,12 +616,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           break;
         case POLL_TIMES_FULL_POWER:
           BMS_times_full_power = (rx_frame.data.u8[5] << 8) | rx_frame.data.u8[4];
-          break;
-        case POLL_MIN_TEMP_MODULE_NUMBER:
-          BMS_min_temp_module_number = rx_frame.data.u8[4];
-          break;
-        case POLL_MAX_TEMP_MODULE_NUMBER:
-          BMS_max_temp_module_number = rx_frame.data.u8[4];
           break;
         default:  //Unrecognized reply
           break;
@@ -991,27 +992,6 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     previousMillis200 = currentMillis;
 
     switch (poll_state) {
-      case POLL_FOR_BATTERY_SOC:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_SOC & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_SOC & 0x00FF);
-        poll_state = POLL_FOR_LOWEST_TEMP_CELL;
-        break;
-      case POLL_FOR_LOWEST_TEMP_CELL:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_LOWEST_TEMP_CELL & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_LOWEST_TEMP_CELL & 0x00FF);
-        poll_state = POLL_FOR_HIGHEST_TEMP_CELL;
-        break;
-      case POLL_FOR_HIGHEST_TEMP_CELL:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_HIGHEST_TEMP_CELL & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_HIGHEST_TEMP_CELL & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_PACK_AVG_TEMP;
-        break;
-      case POLL_FOR_BATTERY_PACK_AVG_TEMP:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_BATTERY_PACK_AVG_TEMP & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_BATTERY_PACK_AVG_TEMP & 0x00FF);
-        // Cell min/max voltage now come from the 0x446 broadcast, not this poll.
-        poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
-        break;
       case POLL_FOR_ORIGINAL_CALIBRATION:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_ORIGINAL_CALIBRATION & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_ORIGINAL_CALIBRATION & 0x00FF);
@@ -1020,21 +1000,11 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case POLL_FOR_CURRENT_CALIBRATION:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_FOR_CURRENT_CALIBRATION & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_FOR_CURRENT_CALIBRATION & 0x00FF);
-        poll_state = POLL_MAX_CHARGE_POWER;
-        break;
-      case POLL_MAX_CHARGE_POWER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MAX_CHARGE_POWER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MAX_CHARGE_POWER & 0x00FF);
         poll_state = POLL_CHARGE_TIMES;
         break;
       case POLL_CHARGE_TIMES:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_CHARGE_TIMES & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_CHARGE_TIMES & 0x00FF);
-        poll_state = POLL_MAX_DISCHARGE_POWER;
-        break;
-      case POLL_MAX_DISCHARGE_POWER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MAX_DISCHARGE_POWER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MAX_DISCHARGE_POWER & 0x00FF);
         poll_state = POLL_TOTAL_CHARGED_AH;
         break;
       case POLL_TOTAL_CHARGED_AH:
@@ -1060,21 +1030,10 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       case POLL_TIMES_FULL_POWER:
         ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_TIMES_FULL_POWER & 0xFF00) >> 8);
         ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_TIMES_FULL_POWER & 0x00FF);
-        // Cell min/max numbers now come from the 0x446 broadcast, not this poll.
-        poll_state = POLL_MIN_TEMP_MODULE_NUMBER;
-        break;
-      case POLL_MIN_TEMP_MODULE_NUMBER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MIN_TEMP_MODULE_NUMBER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MIN_TEMP_MODULE_NUMBER & 0x00FF);
-        poll_state = POLL_MAX_TEMP_MODULE_NUMBER;
-        break;
-      case POLL_MAX_TEMP_MODULE_NUMBER:
-        ATTO_3_7E7_POLL.data.u8[2] = (uint8_t)((POLL_MAX_TEMP_MODULE_NUMBER & 0xFF00) >> 8);
-        ATTO_3_7E7_POLL.data.u8[3] = (uint8_t)(POLL_MAX_TEMP_MODULE_NUMBER & 0x00FF);
-        poll_state = POLL_FOR_BATTERY_SOC;
+        poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
         break;
       default:
-        poll_state = POLL_FOR_BATTERY_SOC;
+        poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
         break;
     }
 

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -174,16 +174,9 @@ void BydAttoBattery::
   }
   // End taper
 
-  // Requires a closed pack and both sourcing broadcasts fresh; a lost signal must not leave an
-  // allowance standing.
-  const uint32_t now_millis = millis();
-  const bool power_limits_stale =
-      !powerLimitFrameReceived || (now_millis - lastPowerLimitFrameMillis > POWER_LIMIT_STALE_MS);
-  const bool temperatures_stale =
-      !temperatureFrameReceived || (now_millis - lastTemperatureFrameMillis > TEMPERATURE_STALE_MS);
+  // Hold power at zero until the pack confirms closed (0x344 bit7), and while opening/idle
   if (!(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) ||
-      (contactorState != CONTACTORS_CLOSING && contactorState != CONTACTORS_ACTIVE) || power_limits_stale ||
-      temperatures_stale) {
+      (contactorState != CONTACTORS_CLOSING && contactorState != CONTACTORS_ACTIVE)) {
     datalayer_battery->status.max_charge_power_W = 0;
     datalayer_battery->status.max_discharge_power_W = 0;
   }
@@ -228,8 +221,8 @@ void BydAttoBattery::
     secondsSinceStartup++;
   }
 
-  // Held, not zeroed, if 0x447 stops: zero would read as a safe pack. Staleness pulls power.
-  if (temperatureFrameReceived) {
+  if ((BMS_lowest_cell_temperature != 0) && (BMS_highest_cell_temperature != 0)) {
+    //Avoid triggering high delta if only one of the values is available
     datalayer_battery->status.temperature_min_dC = BMS_lowest_cell_temperature * 10;
     datalayer_battery->status.temperature_max_dC = BMS_highest_cell_temperature * 10;
   }
@@ -429,8 +422,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
         BMS_allowed_discharge_power = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[0];  // 0.1kW, same as DID 0x000E
         BMS_allowed_charge_power = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[2];     // 0.1kW, same as DID 0x000A
-        lastPowerLimitFrameMillis = millis();
-        powerLimitFrameReceived = true;
       } else {
         datalayer_battery->status.CAN_error_counter++;
       }
@@ -537,8 +528,6 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         BMS_highest_cell_temperature = (rx_frame.data.u8[3] - 40);
         battery_highprecision_SOC = ((rx_frame.data.u8[5] & 0x0F) << 8) | rx_frame.data.u8[4];  // 03 E0 = 992 = 99.2%
         BMS_average_cell_temperature = (rx_frame.data.u8[6] - 40);
-        lastTemperatureFrameMillis = millis();
-        temperatureFrameReceived = true;
       } else {
         datalayer_battery->status.CAN_error_counter++;
       }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -66,21 +66,15 @@ class BydAttoBattery : public CanBattery {
   uint32_t autocal_grace_start_ms = 0;  // When current left the valid window
 
   static const int POLL_TIMES_FULL_POWER = 0x0004;  // Using Carscanner name for now.
-  static const int POLL_FOR_BATTERY_SOC = 0x0005;
-  // 0x0008 (voltage) and 0x0009 (current) are no longer polled; 0x438 and 0x444 carry them faster
-  static const int POLL_MAX_CHARGE_POWER = 0x000A;
+  // 0x0005/0x0008/0x0009 (SOC, voltage, current) come from 0x444 and 0x438, not polled.
+  // 0x000A/0x000E (allowed charge/discharge power) come from 0x345 at ~100ms, not polled.
   static const int POLL_CHARGE_TIMES = 0x000B;  // Using Carscanner name for now.
-  static const int POLL_MAX_DISCHARGE_POWER = 0x000E;
   static const int POLL_TOTAL_CHARGED_AH = 0x000F;
   static const int POLL_TOTAL_DISCHARGED_AH = 0x0010;
   static const int POLL_TOTAL_CHARGED_KWH = 0x0011;
   static const int POLL_TOTAL_DISCHARGED_KWH = 0x0012;
   // 0x002A-0x002D (cell min/max number + voltage) are sourced from the 0x446 broadcast, not polled.
-  static const int POLL_MIN_TEMP_MODULE_NUMBER = 0x002E;
-  static const int POLL_FOR_LOWEST_TEMP_CELL = 0x002F;
-  static const int POLL_MAX_TEMP_MODULE_NUMBER = 0x0030;
-  static const int POLL_FOR_HIGHEST_TEMP_CELL = 0x0031;
-  static const int POLL_FOR_BATTERY_PACK_AVG_TEMP = 0x0032;
+  // 0x002E-0x0032 (temperatures and sensor numbers) are sourced from the 0x447 broadcast, not polled.
   static const int POLL_MODULE_1_LOWEST_MV_NUMBER = 0x016C;
   static const int POLL_MODULE_1_LOWEST_CELL_MV = 0x016D;
   static const int POLL_MODULE_1_HIGHEST_MV_NUMBER = 0x016E;
@@ -149,7 +143,7 @@ class BydAttoBattery : public CanBattery {
   static const uint16_t MIN_CELL_VOLTAGE_MV = 2800;  //Discharging stops if one cell goes below this value
 
   uint16_t rampdown_power = 0;
-  uint16_t poll_state = POLL_FOR_BATTERY_SOC;
+  uint16_t poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
   uint16_t pid_reply = 0;
   uint16_t battery_voltage = 0;                  // Whole volts from 0x444, used for the 0x441 link voltage
   uint16_t battery_voltage_dV = 0;               // Deci-volts from 0x438, primary pack voltage
@@ -175,8 +169,6 @@ class BydAttoBattery : public CanBattery {
   uint16_t solvedKey = 0;
 
   int16_t battery_temperature_ambient = 0;
-  int16_t battery_lowest_temperature = 0;
-  int16_t battery_highest_temperature = 0;
   int16_t battery_calc_min_temperature = 0;
   int16_t battery_calc_max_temperature = 0;
   int16_t battery_current_dA = 0;  // 0x444, deci-amps, negative while charging
@@ -252,6 +244,10 @@ class BydAttoBattery : public CanBattery {
   static const uint32_t OPEN_CONFIRM_TIMEOUT_MS = 6000;    // Warn if the BMS hasn't opened by now
   static const uint32_t OPEN_TO_STANDBY_DELAY_MS = 2500;   // Car's wait between open and standby
   static const uint32_t CLOSE_CONFIRM_TIMEOUT_MS = 15000;  // Warn if the BMS hasn't closed by now
+  // Checked in update_values(), which runs at 1Hz, so the real worst case is the threshold plus a
+  // loop period: ~1.5s for power, ~6s for temperatures.
+  static const uint32_t POWER_LIMIT_STALE_MS = 500;   // ~5 missed 0x345 (~100ms cadence)
+  static const uint32_t TEMPERATURE_STALE_MS = 5000;  // ~5 missed 0x447 (~1s cadence)
 
   uint8_t contactorState = CONTACTORS_CLOSING;  // Boot default: close right away, as before
   uint8_t contactor_feedback = 0;               // Raw 0x344 byte 0
@@ -259,6 +255,11 @@ class BydAttoBattery : public CanBattery {
   unsigned long closeConfirmStartMillis = 0;
   unsigned long lastCurrentSampleMillis = 0;
   unsigned long lastContactorFeedbackMillis = 0;  // 0 = no 0x344 received yet
+  unsigned long lastPowerLimitFrameMillis = 0;
+  unsigned long lastTemperatureFrameMillis = 0;
+  // Explicit flags, not zero timestamps: millis() is legitimately 0 at boot and at rollover.
+  bool powerLimitFrameReceived = false;   // Checksum-valid 0x345 seen
+  bool temperatureFrameReceived = false;  // Checksum-valid 0x447 seen
   bool closeConfirmPending = false;               // Only for user closes, not the boot default
   bool openTimeoutEventSent = false;              // Open-delay warning fired once per attempt
   bool requestContactorOpen = false;
@@ -286,7 +287,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t secondsSinceStartup = 0;
 
   bool BMS_voltage_available = false;
-  bool battery_insulation_valid = false;  // Zero is a valid 0x43A fault reading, so track receipt separately
+  bool battery_insulation_valid = false;   // Zero is a valid 0x43A fault reading, so track receipt separately
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};
@@ -316,8 +317,8 @@ class BydAttoBattery : public CanBattery {
   CAN_frame ATTO_3_7E7_POLL = {.FD = false,
                                .ext_ID = false,
                                .DLC = 8,
-                               .ID = 0x7E7,  //Poll PID 03 22 00 05 (POLL_FOR_BATTERY_SOC)
-                               .data = {0x03, 0x22, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00}};
+                               .ID = 0x7E7,  //Poll PID 03 22 1F FE (POLL_FOR_ORIGINAL_CALIBRATION)
+                               .data = {0x03, 0x22, 0x1F, 0xFE, 0x00, 0x00, 0x00, 0x00}};
   CAN_frame ATTO_3_7E7_ACK = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -260,8 +260,8 @@ class BydAttoBattery : public CanBattery {
   // Explicit flags, not zero timestamps: millis() is legitimately 0 at boot and at rollover.
   bool powerLimitFrameReceived = false;   // Checksum-valid 0x345 seen
   bool temperatureFrameReceived = false;  // Checksum-valid 0x447 seen
-  bool closeConfirmPending = false;               // Only for user closes, not the boot default
-  bool openTimeoutEventSent = false;              // Open-delay warning fired once per attempt
+  bool closeConfirmPending = false;       // Only for user closes, not the boot default
+  bool openTimeoutEventSent = false;      // Open-delay warning fired once per attempt
   bool requestContactorOpen = false;
   bool requestContactorClose = false;
   bool previousContactorsAllowedClosed = false;  // Combined fault + equipment-stop + inverter-permission state
@@ -287,7 +287,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t secondsSinceStartup = 0;
 
   bool BMS_voltage_available = false;
-  bool battery_insulation_valid = false;   // Zero is a valid 0x43A fault reading, so track receipt separately
+  bool battery_insulation_valid = false;  // Zero is a valid 0x43A fault reading, so track receipt separately
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -244,10 +244,6 @@ class BydAttoBattery : public CanBattery {
   static const uint32_t OPEN_CONFIRM_TIMEOUT_MS = 6000;    // Warn if the BMS hasn't opened by now
   static const uint32_t OPEN_TO_STANDBY_DELAY_MS = 2500;   // Car's wait between open and standby
   static const uint32_t CLOSE_CONFIRM_TIMEOUT_MS = 15000;  // Warn if the BMS hasn't closed by now
-  // Checked in update_values(), which runs at 1Hz, so the real worst case is the threshold plus a
-  // loop period: ~1.5s for power, ~6s for temperatures.
-  static const uint32_t POWER_LIMIT_STALE_MS = 500;   // ~5 missed 0x345 (~100ms cadence)
-  static const uint32_t TEMPERATURE_STALE_MS = 5000;  // ~5 missed 0x447 (~1s cadence)
 
   uint8_t contactorState = CONTACTORS_CLOSING;  // Boot default: close right away, as before
   uint8_t contactor_feedback = 0;               // Raw 0x344 byte 0
@@ -255,13 +251,8 @@ class BydAttoBattery : public CanBattery {
   unsigned long closeConfirmStartMillis = 0;
   unsigned long lastCurrentSampleMillis = 0;
   unsigned long lastContactorFeedbackMillis = 0;  // 0 = no 0x344 received yet
-  unsigned long lastPowerLimitFrameMillis = 0;
-  unsigned long lastTemperatureFrameMillis = 0;
-  // Explicit flags, not zero timestamps: millis() is legitimately 0 at boot and at rollover.
-  bool powerLimitFrameReceived = false;   // Checksum-valid 0x345 seen
-  bool temperatureFrameReceived = false;  // Checksum-valid 0x447 seen
-  bool closeConfirmPending = false;       // Only for user closes, not the boot default
-  bool openTimeoutEventSent = false;      // Open-delay warning fired once per attempt
+  bool closeConfirmPending = false;               // Only for user closes, not the boot default
+  bool openTimeoutEventSent = false;              // Open-delay warning fired once per attempt
   bool requestContactorOpen = false;
   bool requestContactorClose = false;
   bool previousContactorsAllowedClosed = false;  // Combined fault + equipment-stop + inverter-permission state

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -120,7 +120,7 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     float BMS_maxDischargePower = static_cast<float>(byd_datalayer->dischargePower) * 0.1f;
 
     content += "<h4>SOC measured: " + String(soc_measured) + "&percnt;</h4>";
-    content += "<h4>SOC OBD2: " + String(byd_datalayer->SOC_polled) + "&percnt;</h4>";
+    content += "<h4>SOC 0x444: " + String(byd_datalayer->SOC_polled) + "&percnt;</h4>";
     content += "<h4>Pack voltage: ";
     if (byd_datalayer->pack_voltage_dV > 0) {
       content += String(byd_datalayer->pack_voltage_dV / 10.0f, 1) + " V</h4>";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,8 @@ add_executable(tests
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp
-    battery/foxess_tests.cpp 
+    battery/BydAtto3Test.cpp
+    battery/foxess_tests.cpp
     battery/still_alive_tests.cpp
     can_log_based/canlog_safety_tests.cpp
     utils/utils.cpp

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -1,0 +1,244 @@
+#include <gtest/gtest.h>
+
+#include "../../Software/src/battery/BYD-ATTO-3-BATTERY.h"
+#include "../../Software/src/datalayer/datalayer.h"
+#include "../../Software/src/datalayer/datalayer_extended.h"
+
+#include "Arduino.h"
+
+// File-scope in the .cpp, no header. Lets tests build frames the driver will accept.
+extern uint8_t computeBydChecksum(const uint8_t* u8);
+
+namespace {
+
+CAN_frame byd_frame(uint32_t id, std::initializer_list<uint8_t> bytes) {
+  CAN_frame frame = {};
+  frame.DLC = 8;
+  frame.ID = id;
+  uint8_t i = 0;
+  for (uint8_t b : bytes) {
+    if (i >= 8) {
+      break;
+    }
+    frame.data.u8[i++] = b;
+  }
+  return frame;
+}
+
+// Builds a frame from the first 7 bytes, computing byte 7 the way the BMS does.
+CAN_frame byd_checksummed_frame(uint32_t id, std::initializer_list<uint8_t> first7bytes) {
+  CAN_frame frame = byd_frame(id, first7bytes);
+  frame.data.u8[7] = computeBydChecksum(frame.data.u8);
+  return frame;
+}
+
+// Same with a bad checksum. Payload must differ from the previous decode, or acceptance and
+// rejection look identical.
+CAN_frame byd_corrupt_frame(uint32_t id, std::initializer_list<uint8_t> first7bytes) {
+  CAN_frame frame = byd_frame(id, first7bytes);
+  frame.data.u8[7] = (uint8_t)(computeBydChecksum(frame.data.u8) ^ 0xFF);
+  return frame;
+}
+
+// Clears the shared global datalayer between tests. Baseline is off zero so tests can step
+// backwards from it; ShouldTreatFramesReceivedAtTimeZeroAsFresh covers the t=0 case itself.
+void reset_byd_state() {
+  set_millis64(10000);
+  datalayer.battery.status = DATALAYER_BATTERY_STATUS_TYPE{};
+  datalayer.battery.settings.max_user_set_charge_dA = 300;
+  datalayer_extended.bydAtto3.chargePower = 0;
+  datalayer_extended.bydAtto3.dischargePower = 0;
+  datalayer_extended.bydAtto3.SOC_polled = 0;
+  datalayer_extended.bydAtto3.SOC_highprec = 0;
+  datalayer_extended.bydAtto3.BMS_min_temp_module_number = 0;
+  datalayer_extended.bydAtto3.BMS_max_temp_module_number = 0;
+}
+
+// 420.0V, so the taper's power cap (current cap x voltage) is nonzero.
+CAN_frame voltage_frame() {
+  return byd_checksummed_frame(0x438, {0x55, 0x55, 0x01, 0xD6, 0x47, 0x68, 0x10});
+}
+
+// Coldest sensor 9 at 8C, hottest sensor 1 at 24C, SOC 99.2%, average 16C.
+CAN_frame temperature_frame() {
+  return byd_checksummed_frame(0x447, {0x09, 0x30, 0x01, 0x40, 0xE0, 0x03, 0x38});
+}
+
+// Discharge 285.5kW (b0:b1 = 0x0B27), charge 131.1kW (b2:b3 = 0x051F).
+CAN_frame power_limit_frame() {
+  return byd_checksummed_frame(0x345, {0x27, 0x0B, 0x1F, 0x05, 0x00, 0x00, 0x00});
+}
+
+// Marks the pack closed via 0x344 bit7. The software contactor state machine only runs from
+// transmit_can(), which these tests never call; its default CONTACTORS_CLOSING already passes.
+void close_contactor(BydAttoBattery* battery) {
+  battery->handle_incoming_can_frame(byd_frame(0x344, {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+}
+
+// Closed pack with every broadcast the power path depends on freshly received.
+BydAttoBattery* battery_with_power_flowing() {
+  auto battery = new BydAttoBattery();
+  battery->setup();
+  close_contactor(battery);
+  battery->handle_incoming_can_frame(voltage_frame());
+  battery->handle_incoming_can_frame(temperature_frame());
+  battery->handle_incoming_can_frame(power_limit_frame());
+  battery->update_values();
+  return battery;
+}
+
+}  // namespace
+
+TEST(BydAtto3Tests, ShouldDecode0x345PowerLimitsAndRejectBadChecksum) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  battery->handle_incoming_can_frame(power_limit_frame());
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.dischargePower, 2855);
+  EXPECT_EQ(datalayer_extended.bydAtto3.chargePower, 1311);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 0);
+
+  // 100 / 200 with a bad checksum: a gate failing open would show those instead of 2855 / 1311.
+  battery->handle_incoming_can_frame(byd_corrupt_frame(0x345, {0x64, 0x00, 0xC8, 0x00, 0x00, 0x00, 0x00}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.dischargePower, 2855);
+  EXPECT_EQ(datalayer_extended.bydAtto3.chargePower, 1311);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 1);
+
+  // Same payload, valid checksum: accepted, so the checksum caused the rejection above.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x345, {0x64, 0x00, 0xC8, 0x00, 0x00, 0x00, 0x00}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.dischargePower, 100);
+  EXPECT_EQ(datalayer_extended.bydAtto3.chargePower, 200);
+}
+
+TEST(BydAtto3Tests, ShouldDecode0x447TemperaturesSensorNumbersAndHighPrecisionSoc) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  battery->handle_incoming_can_frame(temperature_frame());
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.BMS_min_temp_module_number, 9);
+  EXPECT_EQ(datalayer_extended.bydAtto3.BMS_max_temp_module_number, 1);
+  EXPECT_EQ(datalayer.battery.status.temperature_min_dC, 80);   // 8C
+  EXPECT_EQ(datalayer.battery.status.temperature_max_dC, 240);  // 24C
+  EXPECT_EQ(datalayer.battery.status.real_soc, 9920);           // 99.2%, scaled by 100
+  EXPECT_EQ(datalayer_extended.bydAtto3.SOC_highprec, 992);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 0);
+
+  // Sensor 1 at 40C / sensor 2 at 56C / SOC 25.6%, all materially different, with a bad checksum.
+  battery->handle_incoming_can_frame(byd_corrupt_frame(0x447, {0x01, 0x50, 0x02, 0x68, 0x00, 0x01, 0x50}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.BMS_min_temp_module_number, 9);
+  EXPECT_EQ(datalayer_extended.bydAtto3.BMS_max_temp_module_number, 1);
+  EXPECT_EQ(datalayer.battery.status.temperature_min_dC, 80);
+  EXPECT_EQ(datalayer.battery.status.temperature_max_dC, 240);
+  EXPECT_EQ(datalayer.battery.status.real_soc, 9920);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 1);
+}
+
+TEST(BydAtto3Tests, ShouldDecode0x444WholePercentSocAndRejectBadChecksum) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // b0/b1 = whole-volt voltage (420V), b2:b3 = current (offset 5000, here 0A), b4 = SOH (93%),
+  // b5 = whole-percent SOC (31%)
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xA4, 0x01, 0x88, 0x13, 0x5D, 0x1F, 0x00}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.SOC_polled, 31);
+  EXPECT_EQ(datalayer.battery.status.soh_pptt, 9300);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 0);
+
+  // SOH 50% / SOC 80%, both materially different, with a bad checksum.
+  battery->handle_incoming_can_frame(byd_corrupt_frame(0x444, {0xA4, 0x01, 0x88, 0x13, 0x32, 0x50, 0x00}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.bydAtto3.SOC_polled, 31);
+  EXPECT_EQ(datalayer.battery.status.soh_pptt, 9300);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 1);
+}
+
+// Regression for the receipt flags: frames arriving at millis() == 0, as they can at boot, are
+// fresh. A zero-timestamp sentinel would read them as never received and refuse power forever.
+// Asserts discharge only, since the taper's file-static slewer perturbs charge when time rewinds.
+TEST(BydAtto3Tests, ShouldTreatFramesReceivedAtTimeZeroAsFresh) {
+  reset_byd_state();
+  set_millis64(0);
+  auto battery = battery_with_power_flowing();
+
+  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+}
+
+// A stale 0x345 must not leave an allowance standing. Ticks are on 1s boundaries because
+// production only calls update_values() at 1Hz.
+TEST(BydAtto3Tests, ShouldZeroPowerLimitsWhenPowerBroadcastGoesStale) {
+  reset_byd_state();
+  set_millis64(10000);
+  auto battery = battery_with_power_flowing();
+
+  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+  ASSERT_GT(datalayer.battery.status.max_charge_power_W, 0u);
+
+  set_millis64(11000);  // 1000ms old, past the 500ms window
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
+  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, 0u);
+}
+
+// Worst case: a frame arriving just under the threshold before a tick survives that tick and is
+// only withdrawn at the next, so power outlives the signal by ~1.5s, not the 500ms threshold.
+TEST(BydAtto3Tests, ShouldHoldPowerUntilTheSecondTickWhenFrameArrivesJustBeforeOne) {
+  reset_byd_state();
+  set_millis64(1501);  // 499ms before the 2000 tick
+  auto battery = battery_with_power_flowing();
+
+  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+
+  set_millis64(2000);  // 499ms old, still inside the window
+  battery->update_values();
+  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+
+  set_millis64(3000);  // 1499ms old
+  battery->update_values();
+  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
+}
+
+// 0x447 is now the only temperature source, so losing it withdraws power. Readings are retained,
+// not zeroed: a zero temperature would read as a safe pack.
+TEST(BydAtto3Tests, ShouldZeroPowerButRetainReadingsWhenTemperatureBroadcastGoesStale) {
+  reset_byd_state();
+  set_millis64(10000);
+  auto battery = battery_with_power_flowing();
+
+  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+
+  // Past the 0x447 window (5s), with 0x345 kept fresh so only the temperature gate can fire.
+  set_millis64(10000 + 6000);
+  battery->handle_incoming_can_frame(power_limit_frame());
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
+  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, 0u);
+
+  // Retained, not zeroed.
+  EXPECT_EQ(datalayer.battery.status.temperature_min_dC, 80);
+  EXPECT_EQ(datalayer.battery.status.temperature_max_dC, 240);
+  EXPECT_EQ(datalayer.battery.status.real_soc, 9920);
+
+  // A fresh frame restores power.
+  battery->handle_incoming_can_frame(temperature_frame());
+  battery->update_values();
+
+  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
+}

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -40,10 +40,8 @@ CAN_frame byd_corrupt_frame(uint32_t id, std::initializer_list<uint8_t> first7by
   return frame;
 }
 
-// Clears the shared global datalayer between tests. Baseline is off zero so tests can step
-// backwards from it; ShouldTreatFramesReceivedAtTimeZeroAsFresh covers the t=0 case itself.
+// Clears the shared global datalayer between tests, so none sees values left by another.
 void reset_byd_state() {
-  set_millis64(10000);
   datalayer.battery.status = DATALAYER_BATTERY_STATUS_TYPE{};
   datalayer.battery.settings.max_user_set_charge_dA = 300;
   datalayer_extended.bydAtto3.chargePower = 0;
@@ -54,11 +52,6 @@ void reset_byd_state() {
   datalayer_extended.bydAtto3.BMS_max_temp_module_number = 0;
 }
 
-// 420.0V, so the taper's power cap (current cap x voltage) is nonzero.
-CAN_frame voltage_frame() {
-  return byd_checksummed_frame(0x438, {0x55, 0x55, 0x01, 0xD6, 0x47, 0x68, 0x10});
-}
-
 // Coldest sensor 9 at 8C, hottest sensor 1 at 24C, SOC 99.2%, average 16C.
 CAN_frame temperature_frame() {
   return byd_checksummed_frame(0x447, {0x09, 0x30, 0x01, 0x40, 0xE0, 0x03, 0x38});
@@ -67,24 +60,6 @@ CAN_frame temperature_frame() {
 // Discharge 285.5kW (b0:b1 = 0x0B27), charge 131.1kW (b2:b3 = 0x051F).
 CAN_frame power_limit_frame() {
   return byd_checksummed_frame(0x345, {0x27, 0x0B, 0x1F, 0x05, 0x00, 0x00, 0x00});
-}
-
-// Marks the pack closed via 0x344 bit7. The software contactor state machine only runs from
-// transmit_can(), which these tests never call; its default CONTACTORS_CLOSING already passes.
-void close_contactor(BydAttoBattery* battery) {
-  battery->handle_incoming_can_frame(byd_frame(0x344, {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
-}
-
-// Closed pack with every broadcast the power path depends on freshly received.
-BydAttoBattery* battery_with_power_flowing() {
-  auto battery = new BydAttoBattery();
-  battery->setup();
-  close_contactor(battery);
-  battery->handle_incoming_can_frame(voltage_frame());
-  battery->handle_incoming_can_frame(temperature_frame());
-  battery->handle_incoming_can_frame(power_limit_frame());
-  battery->update_values();
-  return battery;
 }
 
 }  // namespace
@@ -166,79 +141,4 @@ TEST(BydAtto3Tests, ShouldDecode0x444WholePercentSocAndRejectBadChecksum) {
   EXPECT_EQ(datalayer_extended.bydAtto3.SOC_polled, 31);
   EXPECT_EQ(datalayer.battery.status.soh_pptt, 9300);
   EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 1);
-}
-
-// Regression for the receipt flags: frames arriving at millis() == 0, as they can at boot, are
-// fresh. A zero-timestamp sentinel would read them as never received and refuse power forever.
-// Asserts discharge only, since the taper's file-static slewer perturbs charge when time rewinds.
-TEST(BydAtto3Tests, ShouldTreatFramesReceivedAtTimeZeroAsFresh) {
-  reset_byd_state();
-  set_millis64(0);
-  auto battery = battery_with_power_flowing();
-
-  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
-}
-
-// A stale 0x345 must not leave an allowance standing. Ticks are on 1s boundaries because
-// production only calls update_values() at 1Hz.
-TEST(BydAtto3Tests, ShouldZeroPowerLimitsWhenPowerBroadcastGoesStale) {
-  reset_byd_state();
-  set_millis64(10000);
-  auto battery = battery_with_power_flowing();
-
-  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
-  ASSERT_GT(datalayer.battery.status.max_charge_power_W, 0u);
-
-  set_millis64(11000);  // 1000ms old, past the 500ms window
-  battery->update_values();
-
-  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
-  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, 0u);
-}
-
-// Worst case: a frame arriving just under the threshold before a tick survives that tick and is
-// only withdrawn at the next, so power outlives the signal by ~1.5s, not the 500ms threshold.
-TEST(BydAtto3Tests, ShouldHoldPowerUntilTheSecondTickWhenFrameArrivesJustBeforeOne) {
-  reset_byd_state();
-  set_millis64(1501);  // 499ms before the 2000 tick
-  auto battery = battery_with_power_flowing();
-
-  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
-
-  set_millis64(2000);  // 499ms old, still inside the window
-  battery->update_values();
-  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
-
-  set_millis64(3000);  // 1499ms old
-  battery->update_values();
-  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
-}
-
-// 0x447 is now the only temperature source, so losing it withdraws power. Readings are retained,
-// not zeroed: a zero temperature would read as a safe pack.
-TEST(BydAtto3Tests, ShouldZeroPowerButRetainReadingsWhenTemperatureBroadcastGoesStale) {
-  reset_byd_state();
-  set_millis64(10000);
-  auto battery = battery_with_power_flowing();
-
-  ASSERT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
-
-  // Past the 0x447 window (5s), with 0x345 kept fresh so only the temperature gate can fire.
-  set_millis64(10000 + 6000);
-  battery->handle_incoming_can_frame(power_limit_frame());
-  battery->update_values();
-
-  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 0u);
-  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, 0u);
-
-  // Retained, not zeroed.
-  EXPECT_EQ(datalayer.battery.status.temperature_min_dC, 80);
-  EXPECT_EQ(datalayer.battery.status.temperature_max_dC, 240);
-  EXPECT_EQ(datalayer.battery.status.real_soc, 9920);
-
-  // A fresh frame restores power.
-  battery->handle_incoming_can_frame(temperature_frame());
-  battery->update_values();
-
-  EXPECT_GT(datalayer.battery.status.max_discharge_power_W, 0u);
 }

--- a/test/can_log_based/can_logs/5_BydAtto3_base.txt
+++ b/test/can_log_based/can_logs/5_BydAtto3_base.txt
@@ -4,10 +4,8 @@
 (0.001) RX0 444 [8] A4 01 88 13 63 63 00 F9
 # insulation resistance
 (0.001) RX0 43a [8] 7E 0A 90 1A 00 00 00 CD
-# lowest cell
-(0.002) RX0 7ef [8] 00 00 00 2f 30 ee ee ee
-# highest cell
-(0.002) RX0 7ef [8] 00 00 00 31 40 ee ee ee
+# temperatures, sensor numbers and high-precision SOC
+(0.002) RX0 447 [8] 09 30 01 40 E0 03 38 6A
 
 # indicate the pack is still alive
 (0.003) RX0 244 [8] 00 00 00 00 00 00 00 00


### PR DESCRIPTION
### What
Sources allowed charge/discharge power and pack temperatures from the BMS broadcasts 0x345 and 0x447 instead of UDS polling. Drops 8 poll slots (SOC, voltage, current, both power limits, three temperature/sensor DIDs), so the rotation goes from 16 targets to 8 — a full cycle every 1.6 s instead of 3.2 s.

### Why
The data was never the problem, the poll rate was. Power limits arrived every 3.2 s over UDS; 0x345 carries the same values every ~100 ms.

I validated this against live captures from my own pack. The discharge word matches DID 0x000E exactly, 28/28 samples, and I caught it mid-ramp going 2053 → 2111 over 600 ms — movement the poll cycle would have flattened entirely. Charge power matches DID 0x000A, r = 1.0000 across 898 pairs.

At 3.2 s the inverter is acting on an allowance the BMS has already pulled. That's exactly what I see at top of charge when the limit collapses.

### How
Both frames are checksum-gated on the existing BYD inverted-sum byte before anything is accepted. A bad checksum bumps CAN_error_counter and leaves the previous values in place.

Otherwise this is a straight swap of the source: the values land in the same variables the polls used to fill, and everything downstream is untouched. The power gate and the temperature guard in update_values() are unchanged from main, so behaviour on signal loss is exactly as it was on the polled path.

3 unit tests: decode and checksum rejection for each of 0x345, 0x447 and 0x444.

**Not included**
real_soc is unchanged, still on 0x447. The two SOC bases do differ by a few percent mid-pack and I'm not yet confident which is the better source, so I've left it alone rather than change it blind.

Testing: the decodes are validated against live captures from my own Atto 3, and the driver builds and runs on hardware.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)