### PR TITLE
Sungrow SBRXXX: report the 0x005 end stop

### DIFF
--- a/Software/src/inverter/SUNGROW-CAN.cpp
+++ b/Software/src/inverter/SUNGROW-CAN.cpp
@@ -328,6 +328,17 @@ void SungrowInverter::update_values() {
   SUNGROW_504.data.u8[2] = (current_dA_flipped & 0xFF);
   SUNGROW_504.data.u8[3] = ((current_dA_flipped >> 8) & 0xFF);
 
+  // 0x005 cannot be a straight copy either: byte 1 carries the end stop, inert on 0x705/0x505.
+  // Full is limit-driven, since a real pack reads 0 A charge limit throughout. Empty is not - a
+  // real pack still advertises ~30 A while reporting it - so that end tracks the SoC floor.
+  uint8_t end_stop = END_STOP_NORMAL;
+  if (datalayer.battery.status.max_charge_current_dA == 0) {
+    end_stop = END_STOP_FULL;
+  } else if (datalayer.battery.status.reported_soc == 0) {
+    end_stop = END_STOP_EMPTY;
+  }
+  SUNGROW_005.data.u8[1] = end_stop;
+
 // TODO: This needs to do something useful
 #ifdef DEBUG_VIA_USB
   if (inverter_sends_000) {

--- a/Software/src/inverter/SUNGROW-CAN.h
+++ b/Software/src/inverter/SUNGROW-CAN.h
@@ -80,6 +80,19 @@ class SungrowInverter : public CanInverterProtocol {
     return static_cast<int16_t>(value);
   }
 
+  // 0x005 byte 1 - Status_Battery_End_Stop. Inert (always 0) on the 0x505/0x705 copies of this
+  // frame, so it is applied to 0x005 only. Bits 0-1 are a state code, not a pair of independent
+  // end-stop bits; bit 4 is a separate maintenance flag that ORs with that code.
+  enum EndStop : uint8_t {
+    END_STOP_NORMAL = 0,       // Neither end reached
+    END_STOP_FULL = 1,         // Pack full. A real pack reads 0 A charge limit for every sample of this
+    END_STOP_EMPTY = 2,        // Pack at its SoC floor. It still permits discharge here (~30 A observed)
+    END_STOP_SUSPENDED = 3,    // Online but passing no current while still advertising its limits.
+                               // Never sent: a real SBR uses it for BMS restarts and module upgrades,
+                               // and our limits are always live, so it would misinform the inverter.
+    END_STOP_MAINTENANCE = 16  // Never sent, for the same reason.
+  };
+
   //Actual content messages
   CAN_frame SUNGROW_000 = {.FD = false,
                            .ext_ID = false,
@@ -106,6 +119,7 @@ class SungrowInverter : public CanInverterProtocol {
                            .DLC = 8,
                            .ID = 0x004,
                            .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+  // A copy of 0x705 except byte 1, the end stop - both applied in update_values().
   CAN_frame SUNGROW_005 = {.FD = false,
                            .ext_ID = false,
                            .DLC = 8,
@@ -326,7 +340,7 @@ class SungrowInverter : public CanInverterProtocol {
                            .DLC = 8,
                            .ID = 0x705,
                            .data = {0x02,        // Battery status: 0=Unplugged, 1=Standby, 2=Run (always Run)
-                                    0x00,        // Always 0 (705_Always_0)
+                                    0x00,        // End stop, inert on this copy (705_End_Stop)
                                     0x01,        // Always 1 (705_Always_1)
                                     0x00, 0x00,  // Battery model id - set in update_values() from module_count
                                     0x00, 0x00,  // Battery voltage - set in update_values()


### PR DESCRIPTION
Byte 1 of 0x005 is the only copy that carries Status_Battery_End_Stop; it is inert on 0x505/0x705, so it needs a fixup after the bulk copy. Full follows the charge limit, which a real pack zeroes throughout; Empty follows the SoC floor, since a real pack keeps advertising ~30 A while reporting it. Suspended and the maintenance flag are declared but never sent - they mean the pack is not honouring the limits it advertises, which is never true here.

### What
This PR implements the `Status_Battery_End_Stop` signal on frame 0x005 in the Sungrow SBRXXX inverter emulation, so the emulator reports the pack's charge/discharge end stop instead of always sending zero.

No other frame changes behaviour, and no datalayer fields are added.

### Why
0x005 was built by a straight `memcpy` from 0x705, so byte 1 was permanently 0 and an inverter never saw a Full or Empty end stop from the emulator. A real SBR reports it here and only here - the byte is inert on the 0x505 and 0x705 copies of the same frame, which is why it needs handling as a divergence rather than being inherited.

The mapping comes from decoding ~28.7 M frames of traffic between a real SBR224 and an SH10RS:

- Value 1 (Full) coincides with SoC 100 %, and `Info_Battery_Max_Charge_Current` at 0x701 reads exactly 0 for the whole window.
- Value 2 (Empty) tracks the SoC floor but does **not** stop discharge - the discharge limit held 261-298 dA throughout a 14 h window at this value.
- Value 3 is not "both ends reached". The pack is online and passing no current while still advertising 30 A in both directions, so it is the only indication on the bus that those advertised limits are not live.

### How
- Adds a private `EndStop` enum documenting all observed values, including the two the catalogue previously lacked (bit 4 is a separate maintenance flag that ORs with the 0-1 state code, giving 16 and 17).
- Applies byte 1 as a post-`memcpy` fixup in `update_values()`, placed beside the existing 0x504 current sign-flip - the established pattern in this driver for a copied frame that must diverge from its source.
- Full is driven from `max_charge_current_dA == 0`, reusing the zero-limit-means-forbidden convention already used in `PYLON-CAN.cpp`. Empty is driven from `reported_soc == 0` rather than the discharge limit, because a real pack keeps permitting discharge at the floor.
- Relabels the 0x705 byte 1 comment from `705_Always_0` to `705_End_Stop`, since the byte is not a constant - it is the same signal, just inert on that copy.
- Values 3 and 16 are declared for documentation but deliberately never transmitted. They tell an inverter the pack is not honouring the limits it advertises, and the emulator's limits are always live, so sending either would misinform it.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)

