### PR TITLE
Fix failure reporting in the build step

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -105,7 +105,10 @@ jobs:
         sed -i "/if line\.split.*expected_hash:/i \                print('Hash check, sdkconfig has:', line.split(\"__\")[1].strip(), 'was expecting:', expected_hash, 'data is:', repr(custom_options.strip() + mcu))" ~/.platformio/platforms/espressif32/builder/frameworks/arduino.py || echo "sed failed"
 
     - name: Build image for ${{ matrix.board_name }}
-      run: pio run -e ${{ matrix.pio_env }} 2>&1 | tee checkprogsize.txt
+      shell: bash
+      run: |
+        set -o pipefail
+        pio run -e ${{ matrix.pio_env }} 2>&1 | tee checkprogsize.txt
 
     - name: Capture size report for ${{ matrix.board_name }}
       if: matrix.pio_env != 'compiler_warning_check'


### PR DESCRIPTION
### What
I noticed a small regression from #2615 where the `tee` pipe hid a build failure so that only the capture step afterwards fails

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
