### PR TITLE
Add DFRobot Edge101 support

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -35,6 +35,8 @@ jobs:
             pio_env: "BECom_330"
           - board_name: "Waveshare ESP32S3RS485CAN"
             pio_env: "waveshare_330"
+          - board_name: "DFRobot Edge101"
+            pio_env: "dfrobot_edge101_330"
           - board_name: "Compiler warning check"
             pio_env: "compiler_warning_check"
 

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -34,7 +34,7 @@
 #include "src/inverter/INVERTERS.h"
 
 #if !defined(HW_LILYGO) && !defined(HW_LILYGO2CAN) && !defined(HW_STARK) && !defined(HW_3LB) && !defined(HW_BECOM) && \
-    !defined(HW_WAVESHARE) && !defined(HW_DEVKIT)
+    !defined(HW_WAVESHARE) && !defined(HW_DEVKIT) && !defined(HW_DFROBOT_EDGE101)
 #error You must select a target hardware!
 #endif
 

--- a/Software/src/devboard/hal/hal.cpp
+++ b/Software/src/devboard/hal/hal.cpp
@@ -26,6 +26,9 @@ void init_hal() {
 #elif defined(HW_DEVKIT)
 #include "hw_devkit.h"
   esp32hal = new DevKitHal();
+#elif defined(HW_DFROBOT_EDGE101)
+#include "hw_dfrobot_edge101.h"
+  esp32hal = new DFRobotEdge101Hal();
 #else
 #error "No HW defined."
 #endif

--- a/Software/src/devboard/hal/hw_dfrobot_edge101.h
+++ b/Software/src/devboard/hal/hw_dfrobot_edge101.h
@@ -1,0 +1,77 @@
+#ifndef __HW_DFROBOT_EDGE101_H__
+#define __HW_DFROBOT_EDGE101_H__
+
+#include "hal.h"
+
+/*
+DFRobot Edge101 IOT Controller (SKU DFR0886)
+ESP32-WROOM-32E, 16 MB flash, no PSRAM. USB-serial via CH9102F.
+Isolated CAN (TJA1050), isolated RS485 (TPT75176H), microSD (SPI),
+IP101GRI Ethernet PHY (RMII), PCF8563T RTC (I2C 0x51).
+Pin map: see arduino-esp32 PR #12742 variants/dfrobot_edge101/pins_arduino.h.
+*/
+
+class DFRobotEdge101Hal : public Esp32Hal {
+ public:
+  const char* name() { return "DFRobot Edge101 IOT Controller"; }
+
+  // RS485 via TPT75176H (galvanically isolated), DE and /RE are tied together
+  virtual gpio_num_t RS485_TX_PIN() { return GPIO_NUM_17; }
+  virtual gpio_num_t RS485_RX_PIN() { return GPIO_NUM_36; }
+  virtual gpio_num_t RS485_DE_PIN() { return GPIO_NUM_16; }
+
+  // Native CAN via TJA1050 (galvanically isolated)
+  virtual gpio_num_t CAN_TX_PIN() { return GPIO_NUM_32; }
+  virtual gpio_num_t CAN_RX_PIN() { return GPIO_NUM_35; }
+
+  // microSD (SPI)
+#ifdef SDCARD
+  uint8_t SD_SPI_BUS() override { return VSPI; }
+  virtual gpio_num_t SD_MOSI_PIN() { return GPIO_NUM_12; }
+  virtual gpio_num_t SD_MISO_PIN() { return GPIO_NUM_39; }
+  virtual gpio_num_t SD_SCLK_PIN() { return GPIO_NUM_14; }
+  virtual gpio_num_t SD_CS_PIN() { return GPIO_NUM_5; }
+#endif  // SDCARD
+
+  // User LED
+  virtual gpio_num_t LED_PIN() { return GPIO_NUM_15; }
+
+  // User button — GPIO 38 is input-only on ESP32, no internal pull-up available; board has external pull-up
+  virtual gpio_num_t AP_BUTTON_PIN() { return GPIO_NUM_38; }
+
+  std::vector<comm_interface> available_interfaces() {
+    return {comm_interface::Modbus, comm_interface::RS485, comm_interface::CanNative};
+  }
+
+  virtual const char* name_for_comm_interface(comm_interface comm) {
+    switch (comm) {
+      case comm_interface::CanNative:
+        return "CAN (Native)";
+      case comm_interface::CanFdNative:
+        return "";
+      case comm_interface::CanAddonMcp2515:
+        return "CAN (MCP2515 add-on)";
+      case comm_interface::CanFdAddonMcp2518:
+        return "CAN FD (MCP2518 add-on)";
+      case comm_interface::Modbus:
+        return "Modbus";
+      case comm_interface::RS485:
+        return "RS485";
+      case comm_interface::Highest:
+        return "";
+      default:
+        return Esp32Hal::name_for_comm_interface(comm);
+    }
+  }
+};
+
+#define HalClass DFRobotEdge101Hal
+
+/* ----- Error checks below, don't change (can't be moved to separate file) ----- */
+#ifndef HW_CONFIGURED
+#define HW_CONFIGURED
+#else
+#error Multiple HW defined! Please select a single HW
+#endif
+
+#endif

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -200,7 +200,7 @@ static void check_ap_button() {
 
   if (!ap_button_inited) {
     // Configure lazily, after boot, so we never disturb GPIO0 strapping at reset.
-    pinMode(pin, INPUT_PULLUP);
+    pinMode(pin, (pin < GPIO_NUM_34) ? INPUT_PULLUP : INPUT);
     ap_button_inited = true;
     return;  // let the pull-up settle before the first read
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -133,3 +133,14 @@ build_flags =
     ${common_esp32s3.build_flags}
     -D HW_WAVESHARE
     -D BOARD_HAS_PSRAM
+
+[env:dfrobot_edge101_330]
+extends = common_esp32
+board_build.arduino.memory_type = dio_qspi
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+build_flags =
+    ${common_esp32.build_flags}
+    -D HW_DFROBOT_EDGE101
+    -D SDCARD


### PR DESCRIPTION
### What
This adds support for the [DFRobot Edge101](https://www.dfrobot.com/product-2934.html) board that I am running for two weeks now.

Schematic: https://dfimg.dfrobot.com/wiki/23038/DFR0886_edge101-esp32_schematics_1.0.pdf

### Why

- isolated CAN
- isolated RS485
- Ethernet (Will be included in a follow-up PR for easier review)
- External antenna
- PCIe expansion slot with UART
- Case with DIN Rail mount (that fits perfectly inside of a Fronius Verto) <img width="8160" height="6144" alt="dfrobot101_side" src="https://github.com/user-attachments/assets/1b4b82b2-f685-494b-a1c9-84088f84647c" />
- External IO header (where you could attach an external MCP2518FD)
- SD Card slot
- 16MB Flash
- RTC (not configured since this project only uses runtime)
- Good availability: https://octopart.com/de/part/dfrobot/DFR0886
- Affordable (I bought two from Digikey for 80€ including shipping)

This is one the best options with ethernet that I could find. The other notable alternatives are the LILYGO T-Connect Pro(#2234) and the [Waveshare ESP32-S3-POE-ETH-8DI-8DO](https://www.waveshare.com/ESP32-S3-POE-ETH-8DI-8DO.htm). But the Waveshare would only barely fit inside of the Verto even if you cut off the sides of the case. The LILYGO is more expensive and has even more features but is not as widely available. The main downsides of this board is that it´s not an S3.

### How
~~Unfortunately adding SPI SD support also increases the binary size of the other boards until we can restore LTO from #2650~~

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)