### PR TITLE
Stop overwriting Tesla GTW driver defaults with zeros on fresh installs

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -141,11 +141,17 @@ void init_stored_settings() {
   user_selected_daly_power_at_0_degree_C = settings.getUInt("DALYPWR0C", 800);
   user_selected_use_estimated_SOC = settings.getBool("SOCESTIMATED", false);
   user_selected_tesla_digital_HVIL = settings.getBool("DIGITALHVIL", false);
-  user_selected_tesla_GTW_country = settings.getUInt("GTWCOUNTRY", 0);
-  user_selected_tesla_GTW_rightHandDrive = settings.getBool("GTWRHD", false);
-  user_selected_tesla_GTW_mapRegion = settings.getUInt("GTWMAPREG", 0);
-  user_selected_tesla_GTW_chassisType = settings.getUInt("GTWCHASSIS", 0);
-  user_selected_tesla_GTW_packEnergy = settings.getUInt("GTWPACK", 0);
+  // Fall back to the value the global already holds, which is the driver's
+  // own default: the statics initialize before init_stored_settings() runs.
+  // A literal fallback here would both duplicate the constant and, because
+  // these are written raw into the emulated gateway frame with no 0-means-
+  // skip semantics, silently broadcast zeros on any install that never saved
+  // the keys.
+  user_selected_tesla_GTW_country = settings.getUInt("GTWCOUNTRY", user_selected_tesla_GTW_country);
+  user_selected_tesla_GTW_rightHandDrive = settings.getBool("GTWRHD", user_selected_tesla_GTW_rightHandDrive);
+  user_selected_tesla_GTW_mapRegion = settings.getUInt("GTWMAPREG", user_selected_tesla_GTW_mapRegion);
+  user_selected_tesla_GTW_chassisType = settings.getUInt("GTWCHASSIS", user_selected_tesla_GTW_chassisType);
+  user_selected_tesla_GTW_packEnergy = settings.getUInt("GTWPACK", user_selected_tesla_GTW_packEnergy);
   user_selected_primo_gen24 = settings.getBool("PRIMOGEN24", false);
 
   auto readIf = [&settings](const char* settingName) {

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -141,12 +141,6 @@ void init_stored_settings() {
   user_selected_daly_power_at_0_degree_C = settings.getUInt("DALYPWR0C", 800);
   user_selected_use_estimated_SOC = settings.getBool("SOCESTIMATED", false);
   user_selected_tesla_digital_HVIL = settings.getBool("DIGITALHVIL", false);
-  // Fall back to the value the global already holds, which is the driver's
-  // own default: the statics initialize before init_stored_settings() runs.
-  // A literal fallback here would both duplicate the constant and, because
-  // these are written raw into the emulated gateway frame with no 0-means-
-  // skip semantics, silently broadcast zeros on any install that never saved
-  // the keys.
   user_selected_tesla_GTW_country = settings.getUInt("GTWCOUNTRY", user_selected_tesla_GTW_country);
   user_selected_tesla_GTW_rightHandDrive = settings.getBool("GTWRHD", user_selected_tesla_GTW_rightHandDrive);
   user_selected_tesla_GTW_mapRegion = settings.getUInt("GTWMAPREG", user_selected_tesla_GTW_mapRegion);


### PR DESCRIPTION
During a code review this surfaced: `init_stored_settings()` loads the five GTW keys with fallbacks `0/false/0/0/0`, unconditionally overwriting the driver's intended defaults (`BATTERIES.cpp`: country `17477` = ASCII "DE", right-hand-drive `true`, mapRegion `2`, chassisType `2`, packEnergy `1` = 74 kWh). The values are written raw into the emulated gateway's 0x7FF frame with no 0-means-skip semantics, so any install that never saved these settings broadcasts country 0 / 50 kWh / chassis 0 — and the driver-side initializers are effectively dead code.

Fix: use the current global value as the `getUInt`/`getBool` fallback, so the driver's static initializer remains the single source of defaults. Installs with stored settings are unaffected (stored keys win, as before), and the settings page now renders the intended defaults instead of zeros.

Also checked the neighbouring driver-setting loads for the same pattern (Daly derating, CT clamp calibration, LEAF interlock, BYD auto-cal): their core fallbacks already match the driver defaults, so nothing else was touched.

Note: drafted with AI assistance, reviewed by me.
