### PR TITLE
Feature: Add cell-grid geometry (cells_per_row) to battery info — Renault Zoe Gen2 as first example

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -477,6 +477,7 @@ void RenaultZoeGen2Battery::setup(void) {  // Performs one time setup at startup
   datalayer.system.info.battery_protocol[63] = '\0';
   datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer_battery->info.number_of_cells = 96;
+  datalayer_battery->info.cells_per_row = 8;  // 12x 8s2p modules -> render as 8 columns x 12 rows
   datalayer_battery->info.total_capacity_Wh = 52000;
   datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
   datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -45,6 +45,14 @@ struct DATALAYER_BATTERY_INFO_TYPE {
   /** uint8_t */
   /** Total number of cells in the pack */
   uint8_t number_of_cells = 0;
+  /** Cell-monitor grid layout: number of columns to render the cell grid with.
+   * 0 = geometry unknown, in which case the cell monitor falls back to a
+   * responsive flow-wrap layout. When >0, the cell monitor renders a fixed
+   * grid this many columns wide; the number of rows is derived as
+   * ceil(number_of_cells / cells_per_row).
+   * Example: Renault Zoe Gen2 is 12x 8s2p -> 96 cells, cells_per_row = 8 -> 8 columns x 12 rows.
+   */
+  uint8_t cells_per_row = 0;
 
   /** Other */
   /** Chemistry of the pack. Autodetect, or force specific chemistry */


### PR DESCRIPTION
### What
Adds an optional per-battery geometry hint — `cells_per_row` — to `DATALAYER_BATTERY_INFO_TYPE`, and populates it for the **Renault Zoe Gen2 as the first example** (`8`). This establishes the mechanism; the Zoe Gen2 is intended to be the first of many, with geometries for other batteries contributed over time. Any battery that doesn't set the field keeps the current behaviour, so nothing else is affected.

### Why
The cell monitor currently lays cells out as a flat, responsive flow-wrap: the number of columns is just an accident of window width and carries no information about the pack. For batteries whose physical layout is known, we can do better. The Zoe Gen2 is `12 × 8s2p` (96 cells), which is naturally an **8-column × 12-row** grid.

This PR only adds the *data*; it's deliberately frontend-agnostic. Both the current server-rendered cell monitor and the new JSON API (`/api/cells`, in the v10.0 frontend work) read from `datalayer.battery.info`, so putting geometry here means it survives the frontend migration untouched.

We only know the geometry of a handful of packs today, so this is designed to be **incrementally adoptable**: one battery opts in as the reference implementation now, and contributors can add `cells_per_row` for the batteries they own — one line each — as the layouts become known. Unknown geometry stays the safe default, so there's no obligation to fill everything in at once.



### How
- New field `uint8_t cells_per_row = 0` in `DATALAYER_BATTERY_INFO_TYPE`, adjacent to `number_of_cells`. `0` = geometry unknown (unchanged flow-wrap behaviour); `>0` = render a fixed grid this many columns wide, with rows derived as `ceil(number_of_cells / cells_per_row)`.
- `RenaultZoeGen2Battery::setup()` sets `cells_per_row = 8`.
- Single `uint8_t`, placed in the existing `uint8_t` block, so no change to struct padding/flash size.

### Adding geometry for another battery
It's intentionally a one-liner in that battery's `setup()`:
```cpp
datalayer_battery->info.cells_per_row = <columns>;  // e.g. series-cells-per-module
```
Pick the column count that reflects the pack's physical layout (typically the number of series cells per module), such that `number_of_cells / cells_per_row` gives the row count you want to see. Leave it unset (`0`) if the layout isn't known — the cell monitor falls back to the existing flow-wrap.

### Notes
- This is the data-model half of a two-part change. The visible grid rendering lands separately in the new frontend (follow-up PR against the `experiment/new-frontend` branch). This PR is safe to merge on its own — with no consumer yet, it's inert.
- The Zoe Gen2 value is the only geometry defined here; contributions for other batteries are welcome and expected as follow-ups.
