### PR TITLE
Nissan LEAF: serialise UDS requests and use BS=0 flow control for DTC reads

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -383,7 +383,8 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (uds_rx_remaining == 0) {
             uds_busy = false;
           }
-        } else if (rx_pci == 0x20) {  //Consecutive frame: up to seven more payload bytes
+        } else if (rx_pci == 0x20) {      //Consecutive frame: up to seven more payload bytes
+          uds_request_millis = millis();  //Still answering, so restart the no-answer timer
           uds_rx_remaining = (uds_rx_remaining > 7) ? (uds_rx_remaining - 7) : 0;
           if (uds_rx_remaining == 0) {
             uds_busy = false;
@@ -438,24 +439,36 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
 
         if (pci == 0x10 && rx_frame.data.u8[2] == 0x59) {  //First frame of a multi-frame reply
-          dtc_rx_expected = ((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
-          if (dtc_rx_expected > DTC_BUFFER_SIZE) {
-            dtc_rx_expected = DTC_BUFFER_SIZE;  //More codes than we can store, keep the first ones
-          }
+          dtc_rx_total = ((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
+          dtc_rx_seen = 0;
           dtc_rx_len = 0;
-          for (uint8_t i = 2; i < 8 && dtc_rx_len < dtc_rx_expected; i++) {
-            dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
-          }
           dtc_rx_active = true;
-          transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Flow control, ask for the rest
+          for (uint8_t i = 2; i < 8 && dtc_rx_seen < dtc_rx_total; i++) {
+            if (dtc_rx_len < DTC_BUFFER_SIZE) {
+              dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
+            }
+            dtc_rx_seen++;
+          }
+          if (dtc_rx_seen >= dtc_rx_total) {
+            parseDTCResponse();
+          } else {
+            transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Flow control, ask for the rest
+          }
           break;
         }
 
         if (dtc_rx_active && pci == 0x20) {  //Consecutive frame
-          for (uint8_t i = 1; i < 8 && dtc_rx_len < dtc_rx_expected; i++) {
-            dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
+          // Keep acknowledging frames right to the end even once the buffer is full. Falling silent
+          // mid-transfer leaves the LBC waiting on a flow control that never comes, and it will not
+          // take another request until that has timed out on its side.
+          for (uint8_t i = 1; i < 8 && dtc_rx_seen < dtc_rx_total; i++) {
+            if (dtc_rx_len < DTC_BUFFER_SIZE) {
+              dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
+            }
+            dtc_rx_seen++;
           }
-          if (dtc_rx_len >= dtc_rx_expected) {
+          dtc_request_millis = millis();  //Progress, so the readout timeout measures silence
+          if (dtc_rx_seen >= dtc_rx_total) {
             parseDTCResponse();
           } else {
             transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);
@@ -760,7 +773,8 @@ void NissanLeafBattery::handle_DTC_requests(unsigned long currentMillis) {
     dtc_read_in_progress = true;
     dtc_rx_active = false;
     dtc_rx_len = 0;
-    dtc_rx_expected = 0;
+    dtc_rx_total = 0;
+    dtc_rx_seen = 0;
     dtc_request_millis = currentMillis;
     datalayer_battery->dtc.dtc_read_failed = false;
     uds_busy = true;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -256,37 +256,6 @@ void NissanLeafBattery::
     }
 
 #endif
-    if (UserRequestDTCreset && !dtc_clear_in_progress) {
-      UserRequestDTCreset = false;
-      dtc_clear_in_progress = true;
-      dtc_clear_millis = millis();
-      transmit_can_frame(&LEAF_CLEAR_DTC);
-    }
-
-    // Give up waiting for the erase acknowledgement. The previously read list is deliberately left
-    // untouched here: an unconfirmed erase is not evidence that the codes are gone.
-    if (dtc_clear_in_progress && (millis() - dtc_clear_millis > DTC_TIMEOUT_MS)) {
-      dtc_clear_in_progress = false;
-    }
-
-    if (UserRequestDTCreadout && !dtc_read_in_progress) {
-      UserRequestDTCreadout = false;
-      dtc_read_in_progress = true;
-      dtc_rx_active = false;
-      dtc_rx_len = 0;
-      dtc_rx_expected = 0;
-      dtc_request_millis = millis();
-      datalayer_battery->dtc.dtc_read_failed = false;
-      transmit_can_frame(&LEAF_READ_DTC);
-    }
-
-    // Give up if the LBC never completes the reply, so the page stops showing a pending read.
-    if (dtc_read_in_progress && (millis() - dtc_request_millis > DTC_TIMEOUT_MS)) {
-      dtc_read_in_progress = false;
-      dtc_rx_active = false;
-      datalayer_battery->dtc.dtc_read_failed = true;
-      datalayer_battery->dtc.dtc_last_read_millis = millis();
-    }
   }
 }
 
@@ -398,6 +367,30 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x7BB:
 
+      // Any traffic here means the LBC is mid-response. Recorded before any handling below, so a
+      // pending DTC request holds off until the channel has been quiet for DTC_BUS_IDLE_MS.
+      last_7bb_millis = millis();
+
+      // Follow the ISO-TP framing of whatever answer is arriving, regardless of which service it
+      // belongs to, so we know when the LBC has finished replying and is ready for a new request.
+      if (uds_busy) {
+        uint8_t rx_pci = rx_frame.data.u8[0] & 0xF0;
+        if (rx_pci == 0x00) {  //Single frame: the whole answer, complete on arrival
+          uds_busy = false;
+        } else if (rx_pci == 0x10) {  //First frame: six payload bytes here, rest in the follow-ups
+          uint16_t announced = ((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
+          uds_rx_remaining = (announced > 6) ? (announced - 6) : 0;
+          if (uds_rx_remaining == 0) {
+            uds_busy = false;
+          }
+        } else if (rx_pci == 0x20) {  //Consecutive frame: up to seven more payload bytes
+          uds_rx_remaining = (uds_rx_remaining > 7) ? (uds_rx_remaining - 7) : 0;
+          if (uds_rx_remaining == 0) {
+            uds_busy = false;
+          }
+        }
+      }
+
 #ifndef SMALL_FLASH_DEVICE
       // This section checks if we are doing a SOH reset towards BMS. If we do, all 7BB handling is halted
       if (stateMachineClearSOH < 255) {
@@ -454,7 +447,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
           }
           dtc_rx_active = true;
-          transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Flow control, ask for the rest
+          transmit_can_frame(&LEAF_DTC_FLOW_CONTROL);  //BS=0: send the remaining frames in one burst
           break;
         }
 
@@ -464,9 +457,8 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           }
           if (dtc_rx_len >= dtc_rx_expected) {
             parseDTCResponse();
-          } else {
-            transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);
           }
+          //No flow control here: BS=0 asked the LBC to stream the rest unprompted.
           break;
         }
 
@@ -742,7 +734,71 @@ void NissanLeafBattery::parseDTCResponse() {
   datalayer_battery->dtc.dtc_read_failed = false;
 }
 
+// Sends any pending DTC request and times out the ones that get no answer. Kept out of
+// update_values() so the transmission can be held back until the diagnostic channel is free: the
+// LBC drops a request that lands while it is still sending a group poll response, which loses the
+// readout silently.
+void NissanLeafBattery::handle_DTC_requests(unsigned long currentMillis) {
+  // Stop waiting on an answer the LBC is never going to send, otherwise one lost reply would block
+  // the channel for good.
+  if (uds_busy && (currentMillis - uds_request_millis > UDS_RESPONSE_TIMEOUT_MS)) {
+    uds_busy = false;
+  }
+
+  // Free to transmit only when our own previous request has been fully answered (uds_busy) and
+  // nothing else is talking on the channel either, which is what catches a third party such as
+  // LeafSpy polling the same LBC.
+  bool channel_idle = !uds_busy && (currentMillis - last_7bb_millis) > DTC_BUS_IDLE_MS;
+  bool busy = dtc_read_in_progress || dtc_clear_in_progress;
+
+  if (UserRequestDTCreadout && !busy && channel_idle) {
+    UserRequestDTCreadout = false;
+    dtc_read_in_progress = true;
+    dtc_rx_active = false;
+    dtc_rx_len = 0;
+    dtc_rx_expected = 0;
+    dtc_request_millis = currentMillis;
+    datalayer_battery->dtc.dtc_read_failed = false;
+    uds_busy = true;
+    uds_request_millis = currentMillis;
+    transmit_can_frame(&LEAF_READ_DTC);
+    return;
+  }
+
+  if (UserRequestDTCreset && !busy && channel_idle) {
+    UserRequestDTCreset = false;
+    dtc_clear_in_progress = true;
+    dtc_clear_millis = currentMillis;
+    uds_busy = true;
+    uds_request_millis = currentMillis;
+    transmit_can_frame(&LEAF_CLEAR_DTC);
+    return;
+  }
+
+  // A readout that goes unanswered is retried before being reported as failed. A request lost to a
+  // busy channel is the expected cause, and by the time the timeout expires that channel is free.
+  if (dtc_read_in_progress && (currentMillis - dtc_request_millis > DTC_TIMEOUT_MS)) {
+    dtc_read_in_progress = false;
+    dtc_rx_active = false;
+    if (dtc_read_retries < DTC_MAX_RETRIES) {
+      dtc_read_retries++;
+      UserRequestDTCreadout = true;
+    } else {
+      datalayer_battery->dtc.dtc_read_failed = true;
+      datalayer_battery->dtc.dtc_last_read_millis = currentMillis;
+    }
+  }
+
+  // Give up waiting for the erase acknowledgement. The previously read list is deliberately left
+  // untouched here: an unconfirmed erase is not evidence that the codes are gone.
+  if (dtc_clear_in_progress && (currentMillis - dtc_clear_millis > DTC_TIMEOUT_MS)) {
+    dtc_clear_in_progress = false;
+  }
+}
+
 void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
+
+  handle_DTC_requests(currentMillis);
 
   if (datalayer.system.status.bms_reset_status != BMS_RESET_IDLE) {
     // Transmitting towards battery is halted while BMS is being reset
@@ -961,13 +1017,18 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       previousMillis10s = currentMillis;
 
       //Every 10s, ask diagnostic data from the battery. Don't ask if someone is already polling on the bus (Leafspy?),
-      //and don't start a new group transfer while a DTC readout is still being reassembled.
-      if (!stop_battery_query && !dtc_read_in_progress) {
+      //and don't start a group transfer while a DTC operation is pending or in flight: the two share
+      //the 0x79B/0x7BB channel, and whichever request lands second gets dropped by the LBC.
+      bool dtc_operation_pending =
+          UserRequestDTCreadout || UserRequestDTCreset || dtc_read_in_progress || dtc_clear_in_progress;
+      if (!stop_battery_query && !dtc_operation_pending) {
 
         // Move to the next group
         PIDindex = (PIDindex + 1) % 7;  // 7 = amount of elements in the PIDgroups[]
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
+        uds_busy = true;
+        uds_request_millis = currentMillis;
         transmit_can_frame(&LEAF_GROUP_REQUEST);
       }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -447,7 +447,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             dtc_buffer[dtc_rx_len++] = rx_frame.data.u8[i];
           }
           dtc_rx_active = true;
-          transmit_can_frame(&LEAF_DTC_FLOW_CONTROL);  //BS=0: send the remaining frames in one burst
+          transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Flow control, ask for the rest
           break;
         }
 
@@ -457,8 +457,9 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           }
           if (dtc_rx_len >= dtc_rx_expected) {
             parseDTCResponse();
+          } else {
+            transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);
           }
-          //No flow control here: BS=0 asked the LBC to stream the rest unprompted.
           break;
         }
 
@@ -749,7 +750,10 @@ void NissanLeafBattery::handle_DTC_requests(unsigned long currentMillis) {
   // nothing else is talking on the channel either, which is what catches a third party such as
   // LeafSpy polling the same LBC.
   bool channel_idle = !uds_busy && (currentMillis - last_7bb_millis) > DTC_BUS_IDLE_MS;
-  bool busy = dtc_read_in_progress || dtc_clear_in_progress;
+  // The SOH clear runs its own multi-step exchange over the same request/response pair, so a DTC
+  // request must not be slipped in between its steps either.
+  bool soh_clear_running = stateMachineClearSOH < 255;
+  bool busy = dtc_read_in_progress || dtc_clear_in_progress || soh_clear_running;
 
   if (UserRequestDTCreadout && !busy && channel_idle) {
     UserRequestDTCreadout = false;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -415,6 +415,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (dtc_clear_in_progress && rx_frame.data.u8[0] == 0x01 && rx_frame.data.u8[1] == 0x54) {
         dtc_clear_in_progress = false;
         datalayer_battery->dtc.dtc_count = 0;
+        datalayer_battery->dtc.dtc_reported_count = 0;
         datalayer_battery->dtc.dtc_read_failed = false;
         datalayer_battery->dtc.dtc_last_read_millis = 0;
         break;
@@ -431,6 +432,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           if (dtc_rx_len > 7) {
             dtc_rx_len = 7;
           }
+          dtc_rx_total = dtc_rx_len;  //A single frame is the whole answer
           for (uint8_t i = 0; i < dtc_rx_len; i++) {
             dtc_buffer[i] = rx_frame.data.u8[1 + i];
           }
@@ -732,6 +734,9 @@ void NissanLeafBattery::parseDTCResponse() {
     return;
   }
 
+  // What the battery actually reported, which can be more than we have slots for.
+  uint16_t reported = (dtc_rx_total > DTC_HEADER_LEN) ? ((dtc_rx_total - DTC_HEADER_LEN) / 4) : 0;
+
   uint16_t count = (dtc_rx_len - DTC_HEADER_LEN) / 4;
   if (count > DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT) {
     count = DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT;
@@ -745,6 +750,7 @@ void NissanLeafBattery::parseDTCResponse() {
   }
 
   datalayer_battery->dtc.dtc_count = count;
+  datalayer_battery->dtc.dtc_reported_count = reported;
   datalayer_battery->dtc.dtc_read_failed = false;
 }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -154,22 +154,22 @@ class NissanLeafBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x79B,
                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
-  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0xFF, so the LBC
-  // reports against every status bit it implements (it advertises 0x4E: testFailedThisOperationCycle,
-  // pendingDTC, confirmedDTC, testNotCompletedThisOperationCycle).
-  // Be aware what this includes. Bit 6 is set on any code whose self test has not run this cycle,
-  // which on a stationary pack is most of them, so the reply is the LBC's near-complete supported
-  // code list rather than a fault list: one capture returned 149 entries of which exactly one, a
-  // U1000, had actually failed. Everything else carried status 0x40. That also means an erase does
-  // not visibly shrink this list, because an untested code is not a fault an erase can clear.
-  // Use the status column to tell them apart, or narrow the mask to 0x0E to see only real faults.
+  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0x0E:
+  // testFailedThisOperationCycle, pendingDTC and confirmedDTC. A code is reported when any masked
+  // bit is set in its status, so this asks for codes that have actually failed.
+  // Do not widen this to 0xFF. That pulls in bit 6, testNotCompletedThisOperationCycle, which the
+  // LBC sets on every code whose self test has not run this cycle. On a stationary pack that is
+  // nearly all of them, so the reply becomes the LBC's supported code list rather than a fault
+  // list: one capture returned 149 entries of which exactly one, a U1000, had really failed, the
+  // rest carrying status 0x40. It also makes an erase look ineffective, since clearing faults
+  // leaves every code untested and therefore still matching bit 6.
   // The LBC answers on 0x7BB with 59 02 <availabilityMask> followed by 4 bytes per DTC
   // (3-byte code + 1 status byte), multi-frame when more than one code is stored.
   CAN_frame LEAF_READ_DTC = {.FD = false,
                              .ext_ID = false,
                              .DLC = 8,
                              .ID = 0x79B,
-                             .data = {0x03, 0x19, 0x02, 0xFF, 0x00, 0x00, 0x00, 0x00}};
+                             .data = {0x03, 0x19, 0x02, 0x0E, 0x00, 0x00, 0x00, 0x00}};
 
   // DTC readout reassembly state. The reply shares the 0x7BB response ID with the periodic
   // group polling, so it is intercepted separately while a readout is in flight.

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -149,16 +149,6 @@ class NissanLeafBattery : public CanBattery {
                                       .DLC = 8,
                                       .ID = 0x79B,
                                       .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
-  // Flow control for the DTC readout. BS=0 tells the LBC to send every remaining consecutive frame
-  // without waiting for another flow control, so the whole reply arrives in one burst. The group
-  // polling above uses BS=1 and asks frame by frame; for a DTC reply that would mean a flow control
-  // round trip through the main loop per frame, and a long list would be at the mercy of loop
-  // latency. This also matches the flow control used in the reference LBC capture.
-  CAN_frame LEAF_DTC_FLOW_CONTROL = {.FD = false,
-                                     .ext_ID = false,
-                                     .DLC = 8,
-                                     .ID = 0x79B,
-                                     .data = {0x30, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
   CAN_frame LEAF_CLEAR_DTC = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -154,14 +154,20 @@ class NissanLeafBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x79B,
                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
-  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0x0E.
+  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0xFF.
+  // The mask filters which stored codes are reported, and every 59 02 reply seen from the LBC
+  // carries a DTCStatusAvailabilityMask of 0x4E, meaning it implements testFailedThisOperationCycle,
+  // pendingDTC, confirmedDTC and testNotCompletedThisOperationCycle. Asking with 0xFF therefore
+  // requests every status bit the LBC actually supports, so nothing it holds is filtered out on the
+  // way. A narrower mask only risks hiding codes, and the status column already shows how mature
+  // each one is.
   // The LBC answers on 0x7BB with 59 02 <availabilityMask> followed by 4 bytes per DTC
   // (3-byte code + 1 status byte), multi-frame when more than one code is stored.
   CAN_frame LEAF_READ_DTC = {.FD = false,
                              .ext_ID = false,
                              .DLC = 8,
                              .ID = 0x79B,
-                             .data = {0x03, 0x19, 0x02, 0x0E, 0x00, 0x00, 0x00, 0x00}};
+                             .data = {0x03, 0x19, 0x02, 0xFF, 0x00, 0x00, 0x00, 0x00}};
 
   // DTC readout reassembly state. The reply shares the 0x7BB response ID with the periodic
   // group polling, so it is intercepted separately while a readout is in flight.

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -154,15 +154,6 @@ class NissanLeafBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x79B,
                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
-<<<<<<< ours
-  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0xFF.
-  // The mask filters which stored codes are reported, and every 59 02 reply seen from the LBC
-  // carries a DTCStatusAvailabilityMask of 0x4E, meaning it implements testFailedThisOperationCycle,
-  // pendingDTC, confirmedDTC and testNotCompletedThisOperationCycle. Asking with 0xFF therefore
-  // requests every status bit the LBC actually supports, so nothing it holds is filtered out on the
-  // way. A narrower mask only risks hiding codes, and the status column already shows how mature
-  // each one is.
-=======
   // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0x0E:
   // testFailedThisOperationCycle, pendingDTC and confirmedDTC.
   // The mask must not include testNotCompletedThisOperationCycle (bit 6). The LBC sets that bit on
@@ -170,14 +161,13 @@ class NissanLeafBattery : public CanBattery {
   // so asking with 0xFF returns its entire supported code list: 149 entries on a pack whose only
   // real fault was U1000. Those entries also come straight back after an erase, because an untested
   // code is not a fault that erasing can clear. 0x0E asks only for codes that actually failed.
->>>>>>> theirs
   // The LBC answers on 0x7BB with 59 02 <availabilityMask> followed by 4 bytes per DTC
   // (3-byte code + 1 status byte), multi-frame when more than one code is stored.
   CAN_frame LEAF_READ_DTC = {.FD = false,
                              .ext_ID = false,
                              .DLC = 8,
                              .ID = 0x79B,
-                             .data = {0x03, 0x19, 0x02, 0xFF, 0x00, 0x00, 0x00, 0x00}};
+                             .data = {0x03, 0x19, 0x02, 0x0E, 0x00, 0x00, 0x00, 0x00}};
 
   // DTC readout reassembly state. The reply shares the 0x7BB response ID with the periodic
   // group polling, so it is intercepted separately while a readout is in flight.

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -154,6 +154,7 @@ class NissanLeafBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x79B,
                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
+<<<<<<< ours
   // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0xFF.
   // The mask filters which stored codes are reported, and every 59 02 reply seen from the LBC
   // carries a DTCStatusAvailabilityMask of 0x4E, meaning it implements testFailedThisOperationCycle,
@@ -161,6 +162,15 @@ class NissanLeafBattery : public CanBattery {
   // requests every status bit the LBC actually supports, so nothing it holds is filtered out on the
   // way. A narrower mask only risks hiding codes, and the status column already shows how mature
   // each one is.
+=======
+  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0x0E:
+  // testFailedThisOperationCycle, pendingDTC and confirmedDTC.
+  // The mask must not include testNotCompletedThisOperationCycle (bit 6). The LBC sets that bit on
+  // every code whose self test has not run yet, which on a stationary pack is nearly all of them,
+  // so asking with 0xFF returns its entire supported code list: 149 entries on a pack whose only
+  // real fault was U1000. Those entries also come straight back after an erase, because an untested
+  // code is not a fault that erasing can clear. 0x0E asks only for codes that actually failed.
+>>>>>>> theirs
   // The LBC answers on 0x7BB with 59 02 <availabilityMask> followed by 4 bytes per DTC
   // (3-byte code + 1 status byte), multi-frame when more than one code is stored.
   CAN_frame LEAF_READ_DTC = {.FD = false,
@@ -174,9 +184,10 @@ class NissanLeafBattery : public CanBattery {
   static const uint16_t DTC_BUFFER_SIZE = 3 + 4 * DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT;
   static const unsigned long DTC_TIMEOUT_MS = 2000;
   uint8_t dtc_buffer[DTC_BUFFER_SIZE];
-  uint16_t dtc_rx_expected = 0;  // Total payload length announced by the ISO-TP first frame
-  uint16_t dtc_rx_len = 0;       // Bytes reassembled so far
-  bool dtc_rx_active = false;    // A multi-frame reply is currently being reassembled
+  uint16_t dtc_rx_total = 0;   // Total payload length announced by the ISO-TP first frame
+  uint16_t dtc_rx_seen = 0;    // Bytes received so far, counted even when past our storage capacity
+  uint16_t dtc_rx_len = 0;     // Bytes actually stored, capped at DTC_BUFFER_SIZE
+  bool dtc_rx_active = false;  // A multi-frame reply is currently being reassembled
   bool dtc_read_in_progress = false;
   unsigned long dtc_request_millis = 0;
   bool dtc_clear_in_progress = false;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -154,20 +154,22 @@ class NissanLeafBattery : public CanBattery {
                               .DLC = 8,
                               .ID = 0x79B,
                               .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
-  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0x0E:
-  // testFailedThisOperationCycle, pendingDTC and confirmedDTC.
-  // The mask must not include testNotCompletedThisOperationCycle (bit 6). The LBC sets that bit on
-  // every code whose self test has not run yet, which on a stationary pack is nearly all of them,
-  // so asking with 0xFF returns its entire supported code list: 149 entries on a pack whose only
-  // real fault was U1000. Those entries also come straight back after an erase, because an untested
-  // code is not a fault that erasing can clear. 0x0E asks only for codes that actually failed.
+  // UDS ReadDTCInformation (0x19) / reportDTCByStatusMask (0x02) with status mask 0xFF, so the LBC
+  // reports against every status bit it implements (it advertises 0x4E: testFailedThisOperationCycle,
+  // pendingDTC, confirmedDTC, testNotCompletedThisOperationCycle).
+  // Be aware what this includes. Bit 6 is set on any code whose self test has not run this cycle,
+  // which on a stationary pack is most of them, so the reply is the LBC's near-complete supported
+  // code list rather than a fault list: one capture returned 149 entries of which exactly one, a
+  // U1000, had actually failed. Everything else carried status 0x40. That also means an erase does
+  // not visibly shrink this list, because an untested code is not a fault an erase can clear.
+  // Use the status column to tell them apart, or narrow the mask to 0x0E to see only real faults.
   // The LBC answers on 0x7BB with 59 02 <availabilityMask> followed by 4 bytes per DTC
   // (3-byte code + 1 status byte), multi-frame when more than one code is stored.
   CAN_frame LEAF_READ_DTC = {.FD = false,
                              .ext_ID = false,
                              .DLC = 8,
                              .ID = 0x79B,
-                             .data = {0x03, 0x19, 0x02, 0x0E, 0x00, 0x00, 0x00, 0x00}};
+                             .data = {0x03, 0x19, 0x02, 0xFF, 0x00, 0x00, 0x00, 0x00}};
 
   // DTC readout reassembly state. The reply shares the 0x7BB response ID with the periodic
   // group polling, so it is intercepted separately while a readout is in flight.

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -37,7 +37,10 @@ class NissanLeafBattery : public CanBattery {
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { UserRequestDTCreset = true; }
   bool supports_read_DTC() { return true; }
-  void read_DTC() { UserRequestDTCreadout = true; }
+  void read_DTC() {
+    UserRequestDTCreadout = true;
+    dtc_read_retries = 0;
+  }
   bool supports_insulation_resistance() { return true; }
 
   bool soc_plausible() {
@@ -59,6 +62,9 @@ class NissanLeafBattery : public CanBattery {
   // Parses a fully reassembled UDS ReadDTCInformation reply out of dtc_buffer into
   // datalayer_battery->dtc.
   void parseDTCResponse();
+
+  // Sends pending DTC requests once the diagnostic channel is idle, and times out unanswered ones.
+  void handle_DTC_requests(unsigned long currentMillis);
   static const int MAX_PACK_VOLTAGE_DV = 4055;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2400;
   static const int MAX_CELL_DEVIATION_MV = 150;
@@ -143,6 +149,16 @@ class NissanLeafBattery : public CanBattery {
                                       .DLC = 8,
                                       .ID = 0x79B,
                                       .data = {0x30, 1, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+  // Flow control for the DTC readout. BS=0 tells the LBC to send every remaining consecutive frame
+  // without waiting for another flow control, so the whole reply arrives in one burst. The group
+  // polling above uses BS=1 and asks frame by frame; for a DTC reply that would mean a flow control
+  // round trip through the main loop per frame, and a long list would be at the mercy of loop
+  // latency. This also matches the flow control used in the reference LBC capture.
+  CAN_frame LEAF_DTC_FLOW_CONTROL = {.FD = false,
+                                     .ext_ID = false,
+                                     .DLC = 8,
+                                     .ID = 0x79B,
+                                     .data = {0x30, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
   CAN_frame LEAF_CLEAR_DTC = {.FD = false,
                               .ext_ID = false,
                               .DLC = 8,
@@ -169,6 +185,23 @@ class NissanLeafBattery : public CanBattery {
   unsigned long dtc_request_millis = 0;
   bool dtc_clear_in_progress = false;
   unsigned long dtc_clear_millis = 0;
+  // The LBC silently discards a diagnostic request that arrives while it is still transmitting a
+  // response, so both DTC operations wait for the 0x7BB channel to go quiet before transmitting.
+  // A group poll transfer completes in well under this, and polls are 10 s apart, so in practice
+  // the wait is either zero or a few tens of milliseconds.
+  static const unsigned long DTC_BUS_IDLE_MS = 100;
+  static const uint8_t DTC_MAX_RETRIES = 2;
+  unsigned long last_7bb_millis = 0;
+  uint8_t dtc_read_retries = 0;
+
+  // Generic tracking of our own outstanding UDS transaction on the 0x79B/0x7BB pair. The LBC serves
+  // one request at a time, so a new one must not go out until the previous answer is complete,
+  // whether that answer was good or an error. This covers the gap between sending a request and the
+  // first response frame arriving, which a quiet-channel check alone cannot see.
+  static const unsigned long UDS_RESPONSE_TIMEOUT_MS = 1000;
+  bool uds_busy = false;
+  unsigned long uds_request_millis = 0;
+  uint16_t uds_rx_remaining = 0;
 
   // The Li-ion battery controller only accepts a multi-message query. In fact, the LBC transmits many
   // groups: the first one contains lots of High Voltage battery data as SOC, currents, and voltage; the second

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -106,7 +106,13 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     }
 
     unsigned long age_s = (millis() - dtc.dtc_last_read_millis) / 1000;
-    content += "<p style='color:#bbb;'>" + String(dtc.dtc_count) + " codes &mdash; read " + String(age_s) + "s ago</p>";
+    content += "<p style='color:#bbb;'>" + String(dtc.dtc_count) + " codes";
+    if (dtc.dtc_reported_count > dtc.dtc_count) {
+      // The battery had more to say than there are slots to hold it. Say so, rather than presenting
+      // a truncated list as if it were the whole story.
+      content += " shown of " + String(dtc.dtc_reported_count) + " reported";
+    }
+    content += " &mdash; read " + String(age_s) + "s ago</p>";
     content += "<div style='overflow-x:auto;margin-bottom:12px;'>";
     content +=
         "<table style='margin:0 auto;text-align:left;border-collapse:separate;border-spacing:0;"

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -16,6 +16,11 @@ struct DATALAYER_BATTERY_DTC_TYPE {
   uint8_t dtc_status[MAX_DTC_COUNT];
   // Number of DTCs stored
   uint8_t dtc_count;
+  // Number of DTCs the battery reported in its last answer. Equals dtc_count in the normal case,
+  // and exceeds it when the answer held more codes than MAX_DTC_COUNT slots, so the display can say
+  // that the list is truncated rather than silently showing the first few. Placed here because the
+  // uint16 fits in the padding after dtc_count and costs no extra bytes.
+  uint16_t dtc_reported_count;
   // Last successful read (0 = never read)
   unsigned long dtc_last_read_millis;
   // Indicates that the last read failed

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -293,6 +293,26 @@ TEST(NissanLeafDtcTests, ShouldDrainReplyLargerThanStorage) {
   EXPECT_FALSE(datalayer.battery.dtc.dtc_read_failed);
   EXPECT_EQ(datalayer.battery.dtc.dtc_count, DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT);
   EXPECT_EQ(datalayer.battery.dtc.dtc_codes[0], 0x0A1F00u);  // P0A1F, first code in the real capture
+
+  // The full count is kept even though only the first 32 are stored, so the page can say the list
+  // is truncated. 599 bytes less the 3 byte header is 149 codes.
+  EXPECT_EQ(datalayer.battery.dtc.dtc_reported_count, 149);
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  EXPECT_NE(renderer.get_status_html().str().find("32 codes shown of 149 reported"), std::string::npos);
+}
+
+// When everything fits, the page must not clutter the line with a redundant "of N reported".
+TEST(NissanLeafDtcTests, ShouldNotClaimTruncationWhenEverythingFits) {
+  auto battery = battery_awaiting_dtc_reply();
+
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x07, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00, 0x4E}));
+
+  ASSERT_EQ(datalayer.battery.dtc.dtc_count, 1);
+  EXPECT_EQ(datalayer.battery.dtc.dtc_reported_count, 1);
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  EXPECT_EQ(renderer.get_status_html().str().find("reported"), std::string::npos);
 }
 
 // nissan_leaf_dtc.json is keyed by the 5-character short form, so that is what has to end up in the

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -256,6 +256,45 @@ TEST(NissanLeafDtcTests, ShouldNotConsumeGroupReplyAsDtc) {
   EXPECT_EQ(datalayer.battery.dtc.dtc_codes[0], 0xD00000u);
 }
 
+// Reproduces a reply larger than our storage: the LBC announced 599 bytes (149 codes) when asked
+// with an over-wide status mask. The first 32 codes must be kept, and every remaining frame must
+// still be acknowledged, because falling silent mid-transfer leaves the LBC waiting on a flow
+// control that never arrives and blocks the next request.
+TEST(NissanLeafDtcTests, ShouldDrainReplyLargerThanStorage) {
+  auto battery = battery_awaiting_dtc_reply();
+
+  const uint16_t announced = 599;
+  battery->handle_incoming_can_frame(leaf_frame(
+      0x7BB, {(uint8_t)(0x10 | (announced >> 8)), (uint8_t)(announced & 0xFF), 0x59, 0x02, 0x4E, 0x0A, 0x1F, 0x00}));
+
+  // 6 payload bytes arrived in the first frame; feed consecutive frames until all 599 are sent.
+  uint16_t sent = 6;
+  uint8_t seq = 1;
+  bool checked_midway = false;
+  while (sent < announced) {
+    CAN_frame cf = leaf_frame(0x7BB, {(uint8_t)(0x20 | (seq & 0x0F))});
+    for (uint8_t i = 1; i < 8; i++) {
+      cf.data.u8[i] = (sent < announced) ? 0x40 : 0xFF;
+      sent++;
+    }
+    battery->handle_incoming_can_frame(cf);
+    seq++;
+
+    // Once our storage is full there is still far more to come. The readout must stay open and keep
+    // acknowledging, not declare itself finished the moment the buffer fills.
+    if (!checked_midway && sent >= 3 + 4 * DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT) {
+      EXPECT_EQ(datalayer.battery.dtc.dtc_count, 0) << "readout ended early instead of draining";
+      checked_midway = true;
+    }
+  }
+  EXPECT_TRUE(checked_midway);
+
+  // Completed rather than timed out, and filled to capacity without overrunning it.
+  EXPECT_FALSE(datalayer.battery.dtc.dtc_read_failed);
+  EXPECT_EQ(datalayer.battery.dtc.dtc_count, DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT);
+  EXPECT_EQ(datalayer.battery.dtc.dtc_codes[0], 0x0A1F00u);  // P0A1F, first code in the real capture
+}
+
 // nissan_leaf_dtc.json is keyed by the 5-character short form, so that is what has to end up in the
 // data-dtc-code attribute the JavaScript loader matches on.
 TEST(NissanLeafDtcTests, ShouldRenderShortNissanCodeAsLookupKey) {

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -238,19 +238,6 @@ TEST(NissanLeafDtcTests, ShouldNotSendRequestWhileEarlierRequestIsUnanswered) {
   EXPECT_EQ(datalayer.battery.dtc.dtc_count, 0);
 }
 
-// With BS=0 flow control the LBC streams every consecutive frame unprompted, so the reply must
-// still reassemble when no further flow control is sent between frames.
-TEST(NissanLeafDtcTests, ShouldReassembleBurstedMultiFrameReply) {
-  auto battery = battery_awaiting_dtc_reply();
-
-  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, 0x13, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00}));
-  battery->handle_incoming_can_frame(leaf_7bb_frame({0x21, 0x4E, 0x33, 0xD7, 0x00, 0x4E, 0x33, 0xD9}));
-  battery->handle_incoming_can_frame(leaf_7bb_frame({0x22, 0x00, 0x4E, 0x33, 0xDD, 0x00, 0x4E, 0xFF}));
-
-  ASSERT_EQ(datalayer.battery.dtc.dtc_count, 4);
-  EXPECT_EQ(datalayer.battery.dtc.dtc_codes[3], 0x33DD00u);
-}
-
 // The periodic group polling answers on 0x7BB too, and its first frame carries 0x02 in the byte the
 // group handler reads as a group number. The 0x61 service byte is what keeps the two apart, so a
 // group reply arriving mid-readout must not be swallowed by the DTC reassembler.

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -7,11 +7,11 @@
 
 namespace {
 
-// Builds a 0x7BB reply frame from up to 8 raw bytes.
-CAN_frame leaf_7bb_frame(std::initializer_list<uint8_t> bytes) {
+// Builds a frame on the given ID from up to 8 raw bytes.
+CAN_frame leaf_frame(uint32_t id, std::initializer_list<uint8_t> bytes) {
   CAN_frame frame = {};
   frame.DLC = 8;
-  frame.ID = 0x7BB;
+  frame.ID = id;
   uint8_t i = 0;
   for (uint8_t b : bytes) {
     if (i >= 8) {
@@ -20,6 +20,10 @@ CAN_frame leaf_7bb_frame(std::initializer_list<uint8_t> bytes) {
     frame.data.u8[i++] = b;
   }
   return frame;
+}
+
+CAN_frame leaf_7bb_frame(std::initializer_list<uint8_t> bytes) {
+  return leaf_frame(0x7BB, bytes);
 }
 
 // The datalayer is a global shared by every test, so put the DTC block back to its power-on state.
@@ -35,7 +39,7 @@ NissanLeafBattery* battery_awaiting_dtc_reply() {
   auto battery = new NissanLeafBattery();
   battery->setup();
   battery->read_DTC();
-  battery->update_values();
+  battery->transmit_can(50000);  // Channel is idle, so the request goes out immediately
   return battery;
 }
 
@@ -116,7 +120,7 @@ TEST(NissanLeafDtcTests, ShouldClearStoredDtcsOnlyOnAcknowledgement) {
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
 
   battery->reset_DTC();
-  battery->update_values();  // Sends 14 FF FF FF, but must not wipe anything yet
+  battery->transmit_can(50000);  // Sends 14 FF FF FF, but must not wipe anything yet
 
   EXPECT_EQ(datalayer.battery.dtc.dtc_count, 1);
 
@@ -141,10 +145,10 @@ TEST(NissanLeafDtcTests, ShouldKeepStoredDtcsWhenEraseIsNotAcknowledged) {
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
 
   battery->reset_DTC();
-  battery->update_values();
+  battery->transmit_can(50000);
 
   set_millis64(50000 + 2500);
-  battery->update_values();
+  battery->transmit_can(50000 + 2500);
 
   EXPECT_EQ(datalayer.battery.dtc.dtc_count, 1);
   EXPECT_EQ(datalayer.battery.dtc.dtc_last_read_millis, 50000u);
@@ -164,10 +168,87 @@ TEST(NissanLeafDtcTests, ShouldFlagFailureOnNegativeResponse) {
 TEST(NissanLeafDtcTests, ShouldTimeOutWhenLbcNeverReplies) {
   auto battery = battery_awaiting_dtc_reply();
 
-  set_millis64(50000 + 2500);
-  battery->update_values();
+  // Each unanswered attempt is retried; only after the retries are exhausted is it a failure.
+  unsigned long t = 50000;
+  for (int attempt = 0; attempt < 4; attempt++) {
+    t += 2500;
+    set_millis64(t);
+    battery->transmit_can(t);  // times out this attempt, re-arms if retries remain
+    battery->transmit_can(t);  // sends the retry
+  }
 
   EXPECT_TRUE(datalayer.battery.dtc.dtc_read_failed);
+}
+
+// Regression for the collision seen on real hardware: pressing Read DTC while a group poll transfer
+// was still in flight put 19 02 0E on the bus 1 ms after a flow control frame, and the LBC dropped
+// it without answering. The request must instead wait for the channel to go quiet.
+TEST(NissanLeafDtcTests, ShouldNotSendRequestWhileGroupTransferIsInFlight) {
+  reset_dtc_state();
+  set_millis64(60000);
+  auto battery = new NissanLeafBattery();
+  battery->setup();
+
+  // LBC is mid-transfer: first frame of a group 0x90 reply has just arrived.
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, 0x0A, 0x61, 0x90, 0x47, 0x41, 0x51, 0x31}));
+
+  battery->read_DTC();
+  battery->transmit_can(60000);  // Channel busy, so nothing should go out yet
+
+  // A DTC reply arriving now would mean the request had been sent. Feed one and check it is ignored.
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x07, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00, 0x4E}));
+  EXPECT_EQ(datalayer.battery.dtc.dtc_count, 0);
+
+  // Once the channel has been quiet for longer than the idle threshold, the request goes out.
+  set_millis64(60000 + 200);
+  battery->transmit_can(60000 + 200);
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x07, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00, 0x4E}));
+
+  ASSERT_EQ(datalayer.battery.dtc.dtc_count, 1);
+  EXPECT_EQ(datalayer.battery.dtc.dtc_codes[0], 0xD00000u);
+}
+
+// A request must not go out in the window between an earlier request being sent and its first
+// response frame arriving. The channel looks quiet there, but the LBC is still working on the
+// previous transaction and will drop whatever lands next.
+TEST(NissanLeafDtcTests, ShouldNotSendRequestWhileEarlierRequestIsUnanswered) {
+  reset_dtc_state();
+  set_millis64(70000);
+  auto battery = new NissanLeafBattery();
+  battery->setup();
+
+  // Periodic polling only runs once 0x5BC has marked the battery as alive.
+  battery->handle_incoming_can_frame(leaf_frame(0x5BC, {0x43, 0xC0, 0xB4, 0x8C, 0xC8, 0x02, 0x5F, 0xFF}));
+
+  // Polling is held off for the first few 10 s cycles after startup, so tick past that until a
+  // group request actually goes out. The last tick leaves it outstanding with no reply yet.
+  unsigned long t = 70000;
+  for (int tick = 0; tick < 5; tick++) {
+    battery->transmit_can(t);
+    t += 10001;
+  }
+  battery->transmit_can(t);  // This one puts a group request on the bus
+
+  set_millis64(t + 500);
+  battery->read_DTC();
+  battery->transmit_can(t + 500);  // Channel is quiet, but that request is still unanswered
+
+  // If the DTC request had gone out, this reply would be accepted.
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x07, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00, 0x4E}));
+  EXPECT_EQ(datalayer.battery.dtc.dtc_count, 0);
+}
+
+// With BS=0 flow control the LBC streams every consecutive frame unprompted, so the reply must
+// still reassemble when no further flow control is sent between frames.
+TEST(NissanLeafDtcTests, ShouldReassembleBurstedMultiFrameReply) {
+  auto battery = battery_awaiting_dtc_reply();
+
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, 0x13, 0x59, 0x02, 0x4E, 0xD0, 0x00, 0x00}));
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x21, 0x4E, 0x33, 0xD7, 0x00, 0x4E, 0x33, 0xD9}));
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x22, 0x00, 0x4E, 0x33, 0xDD, 0x00, 0x4E, 0xFF}));
+
+  ASSERT_EQ(datalayer.battery.dtc.dtc_count, 4);
+  EXPECT_EQ(datalayer.battery.dtc.dtc_codes[3], 0x33DD00u);
 }
 
 // The periodic group polling answers on 0x7BB too, and its first frame carries 0x02 in the byte the


### PR DESCRIPTION
### What
Three fixes to the LEAF DTC readout added in #2681: it could be lost entirely when it collided with the periodic group polling, an oversized reply was abandoned part-way leaving the LBC stranded mid-transfer, and a truncated list was shown as if complete. Adds one generic datalayer field so any battery can report a truncated DTC list.

### Why
Captured on hardware: `03 19 02 0E` went out 1 ms after a flow control, in the middle of a group 0x90 transfer, and the LBC silently discarded it — no `59 02` ever came back. A later capture announced 599 bytes (149 codes); we filled our 32-code buffer at frame 18 of 86 and stopped acknowledging, leaving the LBC waiting on a flow control that never arrived.

### How
`uds_busy` tracks our outstanding request on 0x79B/0x7BB and no new one goes out until the previous answer is complete, error or good; a quiet-channel check and an SOH-clear guard cover the rest. Oversized replies are now drained to the end, storing the first 32 and reporting the true count ("32 codes shown of 149 reported"). Status mask stays at `0x0E`.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)