### PR TITLE
ISOTP/UDS library tweaks (const-ing the things)

### DIFF
--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -1308,7 +1308,7 @@ void MebBattery::uds_read_data_by_id(uint16_t did, unsigned long currentMillis) 
   uds_request_timestamp = currentMillis;
 }
 
-void MebBattery::on_isotp_can_tx(uint32_t can_id, uint8_t* can_data, uint8_t can_dlc) {
+void MebBattery::on_isotp_can_tx(uint32_t can_id, const uint8_t* can_data, uint8_t can_dlc) {
   // Called by the ISO-TP layer to emit a raw CAN-FD frame.
   CAN_frame frame;
   frame.FD = true;
@@ -1319,12 +1319,12 @@ void MebBattery::on_isotp_can_tx(uint32_t can_id, uint8_t* can_data, uint8_t can
   transmit_can_frame(&frame);
 }
 
-void MebBattery::on_isotp_rx_complete(uint8_t* data, int len, isotp_tatype tatype) {
+void MebBattery::on_isotp_rx_complete(const uint8_t* data, int len, isotp_tatype tatype) {
   // A complete UDS message has been assembled by the ISO-TP layer.
   uds_response_handler(data, len, tatype);
 }
 
-void MebBattery::uds_response_handler(uint8_t* data, int len, enum isotp_tatype type) {
+void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_tatype type) {
   if (len < 1)
     return;
   uint8_t response_service_id = data[0];

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -39,15 +39,15 @@ class MebBattery : public CanBattery, public IsoTp {
   /* validate crc for some CAN frames */
   uint8_t vw_crc_calc(const uint8_t* inputBytes, uint8_t length, uint32_t address);
   /* send a UDS ReadDataByIdentifier request for did via ISO-TP */
-  void uds_read_data_by_id(uint16_t did, unsigned long currentMillis);
+  void uds_read_data_by_id(const uint16_t did, unsigned long currentMillis);
   /* handle a UDS response assembled by the ISO-TP layer */
-  void uds_response_handler(uint8_t* data, int len, enum isotp_tatype type);
+  void uds_response_handler(const uint8_t* data, int len, enum isotp_tatype type);
   /* drive the BMS reset state machine — called every transmit_can() tick */
   void handle_bms_reset(unsigned long currentMillis);
   /* IsoTp override: send a raw CAN frame */
-  void on_isotp_can_tx(uint32_t can_id, uint8_t* can_data, uint8_t can_dlc) override;
+  void on_isotp_can_tx(uint32_t can_id, const uint8_t* can_data, uint8_t can_dlc) override;
   /* IsoTp override: process an assembled ISO-TP message */
-  void on_isotp_rx_complete(uint8_t* data, int len, isotp_tatype tatype) override;
+  void on_isotp_rx_complete(const uint8_t* data, int len, isotp_tatype tatype) override;
   MebHtmlRenderer renderer;
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;

--- a/Software/src/lib/uds_isotp/isotp.cpp
+++ b/Software/src/lib/uds_isotp/isotp.cpp
@@ -43,7 +43,7 @@ void IsoTp::send_fc(uint8_t flowstatus) {
   _rxtimer = CONFIG_ISOTP_CR_TIMEOUT;
 }
 
-void IsoTp::rcv_fc(uint8_t* can_data, uint8_t can_dlc) {
+void IsoTp::rcv_fc(const uint8_t* can_data, uint8_t can_dlc) {
   uint8_t off = addr_off();
   if (_tx.state == ISOTP_WAIT_FC || _tx.state == ISOTP_WAIT_FIRST_FC) {
     _txtimer = 0;
@@ -85,7 +85,7 @@ void IsoTp::rcv_fc(uint8_t* can_data, uint8_t can_dlc) {
   }
 }
 
-void IsoTp::rcv_sf(uint8_t* can_data, uint8_t can_dlc) {
+void IsoTp::rcv_sf(const uint8_t* can_data, uint8_t can_dlc) {
   uint8_t off = addr_off();
   uint8_t sf_pci_size = SF_PCI_SZ;
   _rxtimer  = 0;
@@ -105,7 +105,7 @@ void IsoTp::rcv_sf(uint8_t* can_data, uint8_t can_dlc) {
   }
 }
 
-void IsoTp::rcv_ff(uint8_t* can_data, uint8_t can_dlc) {
+void IsoTp::rcv_ff(const uint8_t* can_data, uint8_t can_dlc) {
   uint8_t off = addr_off();
   _rxtimer  = 0;
   _rx.state = ISOTP_IDLE;
@@ -127,7 +127,7 @@ void IsoTp::rcv_ff(uint8_t* can_data, uint8_t can_dlc) {
   }
 }
 
-void IsoTp::rcv_cf(uint8_t* can_data, uint8_t can_dlc) {
+void IsoTp::rcv_cf(const uint8_t* can_data, uint8_t can_dlc) {
   uint8_t off = addr_off();
   if (_rx.state == ISOTP_WAIT_DATA) {
     _rxtimer = 0;
@@ -231,7 +231,7 @@ void IsoTp::isotp_init(uint32_t tx_id, isotp_addrmode addrmode, uint8_t tx_addr,
   _rx_addr    = rx_addr;
 }
 
-void IsoTp::isotp_send(uint8_t* data, int len) {
+void IsoTp::isotp_send(const uint8_t* data, int len) {
   uint8_t off = addr_off();
   if (_tx.state == ISOTP_IDLE && len <= CONFIG_ISOTP_MAX_MSG_LENGTH) {
     memcpy(_tx.buf, data, len);
@@ -246,7 +246,7 @@ void IsoTp::isotp_send(uint8_t* data, int len) {
   }
 }
 
-void IsoTp::isotp_receive(uint8_t* can_data, uint8_t can_dlc, isotp_tatype tatype) {
+void IsoTp::isotp_receive(const uint8_t* can_data, uint8_t can_dlc, isotp_tatype tatype) {
   uint8_t off = addr_off();
   /* in extended mode, silently discard frames not addressed to us */
   if (off && can_data[0] != _rx_addr) return;
@@ -308,6 +308,6 @@ void IsoTp::isotp_poll() {
   }
 }
 
-bool IsoTp::isotp_is_busy() const{
+bool IsoTp::isotp_is_busy() const {
   return _rx.state != ISOTP_IDLE || _tx.state != ISOTP_IDLE;
 }

--- a/Software/src/lib/uds_isotp/isotp.h
+++ b/Software/src/lib/uds_isotp/isotp.h
@@ -46,10 +46,10 @@ class IsoTp {
                   uint8_t rx_addr = 0x00);
 
   /** Enqueue a message for transmission (up to CONFIG_ISOTP_MAX_MSG_LENGTH bytes). */
-  void isotp_send(uint8_t* data, int len);
+  void isotp_send(const uint8_t* data, int len);
 
   /** Feed a raw received CAN frame into the state machine. */
-  void isotp_receive(uint8_t* can_data, uint8_t can_dlc, isotp_tatype tatype);
+  void isotp_receive(const uint8_t* can_data, uint8_t can_dlc, isotp_tatype tatype);
 
   /** Must be called every 1 ms to drive timers and retransmissions. */
   void isotp_poll();
@@ -59,10 +59,10 @@ class IsoTp {
 
  protected:
   /** Called by the protocol layer when it needs to emit a raw CAN frame. */
-  virtual void on_isotp_can_tx(uint32_t can_id, uint8_t* can_data, uint8_t can_dlc) = 0;
+  virtual void on_isotp_can_tx(uint32_t can_id, const uint8_t* can_data, uint8_t can_dlc) = 0;
 
   /** Called when a complete ISO-TP message has been assembled. */
-  virtual void on_isotp_rx_complete(uint8_t* data, int len, isotp_tatype tatype) = 0;
+  virtual void on_isotp_rx_complete(const uint8_t* data, int len, isotp_tatype tatype) = 0;
 
  private:
   struct TpCon {
@@ -93,10 +93,10 @@ class IsoTp {
   uint8_t addr_off() const { return (_addrmode == ISOTP_ADDRMODE_EXTENDED) ? 1 : 0; }
 
   void send_fc(uint8_t flowstatus);
-  void rcv_fc(uint8_t* can_data, uint8_t can_dlc);
-  void rcv_sf(uint8_t* can_data, uint8_t can_dlc);
-  void rcv_ff(uint8_t* can_data, uint8_t can_dlc);
-  void rcv_cf(uint8_t* can_data, uint8_t can_dlc);
+  void rcv_fc(const uint8_t* can_data, uint8_t can_dlc);
+  void rcv_sf(const uint8_t* can_data, uint8_t can_dlc);
+  void rcv_ff(const uint8_t* can_data, uint8_t can_dlc);
+  void rcv_cf(const uint8_t* can_data, uint8_t can_dlc);
   void do_send_sf();
   void do_send_ff();
   void do_send_cf();

--- a/Software/src/lib/uds_isotp/uds.h
+++ b/Software/src/lib/uds_isotp/uds.h
@@ -201,6 +201,15 @@ enum AccessTimingParametersType : uint8_t {
 //   Negative response handling
 // ================================================================
 
+/**
+ * @brief Negative Response SID
+ *
+ * Every negative response message starts with 0x7F (Section 8.4, p. 34):
+ * [0x7F][request SID][NRC]. 0x7F is not a service identifier itself, so it
+ * lives here rather than in the SID enum above.
+ */
+constexpr uint8_t kNegativeResponseSid = 0x7F;
+
 enum NegativeResponseCode : uint8_t {
   GeneralReject                    = 0x10,
   ServiceNotSupported              = 0x11,


### PR DESCRIPTION
### What
Some minor API changes to the ISOTP library (should be no functionality changes).

Adds `const` in a few places where it makes sense, tightening the API contract.

Also sneaks in a constant for NR_SID (0x7F).

### Why
Should reduce risk of future bugs by making the interfaces more robust.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
