### PR TITLE
UdsCanBattery superclass

### DIFF
--- a/Software/src/battery/UdsCanBattery.cpp
+++ b/Software/src/battery/UdsCanBattery.cpp
@@ -1,0 +1,502 @@
+#include "UdsCanBattery.h"
+
+#include <Arduino.h>
+#include "../devboard/utils/events.h"
+#include "../devboard/utils/logging.h"
+
+// Timeouts (to wait for a UDS response) in 100ms ticks
+constexpr uint16_t UDS_TIMEOUT_CLEAR_DTC = 25;
+constexpr uint16_t UDS_TIMEOUT_READ_DTC = 20;
+constexpr uint16_t UDS_TIMEOUT_READ_DID = 2;
+// How many times to retry a particular PID read before giving up.
+constexpr uint16_t UDS_PID_MAX_RETRIES = 10;
+// Traffic on 0x7DF (or on uds_address) that isn't ours implies an external
+// diagnostic tool is in use.
+constexpr uint16_t UDS_BROADCAST_REQUEST_ADDRESS = 0x7DF;
+// How long to back off after detecting another diagnostic tool on the bus.
+constexpr uint16_t UDS_EXTERNAL_TOOL_BACKOFF_TICKS = 50;  // 5 seconds
+
+//#define UDS_DEBUG 1
+
+void UdsCanBattery::transmit_uds_can(unsigned long currentMillis) {
+  // Called from batteries' own transmit_can() methods.
+
+  // Poll the underlying ISO-TP layer (at the native ~1KHz rate).
+  isotp_poll();
+
+  // Otherwise we do UDS operations every 100ms.
+  if (currentMillis - previousUdsMillis100 < INTERVAL_100_MS) {
+    return;
+  }
+  previousUdsMillis100 = currentMillis;
+
+  if (seq_pause_ticks > 0) {
+    // We're in a pause period (eg. after a BMS reset, or while an external
+    // tool is using the bus); count it down. New sends are gated by priority
+    // at the send points (send_sequence_message / transmit_uds_pid_scan),
+    // while in-flight transactions keep being ticked normally.
+    seq_pause_ticks--;
+  }
+
+  if (transaction_tick()) {
+    // A request is still in flight (sequence step or PID request), bail.
+    return;
+  }
+
+  if (isotp_is_busy()) {
+    // ISO-TP transaction in progress, wait for it to finish before sending new requests.
+    return;
+  }
+
+  if (seq_state != UDS_STATE_IDLE) {
+    // A sequence is active but nothing is awaiting a response right now: hold
+    // the bus so PID scanning doesn't get in the way.
+    return;
+  }
+
+  if (pending_seq_state != UDS_STATE_IDLE) {
+    // A new sequence was requested, start it now.
+    uint16_t state = pending_seq_state;
+    pending_seq_state = UDS_STATE_IDLE;
+    handle_sequence(state, 0, nullptr, 0);
+    return;
+  }
+
+  if (transmit_uds_pid_scan()) {
+    // We did a PID scan.
+    return;
+  }
+}
+
+bool UdsCanBattery::transaction_tick() {
+  if (uds_transaction_timeout <= 0) {
+    return false;
+  }
+
+  if (--uds_transaction_timeout > 0) {
+    // Still busy, do not send new requests
+    return true;
+  }
+
+  // The current request timed out.
+  uds_current_response_address = 0;
+
+  if (seq_state != UDS_STATE_IDLE) {
+    // A sequence step timed out, retry if we have any retries left. If the
+    // pause now blocks this priority (e.g. an external tool appeared), don't
+    // retry into it — give the step up instead.
+    if (++seq_msg.retries <= seq_msg.max_retries && !uds_paused_for(seq_msg.priority)) {
+      uds_send((SID)seq_msg.sid, seq_msg.data, seq_msg.len, seq_msg.timeout_ticks);
+      return true;
+    }
+    const uint16_t failed = seq_state;
+    seq_state = UDS_STATE_IDLE;
+    // Notify the subclass that it failed
+    on_uds_sequence_timeout(failed);
+  } else if (pending_pid != 0) {
+    // Our PID scan must have timed out
+    on_uds_pid_scan_timeout();
+  }
+
+  return false;
+}
+
+bool UdsCanBattery::start_sequence(uint16_t state) {
+  if (pending_seq_state != UDS_STATE_IDLE) {
+    // A sequence is already active or a PID request is in flight: refuse.
+    return false;
+  }
+
+  pending_seq_state = state;
+  return true;
+}
+
+bool UdsCanBattery::send_sequence_message(uint16_t state, SID sid, const uint8_t* data, uint16_t length,
+                                          uint16_t timeout_ticks, uint8_t max_retries, UdsPriority priority) {
+  if (seq_state != UDS_STATE_IDLE || pending_pid != 0 || uds_paused_for(priority)) {
+    // A sequence is already active, a PID request is in flight, or the pause
+    // blocks this priority: refuse.
+    return false;
+  }
+
+  if (length > sizeof(seq_msg.data)) {
+    // Payload doesn't fit the sequence buffer; refuse rather than truncate.
+    return false;
+  }
+
+  seq_state = state;
+  seq_msg.sid = (uint8_t)sid;
+  seq_msg.len = length;
+  memcpy(seq_msg.data, data, seq_msg.len);
+  seq_msg.timeout_ticks = timeout_ticks;
+  seq_msg.retries = 0;
+  seq_msg.max_retries = max_retries;
+  seq_msg.priority = priority;
+  uds_send(sid, seq_msg.data, seq_msg.len, timeout_ticks);
+  return true;
+}
+
+void UdsCanBattery::pause_uds(uint16_t ticks_100ms, UdsPriority block_upto) {
+  seq_pause_ticks = ticks_100ms;
+  seq_pause_level = block_upto;
+}
+
+bool UdsCanBattery::handle_incoming_uds_can_frame(CAN_frame rx) {
+  // A UDS request frame being received implies that there is a diagnostic tool
+  // on the bus. Back off so we don't interfere with it.
+  if (rx.ID == uds_address || rx.ID == UDS_BROADCAST_REQUEST_ADDRESS) {
+    if (seq_pause_ticks == 0) {
+      logging.println("UDS: external diagnostic traffic detected, backing off");
+    }
+    pause_uds(UDS_EXTERNAL_TOOL_BACKOFF_TICKS, UdsPriority::Custom);
+    return true;
+  }
+
+  if (uds_current_response_address > 0 && rx.ID != uds_current_response_address) {
+    // Not from the address we're mid-transaction with, ignore
+    return false;
+  } else if (uds_response_address > 0 && rx.ID != uds_response_address) {
+    // Not from the address we're expecting responses from, ignore
+    return false;
+  } else if (uds_response_address == 0 && (rx.ID < MIN_UDS_RESPONSE_ID || rx.ID > MAX_UDS_RESPONSE_ID)) {
+    // Outside the range of potential UDS response IDs, ignore
+    return false;
+  }
+
+#ifdef UDS_DEBUG
+  logging.printf("UDS RX: ID=0x%03X DLC=%d data=", rx.ID, rx.DLC);
+  for (int i = 0; i < rx.DLC; i++) {
+    logging.printf("%02X ", rx.data.u8[i]);
+  }
+  logging.println();
+#endif
+
+  // Record the address the current transaction is coming from.
+  uds_current_response_address = rx.ID;
+
+  // Pass down to the ISO-TP layer for reassembly.
+  isotp_receive(rx.data.u8, rx.DLC, ISOTP_TATYPE_PHYSICAL);
+
+  return true;
+}
+
+void UdsCanBattery::on_isotp_can_tx(uint32_t can_id, const uint8_t* can_data, uint8_t can_dlc) {
+
+#ifdef UDS_DEBUG
+  logging.printf("UDS TX: ID=0x%03X DLC=%d data=", can_id, can_dlc);
+  for (int i = 0; i < can_dlc; i++) {
+    logging.printf("%02X ", can_data[i]);
+  }
+  logging.println();
+#endif
+
+  // This is called by isotp_poll() from transmit_uds_can(..)
+  CAN_frame frame = {};
+  frame.ID = uds_address;  // Ignore the can_id from the ISO-TP layer, use our own.
+  frame.DLC = can_dlc;
+  memcpy(frame.data.u8, can_data, can_dlc);
+  transmit_can_frame(&frame);
+}
+
+void UdsCanBattery::on_isotp_rx_complete(const uint8_t* data, int len, isotp_tatype tatype) {
+  // The ISO-TP layer has reassembled a complete UDS response, pass it on for processing.
+  on_uds_receive(data, len);
+}
+
+static inline uint32_t parseBigEndianValue(const uint8_t* data, uint16_t length) {
+  uint32_t val = 0;
+  for (uint16_t i = 0; i < length && i < 4; i++) {
+    val = (val << 8) | data[i];
+  }
+  return val;
+}
+
+bool UdsCanBattery::transmit_uds_pid_scan() {
+  // Called during the transmit phase if there's nothing else to do. Sends the
+  // next request in the PID scan cycle. The PID list is walked in order and
+  // wraps around at the end; if handle_pid() requested a one-shot detour PID,
+  // that is sent instead and the list walk resumes afterwards.
+
+  if (pid_list == nullptr || pid_list_len == 0) {
+    return false;
+  }
+
+  if (uds_paused_for(UdsPriority::PidScan)) {
+    // The current pause blocks PID scanning (pause level >= PidScan). Leave
+    // the scan position untouched so it resumes where it left off.
+    return false;
+  }
+
+  if (next_pid == 0) {
+    // Pick the next PID from the scan list (wrapping around at the end).
+    if (pid_scan_index >= pid_list_len) {
+      pid_scan_index = 0;
+    }
+    next_pid = pid_list[pid_scan_index];
+  }
+
+  // Request the next PID
+  pending_pid = next_pid;
+  const uint8_t data[2] = {(uint8_t)((next_pid >> 8) & 0xFF), (uint8_t)(next_pid & 0xFF)};
+  uds_send(SID::ReadDataByIdentifier, data, sizeof(data), UDS_TIMEOUT_READ_DID);
+  return true;
+}
+
+bool UdsCanBattery::on_uds_pid_scan_response(uint8_t sid, const uint8_t* data, uint16_t len) {
+  // Possibly a PID response - if so, handle and return true (the PID
+  // transaction is finished). Returns false if the message doesn't finish the
+  // current PID transaction (unmatched frame, malformed response, or
+  // ResponsePending, for which we keep waiting).
+
+  if (sid == UDS_RESPONSE_SID_OF(SID::ReadDataByIdentifier)) {
+    // This is a normal PID response, pass it to the handler
+    if (len < 3) {
+      // Malformed: no DID present, keep waiting for a proper response.
+      return false;
+    }
+    uint16_t did = (data[1] << 8) | data[2];
+    // Value starts at data[3]
+    // Decode up to 4 bytes of value, big endian.
+    uint32_t val = len > 3 ? parseBigEndianValue(&data[3], len - 3) : 0;
+
+    // The handler returns 0 to advance the scan list, or a PID to query
+    // out-of-sequence first (a one-shot detour).
+    next_pid = handle_pid(did, val, &data[3], len - 3);
+    if (next_pid == 0) {
+      advance_pid_scan();
+    }
+    pending_pid = 0;
+    pid_retries = 0;
+    return true;
+  } else if (sid == kNegativeResponseSid && len >= 3 && data[1] == (uint8_t)SID::ReadDataByIdentifier) {
+    if (data[2] == NegativeResponseCode::RequestCorrectlyReceived_ResponsePending) {
+      // ResponsePending: keep waiting for the real response.
+      return false;
+    }
+    // Negative response to a PID request. Errors are swallowed for now: move
+    // on to the next PID in the scan list.
+    next_pid = 0;
+    advance_pid_scan();
+    pending_pid = 0;
+    pid_retries = 0;
+    return true;
+  }
+
+  return false;
+}
+
+void UdsCanBattery::on_uds_pid_scan_timeout() {
+  // Called when a PID scan request times out.
+
+  pid_retries++;
+  if (pid_retries < UDS_PID_MAX_RETRIES) {
+    // Keep retrying...
+    return;
+  }
+
+  // Move on to the next PID in the scan list.
+  next_pid = 0;
+  advance_pid_scan();
+  pending_pid = 0;
+  pid_retries = 0;
+}
+
+void UdsCanBattery::on_uds_receive(const uint8_t* data, uint16_t len) {
+  // We've received a complete UDS response message.
+
+  if (len < 1) {
+    return;
+  }
+
+  const SID sid = (SID)data[0];
+
+  // Debugging
+  if (sid != UDS_RESPONSE_SID_OF(SID::ReadDataByIdentifier)) {
+    logging.printf("UDS RX: SID=0x%02X data=", (uint8_t)sid);
+    for (int i = 0; i < len; i++) {
+      logging.printf("%02X ", data[i]);
+    }
+    logging.println();
+  }
+
+  if (seq_state == UDS_STATE_IDLE && pending_pid == 0) {
+    // Nothing in flight: this can't be a response to anything we sent. Don't
+    // let it pin the response address for a future transaction.
+    uds_current_response_address = 0;
+    return;
+  }
+
+  if (seq_state != UDS_STATE_IDLE) {
+    // Is this a response to the in-flight sequence step (positive or negative)?
+    const bool matched = (sid == UDS_RESPONSE_SID_OF(seq_msg.sid)) ||
+                         (sid == kNegativeResponseSid && len >= 3 && data[1] == seq_msg.sid);
+    if (matched && sid == kNegativeResponseSid &&
+        data[2] == NegativeResponseCode::RequestCorrectlyReceived_ResponsePending) {
+      // ResponsePending: the ECU is still working on the step. Keep waiting for
+      // the real response and extend the transaction timeout.
+      uds_transaction_timeout = seq_msg.timeout_ticks;
+    } else if (matched) {
+      // The current transaction is now finished.
+      uds_transaction_timeout = 0;
+      uds_current_response_address = 0;
+      const uint16_t state = seq_state;
+      // Go back to idle, the following functions may then override with the next step
+      seq_state = UDS_STATE_IDLE;
+      handle_sequence(state, (uint8_t)sid, data, len);
+    }
+    // Unmatched messages (stray/late responses) are ignored without touching
+    // the in-flight transaction, so a stray frame can't kill the request.
+    return;
+  }
+
+  // No sequence active, handle PID scan responses.
+  if (pending_pid != 0 && on_uds_pid_scan_response(sid, data, len)) {
+    // The response finished the PID transaction.
+    uds_transaction_timeout = 0;
+    uds_current_response_address = 0;
+  }
+}
+
+void UdsCanBattery::handle_sequence(uint16_t state, uint8_t sid, const uint8_t* data, uint16_t len) {
+  // Dispatches responses for sequence states. Subclasses can override this to
+  // handle their own sequence states.
+  if (state & UDS_STATE_INTERNAL) {
+    handle_internal_sequence(state, sid, data, len);
+  } else {
+    on_uds_sequence_step(state, sid, data, len);
+  }
+}
+
+void UdsCanBattery::handle_internal_sequence(uint16_t state, uint8_t sid, const uint8_t* data, uint16_t len) {
+  // Handle internal sequence responses.
+  switch (state) {
+    case UDS_STATE_READ_DTC_START:
+      // Start a DTC readout sequence
+      send_sequence_message(UDS_STATE_READ_DTC, SID::ReadDTCInformation, (const uint8_t*)"\x02\x09", 2,
+                            UDS_TIMEOUT_READ_DTC, 2);
+      break;
+    case UDS_STATE_READ_DTC:
+      if (sid == UDS_RESPONSE_SID_OF(SID::ReadDTCInformation)) {
+        handle_dtc_response(data, len);
+      } else if (dtc != nullptr) {
+        // Negative response to the DTC read: mark the readout as failed.
+        dtc->dtc_read_failed = true;
+        dtc->dtc_last_read_millis = millis();
+      }
+      break;
+
+    case UDS_STATE_CLEAR_DTC_START:
+      // Start a DTC clear sequence
+      send_sequence_message(UDS_STATE_CLEAR_DTC, SID::ClearDiagnosticInformation, (const uint8_t*)"\xFF\xFF\xFF", 3,
+                            UDS_TIMEOUT_CLEAR_DTC, 2);
+      break;
+    case UDS_STATE_CLEAR_DTC:
+      // Positive response (0x54): nothing to do, the sequence has ended.
+      break;
+  }
+}
+
+void UdsCanBattery::handle_dtc_response(const uint8_t* data, uint16_t len) {
+  if (dtc == nullptr)
+    return;
+
+  if (len < 2 || data[1] != 0x02) {
+    // Unexpected report type or a malformed response — treat as a failed readout.
+    dtc->dtc_read_failed = true;
+  } else {
+    dtc->dtc_read_failed = false;
+    int dtcStartIndex = 3;  // Skip 59 02 <statusAvailabilityMask>
+    int availableBytes = len - dtcStartIndex;
+    int maxDtcCount = availableBytes / 4;
+
+    if (maxDtcCount > dtc->MAX_DTC_COUNT) {
+      maxDtcCount = dtc->MAX_DTC_COUNT;
+      logging.println("DTC count exceeds buffer, truncating");
+    }
+    if (maxDtcCount < 0)
+      maxDtcCount = 0;
+
+    for (int i = 0; i < maxDtcCount; i++) {
+      int offset = dtcStartIndex + (i * 4);
+      // Bounds check to ensure we don't read beyond the buffer
+      if (offset + 3 > len)
+        break;
+      // Combine 3 bytes into a single uint32
+      uint32_t dtcCode =
+          ((uint32_t)data[offset] << 16) | ((uint32_t)data[offset + 1] << 8) | (uint32_t)data[offset + 2];
+      uint8_t dtcStatus = data[offset + 3];
+      dtc->dtc_codes[i] = dtcCode;
+      dtc->dtc_status[i] = dtcStatus;
+    }
+    dtc->dtc_count = maxDtcCount;
+  }
+  dtc->dtc_last_read_millis = millis();
+}
+
+// Low level UDS send
+
+void UdsCanBattery::uds_send(SID service_id, const uint8_t* data, uint16_t length, uint32_t timeout) {
+  uint8_t payload[256];
+
+  if (length >= sizeof(payload)) {
+    return;
+  }
+  payload[0] = static_cast<uint8_t>(service_id);
+  memcpy(&payload[1], data, length);
+  isotp_send(payload, length + 1);
+
+  // Debugging
+  if (service_id != SID::ReadDataByIdentifier) {
+    logging.printf("UDS TX: SID=0x%02X data=", (uint8_t)service_id);
+    for (int i = 0; i < length; i++) {
+      logging.printf("%02X ", data[i]);
+    }
+    logging.println();
+  }
+
+  uds_transaction_timeout = timeout;
+}
+
+void UdsCanBattery::setup_uds(uint16_t uds_address, uint16_t uds_response_address) {
+  this->uds_address = uds_address;
+  isotp_init(uds_address);
+  this->uds_response_address = uds_response_address;
+  this->pid_scan_index = 0;
+  this->next_pid = 0;
+  this->pending_pid = 0;
+}
+
+void UdsCanBattery::set_pid_scan_list(const uint16_t* pid_list, uint16_t length) {
+  // Point at the (possibly flash-resident) list; the scan restarts from the
+  // beginning of the new list.
+  this->pid_list = pid_list;
+  this->pid_list_len = length;
+  this->pid_scan_index = 0;
+  this->next_pid = 0;
+  this->pending_pid = 0;
+}
+
+String UdsBatteryHtmlRenderer::get_status_html() {
+  String ret = battery.get_uds_info_html();
+  if (battery.dtc != nullptr) {
+    ret += BatteryHtmlRenderer::render_dtc_section_html(*battery.dtc, battery.get_dtc_json_filename(),
+                                                        battery.get_dtc_standard_code_string());
+  }
+  return ret;
+}
+
+bool UdsCanBattery::supports_read_DTC() {
+  return true;
+}
+
+bool UdsCanBattery::supports_reset_DTC() {
+  return true;
+}
+
+void UdsCanBattery::read_DTC() {
+  start_sequence(UDS_STATE_READ_DTC_START);
+}
+
+void UdsCanBattery::reset_DTC() {
+  start_sequence(UDS_STATE_CLEAR_DTC_START);
+}

--- a/Software/src/battery/UdsCanBattery.h
+++ b/Software/src/battery/UdsCanBattery.h
@@ -1,0 +1,267 @@
+#pragma once
+
+#include "../lib/uds_isotp/isotp.h"
+#include "../lib/uds_isotp/uds.h"
+#include "CanBattery.h"
+#include "freertos/FreeRTOS.h"
+
+#include <atomic>
+
+// Extend this class to add UDS features to a battery integration.
+//
+// 1. Call `setup_uds(uint16_t uds_address, uint16_t uds_response_address)` in
+//    your battery's setup() function to initialize UDS handling.
+//     - uds_address (the CAN ID of the ECU to query, e.g. 0x7DF for generic
+//       requests)
+//     - uds_response_address (the CAN ID that UDS responses must come from, or
+//       0 to auto-detect)
+//
+// 2. Call `set_pid_scan_list(const uint16_t* pids, uint16_t length)` to set the
+//    list of PIDs to query, in scan order (e.g. {0xF18A, 0xF120, ...}). The
+//    list is walked from start to end and then wraps around. Call it again at
+//    any time to switch to a different list. PID scanning runs whenever no
+//    sequence (below) is active.
+//
+// 3. Call `transmit_uds_can(unsigned long currentMillis)` in your battery's
+//    transmit_can() function to send UDS requests periodically.
+//
+// 4. Call `handle_incoming_uds_can_frame(CAN_frame rx_frame)` in your battery's
+//    `handle_incoming_can_frame(CAN_frame rx_frame)` function to process
+//    incoming UDS responses. If it returns true, the frame was handled by the
+//    UDS layer so you can ignore it.
+//
+// 5. Override `handle_pid(uint16_t pid, uint32_t value, const uint8_t* data,
+//    uint16_t length)` to be passed successful PID query responses. The
+//    arguments are:
+//     - pid: the PID that the response is for
+//     - value: the value of the PID (big-endian, truncated to four bytes if the
+//       response is longer)
+//     - data: the raw data bytes of the value
+//     - length: the length of the value in bytes Only successful responses are
+//       passed to handle_pid - failed requests (timeouts, negative responses)
+//       are retried and then skipped without notifying the handler. Return 0 to
+//       continue with the next PID in the scan list, or return a PID to request
+//       it once out-of-sequence first (e.g. to sample a fast-changing PID more
+//       often), after which the scan list resumes where it left off.
+//
+// SEQUENCES
+//
+// Multi-step UDS operations (resets, writes, routine control, security access,
+// ...) are built from sequences of steps.
+//   - Define an enum with a state for each step in your sequences.
+//   - Start a sequence with `start_sequence(STARTING_STATE)`
+//   - Override `on_uds_sequence_step(state, sid, data, len)` to handle any
+//     response and send the next step.
+//   - Optionally override `on_uds_sequence_timeout(state)` to handle a step
+//     timing out (the superclass retries automatically).
+
+class UdsCanBattery;
+
+// Default HTML renderer for UDS batteries. Avoids needing a custom renderer
+// class for simple UDS batteries that just show some basic information above
+// the DTC section.
+
+class UdsBatteryHtmlRenderer : public BatteryHtmlRenderer {
+ public:
+  explicit UdsBatteryHtmlRenderer(UdsCanBattery& battery) : battery(battery) {}
+
+  String get_status_html() override;
+
+  // Reads only per-instance data (the battery's own dtc pointer and info
+  // HTML), so the advanced page may also show it for battery 2/3.
+  bool renders_own_battery_data() override { return true; }
+
+ private:
+  UdsCanBattery& battery;
+};
+
+class UdsCanBattery : public CanBattery, public IsoTp {
+ public:
+  UdsCanBattery(CAN_Speed speed = CAN_Speed::CAN_SPEED_500KBPS) : CanBattery(speed), uds_renderer(*this) {}
+  UdsCanBattery(CAN_Interface interface, CAN_Speed speed = CAN_Speed::CAN_SPEED_500KBPS)
+      : CanBattery(interface, speed), uds_renderer(*this) {}
+
+  // Sequence step states for our own functions. Internal states here should
+  // have the UDS_STATE_INTERNAL bit set, subclass states should not.
+  enum UdsState : uint16_t {
+    UDS_STATE_IDLE = 0,
+    UDS_STATE_INTERNAL = 0x8000,
+    // Superclass-internal sequences.
+    UDS_STATE_READ_DTC_START = UDS_STATE_INTERNAL | 0x01,
+    UDS_STATE_READ_DTC,  // 0x19 0x02
+    UDS_STATE_CLEAR_DTC_START = UDS_STATE_INTERNAL | 0x03,
+    UDS_STATE_CLEAR_DTC,  // 0x14 FF FF FF
+  };
+
+  // Priority levels for UDS traffic, used by pause_uds() and
+  // send_sequence_message(). Higher priority can bypass pauses, a pause at
+  // level N blocks new sends with priority <= N.
+  enum class UdsPriority : uint8_t {
+    Sequence = 0,  // Sequence steps (the send_sequence_message() default)
+    PidScan = 1,   // Regular PID scanning
+    Custom = 2,    // User-initiated custom diagnostic messages
+  };
+
+  inline bool uds_is_busy() const { return seq_state != UDS_STATE_IDLE || pending_pid != 0 || seq_pause_ticks > 0; }
+
+  virtual bool supports_read_DTC();
+  virtual bool supports_reset_DTC();
+  virtual void read_DTC();
+  virtual void reset_DTC();
+
+  // Advanced battery page (see UdsBatteryHtmlRenderer). The built-in renderer
+  // shows the DTC section; override these hooks to customize it without
+  // writing a whole renderer class:
+  //  - get_uds_info_html(): HTML displayed above the DTC section (e.g. UDS
+  //    address, VIN, raw PID payloads).
+  //  - get_dtc_json_filename(): DTC description JSON file under
+  //    BatteryHtmlRenderer::GITHUB_RAW_BASE_URL, or "" to only offer the
+  //    local file picker.
+  //  - get_dtc_standard_code_string(): false for raw 6-digit hex codes, true
+  //    for SAE-format codes (e.g. P0C9500).
+  virtual String get_uds_info_html() { return String(); }
+  virtual const char* get_dtc_json_filename() { return ""; }
+  virtual bool get_dtc_standard_code_string() { return true; }
+
+  // The built-in generic renderer. Override to provide a fully custom page.
+  virtual BatteryHtmlRenderer& get_status_renderer() override { return uds_renderer; }
+
+  // Temporarily block new UDS sends for the given number of 100ms ticks. Blocks
+  // transmits at or below the specified priority level, higher priority ones
+  // can still send. In-flight transactions are unaffected — they may still
+  // complete and time out; retries whose priority is blocked are given up
+  // instead of re-sent. Call with 0 ticks to clear.
+  void pause_uds(uint16_t ticks_100ms, UdsPriority block_upto = UdsPriority::PidScan);
+
+  DATALAYER_BATTERY_DTC_TYPE* dtc = nullptr;
+
+ protected:
+  // Initializes the UDS layer. Must be called by subclasses in their setup() function.
+  void setup_uds(uint16_t uds_address, uint16_t uds_response_address);
+  // Set (or change) the list of PIDs to scan, in order. The list is cycled
+  // repeatedly - the scan restarts from the beginning of the new list.
+  void set_pid_scan_list(const uint16_t* pid_list, uint16_t length);
+
+  // Must be called by subclasses inside their `transmit_can` method.
+  void transmit_uds_can(unsigned long currentMillis);
+  // Must be called by subclasses inside their `handle_incoming_can_frame` method.
+  bool handle_incoming_uds_can_frame(CAN_frame rx_frame);
+
+  // Queues a new UDS sequence. Doesn't send anything yet, but during the next
+  // UDS tick, `on_uds_sequence_step` will be called with the given state,
+  // allowing the subclass to send the first step. Returns false if a sequence
+  // is already active or a PID scan is in flight.
+  bool start_sequence(uint16_t state);
+
+  // Send a single step of a UDS sequence. The state is handed back to
+  // on_uds_sequence_step() along with the response. The step is retried
+  // automatically on timeout, up to `max_retries`. Increasing `priority` allows
+  // the send to override pauses (depending on level). Returns false if unable
+  // to send.
+  bool send_sequence_message(uint16_t state, SID sid, const uint8_t* data, uint16_t len, uint16_t timeout_ticks = 10,
+                             uint8_t max_retries = 2, UdsPriority priority = UdsPriority::Sequence);
+
+  // Override this to receive responses to your UDS sequence steps. The state
+  // that was passed with the request is handed back here, along with the
+  // response SID and payload. The subclass can call send_sequence_message()
+  // again to send another message, or send nothing to end it.
+  virtual void on_uds_sequence_step(uint16_t state, uint8_t sid, const uint8_t* data, uint16_t len) {}
+
+  // Override this to be notified when a UDS sequence step has timed out and
+  // exhausted its retry budget. The state that was passed with the request is
+  // handed back here.
+  virtual void on_uds_sequence_timeout(uint16_t state) {}
+
+  // Override this to be passed successful PID query responses. A return value
+  // of 0 causes the PID list to be scanned in order. Return a PID to read it
+  // next, out-of-sequence (e.g. to sample a specific PID more often), after
+  // which the scan list resumes where it left off.
+  virtual uint16_t handle_pid(uint16_t pid, uint32_t value, const uint8_t* data, uint16_t length) { return 0; }
+
+  // Called by the ISO-TP layer to emit CAN frames or notify of complete UDS responses.
+  virtual void on_isotp_can_tx(uint32_t can_id, const uint8_t* can_data, uint8_t can_dlc) override;
+  virtual void on_isotp_rx_complete(const uint8_t* data, int len, isotp_tatype tatype) override;
+
+  // The address we'll send UDS requests to.
+  uint16_t uds_address = 0x7DF;
+  // The address we require UDS responses to come from, or 0 to accept from any
+  // address in the valid range.
+  uint16_t uds_response_address = 0;
+  // The address we are currently receiving a UDS response from.
+  uint16_t uds_current_response_address = 0;
+
+ private:
+  // True if the current pause blocks new sends of the given priority.
+  inline bool uds_paused_for(UdsPriority priority) const { return seq_pause_ticks > 0 && priority <= seq_pause_level; }
+
+  bool transaction_tick();
+
+  // Advance to the next entry in the PID scan list, wrapping around at the end.
+  inline void advance_pid_scan() {
+    if (++pid_scan_index >= pid_list_len) {
+      pid_scan_index = 0;
+    }
+  }
+
+  void uds_send(SID service_id, const uint8_t* data, uint16_t length, uint32_t timeout = 0);
+  bool transmit_uds_pid_scan();
+  bool on_uds_pid_scan_response(uint8_t sid, const uint8_t* data, uint16_t len);
+  void on_uds_pid_scan_timeout();
+  void on_uds_receive(const uint8_t* data, uint16_t len);
+  void handle_dtc_response(const uint8_t* data, uint16_t len);
+  // Dispatches responses for sequence states
+  void handle_sequence(uint16_t state, uint8_t sid, const uint8_t* data, uint16_t len);
+  // Dispatches responses for superclass-internal sequence states.
+  void handle_internal_sequence(uint16_t state, uint8_t sid, const uint8_t* data, uint16_t len);
+  // The request currently in flight as part of a sequence.
+  struct {
+    uint8_t sid;
+    uint8_t data[16];
+    uint8_t len;
+    uint16_t timeout_ticks;  // original timeout, re-applied on each retry
+    uint8_t retries;
+    uint8_t max_retries;
+    UdsPriority priority;  // pause priority of this step
+  } seq_msg;
+
+  // The range of response IDs (addresses) we'll accept UDS responses from if auto-detecting.
+  static const uint16_t MIN_UDS_RESPONSE_ID = 0x780;
+  static const uint16_t MAX_UDS_RESPONSE_ID = 0x7EF;
+
+  uint32_t previousUdsMillis100 = 0;
+  // The list of PIDs to scan, in order. Set with set_pid_scan_list(). The list
+  // is walked from start to end, then wraps around to the beginning.
+  const uint16_t* pid_list = nullptr;
+  // Number of PIDs in pid_list.
+  uint16_t pid_list_len = 0;
+  // Current position in the scan cycle. Advanced after each request completes,
+  // unless handle_pid() returned a detour PID (which is requested for one step
+  // first, before the scan list resumes here).
+  uint16_t pid_scan_index = 0;
+  // The next PID to request. 0 = pick the next entry from pid_list, nonzero =
+  // a one-shot detour PID returned by handle_pid(), requested before the scan
+  // list continues.
+  uint16_t next_pid = 0;
+  // The PID currently being requested.
+  uint16_t pending_pid = 0;
+  // How many times we've retried the current PID request.
+  uint32_t pid_retries = 0;
+  // Current position in the active sequence, or UDS_STATE_IDLE if no sequence
+  // is active. Set by send_sequence_message(), cleared when the response is
+  // dispatched or the step's retry budget is exhausted.
+  uint16_t seq_state = UDS_STATE_IDLE;
+  // The pending next state to start a sequence. Set by start_sequence() and
+  // cleared when the sequence is started.
+  std::atomic<uint16_t> pending_seq_state{UDS_STATE_IDLE};
+  // How many 100ms ticks of quiet (new sends blocked) remain, set by
+  // pause_uds().
+  uint16_t seq_pause_ticks = 0;
+  // The highest priority blocked by the current pause (pause_uds() second
+  // argument).
+  UdsPriority seq_pause_level = UdsPriority::PidScan;
+  // How many ticks left for the current request to complete, before it is
+  // retried (or given up).
+  int16_t uds_transaction_timeout = 0;
+
+  UdsBatteryHtmlRenderer uds_renderer;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,6 +158,7 @@ add_executable(tests
     ../Software/src/battery/THINK-BATTERY.cpp
     ../Software/src/battery/THUNDERSTRUCK-BMS.cpp
     ../Software/src/battery/GEELY-SEA-BATTERY.cpp
+    ../Software/src/battery/UdsCanBattery.cpp
     ../Software/src/battery/VOLVO-SPA-BATTERY.cpp
     ../Software/src/battery/VOLVO-SPA-HYBRID-BATTERY.cpp
     ../Software/src/inverter/AFORE-CAN.cpp


### PR DESCRIPTION
### What
A superclass that batteries can extend to provide basic UDS functionality. Part of the MG HS/ZS/MarvelR/MG5 refactor, but separated out as a separate commit for feedback.

Functionality:
- Uses the new ISOTP lib for flow control
- Subclass can set a list of PIDs to scan, and it will scan them, one every 200ms.
- PIDs are retried up to 10 times (sometimes they timeout during BMS startup)
- PID results are passed back to `handle_pid` callback for batteries to consume
- The callback can return a PID to allow out-of-turn scanning (eg, one PID more often than the main sequence)
- UDS 'sequences' can be triggered, with a battery callback to send the frames in a sequence (interleaved with PID scanning).
- Some sequences are provided internally (reset DTC, read DTC).
- A basic HTML renderer is included that includes battery-generated string, with the standard DTC readout below.
- A `pause_uds` function allows different degrees of UDS traffic to be paused with a specified timeout
- Any UDS traffic from elsewhere (eg, an external scan tool) will pause our traffic for 5s

**Note: includes ISOTP tweaks which will hopefully be merged first**

Original code was me, refactor was me + DS4F-0731, comments are 90% mine, bugs entirely mine ;)

### Why
Tries to reduce a lot of the common code between integrations, to do with PID scanning and DTC readout.

Handles the sequencing between PID scans and other UDS operations (to avoid confusing the BMS by sending two things at once).

Experimentally rebasing some existing integrations on this superclass has saved about 3kb a time (as well as providing extra features like the DTC read).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
