### PR TITLE
Safety :warning: Apply battery2/battery3 power limits to main battery

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -333,6 +333,24 @@ void update_calculated_values(unsigned long currentMillis) {
     datalayer.battery.settings.max_remote_set_discharge_dA = 0;
   }
 
+  /* Cap max charge/discharge to the lowest battery's limits */
+  if (battery2) {
+    if (datalayer.battery.status.max_charge_power_W > datalayer.battery2.status.max_charge_power_W) {
+      datalayer.battery.status.max_charge_power_W = datalayer.battery2.status.max_charge_power_W;
+    }
+    if (datalayer.battery.status.max_discharge_power_W > datalayer.battery2.status.max_discharge_power_W) {
+      datalayer.battery.status.max_discharge_power_W = datalayer.battery2.status.max_discharge_power_W;
+    }
+  }
+  if (battery3) {
+    if (datalayer.battery.status.max_charge_power_W > datalayer.battery3.status.max_charge_power_W) {
+      datalayer.battery.status.max_charge_power_W = datalayer.battery3.status.max_charge_power_W;
+    }
+    if (datalayer.battery.status.max_discharge_power_W > datalayer.battery3.status.max_discharge_power_W) {
+      datalayer.battery.status.max_discharge_power_W = datalayer.battery3.status.max_discharge_power_W;
+    }
+  }
+
   /* Calculate allowed charge/discharge currents. Prefer live pack voltage for the conversion.
      If unavailable (some drivers report 0 before battery comms are up), fall back to the design
      max voltage - conservative, since it under-estimates current for a given power. If that is


### PR DESCRIPTION
### What
(Sorry, yet another PR!)

In multi-battery setups, apply the power limits of battery 2/3 to the first battery if they are lower (since the first battery limits are the ones that are followed).

(This code has been tested on a double battery setup, works as expected)

### Why
Ensures that batteries are not overcharged/discharged - a SoC discrepancy due to drift, plus a significant delta (a not unreasonable scenario) could cause the 2nd/3rd battery to want to shut off charge before the first one is full. This ensures that this happens.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
