### PR TITLE
Give every environment the same managed-component set

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,28 @@
 [platformio]
 src_dir = ./Software
 
+[env]
+custom_sdkconfig = file://sdkconfig.be_size.defaults
+custom_component_remove =
+    espressif/esp_insights
+    espressif/esp_diag_data_store
+    espressif/esp_diagnostics
+    espressif/esp_rainmaker
+    espressif/rmaker_common
+    espressif/network_provisioning
+    espressif/esp-zboss-lib
+    espressif/esp-zigbee-lib
+    espressif/esp-modbus
+    espressif/esp_modem
+    espressif/esp-sr
+    espressif/esp-dsp
+    espressif/qrcode
+    chmorgan/esp-libhelix-mp3
+    espressif/lan867x
+    espressif/w5500
+    espressif/dm9051
+    espressif/ksz8851snl
+
 [env:compiler_warning_check]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 board = esp32dev
@@ -35,29 +57,6 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode). Small-flash target only.
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-; Drop unused arduino-esp32 managed components: reclaims flash and avoids
-; from-source build breaks (esp_insights https_server.crt, esp-modbus assert).
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags = -I include -DHW_DEVKIT -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 
@@ -72,29 +71,6 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = min_spiffs.csv
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode). Small-flash target only.
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-; Drop unused arduino-esp32 managed components: reclaims flash and avoids
-; from-source build breaks (esp_insights https_server.crt, esp-modbus assert).
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags = -I include -DHW_LILYGO -DSMALL_FLASH_DEVICE -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections 
 lib_deps = 
@@ -109,31 +85,8 @@ board_build.f_flash = 80000000
 board_build.arduino.memory_type = qio_qspi
 board_build.partitions = default_8MB.csv
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode).
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-; Drop unused arduino-esp32 managed components: reclaims flash and avoids
-; from-source build breaks (esp_insights https_server.crt, esp-modbus assert).
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags = -I include -DHW_STARK -Wimplicit-fallthrough -Wextra -Wall
     -fno-exceptions -ffunction-sections -fdata-sections -Wl,--gc-sections
 lib_deps = 
@@ -149,27 +102,6 @@ board_build.partitions = default_16MB.csv
 ; mode), but we're not using it anyway.
 board_build.arduino.memory_type = qio_qspi
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode).
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags = 
     -I include
     -Wimplicit-fallthrough
@@ -193,27 +125,6 @@ monitor_filters = default, time, log2file, esp32_exception_decoder
 board_build.partitions = default_16MB.csv
 board_build.arduino.memory_type = qio_qspi
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode).
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags = 
     -I include
     -Wimplicit-fallthrough
@@ -240,27 +151,6 @@ board_build.partitions = default_16MB.csv
 ; The HAL exposes GPIO21 and comm_rs485.cpp configures UART2 in RS485 half-duplex mode.
 board_build.arduino.memory_type = qio_opi
 framework = arduino
-; Flash-size ESP-IDF overrides (pioarduino hybrid mode).
-custom_sdkconfig = file://sdkconfig.be_size.defaults
-custom_component_remove =
-    espressif/esp_insights
-    espressif/esp_diag_data_store
-    espressif/esp_diagnostics
-    espressif/esp_rainmaker
-    espressif/rmaker_common
-    espressif/network_provisioning
-    espressif/esp-zboss-lib
-    espressif/esp-zigbee-lib
-    espressif/esp-modbus
-    espressif/esp_modem
-    espressif/esp-sr
-    espressif/esp-dsp
-    espressif/qrcode
-    chmorgan/esp-libhelix-mp3
-    espressif/lan867x
-    espressif/w5500
-    espressif/dm9051
-    espressif/ksz8851snl
 build_flags =
     -I include
     -Wimplicit-fallthrough


### PR DESCRIPTION
`custom_component_remove` and `custom_sdkconfig` were repeated per-environment in `platformio.ini` — seven copies that had to be kept identical by hand, and `compiler_warning_check` never got them. That has two consequences:

1. **Build-order-dependent failures.** `custom_component_remove` mutates the shared PlatformIO package store, so environments with different remove-lists corrupt each other's framework state. Which error you get depends on interleaving — the "missing" component was different every time (`network_provisioning`, `libsodium`, `esp-libhelix-mp3`), which is what made it look transient and survive retries.
2. **The warning check measured the wrong image.** Building without the removals and without `custom_sdkconfig`, it came out ~39 KB larger than the firmware users actually get, sat at ~100% of the partition, and failed changes for reasons unrelated to their content.

Fix: move both options into the global `[env]` section, which every environment inherits. One copy means nothing to keep in sync; a future environment inherits the correct set by default, and overriding has to be written deliberately.

Verified:
- The failing sequence (compiler warning check, then BECom immediately after) is green.
- Board firmware is byte-identical: BECom builds to 1,925,200 with and without the change.
- Warning check drops 1,950,828 → 1,911,799 (−39,029) — it now measures the image that ships.

Note: drafted with AI assistance, reviewed by me.
