### PR TITLE
Ignore the per-environment sdkconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ test/tests[1]_include.cmake
 logs
 .dummy/
 managed_components/
-sdkconfig.defaults
-sdkconfig.lilygo_330
+sdkconfig.*
+!sdkconfig.be_size.defaults
 
 # Ignore upload command (removes the need to re-compile after Verify when running Download, in e.g. VS Code)
 upload.bat


### PR DESCRIPTION
Every build writes `sdkconfig.<env>` for the environment being built, but only `sdkconfig.lilygo_330` was listed in `.gitignore` — so building any other environment leaves an untracked file in the working tree, and invites accidentally committing one. Widened to `sdkconfig.*`, with the tracked `sdkconfig.be_size.defaults` explicitly excluded so it stays visible.

Note: drafted with AI assistance, reviewed by me.
