### PR TITLE
feat(renault-zoe-gen1): add UDS Service 0x19 DTC readout & initial JSON

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -155,7 +155,8 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       static uint16_t dtc_exp = 0;
 
       if (pci == 0x00 && rx_frame.data.u8[1] == 0x50 && rx_frame.data.u8[2] == 0xC0) {  // Session 0xC0 granted!
-        CAN_frame f = {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x79B, .data = {0x03, 0x19, 0x02, 0xFF, 0, 0, 0, 0}};
+        CAN_frame f = {
+            .FD = false, .ext_ID = false, .DLC = 8, .ID = 0x79B, .data = {0x03, 0x19, 0x02, 0xFF, 0, 0, 0, 0}};
         transmit_can_frame(&f);
         break;
       }
@@ -168,8 +169,8 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
         for (uint16_t i = 0; i < count; i++) {
           uint16_t offset = 2 + (i * 4);
           datalayer_battery->dtc.dtc_codes[i] = ((uint32_t)rx_frame.data.u8[offset] << 16) |
-                                               ((uint32_t)rx_frame.data.u8[offset + 1] << 8) |
-                                               (uint32_t)rx_frame.data.u8[offset + 2];
+                                                ((uint32_t)rx_frame.data.u8[offset + 1] << 8) |
+                                                (uint32_t)rx_frame.data.u8[offset + 2];
           datalayer_battery->dtc.dtc_status[i] = rx_frame.data.u8[offset + 3];
         }
         datalayer_battery->dtc.dtc_count = count;
@@ -194,8 +195,7 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
           for (uint16_t i = 0; i < count; i++) {
             uint16_t offset = 2 + (i * 4);
             datalayer_battery->dtc.dtc_codes[i] = ((uint32_t)dtc_buf[offset] << 16) |
-                                                 ((uint32_t)dtc_buf[offset + 1] << 8) |
-                                                 (uint32_t)dtc_buf[offset + 2];
+                                                  ((uint32_t)dtc_buf[offset + 1] << 8) | (uint32_t)dtc_buf[offset + 2];
             datalayer_battery->dtc.dtc_status[i] = dtc_buf[offset + 3];
           }
           datalayer_battery->dtc.dtc_count = count;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -75,6 +75,7 @@ void RenaultZoeGen1Battery::
 }
 
 void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
+  uint8_t pci = 0;
   switch (rx_frame.ID) {
     case 0x155:  //10ms - Charging power, current and SOC - Confirmed sent by: Fluence ZE40, Zoe 22/41kWh, Kangoo 33kWh
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -147,11 +148,79 @@ void RenaultZoeGen1Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x7BB:  //Reply from active polling
       frame0 = rx_frame.data.u8[0];
+      pci = frame0 & 0xF0;
+
+      static uint8_t dtc_buf[64];
+      static uint16_t dtc_len = 0;
+      static uint16_t dtc_exp = 0;
+
+      if (pci == 0x00 && rx_frame.data.u8[1] == 0x50 && rx_frame.data.u8[2] == 0xC0) {  // Session 0xC0 granted!
+        CAN_frame f = {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x79B, .data = {0x03, 0x19, 0x02, 0xFF, 0, 0, 0, 0}};
+        transmit_can_frame(&f);
+        break;
+      }
+
+      if (pci == 0x00 && rx_frame.data.u8[1] == 0x59) {  // Single Frame positive DTC reply
+        uint16_t count = (frame0 > 2) ? (frame0 - 2) / 4 : 0;
+        if (count > DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT) {
+          count = DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT;
+        }
+        for (uint16_t i = 0; i < count; i++) {
+          uint16_t offset = 2 + (i * 4);
+          datalayer_battery->dtc.dtc_codes[i] = ((uint32_t)rx_frame.data.u8[offset] << 16) |
+                                               ((uint32_t)rx_frame.data.u8[offset + 1] << 8) |
+                                               (uint32_t)rx_frame.data.u8[offset + 2];
+          datalayer_battery->dtc.dtc_status[i] = rx_frame.data.u8[offset + 3];
+        }
+        datalayer_battery->dtc.dtc_count = count;
+        datalayer_battery->dtc.dtc_read_failed = false;
+        datalayer_battery->dtc.dtc_last_read_millis = millis();
+        requested_poll = 0;
+        break;
+      } else if (pci == 0x00 && rx_frame.data.u8[1] == 0x7F) {  // Negative response
+        datalayer_battery->dtc.dtc_read_failed = true;
+        datalayer_battery->dtc.dtc_last_read_millis = millis();
+        requested_poll = 0;
+        break;
+      } else if (pci == 0x20 && requested_poll == GROUP7_DTC_READ) {  // Consecutive Frame DTC response
+        for (uint8_t i = 1; i < 8 && dtc_len < dtc_exp; i++) {
+          dtc_buf[dtc_len++] = rx_frame.data.u8[i];
+        }
+        if (dtc_len >= dtc_exp && dtc_exp > 0) {
+          uint16_t count = (dtc_len > 2) ? (dtc_len - 2) / 4 : 0;
+          if (count > DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT) {
+            count = DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT;
+          }
+          for (uint16_t i = 0; i < count; i++) {
+            uint16_t offset = 2 + (i * 4);
+            datalayer_battery->dtc.dtc_codes[i] = ((uint32_t)dtc_buf[offset] << 16) |
+                                                 ((uint32_t)dtc_buf[offset + 1] << 8) |
+                                                 (uint32_t)dtc_buf[offset + 2];
+            datalayer_battery->dtc.dtc_status[i] = dtc_buf[offset + 3];
+          }
+          datalayer_battery->dtc.dtc_count = count;
+          datalayer_battery->dtc.dtc_read_failed = false;
+          datalayer_battery->dtc.dtc_last_read_millis = millis();
+          requested_poll = 0;
+        }
+        break;
+      }
 
       switch (frame0) {
         case 0x10:  //PID HEADER, datarow 0
           requested_poll = rx_frame.data.u8[3];
           transmit_can_frame(&ZOE_ACK_79B);
+
+          if (requested_poll == GROUP7_DTC_READ && rx_frame.data.u8[2] == 0x59) {
+            dtc_exp = ((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
+            if (dtc_exp > sizeof(dtc_buf)) {
+              dtc_exp = sizeof(dtc_buf);
+            }
+            dtc_len = 0;
+            for (uint8_t i = 2; i < 8 && dtc_len < dtc_exp; i++) {
+              dtc_buf[dtc_len++] = rx_frame.data.u8[i];
+            }
+          }
 
           if (requested_poll == GROUP1_CELLVOLTAGES_1_POLL) {
             cellvoltages[0] = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
@@ -584,37 +653,49 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
   if (currentMillis - previousMillis250 >= INTERVAL_250_MS) {
     previousMillis250 = currentMillis;
 
-    switch (group) {
-      case 0:
-        current_poll = GROUP1_CELLVOLTAGES_1_POLL;
-        break;
-      case 1:
-        current_poll = GROUP2_CELLVOLTAGES_2_POLL;
-        break;
-      case 2:
-        current_poll = GROUP3_METRICS;
-        break;
-      case 3:
-        current_poll = GROUP4_SOC;
-        break;
-      case 4:
-        current_poll = GROUP5_TEMPERATURE_POLL;
-        break;
-      case 5:
-        current_poll = GROUP6_BALANCING;
-        break;
-      default:
-        break;
-    }
-
-    group = (group + 1) % 6;  // Cycle 0-1-2-3-4-5-0-1...
-
-    ZOE_POLL_79B.data.u8[2] = current_poll;
-
     if (UserRequestedDTCReset == true) {
       transmit_can_frame(&ZOE_CLEAR_DTC);
       UserRequestedDTCReset = false;
+    } else if (UserRequestDTCreadout == true) {
+      requested_poll = GROUP7_DTC_READ;
+      dtc_read_start_millis = currentMillis;
+      datalayer_battery->dtc.dtc_count = 0;
+      datalayer_battery->dtc.dtc_read_failed = false;
+      CAN_frame f = {.FD = false, .ext_ID = false, .DLC = 8, .ID = 0x79B, .data = {0x02, 0x10, 0xC0, 0, 0, 0, 0, 0}};
+      transmit_can_frame(&f);
+      UserRequestDTCreadout = false;
+    } else if (requested_poll == GROUP7_DTC_READ) {
+      // Pause routine parameter polling while DTC read sequence is active
+      if (currentMillis - dtc_read_start_millis >= 2000) {
+        datalayer_battery->dtc.dtc_read_failed = true;
+        datalayer_battery->dtc.dtc_last_read_millis = currentMillis;
+        requested_poll = 0;
+      }
     } else {
+      switch (group) {
+        case 0:
+          current_poll = GROUP1_CELLVOLTAGES_1_POLL;
+          break;
+        case 1:
+          current_poll = GROUP2_CELLVOLTAGES_2_POLL;
+          break;
+        case 2:
+          current_poll = GROUP3_METRICS;
+          break;
+        case 3:
+          current_poll = GROUP4_SOC;
+          break;
+        case 4:
+          current_poll = GROUP5_TEMPERATURE_POLL;
+          break;
+        case 5:
+          current_poll = GROUP6_BALANCING;
+          break;
+        default:
+          break;
+      }
+      group = (group + 1) % 6;  // Cycle 0-1-2-3-4-5-0-1...
+      ZOE_POLL_79B.data.u8[2] = current_poll;
       transmit_can_frame(&ZOE_POLL_79B);
     }
   }
@@ -630,4 +711,23 @@ void RenaultZoeGen1Battery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+}
+
+String RenaultZoeGen1HtmlRenderer::get_status_html() {
+  String content;
+
+  content += "<h4>CUV " + String(battery.datalayer_zoe->CUV) + "</h4>";
+  content += "<h4>HVBIR " + String(battery.datalayer_zoe->HVBIR) + "</h4>";
+  content += "<h4>HVBUV " + String(battery.datalayer_zoe->HVBUV) + "</h4>";
+  content += "<h4>EOCR " + String(battery.datalayer_zoe->EOCR) + "</h4>";
+  content += "<h4>HVBOC " + String(battery.datalayer_zoe->HVBOC) + "</h4>";
+  content += "<h4>HVBOT " + String(battery.datalayer_zoe->HVBOT) + "</h4>";
+  content += "<h4>HVBOV " + String(battery.datalayer_zoe->HVBOV) + "</h4>";
+  content += "<h4>COV " + String(battery.datalayer_zoe->COV) + "</h4>";
+  content += "<h4>Battery mileage " + String(battery.datalayer_zoe->mileage_km) + " km</h4>";
+  content += "<h4>Alltime energy " + String(battery.datalayer_zoe->alltime_kWh) + " kWh</h4>";
+
+  content += render_dtc_section_html(battery.datalayer_battery->dtc, "renault_zoe_gen1_dtc.json", false);
+
+  return content;
 }

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -8,6 +8,7 @@
 
 class RenaultZoeGen1Battery : public CanBattery {
   friend class RenaultZoeGen1HtmlRenderer;
+
  public:
   // Use this constructor for the second battery.
   RenaultZoeGen1Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_ZOE* extended, CAN_Interface targetCan)

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -7,10 +7,11 @@
 #include "RENAULT-ZOE-GEN1-HTML.h"
 
 class RenaultZoeGen1Battery : public CanBattery {
+  friend class RenaultZoeGen1HtmlRenderer;
  public:
   // Use this constructor for the second battery.
   RenaultZoeGen1Battery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_ZOE* extended, CAN_Interface targetCan)
-      : CanBattery(targetCan) {
+      : CanBattery(targetCan), renderer(*this) {
     datalayer_battery = datalayer_ptr;
     allows_contactor_closing = nullptr;
     datalayer_zoe = extended;
@@ -19,7 +20,7 @@ class RenaultZoeGen1Battery : public CanBattery {
   }
 
   // Use the default constructor to create the first or single battery.
-  RenaultZoeGen1Battery() {
+  RenaultZoeGen1Battery() : renderer(*this) {
     datalayer_battery = &datalayer.battery;
     allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
     datalayer_zoe = &datalayer_extended.zoe;
@@ -35,11 +36,14 @@ class RenaultZoeGen1Battery : public CanBattery {
 
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { UserRequestedDTCReset = true; }
+  bool supports_read_DTC() { return true; }
+  void read_DTC() { UserRequestDTCreadout = true; }
 
  private:
   RenaultZoeGen1HtmlRenderer renderer;
 
   bool UserRequestedDTCReset = false;
+  bool UserRequestDTCreadout = false;
 
   static const int MAX_PACK_VOLTAGE_DV = 4040;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 3000;
@@ -77,6 +81,11 @@ class RenaultZoeGen1Battery : public CanBattery {
                              .DLC = 8,
                              .ID = 0x79B,
                              .data = {0x04, 0x14, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}};
+  CAN_frame ZOE_READ_DTC = {.FD = false,
+                            .ext_ID = false,
+                            .DLC = 8,
+                            .ID = 0x79B,
+                            .data = {0x03, 0x19, 0x02, 0xFF, 0x00, 0x00, 0x00, 0x00}};
 
 #define GROUP1_CELLVOLTAGES_1_POLL 0x41
 #define GROUP2_CELLVOLTAGES_2_POLL 0x42
@@ -84,6 +93,7 @@ class RenaultZoeGen1Battery : public CanBattery {
 #define GROUP4_SOC 0x03
 #define GROUP5_TEMPERATURE_POLL 0x04
 #define GROUP6_BALANCING 0x07
+#define GROUP7_DTC_READ 0x02
 
   uint16_t LB_SOC = 50;
   uint16_t LB_Display_SOC = 50;
@@ -131,6 +141,7 @@ class RenaultZoeGen1Battery : public CanBattery {
   uint16_t battery_mileage_in_km = 0;
   uint16_t kWh_from_beginning_of_battery_life = 0;
   bool looping_over_20 = false;
+  unsigned long dtc_read_start_millis = 0;
 };
 
 #endif

--- a/Software/src/battery/RENAULT-ZOE-GEN1-HTML.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-HTML.h
@@ -1,27 +1,18 @@
 #ifndef _RENAULT_ZOE_GEN1_HTML_H
 #define _RENAULT_ZOE_GEN1_HTML_H
 
-#include "../datalayer/datalayer.h"
-#include "../datalayer/datalayer_extended.h"
 #include "../devboard/webserver/BatteryHtmlRenderer.h"
+
+class RenaultZoeGen1Battery;
 
 class RenaultZoeGen1HtmlRenderer : public BatteryHtmlRenderer {
  public:
-  String get_status_html() {
-    String content;
+  explicit RenaultZoeGen1HtmlRenderer(RenaultZoeGen1Battery& battery) : battery(battery) {}
+  String get_status_html() override;
+  bool renders_own_battery_data() override { return true; }
 
-    content += "<h4>CUV " + String(datalayer_extended.zoe.CUV) + "</h4>";
-    content += "<h4>HVBIR " + String(datalayer_extended.zoe.HVBIR) + "</h4>";
-    content += "<h4>HVBUV " + String(datalayer_extended.zoe.HVBUV) + "</h4>";
-    content += "<h4>EOCR " + String(datalayer_extended.zoe.EOCR) + "</h4>";
-    content += "<h4>HVBOC " + String(datalayer_extended.zoe.HVBOC) + "</h4>";
-    content += "<h4>HVBOT " + String(datalayer_extended.zoe.HVBOT) + "</h4>";
-    content += "<h4>HVBOV " + String(datalayer_extended.zoe.HVBOV) + "</h4>";
-    content += "<h4>COV " + String(datalayer_extended.zoe.COV) + "</h4>";
-    content += "<h4>Battery mileage " + String(datalayer_extended.zoe.mileage_km) + " km</h4>";
-    content += "<h4>Alltime energy " + String(datalayer_extended.zoe.alltime_kWh) + " kWh</h4>";
-    return content;
-  }
+ private:
+  RenaultZoeGen1Battery& battery;
 };
 
 #endif

--- a/web_data/dtc/renault_zoe_gen1_dtc.json
+++ b/web_data/dtc/renault_zoe_gen1_dtc.json
@@ -1,0 +1,21 @@
+[
+  {"code": 5230592, "dtc": "4FD000", "s_dsc": "LBC INTERNAL COMMS", "l_dsc": "Lithium Battery Controller internal module communication error"},
+  {"code": 995582, "dtc": "0F30FE", "s_dsc": "CELL SAMPLING SIGNAL", "l_dsc": "Cell voltage sampling circuit intermittent signal invalid"},
+  {"code": 545521, "dtc": "0852F1", "s_dsc": "HV RELAY CIRCUIT FAULT", "l_dsc": "Traction battery relay circuit malfunction"},
+  {"code": 287712, "dtc": "0463E0", "s_dsc": "WATER PUMP AGEING", "l_dsc": "Cooling pump ageing counter threshold reached"},
+  {"code": 824576, "dtc": "0C9500", "s_dsc": "HV INTERLOCK ERROR", "l_dsc": "High voltage interlock loop open circuit"},
+  {"code": 786432, "dtc": "0C0000", "s_dsc": "GENERIC LBC FAULT", "l_dsc": "Generic Lithium Battery Controller error"},
+  {"code": 786688, "dtc": "0C0100", "s_dsc": "LBC CHECKSUM FAULT", "l_dsc": "Lithium Battery Controller EEPROM memory checksum fault"},
+  {"code": 786944, "dtc": "0C0200", "s_dsc": "LBC OVER-TEMPERATURE", "l_dsc": "Lithium Battery Controller over-temperature protection threshold exceeded"},
+  {"code": 787200, "dtc": "0C0300", "s_dsc": "CELL OVER-VOLTAGE", "l_dsc": "Lithium Battery Controller cell over-voltage hardware trip"},
+  {"code": 787456, "dtc": "0C0400", "s_dsc": "CELL UNDER-VOLTAGE", "l_dsc": "Lithium Battery Controller cell under-voltage hardware trip"},
+  {"code": 787712, "dtc": "0C0500", "s_dsc": "CURRENT SENSOR FAULT", "l_dsc": "Lithium Battery Controller current shunt sensor out of range"},
+  {"code": 787968, "dtc": "0C0600", "s_dsc": "INSULATION FAULT", "l_dsc": "High voltage battery insulation breakdown or low isolation resistance"},
+  {"code": 788224, "dtc": "0C0700", "s_dsc": "BALANCING FAULT", "l_dsc": "Lithium Battery Controller cell balancing transistor circuit fault"},
+  {"code": 788480, "dtc": "0C0800", "s_dsc": "CAN BUS TIMEOUT", "l_dsc": "Lithium Battery Controller CAN communication bus-off or timeout"},
+  {"code": 824832, "dtc": "0C9600", "s_dsc": "CONTACTOR STUCK CLOSED", "l_dsc": "Main high voltage contactor relay contacts welded or stuck closed"},
+  {"code": 825088, "dtc": "0C9700", "s_dsc": "PRECHARGE FAULT", "l_dsc": "Precharge circuit timeout or inverter DC bus capacitor precharge failure"},
+  {"code": 825344, "dtc": "0C9800", "s_dsc": "MAIN FUSE OPEN", "l_dsc": "Main high voltage battery fuse or manual service disconnect plug open"},
+  {"code": 545777, "dtc": "0853F1", "s_dsc": "HV SHORT CIRCUIT", "l_dsc": "High voltage DC bus short circuit or excessive discharge current surge"},
+  {"code": 546033, "dtc": "0854F1", "s_dsc": "CHARGER DC FAULT", "l_dsc": "Charger high voltage DC input reverse polarity or over-voltage fault"}
+]


### PR DESCRIPTION
### What
This PR adds UDS Service `0x19` DTC readout and Web UI fault translation for the Renault Zoe Gen1 battery controller (LBC).

### Why
Adds brand new DTC reading capability to the Renault Zoe Gen1 integration. Standard KWP2000 Service `0x18` in testing appears to be unsupported by the LBC, so UDS Service `0x19` with session management is introduced to allow diagnosing battery, interlock, contactor, and insulation faults from the Web UI.

### How
* **Session & UDS Dispatch:** Enters Extended Session `02 10 C0`, pauses routine parameter polling, and dispatches UDS Service `0x19` (`03 19 02 FF`).
* **ISO-TP Reassembly:** Reassembles Single Frame (`0x59`) and Consecutive Frame (`0x21`) responses into 4-byte UDS DTC records.
* **UI & Dictionary:** Updates `RenaultZoeGen1HtmlRenderer` and adds `renault_zoe_gen1_dtc.json` with 19 official Renault CLIP / MR457 Section 88B fault codes.

NOTE: AI (Google Gemini 3.6) assisted, code manually reviewed.
> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
