### PR TITLE
fix(renault-zoe-gen1): fix cell 1 double-counting bug in pack voltage…

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -41,9 +41,9 @@ void RenaultZoeGen1Battery::
 
   datalayer_battery->status.temperature_max_dC = max_temperature * 10;
 
-  // Calculate total pack voltage on packs that require this. Only calculate once all cellvotages have been read
+  // Calculate total pack voltage on packs that require this. Only calculate once all cellvoltages have been read
   if (datalayer_battery->status.cell_voltages_mV[95] > 0) {
-    calculated_total_pack_voltage_mV = datalayer_battery->status.cell_voltages_mV[0];
+    calculated_total_pack_voltage_mV = 0;
     for (uint8_t i = 0; i < datalayer_battery->info.number_of_cells; ++i) {
       calculated_total_pack_voltage_mV += datalayer_battery->status.cell_voltages_mV[i];
     }


### PR DESCRIPTION
### What
Fixes a cell 1 double-counting bug in total pack voltage summation for the Renault Zoe Gen1 driver.

### Why
`calculated_total_pack_voltage_mV` was previously initialized to `cell_voltages_mV[0]` prior to running a summation loop that started at `i = 0`. This caused cell 1's voltage to be added twice, overcounting total pack DC bus voltage by ~3.7V. This overcounting may possibly cause solar inverters to ramp down charging current prematurely and increased the risk of false `EVENT_BATTERY_OVERVOLTAGE` safety alarms near full charge. There may also be impacts on balancing voltage not truly being reached.

### How
Initialized `calculated_total_pack_voltage_mV = 0;` before the 96-cell summation loop in [RENAULT-ZOE-GEN1-BATTERY.cpp](RENAULT-ZOE-GEN1-BATTERY.cpp#L46).

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
