### PR TITLE
New battery: VW MQB Evo 2024+ based on MEB

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -149,6 +149,8 @@ const char* name_for_battery_type(BatteryType type) {
       return KiaHyundaiHybridBattery::Name;
     case BatteryType::Meb:
       return MebBattery::Name;
+    case BatteryType::VAGMqbEvo:
+      return MqbEvoBattery::Name;
 #ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return Mg5Battery::Name;
@@ -274,6 +276,8 @@ Battery* create_battery(BatteryType type) {
       return new KiaHyundaiHybridBattery();
     case BatteryType::Meb:
       return new MebBattery();
+    case BatteryType::VAGMqbEvo:
+      return new MqbEvoBattery();
 #ifndef SMALL_FLASH_DEVICE
     case BatteryType::Mg5:
       return new Mg5Battery();

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -59,6 +59,7 @@ enum class BatteryType {
   EnnoidBMS = 52,
   StellantisSmallWide4x4 = 53,
   ChargebyteCCSBattery = 54,
+  VAGMqbEvo = 55,
   Highest
 };
 

--- a/Software/src/battery/CanBattery.h
+++ b/Software/src/battery/CanBattery.h
@@ -8,6 +8,7 @@
 #include "../../src/communication/can/comm_can.h"
 #include "../../src/devboard/utils/types.h"
 #include "../lib/uds_isotp/isotp.h"
+#include "../lib/uds_isotp/uds.h"
 
 // Abstract base class for batteries using the CAN bus
 class CanBattery : public Battery, Transmitter, CanReceiver {

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -203,13 +203,17 @@ void MebBattery::
   datalayer_battery->status.current_dA = (BMS_current - 16300);  // 0.1 * 10
 
   if (nof_cells_determined) {
-    datalayer_battery->info.total_capacity_Wh =
-        ((float)datalayer_battery->info.number_of_cells) * 3.67f * ((float)BMS_capacity_ah) * 0.2f * 1.02564f;
-    // The factor 1.02564 = 1/0.975 is to correct for bottom 2.5% which is reported by the remaining_capacity_Wh,
-    // but which is not actually usable, but if we do not include it, the remaining_capacity_Wh can be larger than
-    // the total_capacity_Wh.
-    // 0.935 and 0.9025 are the different conversions for different battery sizes to go from design capacity to
-    // total_capacity_Wh calculated above.
+    if (BMS_max_usable_batt_energy_Wh > 0) {
+      datalayer_battery->info.total_capacity_Wh = BMS_max_usable_batt_energy_Wh;
+    } else {
+      datalayer_battery->info.total_capacity_Wh =
+          ((float)datalayer_battery->info.number_of_cells) * 3.67f * ((float)BMS_capacity_ah) * 0.2f * 1.02564f;
+      // The factor 1.02564 = 1/0.975 is to correct for bottom 2.5% which is reported by the remaining_capacity_Wh,
+      // but which is not actually usable, but if we do not include it, the remaining_capacity_Wh can be larger than
+      // the total_capacity_Wh.
+      // 0.935 and 0.9025 are the different conversions for different battery sizes to go from design capacity to
+      // total_capacity_Wh calculated above.
+    }
 
     if (battery_soh_polled > 0) {
       datalayer_battery->status.soh_pptt = battery_soh_polled;
@@ -773,6 +777,21 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         BMS_voltage = ((rx_frame.data.u8[7] << 4) + ((rx_frame.data.u8[6] & 0xF0) >> 4));
       }
       break;
+    case BMS_34: {
+      const uint16_t raw_ube = (uint16_t)((uint16_t)rx_frame.data.u8[2] | ((uint16_t)rx_frame.data.u8[3] << 8));
+      const uint16_t raw_ube_t =
+          (uint16_t)((uint16_t)rx_frame.data.u8[4] | ((uint16_t)rx_frame.data.u8[5] << 8));
+      const uint16_t raw_max_ube =
+          (uint16_t)((uint16_t)rx_frame.data.u8[6] | ((uint16_t)rx_frame.data.u8[7] << 8));
+      const uint16_t raw_nominal_voltage = (uint16_t)(((uint16_t)rx_frame.data.u8[8] | ((uint16_t)rx_frame.data.u8[9] << 8)) & 0x07FFU);
+
+      BMS_usable_batt_energy_Wh = ((int32_t)raw_ube * 5) - 7400;
+      BMS_usable_batt_energy_t_Wh = ((int32_t)raw_ube_t * 5) - 7400;
+      BMS_max_usable_batt_energy_Wh = ((int32_t)raw_max_ube * 5) - 7400;
+
+      BMS_nominal_voltage_dV = (uint16_t)(raw_nominal_voltage * 5U);  // 0.5V * 10 => 5 dV
+      break;
+    }
     case ISO_Hybrid_01_Resp_FD:  // Diag reply from battery — feed into the ISO-TP state machine.
       // Multi-frame reassembly and flow control are handled by IsoTp; the assembled UDS message
       // is delivered to on_isotp_rx_complete() -> uds_response_handler().
@@ -858,13 +877,13 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
   // Send 10ms CAN Message
   if (currentMillis - previousMillis10ms >= INTERVAL_10_MS) {
     previousMillis10ms = currentMillis;
+    if (platform == VAGPlatform::MEB) {
+      ESC_51_Auth_frame.data.u8[1] = ((ESC_51_Auth_frame.data.u8[1] & 0xF0) | counter_10ms);
+      ESC_51_Auth_frame.data.u8[0] = vw_crc_calc(ESC_51_Auth_frame.data.u8, ESC_51_Auth_frame.DLC, ESC_51_Auth_frame.ID);
+      counter_10ms = (counter_10ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
-    ESC_51_Auth_frame.data.u8[1] = ((ESC_51_Auth_frame.data.u8[1] & 0xF0) | counter_10ms);
-    ESC_51_Auth_frame.data.u8[0] = vw_crc_calc(ESC_51_Auth_frame.data.u8, ESC_51_Auth_frame.DLC, ESC_51_Auth_frame.ID);
-
-    counter_10ms = (counter_10ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
-
-    transmit_can_frame(&ESC_51_Auth_frame);  // Required for contactor closing
+      transmit_can_frame(&ESC_51_Auth_frame);  // Required for contactor closing
+    }
   }
   // Send 20ms CAN Message
   if (currentMillis - previousMillis20ms >= INTERVAL_20_MS) {
@@ -1019,6 +1038,9 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&Motor_14_frame);
     transmit_can_frame(&Motor_54_frame);
     transmit_can_frame(&Klima_EV_07_frame);  //PTC / EKK voltage free or not
+    if (platform == VAGPlatform::MQB_Evo) {
+      transmit_can_frame(&Motor_EV_01_frame);
+    }
   }
   //Send 200ms message
   if (currentMillis - previousMillis200ms >= INTERVAL_200_MS) {
@@ -1177,6 +1199,9 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     transmit_can_frame(&Reichweite_01_frame);    // Loading profile
     transmit_can_frame(&Systeminfo_01_frame);    // Systeminfo
     transmit_can_frame(&Temperaturen_01_frame);  // Temperature QBit
+    if (platform == VAGPlatform::MQB_Evo) {
+      transmit_can_frame(&Kombi_02_frame);
+    }
     if (basic_settings_state != BasicSettingsState::IDLE) {
       transmit_can_frame(&Tester_present_frame);  // Keep BMS in extended diagnostic session
     }
@@ -1622,8 +1647,8 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
         int availableBytes = len - dtcStartIndex;
         int maxDtcCount = availableBytes / 4;
 
-        if (maxDtcCount > MAX_DTC_COUNT) {
-          maxDtcCount = MAX_DTC_COUNT;
+        if (maxDtcCount > datalayer_battery->dtc.MAX_DTC_COUNT) {
+          maxDtcCount = datalayer_battery->dtc.MAX_DTC_COUNT;
           logging.println("DTC count exceeds buffer, truncating");
         }
         if (maxDtcCount < 0)
@@ -1693,4 +1718,21 @@ void MebBattery::setup(void) {  // Performs one time setup at startup
   // The BMS may still be asleep at power-on, so our first frames won't be ACKed. Ignore
   // this interface's transient CAN errors for a while so they don't clutter the event log.
   ignore_can_errors_for(can_interface, BMS_CAN_ERR_IGNORE_MS);
+}
+
+void MqbEvoBattery::setup(void) {  // Performs one time setup at startup
+  MebBattery::setup();             // Common MEB init (isotp, memsets, defaults).
+
+  platform = VAGPlatform::MQB_Evo;  // Drives the shared transmit/update branches.
+  // MQB Evo battery is available only in one configuration.
+  datalayer_battery->info.number_of_cells = 96;
+  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_96S_DV;
+  datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_96S_DV;
+  nof_cells_determined = true;
+  security_login_key = 20104;  //correct key for MQB Evo
+  renderer.dtc_json_filename = "vag_mqb_dtc.json";
+  poll_pid = PID_SOC; //MQB doesn't use the number of cells detection.
+
+  strncpy(datalayer.system.info.battery_protocol, Name, 63);  // Overwrite the MEB name.
+  datalayer.system.info.battery_protocol[63] = '\0';
 }

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -10,12 +10,10 @@
 #include "../devboard/utils/common_functions.h"  //For CRC calculation
 #include "../devboard/utils/events.h"
 #include "../devboard/utils/logging.h"
-#include "../lib/uds_isotp/uds.h"  // UDS service IDs and negative-response codes
 
 /*
 TODO list
 - Check all TODO:s in the code
-- Investigate why opening and then closing contactors from webpage does not always work
 - remaining_capacity_Wh is based on a lower limit of 5% soc. This means that at 5% soc, remaining_capacity_Wh returns 0.
 */
 
@@ -248,6 +246,14 @@ void MebBattery::
   //Map all cell voltages to the global array
   memcpy(datalayer_battery->status.cell_voltages_mV, cellvoltages_polled, 108 * sizeof(uint16_t));
 
+  datalayer_battery->status.insulation_resistance_kOhm = isolation_resistance_kOhm * 5;
+  if (isolation_status != 0 && isolation_status != 7) {
+    // isolation is available if not in init or active measurement.
+    datalayer_battery->status.insulation_resistance_available = true;
+  } else {
+    datalayer_battery->status.insulation_resistance_available = false;
+  }
+
   if (service_disconnect_switch_missing) {
     set_event(EVENT_HVIL_FAILURE, 1);
   } else {
@@ -260,58 +266,58 @@ void MebBattery::
   }
 
   // Update webserver datalayer for "More battery info" page
-  datalayer_extended.meb.SDSW = service_disconnect_switch_missing;
-  datalayer_extended.meb.pilotline = pilotline_open;
-  datalayer_extended.meb.transportmode = transportation_mode_active;
-  datalayer_extended.meb.componentprotection = component_protection_active;
-  datalayer_extended.meb.shutdown_active = shutdown_active;
-  datalayer_extended.meb.HVIL = BMS_HVIL_status;
-  datalayer_extended.meb.BMS_mode = BMS_mode;
-  datalayer_extended.meb.battery_diagnostic = battery_diagnostic;
-  datalayer_extended.meb.status_HV_PTC_line = status_HV_PTC_line;
-  datalayer_extended.meb.BMS_fault_performance = BMS_fault_performance;
-  datalayer_extended.meb.BMS_fault_emergency_shutdown_crash = BMS_fault_emergency_shutdown_crash;
-  datalayer_extended.meb.BMS_error_shutdown_request = BMS_error_shutdown_request;
-  datalayer_extended.meb.BMS_error_shutdown = BMS_error_shutdown;
-  datalayer_extended.meb.BMS_welded_contactors_status = BMS_welded_contactors_status;
+  datalayer_meb->SDSW = service_disconnect_switch_missing;
+  datalayer_meb->pilotline = pilotline_open;
+  datalayer_meb->transportmode = transportation_mode_active;
+  datalayer_meb->componentprotection = component_protection_active;
+  datalayer_meb->shutdown_active = shutdown_active;
+  datalayer_meb->HVIL = BMS_HVIL_status;
+  datalayer_meb->BMS_mode = BMS_mode;
+  datalayer_meb->battery_diagnostic = battery_diagnostic;
+  datalayer_meb->status_HV_PTC_line = status_HV_PTC_line;
+  datalayer_meb->BMS_fault_performance = BMS_fault_performance;
+  datalayer_meb->BMS_fault_emergency_shutdown_crash = BMS_fault_emergency_shutdown_crash;
+  datalayer_meb->BMS_error_shutdown_request = BMS_error_shutdown_request;
+  datalayer_meb->BMS_error_shutdown = BMS_error_shutdown;
+  datalayer_meb->BMS_welded_contactors_status = BMS_welded_contactors_status;
 
-  datalayer_extended.meb.warning_support = warning_support;
-  datalayer_extended.meb.BMS_status_voltage_free = BMS_status_voltage_free;
-  datalayer_extended.meb.BMS_OBD_MIL = BMS_OBD_MIL;
-  datalayer_extended.meb.BMS_error_status = BMS_error_status;
-  datalayer_extended.meb.BMS_error_lamp_req = BMS_error_lamp_req;
-  datalayer_extended.meb.BMS_warning_lamp_req = BMS_warning_lamp_req;
-  datalayer_extended.meb.BMS_Kl30c_Status = BMS_Kl30c_Status;
-  datalayer_extended.meb.BMS_voltage_intermediate_dV = (BMS_voltage_intermediate - 2000) * 10 / 2;
-  datalayer_extended.meb.BMS_voltage_dV = BMS_voltage * 10 / 4;
-  datalayer_extended.meb.isolation_resistance = isolation_resistance_kOhm * 5;
-  datalayer_extended.meb.battery_heating = battery_heating_active;
-  datalayer_extended.meb.rt_overcurrent = realtime_overcurrent_monitor;
-  datalayer_extended.meb.rt_CAN_fault = realtime_CAN_communication_fault;
-  datalayer_extended.meb.rt_overcharge = realtime_overcharge_warning;
-  datalayer_extended.meb.rt_SOC_high = realtime_SOC_too_high;
-  datalayer_extended.meb.rt_SOC_low = realtime_SOC_too_low;
-  datalayer_extended.meb.rt_SOC_jumping = realtime_SOC_jumping_warning;
-  datalayer_extended.meb.rt_temp_difference = realtime_temperature_difference_warning;
-  datalayer_extended.meb.rt_cell_overtemp = realtime_cell_overtemperature_warning;
-  datalayer_extended.meb.rt_cell_undertemp = realtime_cell_undertemperature_warning;
-  datalayer_extended.meb.rt_battery_overvolt = realtime_battery_overvoltage_warning;
-  datalayer_extended.meb.rt_battery_undervol = realtime_battery_undervoltage_warning;
-  datalayer_extended.meb.rt_cell_overvolt = realtime_cell_overvoltage_warning;
-  datalayer_extended.meb.rt_cell_undervol = realtime_cell_undervoltage_warning;
-  datalayer_extended.meb.rt_cell_imbalance = realtime_cell_imbalance_warning;
-  datalayer_extended.meb.rt_battery_unathorized = realtime_warning_battery_unathorized;
-  if (balancing_active == 1 && datalayer_extended.meb.balancing_active != 1) {
+  datalayer_meb->warning_support = warning_support;
+  datalayer_meb->BMS_status_voltage_free = BMS_status_voltage_free;
+  datalayer_meb->BMS_OBD_MIL = BMS_OBD_MIL;
+  datalayer_meb->BMS_error_status = BMS_error_status;
+  datalayer_meb->BMS_error_lamp_req = BMS_error_lamp_req;
+  datalayer_meb->BMS_warning_lamp_req = BMS_warning_lamp_req;
+  datalayer_meb->BMS_Kl30c_Status = BMS_Kl30c_Status;
+  datalayer_meb->BMS_voltage_intermediate_dV = (BMS_voltage_intermediate - 2000) * 10 / 2;
+  datalayer_meb->BMS_voltage_dV = BMS_voltage * 10 / 4;
+  datalayer_meb->isolation_resistance = isolation_resistance_kOhm * 5;
+  datalayer_meb->battery_heating = battery_heating_active;
+  datalayer_meb->rt_overcurrent = realtime_overcurrent_monitor;
+  datalayer_meb->rt_CAN_fault = realtime_CAN_communication_fault;
+  datalayer_meb->rt_overcharge = realtime_overcharge_warning;
+  datalayer_meb->rt_SOC_high = realtime_SOC_too_high;
+  datalayer_meb->rt_SOC_low = realtime_SOC_too_low;
+  datalayer_meb->rt_SOC_jumping = realtime_SOC_jumping_warning;
+  datalayer_meb->rt_temp_difference = realtime_temperature_difference_warning;
+  datalayer_meb->rt_cell_overtemp = realtime_cell_overtemperature_warning;
+  datalayer_meb->rt_cell_undertemp = realtime_cell_undertemperature_warning;
+  datalayer_meb->rt_battery_overvolt = realtime_battery_overvoltage_warning;
+  datalayer_meb->rt_battery_undervol = realtime_battery_undervoltage_warning;
+  datalayer_meb->rt_cell_overvolt = realtime_cell_overvoltage_warning;
+  datalayer_meb->rt_cell_undervol = realtime_cell_undervoltage_warning;
+  datalayer_meb->rt_cell_imbalance = realtime_cell_imbalance_warning;
+  datalayer_meb->rt_battery_unathorized = realtime_warning_battery_unathorized;
+  if (balancing_active == 1 && datalayer_meb->balancing_active != 1) {
     datalayer_battery->status.balancing_status = BALANCING_STATUS_ACTIVE;
     set_event_latched(EVENT_BALANCING_START, 0);
   }
-  if (balancing_active == 2 && datalayer_extended.meb.balancing_active == 1) {
+  if (balancing_active == 2 && datalayer_meb->balancing_active == 1) {
     datalayer_battery->status.balancing_status = BALANCING_STATUS_READY;
     set_event(EVENT_BALANCING_END, 0);
   }
-  datalayer_extended.meb.balancing_active = balancing_active;
-  datalayer_extended.meb.balancing_request = balancing_request;
-  datalayer_extended.meb.charging_active = charging_active;
+  datalayer_meb->balancing_active = balancing_active;
+  datalayer_meb->balancing_request = balancing_request;
+  datalayer_meb->charging_active = charging_active;
 }
 
 void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -365,7 +371,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       can_msg_received |= RX_BMS_21;
       max_discharge_power_watt =
-          ((rx_frame.data.u8[6] & 0x07) << 10) | (rx_frame.data.u8[5] << 2) | (rx_frame.data.u8[4] & 0xC0) >> 6;  //*100
+          ((rx_frame.data.u8[6] & 0x07) << 10) | (rx_frame.data.u8[5] << 2) | ((rx_frame.data.u8[4] & 0xC0) >> 6);  //*100
       max_discharge_current_amp =
           ((rx_frame.data.u8[3] & 0x01) << 12) | (rx_frame.data.u8[2] << 4) | (rx_frame.data.u8[1] >> 4);  //*0.2
       max_charge_power_watt = (rx_frame.data.u8[7] << 5) | (rx_frame.data.u8[6] >> 3);                     //*100
@@ -401,8 +407,6 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       max_charge_percent = ((rx_frame.data.u8[7] << 3) | rx_frame.data.u8[6] >> 5);                  //*0.05
       min_charge_percent = ((rx_frame.data.u8[4] << 3) | rx_frame.data.u8[3] >> 5);                  //*0.05
       isolation_resistance_kOhm = (((rx_frame.data.u8[3] & 0x1F) << 7) | rx_frame.data.u8[2] >> 1);  //*5
-      datalayer_battery->status.insulation_resistance_kOhm = isolation_resistance_kOhm * 5;
-      datalayer_battery->status.insulation_resistance_available = true;
       break;
     case BMS_25:  // BMS 500ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -414,7 +418,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       status_valve_1 = (rx_frame.data.u8[3] & 0x1C) >> 2;
       status_valve_2 = (rx_frame.data.u8[3] & 0xE0) >> 5;
       temperature_request = (((rx_frame.data.u8[2] & 0x03) << 1) | rx_frame.data.u8[1] >> 7);
-      datalayer_extended.meb.battery_temperature_dC = rx_frame.data.u8[5] * 5 - 400;  //*0,5 -40
+      datalayer_meb->battery_temperature_dC = rx_frame.data.u8[5] * 5 - 400;  //*0,5 -40
       target_flow_temperature_C = rx_frame.data.u8[6];                                //*0,5 -40
       return_temperature_C = rx_frame.data.u8[7];                                     //*0,5 -40
       break;
@@ -454,7 +458,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       switch (mux) {
         case 0:  // Temperatures 1-56. Value is 0xFD if sensor not present
           for (uint8_t i = 0; i < 56; i++) {
-            datalayer_extended.meb.celltemperature_dC[i] = ((int16_t)rx_frame.data.u8[i + 1] * 5) - 400;
+            datalayer_meb->celltemperature_dC[i] = ((int16_t)rx_frame.data.u8[i + 1] * 5) - 400;
           }
           break;
         /*
@@ -692,7 +696,7 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       BMS_error_lamp_req = (rx_frame.data.u8[4] & 0x04) >> 2;
       BMS_warning_lamp_req = (rx_frame.data.u8[4] & 0x08) >> 3;
       BMS_Kl30c_Status = (rx_frame.data.u8[4] & 0x30) >> 4;
-      if (BMS_Kl30c_Status != 0) {  // init state
+      if (BMS_mode != BMS_TARGET_INIT) {  // init state
         BMS_capacity_ah = ((rx_frame.data.u8[4] & 0x03) << 9) | (rx_frame.data.u8[3] << 1) | (rx_frame.data.u8[2] >> 7);
       }
       break;
@@ -721,8 +725,10 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       // through Init with KL_15 properly gated.
       if (!startup_bms_checked) {
         startup_bms_checked = true;
-        if (BMS_mode != BMS_TARGET_INIT) {
-          //logging.println("MEB: BMS already awake at boot (emulator reboot) - triggering BMS reset");
+        if (BMS_mode != BMS_TARGET_INIT && BMS_mode != BMS_TARGET_HV_OFF) {
+#ifdef MEB_DEBUG
+          logging.println("MEB: BMS mode not correct at boot, triggering BMS reset.");
+#endif
           datalayer_meb->UserRequestBMSReset = true;
         }
       }
@@ -833,26 +839,26 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
 
   // DTC readout requested via WebUI: UDS ReadDTCInformation (0x19), report-type 0x02
   // (reportDTCByStatusMask) with status mask 0x09 to read only active/confirmed DTCs.
-  if (!uds_request_pending && datalayer_extended.meb.UserRequestDTCreadout &&
+  if (!uds_request_pending && datalayer_meb->UserRequestDTCreadout &&
       basic_settings_state == BasicSettingsState::IDLE) {
     uint8_t payload[3] = {ReadDTCInformation, 0x02, 0x09};
     isotp_send(payload, sizeof(payload));
     uds_request_pending = true;
     uds_request_timestamp = currentMillis;
-    datalayer_extended.meb.UserRequestDTCreadout = false;  // consume the request
-    datalayer_extended.meb.dtc_read_in_progress = true;
+    datalayer_meb->UserRequestDTCreadout = false;  // consume the request
+    datalayer_meb->dtc_read_in_progress = true;
     datalayer_battery->dtc.dtc_read_failed = false;
   }
 
   // DTC clear requested via WebUI: OBD service 0x04 (ClearDiagnosticInformation) sent to the
   // functional address. Response is handled in uds_response_handler().
-  if (!uds_request_pending && datalayer_extended.meb.UserRequestDTCreset &&
+  if (!uds_request_pending && datalayer_meb->UserRequestDTCreset &&
       basic_settings_state == BasicSettingsState::IDLE) {
     transmit_can_frame(&OBD_CLEAR_DTC);
     uds_request_pending = true;
     uds_request_timestamp = currentMillis;
-    datalayer_extended.meb.UserRequestDTCreset = false;  // consume the request
-    datalayer_extended.meb.dtc_read_in_progress = true;
+    datalayer_meb->UserRequestDTCreset = false;  // consume the request
+    datalayer_meb->dtc_read_in_progress = true;
     datalayer_battery->dtc.dtc_read_failed = false;
   }
 
@@ -868,7 +874,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
       // Set the link voltage back to 0, so that when the BMS comes back, it
       // doesn't immediately skip the precharge.
       BMS_voltage_intermediate = 2000;
-      datalayer_extended.meb.BMS_voltage_intermediate_dV = 0;
+      datalayer_meb->BMS_voltage_intermediate_dV = 0;
 
       // Reset the HV requested state so that we don't skip the precharge.
       hv_requested = false;
@@ -940,9 +946,9 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
         (datalayer.battery.status.real_bms_status == BMS_ACTIVE ||
          (datalayer.battery.status.real_bms_status == BMS_STANDBY &&
           (hv_requested ||
-           (datalayer.battery.status.voltage_dV > 200 && datalayer_extended.meb.BMS_voltage_intermediate_dV > 0 &&
+           (datalayer.battery.status.voltage_dV > 200 && datalayer_meb->BMS_voltage_intermediate_dV > 0 &&
             labs(((int32_t)datalayer.battery.status.voltage_dV) -
-                 ((int32_t)datalayer_extended.meb.BMS_voltage_intermediate_dV)) < 200))))) {
+                 ((int32_t)datalayer_meb->BMS_voltage_intermediate_dV)) < 200))))) {
       // We are either:
       //  - Equipment stop is not active, and the inverter allows contactor closing, and the BMS is not in FAULT state, and either:
       //  - in BMS_ACTIVE state (contactors closed, normal operation)
@@ -1029,6 +1035,9 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
 
     Motor_54_frame.data.u8[1] = ((Motor_54_frame.data.u8[1] & 0xF0) | counter_100ms);
     Motor_54_frame.data.u8[0] = vw_crc_calc(Motor_54_frame.data.u8, Motor_54_frame.DLC, Motor_54_frame.ID);
+
+    Motor_EV_01_frame.data.u8[1] = ((Motor_EV_01_frame.data.u8[1] & 0xF0) | counter_100ms);
+    Motor_EV_01_frame.data.u8[0] = vw_crc_calc(Motor_EV_01_frame.data.u8, Motor_EV_01_frame.DLC, Motor_EV_01_frame.ID);
 
     counter_100ms = (counter_100ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
     transmit_can_frame(&HVK_01_frame);
@@ -1155,7 +1164,8 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     }
     // Send the UDS request only after ≥1 s of CAN activity and when no UDS transaction is
     // pending (ISO-TP is serial — one request/response at a time).
-    if (first_can_msg_timestamp > 0 && currentMillis - first_can_msg_timestamp > 1000 && !uds_request_pending) {
+    if (first_can_msg_timestamp > 0 && currentMillis - first_can_msg_timestamp > 1000 &&
+        !uds_request_pending && basic_settings_state == BasicSettingsState::IDLE) {
       uds_read_data_by_id(current_pid, currentMillis);
     } else {
       // if we could not send the request, don't advance to the next PID.
@@ -1211,8 +1221,8 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
   static auto last_start_precharging = datalayer.system.info.start_precharging;
   static auto last_hv_requested = hv_requested;
   static auto last_voltage_dV = datalayer.battery.status.voltage_dV;
-  static auto last_BMS_voltage_intermediate_dV = datalayer_extended.meb.BMS_voltage_intermediate_dV;
-  static auto BMS_mode = datalayer_extended.meb.BMS_mode;
+  static auto last_BMS_voltage_intermediate_dV = datalayer_meb->BMS_voltage_intermediate_dV;
+  static auto last_bms_mode = BMS_mode;
 
   if (last_real_bms_status != datalayer.battery.status.real_bms_status) {
     logging.printf("MEB: BMS status %d -> %d\n", last_real_bms_status, datalayer.battery.status.real_bms_status);
@@ -1235,15 +1245,15 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     last_voltage_dV = datalayer.battery.status.voltage_dV;
   }
 
-  if (last_BMS_voltage_intermediate_dV != datalayer_extended.meb.BMS_voltage_intermediate_dV) {
+  if (last_BMS_voltage_intermediate_dV != datalayer_meb->BMS_voltage_intermediate_dV) {
     logging.printf("MEB: BMS Voltage intermediate dV %d -> %d\n", last_BMS_voltage_intermediate_dV,
-                   datalayer_extended.meb.BMS_voltage_intermediate_dV);
-    last_BMS_voltage_intermediate_dV = datalayer_extended.meb.BMS_voltage_intermediate_dV;
+                   datalayer_meb->BMS_voltage_intermediate_dV);
+    last_BMS_voltage_intermediate_dV = datalayer_meb->BMS_voltage_intermediate_dV;
   }
 
-  if (BMS_mode != datalayer_extended.meb.BMS_mode) {
-    logging.printf("MEB: BMS mode %d -> %d\n", BMS_mode, datalayer_extended.meb.BMS_mode);
-    BMS_mode = datalayer_extended.meb.BMS_mode;
+  if (last_bms_mode != BMS_mode) {
+    logging.printf("MEB: BMS mode %d -> %d\n", last_bms_mode, BMS_mode);
+    last_bms_mode = BMS_mode;
   }
 }
 
@@ -1491,9 +1501,13 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
             logging.printf("MEB: BasicSettings: routine 0x%04X started\n", (unsigned)basic_settings_routine_id);
 #endif
           } else if (data[1] == Stop) {
-            // trigger now BMS reset
+            // trigger now BMS reset and erase DTCs.
             datalayer_meb->UserRequestBMSReset = true;
+            datalayer_meb->UserRequestDTCreset = true;
             basic_settings_state = BasicSettingsState::IDLE;
+#ifdef MEB_DEBUG
+            logging.printf("MEB: BasicSettings: routine 0x%04X stopped\n", (unsigned)basic_settings_routine_id);
+#endif
           } else {
             // Unexpected sub-function — abort.
             basic_settings_state = BasicSettingsState::IDLE;
@@ -1619,7 +1633,7 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
           if (len < 5)
             break;
           if (pid_reply >= PID_TEMP_POINT_1 && pid_reply <= PID_TEMP_POINT_18) {
-            datalayer_extended.meb.temp_points[pid_reply - PID_TEMP_POINT_1] = (((data[3] << 8) | data[4]) / 8.f) - 40;
+            datalayer_meb->temp_points[pid_reply - PID_TEMP_POINT_1] = (((data[3] << 8) | data[4]) / 8.f) - 40;
           } else if (pid_reply >= PID_CELLVOLTAGE_CELL_1 && pid_reply <= PID_CELLVOLTAGE_CELL_108) {
             // The general case for cell voltages (some specific cases handled above)
             tempval = ((data[3] << 8) | data[4]);
@@ -1635,7 +1649,7 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
       datalayer_battery->dtc.dtc_read_failed = false;
       datalayer_battery->dtc.dtc_count = 0;  // Clear any existing DTCs after a successful erase
       datalayer_battery->dtc.dtc_last_read_millis = 0;
-      datalayer_extended.meb.dtc_read_in_progress = false;
+      datalayer_meb->dtc_read_in_progress = false;
       break;
     case (UDS_RESPONSE_SID_OF(ReadDTCInformation)):  // DTC read positive response (0x59)
       if (data[1] != 0x02) {
@@ -1670,9 +1684,9 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
       }
       uds_request_pending = false;
       datalayer_battery->dtc.dtc_last_read_millis = millis();
-      datalayer_extended.meb.dtc_read_in_progress = false;
+      datalayer_meb->dtc_read_in_progress = false;
       break;
-    case (ServiceNotSupportedInActiveSession):  // Negative response (0x7F)
+    case (kNegativeResponseSid):  // Negative response (0x7F)
       // data[1] = original request service id, data[2] = NRC
       if (len >= 3 && data[2] == RequestCorrectlyReceived_ResponsePending) {
         // NRC 0x78: requestCorrectlyReceived-ResponsePending — the BMS is still processing.
@@ -1681,12 +1695,12 @@ void MebBattery::uds_response_handler(const uint8_t* data, int len, enum isotp_t
       } else if (len >= 3 && data[1] == ReadDTCInformation) {
         // DTC read was rejected — the transaction is complete, allow the next request.
         uds_request_pending = false;
-        datalayer_extended.meb.dtc_read_in_progress = false;
+        datalayer_meb->dtc_read_in_progress = false;
         datalayer_battery->dtc.dtc_read_failed = true;
       } else {
         // Any other NRC: the transaction is complete (rejected), allow the next request.
         uds_request_pending = false;
-        if (basic_settings_state != BasicSettingsState::IDLE) {
+        if (basic_settings_state != BasicSettingsState::IDLE && data[1] == RoutineControl) {
 #ifdef MEB_DEBUG
           logging.printf("MEB: BasicSettings: NRC 0x%02X for SID 0x%02X, aborting\n", len >= 3 ? data[2] : 0,
                          len >= 2 ? data[1] : 0);

--- a/Software/src/battery/MEB-BATTERY.cpp
+++ b/Software/src/battery/MEB-BATTERY.cpp
@@ -370,8 +370,8 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case BMS_21:  // BMS Limits 100ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       can_msg_received |= RX_BMS_21;
-      max_discharge_power_watt =
-          ((rx_frame.data.u8[6] & 0x07) << 10) | (rx_frame.data.u8[5] << 2) | ((rx_frame.data.u8[4] & 0xC0) >> 6);  //*100
+      max_discharge_power_watt = ((rx_frame.data.u8[6] & 0x07) << 10) | (rx_frame.data.u8[5] << 2) |
+                                 ((rx_frame.data.u8[4] & 0xC0) >> 6);  //*100
       max_discharge_current_amp =
           ((rx_frame.data.u8[3] & 0x01) << 12) | (rx_frame.data.u8[2] << 4) | (rx_frame.data.u8[1] >> 4);  //*0.2
       max_charge_power_watt = (rx_frame.data.u8[7] << 5) | (rx_frame.data.u8[6] >> 3);                     //*100
@@ -419,8 +419,8 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       status_valve_2 = (rx_frame.data.u8[3] & 0xE0) >> 5;
       temperature_request = (((rx_frame.data.u8[2] & 0x03) << 1) | rx_frame.data.u8[1] >> 7);
       datalayer_meb->battery_temperature_dC = rx_frame.data.u8[5] * 5 - 400;  //*0,5 -40
-      target_flow_temperature_C = rx_frame.data.u8[6];                                //*0,5 -40
-      return_temperature_C = rx_frame.data.u8[7];                                     //*0,5 -40
+      target_flow_temperature_C = rx_frame.data.u8[6];                        //*0,5 -40
+      return_temperature_C = rx_frame.data.u8[7];                             //*0,5 -40
       break;
     case BMS_31:  // BMS
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -785,11 +785,10 @@ void MebBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case BMS_34: {
       const uint16_t raw_ube = (uint16_t)((uint16_t)rx_frame.data.u8[2] | ((uint16_t)rx_frame.data.u8[3] << 8));
-      const uint16_t raw_ube_t =
-          (uint16_t)((uint16_t)rx_frame.data.u8[4] | ((uint16_t)rx_frame.data.u8[5] << 8));
-      const uint16_t raw_max_ube =
-          (uint16_t)((uint16_t)rx_frame.data.u8[6] | ((uint16_t)rx_frame.data.u8[7] << 8));
-      const uint16_t raw_nominal_voltage = (uint16_t)(((uint16_t)rx_frame.data.u8[8] | ((uint16_t)rx_frame.data.u8[9] << 8)) & 0x07FFU);
+      const uint16_t raw_ube_t = (uint16_t)((uint16_t)rx_frame.data.u8[4] | ((uint16_t)rx_frame.data.u8[5] << 8));
+      const uint16_t raw_max_ube = (uint16_t)((uint16_t)rx_frame.data.u8[6] | ((uint16_t)rx_frame.data.u8[7] << 8));
+      const uint16_t raw_nominal_voltage =
+          (uint16_t)(((uint16_t)rx_frame.data.u8[8] | ((uint16_t)rx_frame.data.u8[9] << 8)) & 0x07FFU);
 
       BMS_usable_batt_energy_Wh = ((int32_t)raw_ube * 5) - 7400;
       BMS_usable_batt_energy_t_Wh = ((int32_t)raw_ube_t * 5) - 7400;
@@ -852,8 +851,7 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
 
   // DTC clear requested via WebUI: OBD service 0x04 (ClearDiagnosticInformation) sent to the
   // functional address. Response is handled in uds_response_handler().
-  if (!uds_request_pending && datalayer_meb->UserRequestDTCreset &&
-      basic_settings_state == BasicSettingsState::IDLE) {
+  if (!uds_request_pending && datalayer_meb->UserRequestDTCreset && basic_settings_state == BasicSettingsState::IDLE) {
     transmit_can_frame(&OBD_CLEAR_DTC);
     uds_request_pending = true;
     uds_request_timestamp = currentMillis;
@@ -885,7 +883,8 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     previousMillis10ms = currentMillis;
     if (platform == VAGPlatform::MEB) {
       ESC_51_Auth_frame.data.u8[1] = ((ESC_51_Auth_frame.data.u8[1] & 0xF0) | counter_10ms);
-      ESC_51_Auth_frame.data.u8[0] = vw_crc_calc(ESC_51_Auth_frame.data.u8, ESC_51_Auth_frame.DLC, ESC_51_Auth_frame.ID);
+      ESC_51_Auth_frame.data.u8[0] =
+          vw_crc_calc(ESC_51_Auth_frame.data.u8, ESC_51_Auth_frame.DLC, ESC_51_Auth_frame.ID);
       counter_10ms = (counter_10ms + 1) % 16;  //Goes from 0-1-2-3...15-0-1-2-3..
 
       transmit_can_frame(&ESC_51_Auth_frame);  // Required for contactor closing
@@ -1164,8 +1163,8 @@ void MebBattery::transmit_can(unsigned long currentMillis) {
     }
     // Send the UDS request only after ≥1 s of CAN activity and when no UDS transaction is
     // pending (ISO-TP is serial — one request/response at a time).
-    if (first_can_msg_timestamp > 0 && currentMillis - first_can_msg_timestamp > 1000 &&
-        !uds_request_pending && basic_settings_state == BasicSettingsState::IDLE) {
+    if (first_can_msg_timestamp > 0 && currentMillis - first_can_msg_timestamp > 1000 && !uds_request_pending &&
+        basic_settings_state == BasicSettingsState::IDLE) {
       uds_read_data_by_id(current_pid, currentMillis);
     } else {
       // if we could not send the request, don't advance to the next PID.
@@ -1745,7 +1744,7 @@ void MqbEvoBattery::setup(void) {  // Performs one time setup at startup
   nof_cells_determined = true;
   security_login_key = 20104;  //correct key for MQB Evo
   renderer.dtc_json_filename = "vag_mqb_dtc.json";
-  poll_pid = PID_SOC; //MQB doesn't use the number of cells detection.
+  poll_pid = PID_SOC;  //MQB doesn't use the number of cells detection.
 
   strncpy(datalayer.system.info.battery_protocol, Name, 63);  // Overwrite the MEB name.
   datalayer.system.info.battery_protocol[63] = '\0';

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -6,13 +6,19 @@
 // Uncomment the next line to enable some debug logging.
 //#define MEB_DEBUG
 
+// VW Group platform battery types.
+enum class VAGPlatform : uint8_t {
+  MEB = 1,
+  MQB_Evo = 2,
+};
+
 class MebBattery : public CanBattery, public IsoTp {
  public:
   // Use this constructor for the second battery.
   MebBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_MEB* extended, CAN_Interface targetCan)
       : CanBattery(targetCan) {
     datalayer_battery = datalayer_ptr;
-
+    datalayer_meb = extended;
     BMS_voltage = 0;
   }
   // Use the default constructor to create the first or single battery.
@@ -36,11 +42,11 @@ class MebBattery : public CanBattery, public IsoTp {
   void reset_crash() { datalayer_extended.meb.UserRequestCrashReset = true; }
   bool supports_reset_BMS() { return true; }
   void reset_BMS() { datalayer_meb->UserRequestBMSReset = true; }
-  static constexpr const char* Name = "Volkswagen Group MEB platform via CAN-FD";
+  static constexpr const char* Name = "VW Group MEB platform via CAN-FD";
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
- private:
+ protected:
   /* calculate CRC for some CAN frames */
   uint8_t vw_crc_calc(const uint8_t* inputBytes, uint8_t length, uint32_t msg_id);
   /* send a UDS ReadDataByIdentifier request for did via ISO-TP */
@@ -59,6 +65,8 @@ class MebBattery : public CanBattery, public IsoTp {
 
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_MEB* datalayer_meb;
+
+  VAGPlatform platform = VAGPlatform::MEB;
 
   static const int MAX_PACK_VOLTAGE_84S_DV = 3528;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_84S_DV = 2520;
@@ -302,7 +310,6 @@ class MebBattery : public CanBattery, public IsoTp {
 
   // ISO-TP / UDS request serialization. Only one UDS transaction (PID poll, DTC read) is
   // outstanding at a time; the next request waits until a response arrives or the timeout expires.
-  static const int MAX_DTC_COUNT = 32;  // matches dtc_codes[] size in DATALAYER_INFO_MEB
   static constexpr unsigned long UDS_REQUEST_TIMEOUT_MS = 1000;
   // time between the routine start response and the routine stop request.
   static constexpr unsigned long BASIC_SETTINGS_ROUTINE_STOP_DELAY_MS = 600;
@@ -371,6 +378,10 @@ class MebBattery : public CanBattery, public IsoTp {
       false;  //Error: Safety-critical error (crash detection) Battery contactors are already opened / will be opened immediately Signal is read directly by the EMS and initiates an AKS of the PWR and an active discharge of the DC link
   uint32_t BMS_voltage_intermediate = 2000;
   uint32_t BMS_voltage = 1480;
+  int32_t BMS_usable_batt_energy_Wh = 0;
+  int32_t BMS_usable_batt_energy_t_Wh = 0;
+  int32_t BMS_max_usable_batt_energy_Wh = 0;
+  uint16_t BMS_nominal_voltage_dV = 0;
   uint8_t BMS_status_voltage_free =
       0;  //0=Init, 1=BMS intermediate circuit voltage-free (U_Zwkr < 20V), 2=BMS intermediate circuit not voltage-free (U_Zwkr >/= 25V, hysteresis), 3=Error
   bool BMS_OBD_MIL = false;
@@ -667,8 +678,22 @@ class MebBattery : public CanBattery, public IsoTp {
                                                .DLC = 8,
                                                .ID = Kombi_02,  // content
                                                .data = {0xFE, 0xFF, 0xEF, 0xFF, 0x3F, 0x1C, 0x02, 0x94}};
-
+  CAN_frame Motor_EV_01_frame = {.FD = true,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = Motor_EV_01,  // content
+                                 .data = {0x00, 0x80, 0x12, 0x00, 0x00, 0x00, 0x30, 0x96}};
   uint32_t can_msg_received = 0;
+};
+
+// MQB Evo shares all of the MEB CAN handling; only the one-time setup differs.
+class MqbEvoBattery : public MebBattery {
+ public:
+  MqbEvoBattery() = default;
+  MqbEvoBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_MEB* extended, CAN_Interface targetCan)
+      : MebBattery(datalayer_ptr, extended, targetCan) {}
+  static constexpr const char* Name = "VW Group MQB Evo 2024+ via CAN-FD";
+  void setup(void) override;
 };
 
 #endif

--- a/Software/src/battery/MEB-BATTERY.h
+++ b/Software/src/battery/MEB-BATTERY.h
@@ -312,7 +312,7 @@ class MebBattery : public CanBattery, public IsoTp {
   // outstanding at a time; the next request waits until a response arrives or the timeout expires.
   static constexpr unsigned long UDS_REQUEST_TIMEOUT_MS = 1000;
   // time between the routine start response and the routine stop request.
-  static constexpr unsigned long BASIC_SETTINGS_ROUTINE_STOP_DELAY_MS = 600;
+  static constexpr unsigned long BASIC_SETTINGS_ROUTINE_STOP_DELAY_MS = 3000;
   bool uds_request_pending = false;
   unsigned long uds_request_timestamp = 0;
 

--- a/Software/src/battery/MEB-HTML.h
+++ b/Software/src/battery/MEB-HTML.h
@@ -7,6 +7,9 @@
 
 class MebHtmlRenderer : public BatteryHtmlRenderer {
  public:
+  // platform's battery setup() overrides
+  const char* dtc_json_filename = "vag_meb_dtc.json";
+
   String get_status_html() {
     String content;
 
@@ -286,7 +289,7 @@ class MebHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Total discharged: " + String(datalayer.battery.status.total_discharged_battery_Wh / 1000.0, 1) +
                " kWh</h4>";
 
-    content += BatteryHtmlRenderer::render_dtc_section_html(datalayer.battery.dtc, "vag_meb_dtc.json", false);
+    content += BatteryHtmlRenderer::render_dtc_section_html(datalayer.battery.dtc, dtc_json_filename, false);
 
     return content;
   }

--- a/Software/src/battery/UdsCanBattery.h
+++ b/Software/src/battery/UdsCanBattery.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../lib/uds_isotp/isotp.h"
-#include "../lib/uds_isotp/uds.h"
 #include "CanBattery.h"
 #include "freertos/FreeRTOS.h"
 


### PR DESCRIPTION
### What
Derive new battery MQB Evo 20,2kW from MEB.
Fix the crash reset routine.
Move the uds.h include to CanBattery.h for easier integration.

### Why
More batteries supported. 💯 

### How
Battery can be selected in web interface.
"VW Group MQB Evo 2024+ via CAN-FD"

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
