### PR TITLE
Feature: BYD - add isolation resistance control

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -348,8 +348,9 @@ void BydAttoBattery::
     if (!datalayer_bydatto->keep_iso_disabled) {
       iso_reassert_needed = false;
     }
-    if (iso_reassert_needed && bms_alive && (millis() - bms_alive_since_ms > 5000) &&
-        (iso_reassert_attempt_ms == 0 || (millis() - iso_reassert_attempt_ms) > 15000) && !diag_busy) {
+    // Disable early and retry fast to beat the BMS's boot-time insulation trip.
+    if (iso_reassert_needed && bms_alive && (millis() - bms_alive_since_ms > 1000) &&
+        (iso_reassert_attempt_ms == 0 || (millis() - iso_reassert_attempt_ms) > 2000) && !diag_busy) {
       isoRoutineAction = 1;  // disable
       datalayer_bydatto->iso_command_status = 1;
       increaseTimeoutIso = 0;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -241,6 +241,8 @@ void BydAttoBattery::
     datalayer_bydatto->pack_voltage_dV = battery_voltage_dV;
     datalayer_bydatto->insulation_ohm_per_volt = battery_insulation_ohm_per_volt;
     datalayer_bydatto->insulation_valid = battery_insulation_valid;
+    datalayer_bydatto->iso_status_valid = (last_35E_ms != 0) && ((millis() - last_35E_ms) < 3000);
+    datalayer_bydatto->iso_measurement_active = battery_iso_measurement_active;
     datalayer_bydatto->battery_temperatures[0] = battery_daughterboard_temperatures[0];
     datalayer_bydatto->battery_temperatures[1] = battery_daughterboard_temperatures[1];
     datalayer_bydatto->battery_temperatures[2] = battery_daughterboard_temperatures[2];
@@ -287,28 +289,76 @@ void BydAttoBattery::
     datalayer_bydatto->contactor_drive_flag = (contactor_feedback & BMS_FEEDBACK_DRIVE_FLAG) != 0;
     datalayer_bydatto->contactor_charge_flag = (contactor_feedback & BMS_FEEDBACK_CHARGE_FLAG) != 0;
 
-    // Update requests from webserver datalayer
-    if (datalayer_bydatto->UserRequestCrashReset && stateMachineClearCrash == NOT_RUNNING) {
+    // Update requests from webserver datalayer. All 0x7E7 diagnostics share the request/reply IDs,
+    // so only one may run at a time; DTC reception counts as busy too.
+    bool diag_busy = (stateMachineClearCrash != NOT_RUNNING) || (stateMachineCalibrateSOC != NOT_RUNNING) ||
+                     (stateMachineReadDTC != NOT_RUNNING) || (stateMachineEraseDTC != NOT_RUNNING) ||
+                     (stateMachineIsoRoutine != NOT_RUNNING) || dtc_rx_active ||
+                     datalayer_bydatto->dtc_read_in_progress;
+
+    if (datalayer_bydatto->UserRequestCrashReset && !diag_busy) {
       stateMachineClearCrash = STARTED;
       datalayer_bydatto->UserRequestCrashReset = false;
+      diag_busy = true;
     }
 
-    if (datalayer_bydatto->UserRequestCalibrateSOC && stateMachineCalibrateSOC == NOT_RUNNING) {
+    if (datalayer_bydatto->UserRequestCalibrateSOC && !diag_busy) {
       stateMachineCalibrateSOC = STARTED;
       datalayer_bydatto->UserRequestCalibrateSOC = false;
+      diag_busy = true;
     }
 
-    if (datalayer_bydatto->UserRequestDTCreadout && stateMachineReadDTC == NOT_RUNNING) {
+    if (datalayer_bydatto->UserRequestDTCreadout && !diag_busy) {
       stateMachineReadDTC = STARTED;
       datalayer_bydatto->dtc_read_in_progress = true;
       datalayer_battery->dtc.dtc_read_failed = false;
       dtc_request_millis = millis();
       datalayer_bydatto->UserRequestDTCreadout = false;
+      diag_busy = true;
     }
 
-    if (datalayer_bydatto->UserRequestDTCreset && stateMachineEraseDTC == NOT_RUNNING) {
+    if (datalayer_bydatto->UserRequestDTCreset && !diag_busy) {
       stateMachineEraseDTC = STARTED;
       datalayer_bydatto->UserRequestDTCreset = false;
+      diag_busy = true;
+    }
+
+    if ((datalayer_bydatto->UserRequestIsoRoutineDisable || datalayer_bydatto->UserRequestIsoRoutineEnable) &&
+        !diag_busy) {
+      isoRoutineAction = datalayer_bydatto->UserRequestIsoRoutineDisable ? 1 : 2;
+      datalayer_bydatto->iso_command_status = 1;  // running
+      increaseTimeoutIso = 0;
+      stateMachineIsoRoutine = STARTED;
+      datalayer_bydatto->UserRequestIsoRoutineDisable = false;
+      datalayer_bydatto->UserRequestIsoRoutineEnable = false;
+      diag_busy = true;
+    }
+
+    // keep_iso_disabled: the monitor re-enables on every BMS power-up, so re-send disable after each
+    // BMS start (arm on the CAN alive edge, retry until accepted).
+    bool bms_alive = (lastContactorFeedbackMillis != 0) && ((millis() - lastContactorFeedbackMillis) < 3000);
+    if (bms_alive && !bms_was_alive) {
+      bms_alive_since_ms = millis();
+      if (datalayer_bydatto->keep_iso_disabled) {
+        iso_reassert_needed = true;
+        iso_reassert_attempt_ms = 0;
+      }
+    }
+    bms_was_alive = bms_alive;
+    if (!datalayer_bydatto->keep_iso_disabled) {
+      iso_reassert_needed = false;
+    }
+    if (iso_reassert_needed && bms_alive && (millis() - bms_alive_since_ms > 5000) &&
+        (iso_reassert_attempt_ms == 0 || (millis() - iso_reassert_attempt_ms) > 15000) && !diag_busy) {
+      isoRoutineAction = 1;  // disable
+      datalayer_bydatto->iso_command_status = 1;
+      increaseTimeoutIso = 0;
+      stateMachineIsoRoutine = STARTED;
+      iso_reassert_attempt_ms = millis();
+      diag_busy = true;
+    }
+    if (iso_reassert_needed && iso_reassert_attempt_ms != 0 && datalayer_bydatto->iso_command_status == 2) {
+      iso_reassert_needed = false;  // accepted, monitor disabled until the next BMS restart
     }
     // Fail the read if the BMS never answers
     if (datalayer_bydatto->dtc_read_in_progress && (millis() - dtc_request_millis > 2000)) {
@@ -428,6 +478,13 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x35E:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      // b0 bit 0x80 = isolation measurement active (set = running, clear = disabled/idle)
+      if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
+        battery_iso_measurement_active = (rx_frame.data.u8[0] & 0x80) != 0;
+        last_35E_ms = millis();
+      } else {
+        datalayer_battery->status.CAN_error_counter++;
+      }
       break;
     case 0x360:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -559,6 +616,18 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if ((rx_frame.data.u8[0] == 0x02) && (rx_frame.data.u8[1] == 0x67) && (rx_frame.data.u8[2] == 0x02) &&
           (rx_frame.data.u8[3] == 0xAA)) {
         servicemode = APPROVED;
+      }
+
+      // ISO routine reply (only while it is running): 71 = accepted; any 7F = rejected (session,
+      // security, or routine NRC). Ends the machine on the reply.
+      if (stateMachineIsoRoutine != NOT_RUNNING) {
+        if (rx_frame.data.u8[1] == 0x71 && rx_frame.data.u8[3] == 0x20 && rx_frame.data.u8[4] == 0x08) {
+          datalayer_bydatto->iso_command_status = 2;  // routine accepted
+          stateMachineIsoRoutine = NOT_RUNNING;
+        } else if (rx_frame.data.u8[1] == 0x7F) {
+          datalayer_bydatto->iso_command_status = 3;  // NRC
+          stateMachineIsoRoutine = NOT_RUNNING;
+        }
       }
 
       if (rx_frame.data.u8[0] == 0x10) {
@@ -985,6 +1054,56 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
       default:
         break;
     }
+    switch (stateMachineIsoRoutine) {
+      case STARTED:
+        // DiagnosticSessionControl enter extendedDiagnosticSession (10 03)
+        solvedKey = 0;  // force a fresh seed before the key is sent
+        increaseTimeoutIso = 0;
+        ATTO_3_7E7_RESET_SOC.data = {0x02, 0x10, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00};
+        transmit_can_frame(&ATTO_3_7E7_RESET_SOC);
+        stateMachineIsoRoutine = RUNNING_STEP_1;
+        break;
+      case RUNNING_STEP_1:
+        // SecurityAccess requestSeed (27 01)
+        ATTO_3_7E7_RESET_SOC.data = {0x02, 0x27, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00};
+        transmit_can_frame(&ATTO_3_7E7_RESET_SOC);
+        stateMachineIsoRoutine = RUNNING_STEP_2;
+        break;
+      case RUNNING_STEP_2:
+        // Wait for the seed (RX sets solvedKey), then SecurityAccess sendKey (27 02)
+        if (solvedKey > 0) {
+          ATTO_3_7E7_RESET_SOC.data = {
+              0x04, 0x27, 0x02, (uint8_t)((solvedKey & 0xFF00) >> 8), (uint8_t)(solvedKey & 0x00FF), 0x00, 0x00, 0x00};
+          transmit_can_frame(&ATTO_3_7E7_RESET_SOC);
+          stateMachineIsoRoutine = RUNNING_STEP_3;
+        } else if (++increaseTimeoutIso > 30) {
+          datalayer_bydatto->iso_command_status = 4;  // no reply
+          stateMachineIsoRoutine = NOT_RUNNING;
+        }
+        break;
+      case RUNNING_STEP_3: {
+        // RoutineControl (1 disable -> 31 01, 2 enable -> 31 02)
+        uint8_t subfn = (isoRoutineAction == 1) ? 0x01 : 0x02;
+        ATTO_3_7E7_RESET_SOC.data = {0x04, 0x31, subfn, 0x20, 0x08, 0x00, 0x00, 0x00};
+        transmit_can_frame(&ATTO_3_7E7_RESET_SOC);
+        increaseTimeoutIso = 0;
+        stateMachineIsoRoutine = RUNNING_STEP_4;  // RX ends the machine on 71/7F
+        break;
+      }
+      case RUNNING_STEP_4:
+        // Wait for the routine reply (RX ends the machine); time out so the UI can't stick.
+        if (++increaseTimeoutIso > 20) {  // ~2 s at 100 ms/tick
+          if (datalayer_bydatto->iso_command_status == 1) {
+            datalayer_bydatto->iso_command_status = 4;  // no reply
+          }
+          stateMachineIsoRoutine = NOT_RUNNING;
+        }
+        break;
+      case NOT_RUNNING:
+        break;
+      default:
+        break;
+    }
   }
   // Send 200ms CAN Message
   if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
@@ -1080,7 +1199,8 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     if ((stateMachineClearCrash == NOT_RUNNING) && (stateMachineCalibrateSOC == NOT_RUNNING) &&
         (stateMachineReadDTC == NOT_RUNNING) && (stateMachineEraseDTC == NOT_RUNNING) &&
-        !dtc_rx_active) {  //Don't poll battery for data if any diag ongoing
+        (stateMachineIsoRoutine == NOT_RUNNING) && !dtc_rx_active &&
+        !datalayer_bydatto->dtc_read_in_progress) {  //Don't poll battery for data if any diag ongoing
       transmit_can_frame(&ATTO_3_7E7_POLL);
     }
   }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -297,7 +297,7 @@ class BydAttoBattery : public CanBattery {
   uint8_t secondsSinceStartup = 0;
 
   bool BMS_voltage_available = false;
-  bool battery_insulation_valid = false;  // Zero is a valid 0x43A fault reading, so track receipt separately
+  bool battery_insulation_valid = false;        // Zero is a valid 0x43A fault reading, so track receipt separately
   bool battery_iso_measurement_active = false;  // 0x35E b0 bit0x80
   unsigned long last_35E_ms = 0;                // 0 = 0x35E not yet received (staleness)
   bool calibrationAH_seeded = false;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -192,9 +192,20 @@ class BydAttoBattery : public CanBattery {
   static const uint8_t RUNNING_STEP_1 = 1;
   static const uint8_t RUNNING_STEP_2 = 2;
   static const uint8_t RUNNING_STEP_3 = 3;
+  static const uint8_t RUNNING_STEP_4 = 4;
   uint8_t battery_type = NOT_DETERMINED_YET;
   uint8_t stateMachineClearCrash = NOT_RUNNING;
   uint8_t stateMachineCalibrateSOC = NOT_RUNNING;
+
+  // Isolation monitor routine (RoutineControl 0x2008); shares the 0x7E7 session with SOC cal.
+  uint8_t stateMachineIsoRoutine = NOT_RUNNING;
+  uint8_t isoRoutineAction = 0;  // 1 disable (31 01), 2 enable (31 02)
+  uint8_t increaseTimeoutIso = 0;
+  // keep_iso_disabled enforcement: re-send disable after each BMS start (monitor re-enables on power-up)
+  bool bms_was_alive = false;
+  bool iso_reassert_needed = false;
+  unsigned long bms_alive_since_ms = 0;
+  unsigned long iso_reassert_attempt_ms = 0;
 
   // DTC readout: request 0x19 02 09, reassemble the 0x59 02 ISO-TP reply, parse 4 bytes per DTC.
   static const int MAX_DTC_COUNT = 30;
@@ -287,6 +298,8 @@ class BydAttoBattery : public CanBattery {
 
   bool BMS_voltage_available = false;
   bool battery_insulation_valid = false;  // Zero is a valid 0x43A fault reading, so track receipt separately
+  bool battery_iso_measurement_active = false;  // 0x35E b0 bit0x80
+  unsigned long last_35E_ms = 0;                // 0 = 0x35E not yet received (staleness)
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -127,16 +127,6 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += "Not received</h4>";
     }
-    // 0x43A reports Ohm/V, so scale by pack voltage to get absolute resistance
-    content += "<h4>Insulation resistance: ";
-    if (byd_datalayer->insulation_valid) {
-      float insulation_kohm =
-          static_cast<float>(byd_datalayer->insulation_ohm_per_volt) * (dl_bat.status.voltage_dV / 10.0f) / 1000.0f;
-      content += String(insulation_kohm, 1) + " k&Omega; (" + String(byd_datalayer->insulation_ohm_per_volt) +
-                 " &Omega;/V)</h4>";
-    } else {
-      content += "Not received</h4>";
-    }
     if (byd_datalayer->battery_temperatures[0] != 215) {
       content += "<h4>Temperature sensor 1: " + String(byd_datalayer->battery_temperatures[0]) + " &deg;C</h4>";
     }
@@ -303,6 +293,80 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Calibration target capacity: " + String(byd_datalayer->calibrationTargetAH) +
                " AH <button onclick='editCalTargetAH" + s + "()'>Edit</button></h4>";
 
+    // Isolation monitor control, per battery.
+    {
+      const char* iso_label_td = "<td style='padding:3px 14px 3px 0;color:#d8dee4'>";
+      const char* iso_value_td = "<td style='padding:3px 0;color:white;font-weight:bold'>";
+
+      content += "<div style='max-width:560px;margin:16px auto;text-align:center;color:white'>";
+      content += "<h4 style='margin:0 0 8px 0;color:white'>Isolation resistance monitor</h4>";
+      content += "<table style='margin:0 auto;border-collapse:collapse;font-size:0.95em;text-align:left;color:white'>";
+
+      // Monitoring status from 0x35E b0 bit0x80; only unambiguous when the pack is closed
+      bool iso_closed = byd_datalayer->contactor_main_closed;
+      bool iso_active = byd_datalayer->iso_measurement_active;
+      content += "<tr>";
+      content += iso_label_td;
+      content += "Monitoring:</td>";
+      content += iso_value_td;
+      if (!byd_datalayer->iso_status_valid) {
+        content += "<span style='color:#8b949e'>Unknown</span>";
+      } else if (!iso_closed) {
+        content += "<span style='color:#8b949e'>Inactive (pack open)</span>";
+      } else if (iso_active) {
+        content += "<span style='color:#3fb950'>On</span>";
+      } else {
+        content += "<span style='color:#ff7b72'>Off</span>";
+      }
+      content += "</td></tr>";
+
+      content += "<tr>";
+      content += iso_label_td;
+      content += "Insulation resistance:</td>";
+      content += iso_value_td;
+      if (byd_datalayer->insulation_valid) {
+        float iso_kohm =
+            static_cast<float>(byd_datalayer->insulation_ohm_per_volt) * (dl_bat.status.voltage_dV / 10.0f) / 1000.0f;
+        content += String(iso_kohm, 1) + " k&Omega; (" + String(byd_datalayer->insulation_ohm_per_volt) + " &Omega;/V)";
+      } else {
+        content += "<span style='color:#8b949e'>Not received</span>";
+      }
+      content += "</td></tr>";
+
+      // Command feedback, only shown while something is pending or after a failure
+      if (byd_datalayer->iso_command_status == 1 || byd_datalayer->iso_command_status == 3 ||
+          byd_datalayer->iso_command_status == 4) {
+        content += "<tr>";
+        content += iso_label_td;
+        content += "Last command:</td>";
+        content += iso_value_td;
+        if (byd_datalayer->iso_command_status == 1) {
+          content += "<span style='color:#d29922'>Sending&hellip;</span>";
+        } else if (byd_datalayer->iso_command_status == 3) {
+          content += "<span style='color:#ff7b72'>Rejected</span>";
+        } else {
+          content += "<span style='color:#ff7b72'>No response</span>";
+        }
+        content += "</td></tr>";
+      }
+
+      content += "<tr>";
+      content += iso_label_td;
+      content += "Keep disabled at boot:</td>";
+      content += iso_value_td;
+      content += "<input type='checkbox' id='keepIsoOff" + s + "' ";
+      content += (byd_datalayer->keep_iso_disabled ? "checked" : "");
+      content += " onchange='bydKeepIsoDisabled" + s + "()'>";
+      content += "</td></tr>";
+
+      content += "</table>";
+      content += "<div style='margin:10px 0 0'>";
+      content += "<button onclick='bydIsoEnable" + s + "()'>Enable monitoring</button> ";
+      content += "<button onclick='bydIsoDisable" + s + "()'>Disable monitoring</button>";
+      content += "</div>";
+      content += "</div>";
+    }
+
     content += "<script>";
     content += "function editComplete() {";
     content += "  alert('Update successful!');";
@@ -355,6 +419,23 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "  xhr.onload=editComplete;";
     content += "  xhr.onerror=editError;";
     content += "  xhr.open('GET','/editBydAtto3AutoCalDriftPercent" + s + "?value='+percent,true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function bydIsoSend" + s + "(url){";
+    content += "  var xhr=new XMLHttpRequest();";
+    content += "  xhr.onload=function(){ setTimeout(function(){ location.reload(); }, 2000); };";
+    content += "  xhr.onerror=editError;";
+    content += "  xhr.open('GET',url,true);";
+    content += "  xhr.send();";
+    content += "}";
+    content += "function bydIsoEnable" + s + "(){ bydIsoSend" + s + "('/bydAtto3IsoEnable" + s + "'); }";
+    content += "function bydIsoDisable" + s + "(){ bydIsoSend" + s + "('/bydAtto3IsoDisable" + s + "'); }";
+    content += "function bydKeepIsoDisabled" + s + "(){";
+    content += "  var on = document.getElementById('keepIsoOff" + s + "').checked;";
+    content += "  var xhr=new XMLHttpRequest();";
+    content += "  xhr.onload=editComplete;";
+    content += "  xhr.onerror=editError;";
+    content += "  xhr.open('GET','/bydAtto3KeepIsoDisabled" + s + "?value='+(on?1:0),true);";
     content += "  xhr.send();";
     content += "}";
     content += "</script>";

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -293,7 +293,7 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Calibration target capacity: " + String(byd_datalayer->calibrationTargetAH) +
                " AH <button onclick='editCalTargetAH" + s + "()'>Edit</button></h4>";
 
-    // Isolation monitor control, per battery.
+    // Isolation monitor. Status is per battery; the controls are shown once and apply to both.
     {
       const char* iso_label_td = "<td style='padding:3px 14px 3px 0;color:#d8dee4'>";
       const char* iso_value_td = "<td style='padding:3px 0;color:white;font-weight:bold'>";
@@ -350,20 +350,24 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
         content += "</td></tr>";
       }
 
-      content += "<tr>";
-      content += iso_label_td;
-      content += "Keep disabled at boot:</td>";
-      content += iso_value_td;
-      content += "<input type='checkbox' id='keepIsoOff" + s + "' ";
-      content += (byd_datalayer->keep_iso_disabled ? "checked" : "");
-      content += " onchange='bydKeepIsoDisabled" + s + "()'>";
-      content += "</td></tr>";
+      if (s.length() == 0) {  // one set of controls, applied to every BYD battery
+        content += "<tr>";
+        content += iso_label_td;
+        content += "Keep disabled at boot:</td>";
+        content += iso_value_td;
+        content += "<input type='checkbox' id='keepIsoOff' ";
+        content += (byd_datalayer->keep_iso_disabled ? "checked" : "");
+        content += " onchange='bydKeepIsoDisabled()'>";
+        content += "</td></tr>";
+      }
 
       content += "</table>";
-      content += "<div style='margin:10px 0 0'>";
-      content += "<button onclick='bydIsoEnable" + s + "()'>Enable monitoring</button> ";
-      content += "<button onclick='bydIsoDisable" + s + "()'>Disable monitoring</button>";
-      content += "</div>";
+      if (s.length() == 0) {
+        content += "<div style='margin:10px 0 0'>";
+        content += "<button onclick='bydIsoEnable()'>Enable monitoring</button> ";
+        content += "<button onclick='bydIsoDisable()'>Disable monitoring</button>";
+        content += "</div>";
+      }
       content += "</div>";
     }
 
@@ -421,23 +425,25 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     content += "  xhr.open('GET','/editBydAtto3AutoCalDriftPercent" + s + "?value='+percent,true);";
     content += "  xhr.send();";
     content += "}";
-    content += "function bydIsoSend" + s + "(url){";
-    content += "  var xhr=new XMLHttpRequest();";
-    content += "  xhr.onload=function(){ setTimeout(function(){ location.reload(); }, 2000); };";
-    content += "  xhr.onerror=editError;";
-    content += "  xhr.open('GET',url,true);";
-    content += "  xhr.send();";
-    content += "}";
-    content += "function bydIsoEnable" + s + "(){ bydIsoSend" + s + "('/bydAtto3IsoEnable" + s + "'); }";
-    content += "function bydIsoDisable" + s + "(){ bydIsoSend" + s + "('/bydAtto3IsoDisable" + s + "'); }";
-    content += "function bydKeepIsoDisabled" + s + "(){";
-    content += "  var on = document.getElementById('keepIsoOff" + s + "').checked;";
-    content += "  var xhr=new XMLHttpRequest();";
-    content += "  xhr.onload=editComplete;";
-    content += "  xhr.onerror=editError;";
-    content += "  xhr.open('GET','/bydAtto3KeepIsoDisabled" + s + "?value='+(on?1:0),true);";
-    content += "  xhr.send();";
-    content += "}";
+    if (s.length() == 0) {  // isolation controls are rendered once and apply to every BYD battery
+      content += "function bydIsoSend(url){";
+      content += "  var xhr=new XMLHttpRequest();";
+      content += "  xhr.onload=function(){ setTimeout(function(){ location.reload(); }, 2000); };";
+      content += "  xhr.onerror=editError;";
+      content += "  xhr.open('GET',url,true);";
+      content += "  xhr.send();";
+      content += "}";
+      content += "function bydIsoEnable(){ bydIsoSend('/bydAtto3IsoEnable'); }";
+      content += "function bydIsoDisable(){ bydIsoSend('/bydAtto3IsoDisable'); }";
+      content += "function bydKeepIsoDisabled(){";
+      content += "  var on = document.getElementById('keepIsoOff').checked;";
+      content += "  var xhr=new XMLHttpRequest();";
+      content += "  xhr.onload=editComplete;";
+      content += "  xhr.onerror=editError;";
+      content += "  xhr.open('GET','/bydAtto3KeepIsoDisabled?value='+(on?1:0),true);";
+      content += "  xhr.send();";
+      content += "}";
+    }
     content += "</script>";
 
     auto& dtc = s.length() ? datalayer.battery2.dtc : datalayer.battery.dtc;

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -275,11 +275,12 @@ void init_stored_settings() {
   datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent =
       constrain(settings.getUInt("BYDAUTOCALDRIFT", 5), 1u, 20u);
   datalayer_extended.bydAtto3.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN", true);
-  datalayer_extended.bydAtto3.keep_iso_disabled = settings.getBool("BYDKEEPISOOFF", true);
   datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent =
       constrain(settings.getUInt("BYDAUTOCALDRFT2", 5), 1u, 20u);
   datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN2", true);
-  datalayer_extended.bydAtto3_2.keep_iso_disabled = settings.getBool("BYDKEEPISOOFF2", true);
+  // One isolation-monitor setting for both batteries
+  datalayer_extended.bydAtto3.keep_iso_disabled = settings.getBool("BYDKEEPISOOFF", true);
+  datalayer_extended.bydAtto3_2.keep_iso_disabled = datalayer_extended.bydAtto3.keep_iso_disabled;
 }
 
 void clear_wifi_sta_settings() {
@@ -333,5 +334,4 @@ void store_settings() {
   settings.saveBool("BYDKEEPISOOFF", datalayer_extended.bydAtto3.keep_iso_disabled);
   settings.saveUInt("BYDAUTOCALDRFT2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent);
   settings.saveBool("BYDAUTOCALEN2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled);
-  settings.saveBool("BYDKEEPISOOFF2", datalayer_extended.bydAtto3_2.keep_iso_disabled);
 }

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -275,9 +275,11 @@ void init_stored_settings() {
   datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent =
       constrain(settings.getUInt("BYDAUTOCALDRIFT", 5), 1u, 20u);
   datalayer_extended.bydAtto3.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN", true);
+  datalayer_extended.bydAtto3.keep_iso_disabled = settings.getBool("BYDKEEPISOOFF", true);
   datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent =
       constrain(settings.getUInt("BYDAUTOCALDRFT2", 5), 1u, 20u);
   datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled = settings.getBool("BYDAUTOCALEN2", true);
+  datalayer_extended.bydAtto3_2.keep_iso_disabled = settings.getBool("BYDKEEPISOOFF2", true);
 }
 
 void clear_wifi_sta_settings() {
@@ -328,6 +330,8 @@ void store_settings() {
   settings.saveUInt("BMSRESETDUR", datalayer.battery.settings.user_set_bms_reset_duration_ms);
   settings.saveUInt("BYDAUTOCALDRIFT", datalayer_extended.bydAtto3.auto_calibrate_soc_drift_percent);
   settings.saveBool("BYDAUTOCALEN", datalayer_extended.bydAtto3.auto_calibrate_soc_enabled);
+  settings.saveBool("BYDKEEPISOOFF", datalayer_extended.bydAtto3.keep_iso_disabled);
   settings.saveUInt("BYDAUTOCALDRFT2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent);
   settings.saveBool("BYDAUTOCALEN2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled);
+  settings.saveBool("BYDKEEPISOOFF2", datalayer_extended.bydAtto3_2.keep_iso_disabled);
 }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -208,10 +208,10 @@ struct DATALAYER_INFO_BYDATTO3 {
   // Isolation monitor control (RoutineControl 0x2008): disable = 31 01, enable = 31 02.
   bool UserRequestIsoRoutineEnable;
   bool UserRequestIsoRoutineDisable;
-  bool keep_iso_disabled;         // re-send disable on each BMS start (persisted)
-  bool iso_measurement_active;    // 0x35E b0 bit0x80: isolation measurement running
-  bool iso_status_valid;          // fresh 0x35E seen (else status unknown)
-  uint8_t iso_command_status;     // 0 idle, 1 running, 2 accepted, 3 rejected, 4 no reply
+  bool keep_iso_disabled;       // re-send disable on each BMS start (persisted)
+  bool iso_measurement_active;  // 0x35E b0 bit0x80: isolation measurement running
+  bool iso_status_valid;        // fresh 0x35E seen (else status unknown)
+  uint8_t iso_command_status;   // 0 idle, 1 running, 2 accepted, 3 rejected, 4 no reply
 };
 
 struct DATALAYER_INFO_CELLPOWER {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -204,6 +204,14 @@ struct DATALAYER_INFO_BYDATTO3 {
   bool dtc_read_in_progress;
   bool UserRequestDTCreadout;  // User requesting DTC readout via WebUI
   bool UserRequestDTCreset;    // User requesting DTC erase via WebUI
+
+  // Isolation monitor control (RoutineControl 0x2008): disable = 31 01, enable = 31 02.
+  bool UserRequestIsoRoutineEnable;
+  bool UserRequestIsoRoutineDisable;
+  bool keep_iso_disabled;         // re-send disable on each BMS start (persisted)
+  bool iso_measurement_active;    // 0x35E b0 bit0x80: isolation measurement running
+  bool iso_status_valid;          // fresh 0x35E seen (else status unknown)
+  uint8_t iso_command_status;     // 0 idle, 1 running, 2 accepted, 3 rejected, 4 no reply
 };
 
 struct DATALAYER_INFO_CELLPOWER {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -706,41 +706,25 @@ void init_webserver() {
     datalayer_extended.bydAtto3.calibrationTargetAH = static_cast<uint16_t>(value.toFloat());
   });
 
-  // Isolation monitor control (RoutineControl 0x2008), per battery.
+  // Isolation monitor control (RoutineControl 0x2008). One setting, applied to both batteries.
   def_route_with_auth("/bydAtto3IsoDisable", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     datalayer_extended.bydAtto3.UserRequestIsoRoutineDisable = true;
+    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineDisable = true;
     request->send(200, "text/plain", "OK");
   });
   def_route_with_auth("/bydAtto3IsoEnable", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     datalayer_extended.bydAtto3.UserRequestIsoRoutineEnable = true;
+    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineEnable = true;
     request->send(200, "text/plain", "OK");
   });
   def_route_with_auth("/bydAtto3KeepIsoDisabled", server, HTTP_GET, [](AsyncWebServerRequest* request) {
     if (request->hasParam("value")) {
       bool enabled = request->getParam("value")->value().toInt() != 0;
       datalayer_extended.bydAtto3.keep_iso_disabled = enabled;
-      Preferences prefs;
-      prefs.begin("batterySettings", false);
-      prefs.putBool("BYDKEEPISOOFF", enabled);
-      prefs.end();
-    }
-    request->send(200, "text/plain", "OK");
-  });
-  def_route_with_auth("/bydAtto3IsoDisable2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineDisable = true;
-    request->send(200, "text/plain", "OK");
-  });
-  def_route_with_auth("/bydAtto3IsoEnable2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineEnable = true;
-    request->send(200, "text/plain", "OK");
-  });
-  def_route_with_auth("/bydAtto3KeepIsoDisabled2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    if (request->hasParam("value")) {
-      bool enabled = request->getParam("value")->value().toInt() != 0;
       datalayer_extended.bydAtto3_2.keep_iso_disabled = enabled;
       Preferences prefs;
       prefs.begin("batterySettings", false);
-      prefs.putBool("BYDKEEPISOOFF2", enabled);
+      prefs.putBool("BYDKEEPISOOFF", enabled);
       prefs.end();
     }
     request->send(200, "text/plain", "OK");

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -706,6 +706,46 @@ void init_webserver() {
     datalayer_extended.bydAtto3.calibrationTargetAH = static_cast<uint16_t>(value.toFloat());
   });
 
+  // Isolation monitor control (RoutineControl 0x2008), per battery.
+  def_route_with_auth("/bydAtto3IsoDisable", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    datalayer_extended.bydAtto3.UserRequestIsoRoutineDisable = true;
+    request->send(200, "text/plain", "OK");
+  });
+  def_route_with_auth("/bydAtto3IsoEnable", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    datalayer_extended.bydAtto3.UserRequestIsoRoutineEnable = true;
+    request->send(200, "text/plain", "OK");
+  });
+  def_route_with_auth("/bydAtto3KeepIsoDisabled", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      bool enabled = request->getParam("value")->value().toInt() != 0;
+      datalayer_extended.bydAtto3.keep_iso_disabled = enabled;
+      Preferences prefs;
+      prefs.begin("batterySettings", false);
+      prefs.putBool("BYDKEEPISOOFF", enabled);
+      prefs.end();
+    }
+    request->send(200, "text/plain", "OK");
+  });
+  def_route_with_auth("/bydAtto3IsoDisable2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineDisable = true;
+    request->send(200, "text/plain", "OK");
+  });
+  def_route_with_auth("/bydAtto3IsoEnable2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    datalayer_extended.bydAtto3_2.UserRequestIsoRoutineEnable = true;
+    request->send(200, "text/plain", "OK");
+  });
+  def_route_with_auth("/bydAtto3KeepIsoDisabled2", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      bool enabled = request->getParam("value")->value().toInt() != 0;
+      datalayer_extended.bydAtto3_2.keep_iso_disabled = enabled;
+      Preferences prefs;
+      prefs.begin("batterySettings", false);
+      prefs.putBool("BYDKEEPISOOFF2", enabled);
+      prefs.end();
+    }
+    request->send(200, "text/plain", "OK");
+  });
+
   // Battery 2 auto-calibration routes
   update_string_setting("/editCalTargetSOC2", [](String value) {
     datalayer_extended.bydAtto3_2.calibrationTargetSOC = static_cast<uint16_t>(value.toFloat());


### PR DESCRIPTION
### What
A control on the BYD more battery info page to turn the pack's own insulation-resistance monitor off (and back on), with a live status showing whether it's on, and a "keep it off after every restart" tickbox.  This is enabled by default.

### Why
A repurposed pack often runs with its case earthed to the frame, which the pack reads as a leakage fault — it then refuses to charge in the correct manner and drops rated power by raising a DTC. In these installs the inverter already does its own insulation test and is responsible for it, so the pack's duplicate check is just getting in the way. Turning it off lets the pack run normally.

### How
Battery Emulator sends the same diagnostic command a dealer scan tool uses (over the pack's UDS channel, unlocked with the security key we already had for SOC reset etc). The monitor forgets the setting every time the battery is power-cycled, so the tickbox re-sends the "off" command a few seconds after each startup. Status is read from a broadcast the pack already sends to check the status of the monitor.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
