### PR TITLE
Stop starting an automatic precharge that is aborted on the next tick

### DIFF
--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -12,8 +12,6 @@ uint16_t precharge_max_precharge_time_before_fault = 15000;
 uint16_t Precharge_max_PWM_Freq = 34000;
 
 // Hardcoded parameters
-#define Precharge_default_PWM_Freq 11000
-#define Precharge_min_PWM_Freq 5000
 #define Precharge_PWM_Res 8
 #define PWM_Freq 20000  // 20 kHz frequency, beyond audible range
 #define PWM_Precharge_Channel 0
@@ -49,6 +47,17 @@ bool init_precharge_control() {
   return true;
 }
 
+// A precharge sequence may only run while these hold. The start gate and the
+// abort check share them, so a sequence is never started that the next tick
+// would abort - which would otherwise toggle the inverter-disconnect contactor
+// on every pass of the 10 ms core loop.
+static bool precharge_conditions_ok() {
+  return datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active &&
+         datalayer.system.status.system_status == ACTIVE &&
+         (datalayer.battery.status.real_bms_status == BMS_STANDBY ||
+          datalayer.battery.status.real_bms_status == BMS_ACTIVE);
+}
+
 // Main functions
 void handle_precharge_control(unsigned long currentMillis) {
   auto hia4v1_pin = esp32hal->HIA4V1_PIN();
@@ -73,7 +82,7 @@ void handle_precharge_control(unsigned long currentMillis) {
 
   switch (datalayer.system.status.precharge_status) {
     case AUTO_PRECHARGE_IDLE:
-      if (datalayer.system.info.start_precharging && datalayer.system.status.inverter_allows_contactor_closing) {
+      if (datalayer.system.info.start_precharging && precharge_conditions_ok()) {
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_START;
       }
       break;
@@ -122,10 +131,7 @@ void handle_precharge_control(unsigned long currentMillis) {
         set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);  // also printing a log entry
         // Force stop any further precharge attempts
         datalayer.system.info.start_precharging = false;
-      } else if ((datalayer.battery.status.real_bms_status != BMS_STANDBY &&
-                  datalayer.battery.status.real_bms_status != BMS_ACTIVE) ||
-                 datalayer.system.status.system_status != ACTIVE || datalayer.system.info.equipment_stop_active ||
-                 !datalayer.system.status.inverter_allows_contactor_closing) {
+      } else if (!precharge_conditions_ok()) {
         pinMode(hia4v1_pin, OUTPUT);
         digitalWrite(hia4v1_pin, LOW);
         digitalWrite(inverter_disconnect_contactor_pin, CONTACTOR_ON);

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -12,8 +12,6 @@ uint16_t precharge_max_precharge_time_before_fault = 15000;
 uint16_t Precharge_max_PWM_Freq = 34000;
 
 // Hardcoded parameters
-#define Precharge_default_PWM_Freq 11000
-#define Precharge_min_PWM_Freq 5000
 #define Precharge_PWM_Res 8
 #define PWM_Freq 20000  // 20 kHz frequency, beyond audible range
 #define PWM_Precharge_Channel 0
@@ -49,6 +47,17 @@ bool init_precharge_control() {
   return true;
 }
 
+// A precharge sequence may only run while these hold. The start gate and the
+// abort check share them, so a sequence is never started that the next tick
+// would abort - which would otherwise toggle the inverter-disconnect contactor
+// on every pass of the 10 ms core loop.
+static bool precharge_conditions_ok() {
+  return datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active &&
+         datalayer.system.status.system_status == ACTIVE &&
+         (datalayer.battery.status.real_bms_status == BMS_STANDBY ||
+          datalayer.battery.status.real_bms_status == BMS_ACTIVE);
+}
+
 // Main functions
 void handle_precharge_control(unsigned long currentMillis) {
   auto hia4v1_pin = esp32hal->HIA4V1_PIN();
@@ -73,7 +82,7 @@ void handle_precharge_control(unsigned long currentMillis) {
 
   switch (datalayer.system.status.precharge_status) {
     case AUTO_PRECHARGE_IDLE:
-      if (datalayer.system.info.start_precharging && datalayer.system.status.inverter_allows_contactor_closing) {
+      if (datalayer.system.info.start_precharging && precharge_conditions_ok()) {
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_START;
       }
       break;
@@ -123,10 +132,7 @@ void handle_precharge_control(unsigned long currentMillis) {
         set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);
         // Force stop any further precharge attempts
         datalayer.system.info.start_precharging = false;
-      } else if ((datalayer.battery.status.real_bms_status != BMS_STANDBY &&
-                  datalayer.battery.status.real_bms_status != BMS_ACTIVE) ||
-                 datalayer.system.status.system_status != ACTIVE || datalayer.system.info.equipment_stop_active ||
-                 !datalayer.system.status.inverter_allows_contactor_closing) {
+      } else if (!precharge_conditions_ok()) {
         pinMode(hia4v1_pin, OUTPUT);
         digitalWrite(hia4v1_pin, LOW);
         digitalWrite(inverter_disconnect_contactor_pin, CONTACTOR_ON);

--- a/Software/src/communication/precharge_control/precharge_control.h
+++ b/Software/src/communication/precharge_control/precharge_control.h
@@ -9,6 +9,11 @@ extern bool precharge_control_enabled;
 extern bool precharge_inverter_normally_open_contactor;
 extern uint16_t precharge_max_precharge_time_before_fault;
 extern uint16_t Precharge_max_PWM_Freq;
+
+// The precharge PWM starts here and is regulated between these bounds as the
+// external voltage closes on the pack voltage.
+#define Precharge_default_PWM_Freq 11000
+#define Precharge_min_PWM_Freq 5000
 /**
  * @brief Contactor initialization
  *

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,10 @@ add_compile_definitions(ESP32 HW_LILYGO COMMON_IMAGE)
 # CONFIGURE_DEPENDS re-globs at build time, so a newly added file is picked up
 # without re-running cmake by hand. The filter drops the leftovers of an
 # in-source `cmake -B build` inside test/, which are not sources.
+# Some firmware sources include headers as "src/...", which PlatformIO resolves
+# from its src_dir (Software/). Give the test build the same root.
+include_directories(../Software)
+
 file(GLOB_RECURSE TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 list(FILTER TEST_SOURCES EXCLUDE REGEX "/build/")
 
@@ -85,6 +89,7 @@ add_executable(tests
     ${TEST_SOURCES}
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+    ../Software/src/communication/precharge_control/precharge_control.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp
     ../Software/src/devboard/safety/safety.cpp
     ../Software/src/devboard/hal/hal.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,10 @@ include_directories("${source_dir}/googletest/include"
 
 include_directories(emul)
 
+# Some firmware sources include headers as "src/...", which PlatformIO resolves
+# from its src_dir (Software/). Give the test build the same root.
+include_directories(../Software)
+
 # For eModBus
 add_compile_definitions(ESP32 HW_LILYGO COMMON_IMAGE)
 
@@ -73,6 +77,7 @@ add_executable(tests
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
     estop_graceful_open_tests.cpp
+    precharge_control_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp
@@ -85,6 +90,7 @@ add_executable(tests
     utils/utils.cpp
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+    ../Software/src/communication/precharge_control/precharge_control.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp
     ../Software/src/devboard/safety/safety.cpp
     ../Software/src/devboard/hal/hal.cpp

--- a/test/emul/Arduino.cpp
+++ b/test/emul/Arduino.cpp
@@ -14,7 +14,21 @@ void delayMicroseconds(unsigned long us) {}
 int digitalRead(uint8_t pin) {
   return 0;
 }
-void digitalWrite(uint8_t pin, uint8_t val) {}
+// Records every pin write so tests can assert what the firmware actually drove
+// (contactor toggling, precharge PWM enable, ...).
+std::vector<PinWrite> g_emul_pin_writes;
+
+void clear_pin_writes() {
+  g_emul_pin_writes.clear();
+}
+
+const std::vector<PinWrite>& get_pin_writes() {
+  return g_emul_pin_writes;
+}
+
+void digitalWrite(uint8_t pin, uint8_t val) {
+  g_emul_pin_writes.push_back({pin, val});
+}
 
 unsigned long micros() {
   return 0;
@@ -29,6 +43,23 @@ bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, int8_t ch
   return true;
 }
 bool ledcWrite(uint8_t pin, uint32_t duty) {
+  return true;
+}
+// Records the precharge PWM frequency the firmware asks for, so the regulation
+// loop can be asserted on the value it actually drove rather than on internal
+// state.
+std::vector<ToneWrite> g_emul_tone_writes;
+
+void clear_tone_writes() {
+  g_emul_tone_writes.clear();
+}
+
+const std::vector<ToneWrite>& get_tone_writes() {
+  return g_emul_tone_writes;
+}
+
+bool ledcWriteTone(uint8_t pin, uint32_t freq) {
+  g_emul_tone_writes.push_back({pin, freq});
   return true;
 }
 

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include "HardwareSerial.h"
 #include "Logging.h"
@@ -142,6 +143,24 @@ int max(int a, int b);
 
 bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, int8_t channel);
 bool ledcWrite(uint8_t pin, uint32_t duty);
+bool ledcWriteTone(uint8_t pin, uint32_t freq);
+
+// A PWM tone write recorded by the emulated ledcWriteTone.
+struct ToneWrite {
+  uint8_t pin;
+  uint32_t freq;
+};
+void clear_tone_writes();
+const std::vector<ToneWrite>& get_tone_writes();
+
+// A pin write recorded by the emulated digitalWrite, for tests that need to
+// assert on what was driven rather than only on state variables.
+struct PinWrite {
+  uint8_t pin;
+  uint8_t value;
+};
+void clear_pin_writes();
+const std::vector<PinWrite>& get_pin_writes();
 
 class ESPClass {
  public:

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #include "HardwareSerial.h"
 #include "Logging.h"
@@ -140,6 +141,24 @@ int max(int a, int b);
 
 bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, int8_t channel);
 bool ledcWrite(uint8_t pin, uint32_t duty);
+bool ledcWriteTone(uint8_t pin, uint32_t freq);
+
+// A PWM tone write recorded by the emulated ledcWriteTone.
+struct ToneWrite {
+  uint8_t pin;
+  uint32_t freq;
+};
+void clear_tone_writes();
+const std::vector<ToneWrite>& get_tone_writes();
+
+// A pin write recorded by the emulated digitalWrite, for tests that need to
+// assert on what was driven rather than only on state variables.
+struct PinWrite {
+  uint8_t pin;
+  uint8_t value;
+};
+void clear_pin_writes();
+const std::vector<PinWrite>& get_pin_writes();
 
 class ESPClass {
  public:

--- a/test/precharge_control_tests.cpp
+++ b/test/precharge_control_tests.cpp
@@ -1,0 +1,406 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/battery/BATTERIES.h"
+#include "../Software/src/communication/precharge_control/precharge_control.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/datalayer/datalayer_extended.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/utils/events.h"
+
+#include "Arduino.h"
+
+namespace {
+
+// The state machine runs from the 10 ms core loop, so a stuck sequence shows
+// up as repeated actuation rather than a single event. Ticking many times is
+// what makes a restart loop visible.
+constexpr int kTicks = 50;
+constexpr unsigned long kTickMs = 10;
+// CONTACTOR_OFF in precharge_control.cpp with the default (normally-closed)
+// wiring: the state that puts the precharge resistor in circuit.
+constexpr uint8_t kContactorOff = 1;
+
+void runTicks(int ticks = kTicks) {
+  for (int i = 0; i < ticks; ++i) {
+    handle_precharge_control(i * kTickMs);
+  }
+}
+
+// Everything the sequence needs in order to run. Individual tests then break
+// exactly one of these.
+void setUpRunnableConditions() {
+  init_hal();
+  precharge_control_enabled = true;
+  datalayer.system.status.precharge_status = AUTO_PRECHARGE_IDLE;
+  datalayer.system.info.start_precharging = true;
+  datalayer.system.status.inverter_allows_contactor_closing = true;
+  datalayer.system.status.battery_allows_contactor_closing = false;
+  datalayer.system.info.equipment_stop_active = false;
+  datalayer.system.status.system_status = ACTIVE;
+  datalayer.battery.status.real_bms_status = BMS_STANDBY;
+  precharge_max_precharge_time_before_fault = 15000;
+  Precharge_max_PWM_Freq = 34000;
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 0;
+  clear_tone_writes();
+  reset_all_events();
+  clear_pin_writes();
+}
+
+bool event_is_active(EVENTS_ENUM_TYPE event) {
+  const EVENTS_STRUCT_TYPE* entry = get_event_pointer(event);
+  return entry->state == EVENT_STATE_ACTIVE || entry->state == EVENT_STATE_ACTIVE_LATCHED;
+}
+
+bool pin_driven(gpio_num_t pin) {
+  for (const PinWrite& write : get_pin_writes()) {
+    if (write.pin == static_cast<uint8_t>(pin)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool pin_driven_to(gpio_num_t pin, uint8_t value) {
+  for (const PinWrite& write : get_pin_writes()) {
+    if (write.pin == static_cast<uint8_t>(pin) && write.value == value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool inverterDisconnectContactorWasDriven() {
+  const uint8_t pin = static_cast<uint8_t>(esp32hal->INVERTER_DISCONNECT_CONTACTOR_PIN());
+  for (const PinWrite& write : get_pin_writes()) {
+    if (write.pin == pin) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+// The start gate used to ignore system_status, so a battery asking to precharge
+// while the system was in FAULT started a sequence that the next tick aborted -
+// toggling the inverter-disconnect contactor on every pass of the core loop.
+TEST(PrechargeControlTests, DoesNotStartWhileSystemStatusIsFault) {
+  setUpRunnableConditions();
+  datalayer.system.status.system_status = FAULT;
+
+  runTicks();
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+  EXPECT_FALSE(inverterDisconnectContactorWasDriven())
+      << "the inverter-disconnect contactor must not be switched while precharge cannot run";
+}
+
+// Same asymmetry on the equipment-stop path: the contactor must stay put during
+// an equipment stop rather than chattering.
+TEST(PrechargeControlTests, DoesNotStartWhileEquipmentStopIsActive) {
+  setUpRunnableConditions();
+  datalayer.system.info.equipment_stop_active = true;
+
+  runTicks();
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+  EXPECT_FALSE(inverterDisconnectContactorWasDriven())
+      << "the inverter-disconnect contactor must not be switched during an equipment stop";
+}
+
+// The condition the start gate already checked keeps working.
+TEST(PrechargeControlTests, DoesNotStartWithoutInverterPermission) {
+  setUpRunnableConditions();
+  datalayer.system.status.inverter_allows_contactor_closing = false;
+
+  runTicks();
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+}
+
+// The fix must not stop a legitimate sequence from starting.
+TEST(PrechargeControlTests, StartsWhenEveryConditionHolds) {
+  setUpRunnableConditions();
+
+  handle_precharge_control(0);
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_START);
+
+  handle_precharge_control(kTickMs);
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+  EXPECT_TRUE(inverterDisconnectContactorWasDriven()) << "starting the sequence does drive the contactor";
+}
+
+// A running sequence still aborts when a condition drops away - the abort side
+// of the shared predicate.
+TEST(PrechargeControlTests, RunningSequenceAbortsWhenEquipmentStopArrives) {
+  setUpRunnableConditions();
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+
+  clear_pin_writes();
+  datalayer.system.info.equipment_stop_active = true;
+  handle_precharge_control(2 * kTickMs);
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+  // Aborting is not just a state change: the precharge PWM has to stop and the
+  // inverter-disconnect contactor has to go back to its resting position, or
+  // the resistor stays in circuit with the sequence no longer running.
+  EXPECT_TRUE(pin_driven_to(esp32hal->HIA4V1_PIN(), LOW)) << "the precharge PWM pin must be driven low on abort";
+  EXPECT_TRUE(pin_driven(esp32hal->INVERTER_DISCONNECT_CONTACTOR_PIN()))
+      << "the inverter-disconnect contactor must be switched back on abort";
+}
+
+// ...and having aborted, it must not immediately start again, which is the loop
+// itself: before the fix this cycled IDLE -> START -> PRECHARGING -> IDLE at the
+// core-loop rate for as long as the blocking condition lasted.
+TEST(PrechargeControlTests, DoesNotRestartAfterAbortingWhileStillBlocked) {
+  setUpRunnableConditions();
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+
+  datalayer.system.info.equipment_stop_active = true;
+  handle_precharge_control(2 * kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+
+  clear_pin_writes();
+  runTicks();
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_IDLE);
+  EXPECT_FALSE(inverterDisconnectContactorWasDriven()) << "the contactor rattle is exactly this write repeating";
+}
+
+// --- The failure paths -----------------------------------------------------
+
+// A precharge that never completes must fail rather than run forever with the
+// resistor in circuit - that is what the timeout is for.
+TEST(PrechargeControlTests, TimeoutDuringPrechargingCausesFailure) {
+  setUpRunnableConditions();
+  precharge_max_precharge_time_before_fault = 100;
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+
+  handle_precharge_control(kTickMs + 100);
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_FAILURE);
+  EXPECT_TRUE(event_is_active(EVENT_AUTOMATIC_PRECHARGE_FAILURE));
+  EXPECT_FALSE(datalayer.system.info.start_precharging) << "a failed sequence must not be retried";
+}
+
+// A BMS fault mid-precharge is a hard failure, not an ordinary abort: it takes
+// the first branch, so it must latch rather than returning to idle where the
+// sequence could immediately restart.
+TEST(PrechargeControlTests, BmsFaultDuringPrechargingCausesFailureNotIdle) {
+  setUpRunnableConditions();
+  if (!battery) {
+    user_selected_battery_type = BatteryType::TestFake;
+    setup_battery();
+  }
+  ASSERT_NE(battery, nullptr);
+  datalayer.system.info.start_precharging = true;
+  datalayer.battery.status.real_bms_status = BMS_STANDBY;
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+
+  datalayer.battery.status.real_bms_status = BMS_FAULT;
+  handle_precharge_control(2 * kTickMs);
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_FAILURE)
+      << "a BMS fault must latch, not fall through to the recoverable idle path";
+}
+
+// The failure state requires a reboot to leave. Nothing - not even every
+// condition being healthy again - may restart the sequence.
+TEST(PrechargeControlTests, FailureStateIsTerminal) {
+  setUpRunnableConditions();
+  precharge_max_precharge_time_before_fault = 100;
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  handle_precharge_control(kTickMs + 100);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_FAILURE);
+
+  // Everything healthy again, and a fresh request.
+  datalayer.system.info.start_precharging = true;
+  datalayer.battery.status.real_bms_status = BMS_STANDBY;
+  datalayer.system.status.system_status = ACTIVE;
+  datalayer.system.info.equipment_stop_active = false;
+  clear_pin_writes();
+  runTicks();
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_FAILURE)
+      << "only a reboot may clear a precharge failure";
+  // The failure branch re-asserts the safe position on every pass rather than
+  // leaving the pin alone, so the property is that it is never driven to the
+  // opposite state - the resistor must not be switched back in.
+  EXPECT_FALSE(pin_driven_to(esp32hal->INVERTER_DISCONNECT_CONTACTOR_PIN(), kContactorOff))
+      << "a latched failure must never re-open the inverter-disconnect contactor";
+}
+
+// The success path: the battery reporting its contactors closed is what ends
+// the sequence, and it must end as COMPLETED rather than idle.
+TEST(PrechargeControlTests, CompletesWhenBatteryAllowsContactorClosing) {
+  setUpRunnableConditions();
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  ASSERT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_PRECHARGING);
+
+  datalayer.system.status.battery_allows_contactor_closing = true;
+  handle_precharge_control(2 * kTickMs);
+
+  EXPECT_EQ(datalayer.system.status.precharge_status, AUTO_PRECHARGE_COMPLETED);
+}
+
+// --- The PWM regulation loop -----------------------------------------------
+//
+// While precharging, the firmware drives the resistor with a PWM whose
+// frequency it walks towards the pack voltage: a large gap moves in fixed
+// steps, a closing gap moves proportionally, and the result is clamped to the
+// configured band. Only the firmware's half of that loop is exercised here -
+// the generator's actual response to it is a bench matter - but the control
+// law itself is arithmetic and needs no hardware.
+
+namespace {
+
+// Puts the sequence into PRECHARGING with a known starting frequency, then
+// clears the recorder so a test sees only what its own step drove.
+void beginPrechargingAt(int32_t pack_dV, int32_t external_dV) {
+  setUpRunnableConditions();
+  datalayer.battery.status.voltage_dV = pack_dV;
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = external_dV;
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+  clear_tone_writes();
+}
+
+uint32_t last_tone() {
+  const std::vector<ToneWrite>& writes = get_tone_writes();
+  return writes.empty() ? 0 : writes.back().freq;
+}
+
+}  // namespace
+
+// Starting the sequence sets the default frequency, so every run begins from
+// the same place regardless of where the last one ended.
+TEST(PrechargeControlTests, StartingTheSequenceDrivesTheDefaultFrequency) {
+  setUpRunnableConditions();
+  clear_tone_writes();
+
+  handle_precharge_control(0);
+  handle_precharge_control(kTickMs);
+
+  ASSERT_FALSE(get_tone_writes().empty());
+  EXPECT_EQ(get_tone_writes().front().freq, Precharge_default_PWM_Freq);
+}
+
+// External below pack: the DC link still has to charge, so the frequency rises.
+TEST(PrechargeControlTests, FrequencyRisesWhileTheLinkIsBelowThePack) {
+  beginPrechargingAt(4000, 3000);
+
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3100;
+  handle_precharge_control(2 * kTickMs);
+
+  ASSERT_FALSE(get_tone_writes().empty());
+  EXPECT_GT(last_tone(), Precharge_default_PWM_Freq);
+}
+
+// External above pack: back off.
+TEST(PrechargeControlTests, FrequencyFallsWhenTheLinkOvershootsThePack) {
+  beginPrechargingAt(3000, 4000);
+
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3900;
+  handle_precharge_control(2 * kTickMs);
+
+  ASSERT_FALSE(get_tone_writes().empty());
+  EXPECT_LT(last_tone(), Precharge_default_PWM_Freq);
+}
+
+// The step size is banded: far away moves a fixed 2000, and closer in moves
+// proportionally to the gap. Getting these bands wrong makes the loop either
+// crawl or oscillate.
+TEST(PrechargeControlTests, StepSizeFollowsTheDistanceBands) {
+  // Gap of 200 dV, beyond the 150 threshold: a flat 2000 step.
+  beginPrechargingAt(4000, 3000);
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3800;
+  handle_precharge_control(2 * kTickMs);
+  EXPECT_EQ(last_tone(), Precharge_default_PWM_Freq + 2000) << "a far gap steps by a flat amount";
+
+  // Gap of 100 dV, inside 150 but beyond 80: six times the gap.
+  beginPrechargingAt(4000, 3000);
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3900;
+  handle_precharge_control(2 * kTickMs);
+  EXPECT_EQ(last_tone(), Precharge_default_PWM_Freq + 100 * 6);
+
+  // Gap of 50 dV, the closest band: three times the gap.
+  beginPrechargingAt(4000, 3000);
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3950;
+  handle_precharge_control(2 * kTickMs);
+  EXPECT_EQ(last_tone(), Precharge_default_PWM_Freq + 50 * 3);
+}
+
+// The band is a hard limit: repeated steps towards it must saturate, not run
+// away past the configured ceiling.
+TEST(PrechargeControlTests, FrequencyIsClampedToTheConfiguredCeiling) {
+  beginPrechargingAt(4000, 1000);
+
+  int32_t external = 1000;
+  for (int i = 0; i < 100; ++i) {
+    external += 1;  // change every pass so the loop keeps regulating
+    datalayer_extended.meb.BMS_voltage_intermediate_dV = external;
+    handle_precharge_control((2 + i) * kTickMs);
+  }
+
+  EXPECT_EQ(last_tone(), Precharge_max_PWM_Freq) << "the frequency must saturate at the ceiling";
+}
+
+TEST(PrechargeControlTests, FrequencyIsClampedToTheConfiguredFloor) {
+  beginPrechargingAt(1000, 4000);
+
+  int32_t external = 4000;
+  for (int i = 0; i < 100; ++i) {
+    external -= 1;
+    datalayer_extended.meb.BMS_voltage_intermediate_dV = external;
+    handle_precharge_control((2 + i) * kTickMs);
+  }
+
+  EXPECT_EQ(last_tone(), Precharge_min_PWM_Freq);
+}
+
+// The loop only reacts to a NEW reading. Some packs report the external
+// voltage every 100 ms while this runs every 10 ms, so regulating on a
+// repeated value would step ten times per measurement and overshoot.
+TEST(PrechargeControlTests, AnUnchangedReadingDoesNotMoveTheFrequency) {
+  beginPrechargingAt(4000, 3000);
+
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 3800;
+  handle_precharge_control(2 * kTickMs);
+  const uint32_t after_first = last_tone();
+  clear_tone_writes();
+
+  // Same reading again, several times.
+  for (int i = 0; i < 5; ++i) {
+    handle_precharge_control((3 + i) * kTickMs);
+  }
+
+  EXPECT_TRUE(get_tone_writes().empty()) << "a repeated reading must not drive the PWM again";
+  EXPECT_EQ(after_first, Precharge_default_PWM_Freq + 2000);
+}
+
+// A zero reading means the pack has not reported yet, not that the link is
+// flat - regulating on it would drive the frequency straight to the ceiling.
+TEST(PrechargeControlTests, AZeroReadingIsIgnoredRatherThanTreatedAsEmpty) {
+  beginPrechargingAt(4000, 3000);
+
+  datalayer_extended.meb.BMS_voltage_intermediate_dV = 0;
+  handle_precharge_control(2 * kTickMs);
+
+  EXPECT_TRUE(get_tone_writes().empty()) << "an absent measurement must not regulate the loop";
+}


### PR DESCRIPTION
`handle_precharge_control()` leaves `AUTO_PRECHARGE_IDLE` when the battery requests precharge and the inverter permits it, but the `AUTO_PRECHARGE_PRECHARGING` state aborts back to idle when the system is not ACTIVE, when an equipment stop is active, or when the BMS is not standby/active. The start gate tests neither of the first two, so whenever one of them is the blocking condition the sequence starts, is aborted on the following tick, and starts again immediately.

Entering the sequence drives the precharge PWM and switches the inverter-disconnect contactor, and the state machine runs on the 10 ms core-loop cadence, so this is a continuous ~20-30 ms switching cycle rather than a one-off. It was reported as an audible contactor rattle on a MEB + SMA setup where the battery requests precharge while the system is in FAULT; the same asymmetry applies while an equipment stop is active.

The fix gives the start gate and the abort check one shared predicate, so a sequence is only started under the conditions it needs in order to keep running. Sequences that used to start and abort within a tick no longer start; nothing that completes today is affected, since these are the conditions the sequence already had to satisfy to survive its first tick. The timeout / BMS-fault path to `AUTO_PRECHARGE_FAILURE` and the restart-after-BMS-reset path in `AUTO_PRECHARGE_COMPLETED` are unchanged.

Tests: `precharge_control.cpp` was not in the test build, so this adds it along with two test-only pieces it needed — `ledcWriteTone` in the Arduino emulation, and a recorder for pin writes in the same spirit as the CAN frame recorder, so the tests can assert that the inverter-disconnect contactor is never switched rather than only that a state variable stayed put. Six tests cover the two blocked cases, the restart loop itself, and three cases that must keep working. Checked against the unfixed file: the three that describe the bug fail there and pass here.

Note: drafted with AI assistance, reviewed by me.