### PR TITLE
Refactor SD support to use SPI

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -52,7 +52,9 @@ uint64_t start_time_values = 0;
 uint64_t start_time_cantx = 0;
 TaskHandle_t main_loop_task;
 TaskHandle_t connectivity_loop_task;
+#ifdef SDCARD
 TaskHandle_t logging_loop_task;
+#endif
 TaskHandle_t mqtt_loop_task;
 Watchdog mqtt_loop_watchdog;
 
@@ -123,6 +125,7 @@ void connectivity_loop(void*) {
   }
 }
 
+#ifdef SDCARD
 void logging_loop(void*) {
   bool sd_initialized = false;
 
@@ -148,6 +151,7 @@ void logging_loop(void*) {
   // Delete the logging task only if SD failed to initialize to prevent panic.
   vTaskDelete(NULL);
 }
+#endif  // SDCARD
 
 /* Linear charge power taper over the top of the SOC window: full power at
    (100.00% - band), reaching 0W at 100.00% scaled SOC. Battery integration
@@ -762,10 +766,12 @@ void setup() {
 
   led_init();
 
+#ifdef SDCARD
   if (datalayer.system.info.CAN_SD_logging_active || datalayer.system.info.SD_logging_active) {
     xTaskCreatePinnedToCore((TaskFunction_t)&logging_loop, "logging_loop", 4096, NULL, TASK_CONNECTIVITY_PRIO,
                             &logging_loop_task, esp32hal->WIFICORE());
   }
+#endif  // SDCARD
 
   init_contactors();
 

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -5,8 +5,10 @@
 #include "CanReceiver.h"
 #include "comm_can.h"
 #include "src/datalayer/datalayer.h"
+#include "src/devboard/hal/hal.h"
 #include "src/devboard/safety/safety.h"
 #include "src/devboard/sdcard/sdcard.h"
+#include "src/devboard/utils/events.h"
 #include "src/devboard/utils/logging.h"
 #include "utils.h"
 
@@ -313,9 +315,11 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
   }
   print_can_frame(*tx_frame, interface, frameDirection(MSG_TX));
 
+#ifdef SDCARD
   if (datalayer.system.info.CAN_SD_logging_active) {
     add_can_frame_to_buffer(*tx_frame, frameDirection(MSG_TX));
   }
+#endif
 
   switch (interface) {
     case CAN_NATIVE: {
@@ -533,6 +537,7 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
     print_can_frame(*rx_frame, interface, frameDirection(MSG_RX));
   }
 
+#ifdef SDCARD
   if (datalayer.system.info.CAN_SD_logging_active) {
     if (interface !=
         CANFD_NATIVE) {  //Avoid printing twice due to receive_frame_canfd_addon sending to both FD interfaces
@@ -540,6 +545,7 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
       add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
     }
   }
+#endif
 
   // Send the frame to all the receivers registered for this interface.
   auto receivers = can_receivers.equal_range(interface);

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -229,8 +229,10 @@ void init_stored_settings() {
   datalayer.system.info.CAN_usb_logging_active = settings.getBool("CANLOGUSB", false);
   datalayer.system.info.usb_logging_active = settings.getBool("USBENABLED", false);
   datalayer.system.info.web_logging_active = settings.getBool("WEBENABLED", false);
+#ifdef SDCARD
   datalayer.system.info.CAN_SD_logging_active = settings.getBool("CANLOGSD", false);
   datalayer.system.info.SD_logging_active = settings.getBool("SDLOGENABLED", false);
+#endif  // SDCARD
   datalayer.system.info.syslog_logging_active = settings.getBool("SYSLOGEN", false);
   syslog_ip = settings.getString("SYSLOGIP").c_str();
   syslog_port = settings.getUInt("SYSLOGPORT", 514);

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -188,11 +188,13 @@ class Esp32Hal {
 
   virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_LED_PIN() { return GPIO_NUM_NC; }
 
+#ifdef SDCARD
   // SD card
   virtual gpio_num_t SD_MISO_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t SD_MOSI_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t SD_SCLK_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t SD_CS_PIN() { return GPIO_NUM_NC; }
+#endif  // SDCARD
 
   // LED
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -190,6 +190,7 @@ class Esp32Hal {
 
 #ifdef SDCARD
   // SD card
+  virtual uint8_t SD_SPI_BUS() = 0;
   virtual gpio_num_t SD_MISO_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t SD_MOSI_PIN() { return GPIO_NUM_NC; }
   virtual gpio_num_t SD_SCLK_PIN() { return GPIO_NUM_NC; }

--- a/Software/src/devboard/hal/hw_3LB.h
+++ b/Software/src/devboard/hal/hw_3LB.h
@@ -56,12 +56,6 @@ class ThreeLBHal : public Esp32Hal {
   virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_PIN() { return GPIO_NUM_36; }
   virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_LED_PIN() { return GPIO_NUM_NC; }
 
-  // SD card
-  virtual gpio_num_t SD_MISO_PIN() { return GPIO_NUM_2; }
-  virtual gpio_num_t SD_MOSI_PIN() { return GPIO_NUM_15; }
-  virtual gpio_num_t SD_SCLK_PIN() { return GPIO_NUM_14; }
-  virtual gpio_num_t SD_CS_PIN() { return GPIO_NUM_13; }
-
   // LED
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_4; }
   virtual uint8_t LED_MAX_BRIGHTNESS() { return 40; }

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -75,6 +75,7 @@ class LilyGoHal : public Esp32Hal {
 
   //        virtual gpio_num_t INVERTER_CONTACTOR_ENABLE_LED_PIN() { return GPIO_NUM_NC; }
 
+#ifdef SDCARD
   // SD card
   virtual gpio_num_t SD_MISO_PIN() {
     if (user_selected_gpioopt4 == GPIOOPT4::DEFAULT_SD_CARD) {
@@ -100,6 +101,7 @@ class LilyGoHal : public Esp32Hal {
     }  //Else user_selected_gpioopt4 == GPIOOPT4::I2C_DISPLAY_SSD1306
     return GPIO_NUM_NC;
   }
+#endif  // SDCARD
 
   // LED
   virtual gpio_num_t LED_PIN() { return GPIO_NUM_4; }

--- a/Software/src/devboard/hal/hw_lilygo.h
+++ b/Software/src/devboard/hal/hw_lilygo.h
@@ -77,6 +77,7 @@ class LilyGoHal : public Esp32Hal {
 
 #ifdef SDCARD
   // SD card
+  uint8_t SD_SPI_BUS() override { return VSPI; }
   virtual gpio_num_t SD_MISO_PIN() {
     if (user_selected_gpioopt4 == GPIOOPT4::DEFAULT_SD_CARD) {
       return GPIO_NUM_2;

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -187,7 +187,7 @@ void init_logging_buffers() {
 }
 
 void deinit_logging_buffers() {
-  if ((!datalayer.system.info.CAN_SD_logging_active) && (!datalayer.system.info.CAN_SD_logging_active)) {
+  if ((!datalayer.system.info.CAN_SD_logging_active) && (!datalayer.system.info.SD_logging_active)) {
     if (can_bufferHandle != NULL) {
       vRingbufferDelete(can_bufferHandle);
     }

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -26,7 +26,7 @@ void delete_can_log() {
 
 void resume_can_writing() {
   can_logging_paused = false;
-  can_log_file = SD_MMC.open(CAN_LOG_FILE, FILE_APPEND);
+  can_log_file = SD.open(CAN_LOG_FILE, FILE_APPEND);
   can_file_open = true;
 }
 
@@ -40,13 +40,13 @@ void delete_log() {
     log_file.close();
     log_file_open = false;
   }
-  SD_MMC.remove(LOG_FILE);
+  SD.remove(LOG_FILE);
   logging_paused = false;
 }
 
 void resume_log_writing() {
   logging_paused = false;
-  log_file = SD_MMC.open(LOG_FILE, FILE_APPEND);
+  log_file = SD.open(LOG_FILE, FILE_APPEND);
   log_file_open = true;
 }
 
@@ -112,7 +112,7 @@ void write_can_frame_to_sdcard() {
         can_file_open = false;
       }
       if (delete_can_file) {
-        SD_MMC.remove(CAN_LOG_FILE);
+        SD.remove(CAN_LOG_FILE);
         delete_can_file = false;
         can_logging_paused = false;
       }
@@ -121,7 +121,7 @@ void write_can_frame_to_sdcard() {
     }
 
     if (can_file_open == false) {
-      can_log_file = SD_MMC.open(CAN_LOG_FILE, FILE_APPEND);
+      can_log_file = SD.open(CAN_LOG_FILE, FILE_APPEND);
       can_file_open = true;
     }
 
@@ -160,7 +160,7 @@ void write_log_to_sdcard() {
     }
 
     if (log_file_open == false) {
-      log_file = SD_MMC.open(LOG_FILE, FILE_APPEND);
+      log_file = SD.open(LOG_FILE, FILE_APPEND);
       log_file_open = true;
     }
 
@@ -204,15 +204,20 @@ bool init_sdcard() {
   auto miso_pin = esp32hal->SD_MISO_PIN();
   auto mosi_pin = esp32hal->SD_MOSI_PIN();
   auto sclk_pin = esp32hal->SD_SCLK_PIN();
+  auto cs_pin = esp32hal->SD_CS_PIN();
 
-  if (!esp32hal->alloc_pins("SD Card", miso_pin, mosi_pin, sclk_pin)) {
+  if (!esp32hal->alloc_pins("SD Card", miso_pin, mosi_pin, sclk_pin, cs_pin)) {
     return false;
   }
 
-  pinMode(miso_pin, INPUT_PULLUP);
+  static SPIClass sd_spi(esp32hal->SD_SPI_BUS());
+  sd_spi.begin(sclk_pin, miso_pin, mosi_pin, cs_pin);
 
-  SD_MMC.setPins(sclk_pin, mosi_pin, miso_pin);
-  if (!SD_MMC.begin("/root", true, true, SDMMC_FREQ_HIGHSPEED)) {
+  constexpr uint32_t SD_SPI_FREQ = 20 * 1000000;  // 20 MHz
+  constexpr uint8_t SD_MAX_OPEN_FILES = 5;        // library default
+  constexpr bool FORMAT_IF_EMPTY = true;
+
+  if (!SD.begin(cs_pin, sd_spi, SD_SPI_FREQ, "/root", SD_MAX_OPEN_FILES, FORMAT_IF_EMPTY)) {
     set_event_latched(EVENT_SD_INIT_FAILED, 0);
     logging.println("SD Card initialization failed!");
     return false;
@@ -231,7 +236,7 @@ bool init_sdcard() {
 void log_sdcard_details() {
 
   logging.print("SD Card Type: ");
-  switch (SD_MMC.cardType()) {
+  switch (SD.cardType()) {
     case CARD_MMC:
       logging.println("MMC");
       break;
@@ -249,17 +254,17 @@ void log_sdcard_details() {
       break;
   }
 
-  if (SD_MMC.cardType() != CARD_NONE) {
+  if (SD.cardType() != CARD_NONE) {
     logging.print("SD Card Size: ");
-    logging.print(SD_MMC.cardSize() / 1024 / 1024);
+    logging.print(SD.cardSize() / 1024 / 1024);
     logging.println(" MB");
 
     logging.print("Total space: ");
-    logging.print(SD_MMC.totalBytes() / 1024 / 1024);
+    logging.print(SD.totalBytes() / 1024 / 1024);
     logging.println(" MB");
 
     logging.print("Used space: ");
-    logging.print(SD_MMC.usedBytes() / 1024 / 1024);
+    logging.print(SD.usedBytes() / 1024 / 1024);
     logging.println(" MB");
   }
 }

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -1,4 +1,7 @@
 #include "sdcard.h"
+
+#ifdef SDCARD
+
 #include "freertos/ringbuf.h"
 
 File can_log_file;
@@ -260,3 +263,5 @@ void log_sdcard_details() {
     logging.println(" MB");
   }
 }
+
+#endif  // SDCARD

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -2,7 +2,7 @@
 #define SDCARD_H
 
 #ifdef SDCARD
-#include <SD_MMC.h>
+#include <SD.h>
 #include "../../communication/can/comm_can.h"
 #include "../hal/hal.h"
 #include "../utils/events.h"

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -1,6 +1,7 @@
 #ifndef SDCARD_H
 #define SDCARD_H
 
+#ifdef SDCARD
 #include <SD_MMC.h>
 #include "../../communication/can/comm_can.h"
 #include "../hal/hal.h"
@@ -27,5 +28,7 @@ void pause_log_writing();
 
 void add_log_to_buffer(const uint8_t* buffer, size_t size);
 void write_log_to_sdcard();
+
+#endif  // SDCARD
 
 #endif  // SDCARD_H

--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -294,9 +294,11 @@ void Logging::add_timestamp(size_t size) {
     datalayer.system.info.logged_can_messages_offset = offset;  // Update offset in buffer
   }
 
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     add_log_to_buffer((uint8_t*)timestr, MAX_LENGTH_TIME_STR);
   }
+#endif
 
   if (datalayer.system.info.usb_logging_active) {
     usb_log_write((const uint8_t*)timestr, strlen(timestr));
@@ -306,7 +308,10 @@ void Logging::add_timestamp(size_t size) {
 size_t Logging::write(const uint8_t* buffer, size_t size) {
   // Check if any logging is enabled at runtime
   if (!datalayer.system.info.web_logging_active && !datalayer.system.info.usb_logging_active &&
-      !datalayer.system.info.SD_logging_active && !datalayer.system.info.syslog_logging_active) {
+#ifdef SDCARD
+      !datalayer.system.info.SD_logging_active &&
+#endif
+      !datalayer.system.info.syslog_logging_active) {
     return 0;
   }
 
@@ -319,9 +324,11 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
     add_timestamp(size);
   }
 
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     add_log_to_buffer(buffer, size);
   }
+#endif
 
   if (datalayer.system.info.usb_logging_active) {
     usb_log_write(buffer, size);
@@ -349,7 +356,10 @@ size_t Logging::write(const uint8_t* buffer, size_t size) {
 void Logging::printf(const char* fmt, ...) {
   // Check if any logging is enabled at runtime
   if (!datalayer.system.info.web_logging_active && !datalayer.system.info.usb_logging_active &&
-      !datalayer.system.info.SD_logging_active && !datalayer.system.info.syslog_logging_active) {
+#ifdef SDCARD
+      !datalayer.system.info.SD_logging_active &&
+#endif
+      !datalayer.system.info.syslog_logging_active) {
     return;
   }
 
@@ -401,9 +411,11 @@ void Logging::printf(const char* fmt, ...) {
     message_buffer[size - 1] = '\n';
   }
 
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     add_log_to_buffer((uint8_t*)message_buffer, size);
   }
+#endif
 
   if (datalayer.system.info.usb_logging_active) {
     usb_log_write((const uint8_t*)message_buffer, size);

--- a/Software/src/devboard/webserver/can_logging_html.cpp
+++ b/Software/src/devboard/webserver/can_logging_html.cpp
@@ -32,7 +32,7 @@ String can_logger_processor(void) {
              "</span> <button onclick='editCANIDCutoff()'>Edit</button></div>";
   content += "<button onclick='refreshPage()'>Refresh data</button> ";
   content += "<button onclick='exportLog()'>Export to .txt</button> ";
-#ifdef LOG_CAN_TO_SD
+#ifdef SDCARD
   content += "<button onclick='deleteLogFile()'>Delete log file</button> ";
 #endif
   content += "<button onclick='stopLoggingAndGoToMainPage()'>Stop &amp; Back to main page</button>";
@@ -64,7 +64,7 @@ String can_logger_processor(void) {
   content += "<script>";
   content += "function refreshPage(){ location.reload(true); }";
   content += "function exportLog() { window.location.href = '/export_can_log'; }";
-#ifdef LOG_CAN_TO_SD
+#ifdef SDCARD
   content += "function deleteLogFile() { window.location.href = '/delete_can_log'; }";
 #endif
   content += "function stopLoggingAndGoToMainPage() {";

--- a/Software/src/devboard/webserver/debug_logging_html.cpp
+++ b/Software/src/devboard/webserver/debug_logging_html.cpp
@@ -57,9 +57,11 @@ String debug_logger_processor(void) {
     content += "<button onclick='refreshPage()'>Refresh data</button> ";
   }
   content += "<button onclick='exportLog()'>Export to .txt</button> ";
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     content += "<button onclick='deleteLog()'>Delete log file</button> ";
   }
+#endif  // SDCARD
   content += "<button onclick='goToMainPage()'>Back to main page</button>";
 
   // Start a new block for the debug log messages
@@ -98,9 +100,11 @@ String debug_logger_processor(void) {
   content += "<script>";
   content += "function refreshPage(){ location.reload(true); }";
   content += "function exportLog() { window.location.href = '/export_log'; }";
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     content += "function deleteLog() { window.location.href = '/delete_log'; }";
   }
+#endif  // SDCARD
   content += "function goToMainPage() { window.location.href = '/'; }";
   content += "</script>";
   content += index_html_footer;

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -698,6 +698,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("WEBENABLED") ? "checked" : "";
   }
 
+#ifdef SDCARD
   if (var == "CANLOGSD") {
     return settings.getBool("CANLOGSD") ? "checked" : "";
   }
@@ -705,6 +706,7 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SDLOGENABLED") {
     return settings.getBool("SDLOGENABLED") ? "checked" : "";
   }
+#endif  // SDCARD
   if (var == "SYSLOGEN") {
     return settings.getBool("SYSLOGEN") ? "checked" : "";
   }
@@ -1150,6 +1152,21 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 #else
 #define GPIOOPT6_SETTING ""
 #endif
+
+#ifdef SDCARD
+#define SD_SETTING_HTML \
+  R"rawliteral(
+        <label>General logging to SD card: </label>
+        <input type='checkbox' name='SDLOGENABLED' value='on' %SDLOGENABLED%
+            title="Store logs on an SD card. Only works on hardware with SD-card slot." />
+
+        <label>CAN message logging to SD card: </label>
+        <input type='checkbox' name='CANLOGSD' value='on' %CANLOGSD%
+            title="Store incoming/outgoing CAN messages on SD card. Only works on hardware with SD-card slot." />
+  )rawliteral"
+#else
+#define SD_SETTING_HTML ""
+#endif  // SDCARD
 
 #define SYSLOG_SETTING_HTML \
   R"rawliteral(
@@ -2162,19 +2179,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         }
         </script>
 
-        <label>General logging to SD card: </label>
-        <input type='checkbox' name='SDLOGENABLED' value='on' %SDLOGENABLED% 
-            title="Store logs on an SD card. Only works on hardware with SD-card slot." />
-
         <label>CAN message logging via USB serial: </label>
-        <input type='checkbox' name='CANLOGUSB' value='on' %CANLOGUSB%  
+        <input type='checkbox' name='CANLOGUSB' value='on' %CANLOGUSB%
             title="WARNING: Causes performance issues! Log incoming/outgoing CAN messages via USB cable. Avoid if possible!" />
 
-        <label>CAN message logging to SD card: </label>
-        <input type='checkbox' name='CANLOGSD' value='on' %CANLOGSD% 
-            title="Store incoming/outgoing CAN messages on on SD card. Only works on hardware with SD-card slot." />
-
-        )rawliteral" SYSLOG_SETTING_HTML R"rawliteral(
+        )rawliteral" SD_SETTING_HTML SYSLOG_SETTING_HTML R"rawliteral(
 
         </div>
         </div>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -329,7 +329,7 @@ void init_webserver() {
     // Define the handler to export can log
     server.on("/export_can_log", HTTP_GET, [](AsyncWebServerRequest* request) {
       pause_can_writing();
-      request->send(SD_MMC, CAN_LOG_FILE, String(), true);
+      request->send(SD, CAN_LOG_FILE, String(), true);
       resume_can_writing();
     });
 
@@ -380,7 +380,7 @@ void init_webserver() {
     // Define the handler to export debug log
     server.on("/export_log", HTTP_GET, [](AsyncWebServerRequest* request) {
       pause_log_writing();
-      request->send(SD_MMC, LOG_FILE, String(), true);
+      request->send(SD, LOG_FILE, String(), true);
       resume_log_writing();
     });
   } else

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -298,7 +298,11 @@ void init_webserver() {
     }
   });
 
-  if (datalayer.system.info.web_logging_active || datalayer.system.info.SD_logging_active) {
+  if (datalayer.system.info.web_logging_active
+#ifdef SDCARD
+      || datalayer.system.info.SD_logging_active
+#endif
+  ) {
     // Route for going to debug logging web page
     server.on("/log", HTTP_GET, [](AsyncWebServerRequest* request) {
       AsyncWebServerResponse* response = request->beginResponse(200, "text/html", debug_logger_processor());
@@ -320,6 +324,7 @@ void init_webserver() {
       },
       handleFileUpload);
 
+#ifdef SDCARD
   if (datalayer.system.info.CAN_SD_logging_active) {
     // Define the handler to export can log
     server.on("/export_can_log", HTTP_GET, [](AsyncWebServerRequest* request) {
@@ -333,7 +338,9 @@ void init_webserver() {
       delete_can_log();
       request->send(200, "text/plain", "Log file deleted");
     });
-  } else {
+  } else
+#endif  // SDCARD
+  {
     // Define the handler to export can log
     server.on("/export_can_log", HTTP_GET, [](AsyncWebServerRequest* request) {
       String logs = String(datalayer.system.info.logged_can_messages);
@@ -362,6 +369,7 @@ void init_webserver() {
     });
   }
 
+#ifdef SDCARD
   if (datalayer.system.info.SD_logging_active) {
     // Define the handler to delete log file
     server.on("/delete_log", HTTP_GET, [](AsyncWebServerRequest* request) {
@@ -375,7 +383,9 @@ void init_webserver() {
       request->send(SD_MMC, LOG_FILE, String(), true);
       resume_log_writing();
     });
-  } else {
+  } else
+#endif  // SDCARD
+  {
     // Define the handler to export debug log
     server.on("/export_log", HTTP_GET, [](AsyncWebServerRequest* request) {
       String logs = String(datalayer.system.info.logged_can_messages);
@@ -434,12 +444,15 @@ void init_webserver() {
   });
 
   const char* boolSettingNames[] = {
-      "DBLBTR",       "CNTCTRL",        "CNTCTRLDBL",  "PWMCNTCTRL",   "PERBMSRESET",   "SDLOGENABLED", "STATICIP",
-      "REMBMSRESET",  "EXTPRECHARGE",   "USBENABLED",  "CANLOGUSB",    "WEBENABLED",    "CANLOGSD",     "WIFIAPENABLED",
-      "MQTTENABLED",  "NOINVDISC",      "HADISC",      "MQTTCELLV",    "GTWRHD",        "DIGITALHVIL",  "PERFPROFILE",
-      "INTERLOCKREQ", "SOCESTIMATED",   "PYLONOFFSET", "PYLONORDER",   "DEYEBYD",       "NCCONTACTOR",  "TRIBTR",
-      "CNTCTRLTRI",   "ESPNOWENABLED",  "PRIMOGEN24",  "CTINVERT",     "LOWPASSFILTER", "WEBAUTH",      "SLOWCANINV",
-      "CHGTAPERSOC",  "MEASURECPUTEMP", "SYSLOGEN",    "PERBMSDEFSOC", "PERBMSSKIPBAL", "INVOFFGRID",
+      "DBLBTR",       "CNTCTRL",      "CNTCTRLDBL",    "PWMCNTCTRL",  "PERBMSRESET",   "STATICIP",     "REMBMSRESET",
+      "EXTPRECHARGE", "USBENABLED",   "CANLOGUSB",     "WEBENABLED",  "WIFIAPENABLED", "MQTTENABLED",  "NOINVDISC",
+      "HADISC",       "MQTTCELLV",    "GTWRHD",        "DIGITALHVIL", "PERFPROFILE",   "INTERLOCKREQ", "SOCESTIMATED",
+      "PYLONOFFSET",  "PYLONORDER",   "DEYEBYD",       "NCCONTACTOR", "TRIBTR",        "CNTCTRLTRI",   "ESPNOWENABLED",
+      "PRIMOGEN24",   "CTINVERT",     "LOWPASSFILTER", "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP",
+      "SYSLOGEN",     "PERBMSDEFSOC", "PERBMSSKIPBAL", "INVOFFGRID",
+#ifdef SDCARD
+      "SDLOGENABLED", "CANLOGSD",
+#endif  // SDCARD
   };
 
   const char* uintSettingNames[] = {
@@ -1629,7 +1642,11 @@ String processor(const String& var) {
     content += "<button onclick='Advanced()'>More Battery Info</button> ";
     content += "<button onclick='CANlog()'>CAN logger</button> ";
     content += "<button onclick='CANreplay()'>CAN replay</button> ";
-    if (datalayer.system.info.web_logging_active || datalayer.system.info.SD_logging_active) {
+    if (datalayer.system.info.web_logging_active
+#ifdef SDCARD
+        || datalayer.system.info.SD_logging_active
+#endif
+    ) {
       content += "<button onclick='Log()'>Log</button> ";
     }
     content += "<button onclick='Cellmon()'>Cellmonitor</button> ";

--- a/platformio.ini
+++ b/platformio.ini
@@ -80,6 +80,7 @@ build_flags =
     -D HW_LILYGO
     -D SMALL_FLASH_DEVICE
     -Werror
+    -D SDCARD
 
 [env:esp32devkit_330]
 extends = common_esp32
@@ -94,6 +95,7 @@ build_flags =
     ${common_esp32.build_flags}
     -D HW_LILYGO
     -D SMALL_FLASH_DEVICE
+    -D SDCARD
 
 [env:stark_330]
 extends = common_esp32


### PR DESCRIPTION
### What
This PR is another prerequisite for #2722. The existing Lilygo board used the dedicated SDIO controller of the ESP32 for SD card access. This is generally the recommended option since it is slightly faster. The main drawback here is that you can only use it on dedicated pins. The alternative is using one of the SPI controllers which is possible on most pins.
The DFRobot board unfortunately does not use the correct pins for SDIO, thus forcing the use of SPI. Even though I placed the additional SPI SDCard implementation behind `ifdef`s the build system was not smart enough to only conditionally compile it in which resulted in the significant flash size increase in the current version of the PR. Neither setting `lib_ldf_mode = chain+` or `lib_ignore` could be used as a workaround.
Therefore this PR also moves the Lilygo to use SPI. Fortunately this also yields a significant flash size reduction most likely since most the SPI code gets compiled in anyways. I also gated the feature so that it does not impact the other boards unlike before.
One of the things I noticed is that the SPI bus assignments are currently somewhat arbitrary which can lead to overlaps. In a follow-up PR I will add some logic that assigns the same bus for matching pins.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
