### PR TITLE
Library :books: Update ESP32 to v3.3.11

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ src_dir = ./Software
 
 [env]
 framework = arduino
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
 custom_sdkconfig = file://sdkconfig.be_size.defaults


### PR DESCRIPTION
### What
This PR updates the ESP32 backbone to v3.3.11

### Why
Newer libraries are always good (bonus smaller flash footprint)

### How
We update from v3.3.9 -> v3.3.11

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
