### PR TITLE
Comment out logging for verbose MQTT errors and messages

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -556,7 +556,7 @@ static bool publish_common_info(void) {
 
       serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
       if (mqtt_publish(info_topics[0].c_str(), mqtt_msg, false) == false) {
-        logging.println("Common info MQTT msg could not be sent");
+        // logging.println("Common info MQTT msg could not be sent");
         return false;
       }
     }
@@ -913,13 +913,13 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_
       mqtt_message_received(event->topic, event->topic_len, event->data, event->data_len);
       break;
     case MQTT_EVENT_ERROR:
-      logging.println("MQTT_ERROR");
-      logging.print("reported from esp-tls");
-      logging.println(event->error_handle->esp_tls_last_esp_err);
-      logging.print("reported from tls stack");
-      logging.println(event->error_handle->esp_tls_stack_err);
-      logging.print("captured as transport's socket errno");
-      logging.println(strerror(event->error_handle->esp_transport_sock_errno));
+      // logging.println("MQTT_ERROR");
+      // logging.print("reported from esp-tls");
+      // logging.println(event->error_handle->esp_tls_last_esp_err);
+      // logging.print("reported from tls stack");
+      // logging.println(event->error_handle->esp_tls_stack_err);
+      // logging.print("captured as transport's socket errno");
+      // logging.println(strerror(event->error_handle->esp_transport_sock_errno));
       break;
     case MQTT_EVENT_SUBSCRIBED:
       break;


### PR DESCRIPTION
### What
Remove from the log MQTT spamming with verbose messages when Wi-Fi is disconnected.

### Why
Simple Wi-Fi disconnection and reconnection produces in the log:
```
  616484.261 MQTT_ERROR
  616484.261 reported from esp-tls32774
  616484.261 reported from tls stack0
  616484.261 captured as transport's socket errnoSuccess
  616484.261 MQTT disconnected!
  616485.561 Common info MQTT msg could not be sent
  616491.161 Common info MQTT msg could not be sent
  616496.761 Common info MQTT msg could not be sent
  616501.267 MQTT_ERROR
  616501.267 reported from esp-tls32774
  616501.267 reported from tls stack0
  616501.267 captured as transport's socket errnoSuccess
  616501.267 MQTT disconnected!
  616502.367 Common info MQTT msg could not be sent
  616507.967 Common info MQTT msg could not be sent
  616513.567 Common info MQTT msg could not be sent
  616518.273 MQTT_ERROR
  616518.273 reported from esp-tls32774
  616518.273 reported from tls stack0
  616518.273 captured as transport's socket errnoSuccess
  616518.273 MQTT disconnected!
  616519.173 Common info MQTT msg could not be sent
  616524.773 Common info MQTT msg could not be sent
  616530.373 Common info MQTT msg could not be sent
  616535.279 MQTT_ERROR
  616535.279 reported from esp-tls32774
  616535.279 reported from tls stack0
  616535.279 captured as transport's socket errnoSuccess
  616535.279 MQTT disconnected!
  616535.979 Common info MQTT msg could not be sent
  616541.579 Common info MQTT msg could not be sent
  616547.179 Common info MQTT msg could not be sent
  616552.285 MQTT_ERROR
  616552.285 reported from esp-tls32774
  616552.285 reported from tls stack0
  616552.285 captured as transport's socket errnoSuccess
  616552.285 MQTT disconnected!
  616552.785 Common info MQTT msg could not be sent
  616558.393 Common info MQTT msg could not be sent
  616563.993 Common info MQTT msg could not be sent
```

### How
Commenting out the verbose lines. Didn't delete them, they can be useful in the future when diagnosing for issues.

After this patch, only `MQTT disconnected!` would appear in the log, which is more than enough informationally for the user.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
