### PR TITLE
Add size report to job summary

### DIFF
--- a/.github/workflows/measure-firmware-size.yml
+++ b/.github/workflows/measure-firmware-size.yml
@@ -115,6 +115,9 @@ jobs:
           > comment.md
         echo "${{ inputs.pr_number }}" > pr_number.txt
 
+    - name: Write job summary
+      run: cat comment.md >> "$GITHUB_STEP_SUMMARY"
+
     - name: Upload firmware size report
       uses: actions/upload-artifact@v7
       with:


### PR DESCRIPTION
### Why
When comparing multiple commits in a series you currently have to check the changes in the Github comment. This is tedious especially when you push multiple commits and the order is build time dependent.

### How
With this simple change you can just click on the job of that commit: https://github.com/ngehrsitz/Battery-Emulator/actions/runs/31174832106/attempts/1#summary-92855069997

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
