### PR TITLE
BETA: Streaming can logging over WiFi

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -114,7 +114,7 @@ void connectivity_loop(void*) {
       update_espnow();
     }
 
-    ota_monitor();
+    webserver_tick();
 
     END_TIME_MEASUREMENT_MAX(wifi, datalayer.system.status.wifi_task_10s_max_us);
 

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -10,6 +10,7 @@
 #include "src/devboard/sdcard/sdcard.h"
 #include "src/devboard/utils/events.h"
 #include "src/devboard/utils/logging.h"
+#include "src/devboard/webserver/webserver_can_streaming.h"
 #include "utils.h"
 
 #include <esp_private/periph_ctrl.h>
@@ -317,7 +318,7 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
 
 #ifdef SDCARD
   if (datalayer.system.info.CAN_SD_logging_active) {
-    add_can_frame_to_buffer(*tx_frame, frameDirection(MSG_TX));
+    add_can_frame_to_buffer(*tx_frame, interface, frameDirection(MSG_TX));
   }
 #endif
 
@@ -528,6 +529,9 @@ static void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirec
       dump_can_frame(frame, interface, msgDir);
     }
   }
+  if (datalayer.system.info.can_streaming_active) {
+    stream_can_frame(frame, interface, msgDir);
+  }
 }
 
 static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interface) {
@@ -542,7 +546,7 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
     if (interface !=
         CANFD_NATIVE) {  //Avoid printing twice due to receive_frame_canfd_addon sending to both FD interfaces
       //TODO: This check can be removed later when refactored to use inline functions for logging
-      add_can_frame_to_buffer(*rx_frame, frameDirection(MSG_RX));
+      add_can_frame_to_buffer(*rx_frame, interface, frameDirection(MSG_RX));
     }
   }
 #endif
@@ -556,39 +560,102 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
   }
 }
 
-void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir) {
-  char* message_string = datalayer.system.info.logged_can_messages;
-  int offset = datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
-  size_t message_string_size = sizeof(datalayer.system.info.logged_can_messages);
+// For formatting CAN frames considerably faster than using snprintf
+static const char* hex = "0123456789abcdef";
 
-  if (offset + 128 > sizeof(datalayer.system.info.logged_can_messages)) {
-    // Not enough space, reset and start from the beginning
-    offset = 0;
+static char* put_hex(char* ptr, uint32_t value, uint8_t digits) {
+  for (int i = digits - 1; i >= 0; i--) {
+    *ptr++ = hex[(value >> (i * 4)) & 0x0f];
   }
-  unsigned long currentTime = millis();
-  // Add timestamp
-  offset += snprintf(message_string + offset, message_string_size - offset, "(%lu.%03lu) ", currentTime / 1000,
-                     currentTime % 1000);
+  return ptr;
+}
 
-  // Add direction. Multiplying the interface by two ensures that SavvyCAN puts TX and RX in a different bus.
-  offset += snprintf(message_string + offset, message_string_size - offset, "%s%d ", (msgDir == MSG_RX) ? "RX" : "TX",
-                     (int)(interface * 2) + (msgDir == MSG_RX ? 0 : 1));
+static char* put_time(char* ptr, unsigned long time) {
+  // Wrap around after 100000 seconds (about 27.7 hours)
+  if (time >= 100000000)
+    time = time % 100000000;
 
-  // Add ID and DLC
-  offset += snprintf(message_string + offset, message_string_size - offset, "%lX [%u] ", frame.ID, frame.DLC);
-
-  // Add data bytes
-  for (uint8_t i = 0; i < frame.DLC; i++) {
-    if (i < frame.DLC - 1) {
-      offset += snprintf(message_string + offset, message_string_size - offset, "%02X ", frame.data.u8[i]);
-    } else {
-      offset += snprintf(message_string + offset, message_string_size - offset, "%02X", frame.data.u8[i]);
+  char buf[8];
+  int i = 0;
+  do {
+    buf[i++] = (time % 10) + '0';
+    time /= 10;
+  } while (time > 0);
+  while (i > 0) {
+    *ptr++ = buf[--i];
+    if (i == 3) {
+      *ptr++ = '.';
     }
   }
-  // Add linebreak
-  offset += snprintf(message_string + offset, message_string_size - offset, "\n");
+  return ptr;
+}
 
-  datalayer.system.info.logged_can_messages_offset = offset;  // Update offset in buffer
+// CAN log formatter: "(12345.678) RX0 123 [8] 01 02 03 ... 0A\n".
+size_t format_can_frame(char* buffer, size_t len, const CAN_frame& frame, CAN_Interface interface,
+                        frameDirection msgDir) {
+  // Worst-case line length: '(' + up-to-8-digit time + optional '.' + ')' + ' '
+  // + "RX"/"TX" + channel digit + ' ' + 8-hex ID + ' ' + '[' + 2-digit DLC + ']'
+  // + 3 bytes per data byte + '\n'.
+  const size_t needed = 1 + 9 + 1 + 1 + 3 + 1 + 8 + 1 + 1 + 2 + 1 + (size_t)frame.DLC * 3 + 1;
+  if (needed > len) {
+    if (len > 0) {
+      buffer[0] = '\0';
+    }
+    return 0;
+  }
+
+  char* ptr = buffer;
+  unsigned long currentTime = millis();
+  *ptr++ = '(';
+  ptr = put_time(ptr, currentTime);
+  *ptr++ = ')';
+  *ptr++ = ' ';
+  if (msgDir == MSG_RX) {
+    *ptr++ = 'R';
+    *ptr++ = 'X';
+    *ptr++ = '0' + ((int)interface * 2);
+  } else {
+    *ptr++ = 'T';
+    *ptr++ = 'X';
+    *ptr++ = '1' + ((int)interface * 2);
+  }
+  *ptr++ = ' ';
+  if (frame.ext_ID)
+    ptr = put_hex(ptr, frame.ID, 8);
+  else
+    ptr = put_hex(ptr, frame.ID, 3);
+  *ptr++ = ' ';
+  *ptr++ = '[';
+  if (frame.DLC > 9) {
+    *ptr++ = '0' + (frame.DLC / 10);
+    *ptr++ = '0' + (frame.DLC % 10);
+  } else
+    *ptr++ = '0' + (frame.DLC);
+  *ptr++ = ']';
+  for (int i = 0; i < frame.DLC; i++) {
+    *ptr++ = ' ';
+    ptr = put_hex(ptr, frame.data.u8[i], 2);
+  }
+  *ptr++ = '\n';
+  *ptr = '\0';
+  return (size_t)(ptr - buffer);
+}
+
+void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir) {
+  char* message_string = datalayer.system.info.logged_can_messages;
+  size_t offset =
+      datalayer.system.info.logged_can_messages_offset;  // Keeps track of the current position in the buffer
+  size_t message_string_size = sizeof(datalayer.system.info.logged_can_messages);
+
+  size_t written = format_can_frame(message_string + offset, message_string_size - offset, frame, interface, msgDir);
+  if (written == 0 && offset != 0) {
+    // Not enough space left at the tail - wrap around and start from the beginning
+    offset = 0;
+    written = format_can_frame(message_string, message_string_size, frame, interface, msgDir);
+  }
+  if (written > 0) {
+    datalayer.system.info.logged_can_messages_offset = offset + written;  // Update offset in buffer
+  }
 }
 
 void stop_can() {

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -413,6 +413,7 @@ receive_frame_can_native() {  // This section checks if we have a complete CAN m
       rx_frame.ID = frame.id;
       rx_frame.ext_ID = frame.ext;
       rx_frame.DLC = frame.len;
+      rx_frame.FD = false;
       for (uint8_t i = 0; i < frame.len && i < 8; i++) {
         rx_frame.data.u8[i] = frame.data[i];
       }
@@ -459,6 +460,8 @@ static void _receive_frame_canfd(ACAN2517FD* canfd, bool first) {
     rx_frame.ID = MCP2518frame.id;
     rx_frame.ext_ID = MCP2518frame.ext;
     rx_frame.DLC = MCP2518frame.len;
+    rx_frame.FD = (MCP2518frame.type == CANFDMessage::CANFD_NO_BIT_RATE_SWITCH ||
+                   MCP2518frame.type == CANFDMessage::CANFD_WITH_BIT_RATE_SWITCH);
     memcpy(rx_frame.data.u8, MCP2518frame.data, std::min(rx_frame.DLC, (uint8_t)sizeof(rx_frame.data.u8)));
     //message incoming, pass it on to the handler
     if (first) {
@@ -605,18 +608,18 @@ size_t format_can_frame(char* buffer, size_t len, const CAN_frame& frame, CAN_In
   }
 
   char* ptr = buffer;
-  unsigned long currentTime = millis();
+  const unsigned long currentTime = millis();
   *ptr++ = '(';
   ptr = put_time(ptr, currentTime);
   *ptr++ = ')';
   *ptr++ = ' ';
   if (msgDir == MSG_RX) {
-    *ptr++ = 'R';
-    *ptr++ = 'X';
+    *ptr++ = frame.FD ? 'R' : 'r';
+    *ptr++ = frame.FD ? 'X' : 'x';
     *ptr++ = '0' + ((int)interface * 2);
   } else {
-    *ptr++ = 'T';
-    *ptr++ = 'X';
+    *ptr++ = frame.FD ? 'T' : 't';
+    *ptr++ = frame.FD ? 'X' : 'x';
     *ptr++ = '1' + ((int)interface * 2);
   }
   *ptr++ = ' ';

--- a/Software/src/communication/can/comm_can.h
+++ b/Software/src/communication/can/comm_can.h
@@ -8,6 +8,12 @@ extern uint16_t user_selected_CAN_ID_cutoff_filter;
 void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir);
 void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface interface);
 
+// Format CAN logs to the given buffer. Returns the number of bytes written, or
+// 0 if the buffer is too small.
+// Null-terminates the buffer if len > 0, but the return value does not include the NUL.
+size_t format_can_frame(char* buffer, size_t len, const CAN_frame& frame, CAN_Interface interface,
+                        frameDirection msgDir);
+
 //These defines are not used if user updates values via Settings page
 #define CRYSTAL_FREQUENCY_MHZ 8
 

--- a/Software/src/datalayer/datalayer.h
+++ b/Software/src/datalayer/datalayer.h
@@ -317,6 +317,8 @@ struct DATALAYER_SYSTEM_INFO_TYPE {
 
   /** bool, determines if CAN messages should be logged for webserver */
   bool can_logging_active = false;
+  /** bool, indicates if a webserver CAN stream is active */
+  bool can_streaming_active = false;
   /** bool, determines if USB serial logging should occur */
   bool CAN_usb_logging_active = false;
   /** bool, determines if USB serial logging should occur */

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -58,12 +58,11 @@ void pause_log_writing() {
 // Reported as a gap marker in the log once the buffer has room again.
 static uint32_t can_frames_dropped = 0;
 
-void add_can_frame_to_buffer(CAN_frame frame, frameDirection msgDir) {
+void add_can_frame_to_buffer(CAN_frame frame, CAN_Interface interface, frameDirection msgDir) {
 
   if (!sd_card_active)
     return;
 
-  unsigned long currentTime = millis();
   // Sized for the worst case: gap marker + header + 64 data bytes (CAN-FD) at 3 chars each
   static char messagestr_buffer[320];
   size_t size = 0;
@@ -75,15 +74,11 @@ void add_can_frame_to_buffer(CAN_frame frame, frameDirection msgDir) {
                      "[%lu CAN frames dropped, SD buffer full]\n", (unsigned long)can_frames_dropped);
   }
 
-  size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size, "(%lu.%03lu) %s %lX [%u] ",
-                   currentTime / 1000, currentTime % 1000, (msgDir == MSG_RX ? "RX0" : "TX1"), frame.ID, frame.DLC);
-
-  for (uint8_t i = 0; i < frame.DLC; i++) {
-    size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size,
-                     (i < frame.DLC - 1) ? "%02X " : "%02X\n", frame.data.u8[i]);
-  }
-  if (frame.DLC == 0) {  // Frames without payload still need to terminate the line
-    size += snprintf(messagestr_buffer + size, sizeof(messagestr_buffer) - size, "\n");
+  // Format the frame, as long as it fits
+  size_t written =
+      format_can_frame(messagestr_buffer + size, sizeof(messagestr_buffer) - size, frame, interface, msgDir);
+  if (written > 0) {
+    size += written;
   }
 
   // One send per frame, zero timeout: this runs in the core task and must never

--- a/Software/src/devboard/sdcard/sdcard.h
+++ b/Software/src/devboard/sdcard/sdcard.h
@@ -16,7 +16,7 @@ void deinit_logging_buffers();
 bool init_sdcard();
 void log_sdcard_details();
 
-void add_can_frame_to_buffer(CAN_frame frame, frameDirection msgDir);
+void add_can_frame_to_buffer(CAN_frame frame, CAN_Interface interface, frameDirection msgDir);
 void write_can_frame_to_sdcard();
 
 void pause_can_writing();

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -23,6 +23,7 @@
 #include "esp_task_wdt.h"
 #include "favicon.h"
 #include "html_escape.h"
+#include "webserver_can_streaming.h"
 
 #include <string>
 
@@ -30,7 +31,6 @@ std::string http_username;
 std::string http_password;
 
 bool webserver_auth = false;
-static constexpr const char* WEB_AUTH_REALM = "Battery Emulator";
 
 // Create AsyncWebServer object on port 80
 AsyncWebServer server(80);
@@ -797,6 +797,8 @@ void init_webserver() {
           }
           request->send(200, "text/plain", "Command performed.");
         });
+
+    register_dump_can_route(server);
   }
 
   // Route for editing BATTERY_USE_VOLTAGE_LIMITS
@@ -921,7 +923,9 @@ String getConnectResultString(wl_status_t status) {
   }
 }
 
-void ota_monitor() {
+void webserver_tick() {
+  can_dump_drain_tick();
+
   if (ota_active && ota_timeout_timer.elapsed()) {
     // OTA timeout, try to restore can and clear the update event
     set_event(EVENT_OTA_UPDATE_TIMEOUT, 0);

--- a/Software/src/devboard/webserver/webserver.h
+++ b/Software/src/devboard/webserver/webserver.h
@@ -27,6 +27,8 @@ extern uint16_t OBC_Charge_Power;
 // OTA status
 extern bool ota_active;
 
+static constexpr const char* WEB_AUTH_REALM = "Battery Emulator";
+
 /**
  * @brief Initialization function for the webserver.
  *
@@ -107,6 +109,7 @@ String formatPowerValue(T value, String unit, int precision);
 
 extern void store_settings();
 
-void ota_monitor();
+bool webserver_auth_is_ready();
+void webserver_tick();
 
 #endif

--- a/Software/src/devboard/webserver/webserver_can_streaming.cpp
+++ b/Software/src/devboard/webserver/webserver_can_streaming.cpp
@@ -1,0 +1,322 @@
+#include "webserver_can_streaming.h"
+#include "../../communication/can/comm_can.h"
+#include "webserver.h"
+
+#include <stdlib.h>
+#include <atomic>
+
+// ---------------------------------------------------------------------------
+// Streaming CAN dump (/dump_can)
+//
+// A browser connects to /dump_can and the request deliberately "hangs": we
+// never call request->send(), so the connection stays open indefinitely. As CAN
+// frames arrive, stream_can_frame() (called from the core loop) writes the
+// formatted log lines straight to the raw TCP socket of that one connection.
+//
+// Only a single concurrent connection is allowed; starting a new one closes any
+// previous stream. The AsyncTCP layer protects the socket itself with its own
+// write mutex, so writing from the CAN task is thread-safe. We still guard our
+// client pointer with a separate mutex so the disconnect callback (which runs on
+// the TCP task, before the AsyncClient is freed) can safely tear the stream down
+// without a race or use-after-free.
+// ---------------------------------------------------------------------------
+static AsyncClient* can_dump_client = nullptr;
+static SemaphoreHandle_t can_dump_mutex = nullptr;
+
+// Replace the active streaming client. Returns the previously active client (if
+// any); the caller is responsible for closing it.
+static AsyncClient* can_dump_swap_client(AsyncClient* client) {
+  AsyncClient* prev = nullptr;
+  if (can_dump_mutex)
+    xSemaphoreTake(can_dump_mutex, portMAX_DELAY);
+  prev = can_dump_client;
+  can_dump_client = client;
+  if (can_dump_mutex)
+    xSemaphoreGive(can_dump_mutex);
+  return prev;
+}
+
+// Close and clear the current streaming client. Closing the socket is async, so
+// its disconnect callback may fire later; that callback matches by pointer below
+// and so will not clobber a client installed after us.
+static void can_dump_close_current() {
+  AsyncClient* c = can_dump_swap_client(nullptr);
+  datalayer.system.info.can_streaming_active = false;
+  if (c != nullptr) {
+    c->close();
+  }
+}
+
+// The AsyncTCP send buffer isn't very big, and calling it is somewhat
+// expensive, so we use a larger ring buffer to store several CAN frames to then
+// be sent in larger chunks where possible.
+//
+// This setting can be adjusted as available RAM permits - 16384 gives great
+// performance in testing, 8192 gives occasional overruns.
+static constexpr size_t CAN_DUMP_RING_SIZE = 8192;
+
+// Always keep this many bytes free at the tail end of the ring.  Each byte is
+// one '\n' overflow-indicator, so this guarantees the drain task can still
+// signal 30 overrun events even when the buffer is nearly saturated.
+static constexpr size_t CAN_DUMP_RING_OVERRUN_RESERVE = 30;
+
+// The ring buffer is heap-allocated when a /dump_can stream starts and freed
+// once the stream disconnects. It must never be torn down while the CAN task is
+// mid-write, so access to the pointer is guarded by an atomic flag (see the
+// busy-lock helpers below).
+static uint8_t* can_dump_ring = nullptr;
+
+// Single-producer / single-consumer lock-free byte ring.
+//  - CAN receive task is the ONLY producer and only writes can_dump_ring_tail.
+//  - drain task is the ONLY consumer and only writes can_dump_ring_head.
+// Indices are monotonic byte counters (never wrapped), so "used = tail - head"
+// is always well-defined; each side needs only a relaxed load of the other's
+// index plus a release/acquire around the buffer copy.
+static std::atomic<size_t> can_dump_ring_head{0};
+static std::atomic<size_t> can_dump_ring_tail{0};
+
+// Guard for the lifetime of can_dump_ring. It is a single binary flag so that
+// the producer (CAN task / ISR, which must never block) can take it with a
+// non-blocking test_and_set and simply drop the frame if it is already held.
+// The free/allocation paths run in task context, where a short blocking spin is
+// acceptable. Holding the lock across the whole buffer write means a free can
+// never run against memory the producer is still touching.
+static std::atomic_flag can_dump_ring_busy = ATOMIC_FLAG_INIT;
+
+static bool __attribute__((noinline)) can_dump_ring_test_and_set() {
+  return can_dump_ring_busy.test_and_set(std::memory_order_acquire);
+}
+
+// Blocking acquisition - only ever called from task context (stream start /
+// tear-down). Never taken from an ISR.
+static void can_dump_ring_lock() {
+  while (can_dump_ring_test_and_set()) {
+    vTaskDelay(1);
+  }
+}
+
+static void can_dump_ring_unlock() {
+  can_dump_ring_busy.clear(std::memory_order_release);
+}
+
+// Set by the /dump_can handler when a brand-new client is installed: the drain
+// task must drop any stale bytes still in the ring before streaming resumes.
+static std::atomic<bool> can_dump_reset_pending{false};
+
+// Called ONLY from the CAN receive task, never blocks. Holds the busy lock for
+// the duration of the write so that a concurrent free (which takes the same
+// lock) can never reclaim the buffer out from under us.
+static void can_dump_ring_push(const char* line, size_t len) {
+  // Non-blocking: if another thread owns the lock right now (e.g. it is tearing
+  // the stream down) just drop this frame rather than stalling the CAN task.
+  if (can_dump_ring_test_and_set())
+    return;
+
+  uint8_t* ring = can_dump_ring;
+  if (ring == nullptr) {  // Ring not allocated - no active stream.
+    can_dump_ring_busy.clear(std::memory_order_release);
+    return;
+  }
+
+  const size_t tail = can_dump_ring_tail.load(std::memory_order_relaxed);
+  const size_t head = can_dump_ring_head.load(std::memory_order_acquire);
+  const size_t used = tail - head;
+  const size_t free = CAN_DUMP_RING_SIZE - used;
+
+  if (free >= len + CAN_DUMP_RING_OVERRUN_RESERVE) {
+    // Append the whole line, wrapping at the ring boundary. Safe to split
+    // across the wrap: we already checked total free >= len + reserve, so the
+    // write can never reach live (unread) data.
+    size_t i = tail % CAN_DUMP_RING_SIZE;
+    size_t n1 = CAN_DUMP_RING_SIZE - i;
+    if (n1 > len)
+      n1 = len;
+    memcpy(&ring[i], line, n1);
+    if (len > n1) {
+      memcpy(&ring[0], line + n1, len - n1);
+    }
+    can_dump_ring_tail.store(tail + len, std::memory_order_release);
+  } else if (free > 0) {
+    // Not enough room for a whole line, but there is still space beyond the
+    // reserve for a newline indicator. These are useful signals of overflow
+    // that are compatible with the log format.
+    ring[tail % CAN_DUMP_RING_SIZE] = '\n';
+    can_dump_ring_tail.store(tail + 1, std::memory_order_release);
+  }
+  // Otherwise we just silently drop the line.
+
+  can_dump_ring_busy.clear(std::memory_order_release);
+}
+
+// Move as many buffered bytes as AsyncTCP can currently accept into the client.
+// Returns false only if the socket is gone / could not be written to.
+static bool can_dump_ring_drain(AsyncClient* client) {
+  if (can_dump_ring == nullptr) {
+    return true;  // No ring buffer yet
+  }
+  const size_t tail = can_dump_ring_tail.load(std::memory_order_acquire);
+  size_t head = can_dump_ring_head.load(std::memory_order_relaxed);
+  size_t used = tail - head;
+  while (used > 0) {
+    size_t space = client->space();
+    if (space == 0)
+      break;  // AsyncTCP full; leave the rest for the next poll.
+    size_t i = head % CAN_DUMP_RING_SIZE;
+    size_t n = CAN_DUMP_RING_SIZE - i;
+    if (n > used)
+      n = used;
+    if (n > space)
+      n = space;
+    size_t written = client->write(reinterpret_cast<const char*>(&can_dump_ring[i]), n, ASYNC_WRITE_FLAG_COPY);
+    if (written == 0) {
+      return false;  // Socket broken or AsyncTCP can no longer accept data.
+    }
+    head += written;
+    can_dump_ring_head.store(head, std::memory_order_release);
+    used = tail - head;
+  }
+  return true;
+}
+
+// Attempt to drain some of the ring to the active client. If the client is
+// gone, or if the socket is broken, stop streaming until a new connection
+// appears. This is called from the connectivity loop.
+void can_dump_drain_tick() {
+  // Wait at most 1ms for the mutex
+  if (xSemaphoreTake(can_dump_mutex, 1 / portTICK_PERIOD_MS) != pdTRUE) {
+    return;  // Failed to take the mutex, bail
+  }
+
+  AsyncClient* client = can_dump_client;
+
+  if (can_dump_reset_pending.exchange(false)) {
+    // Drop anything buffered by the previous stream before allowing new frames.
+    const size_t tail = can_dump_ring_tail.load(std::memory_order_acquire);
+    can_dump_ring_head.store(tail, std::memory_order_release);
+    if (client != nullptr) {
+      datalayer.system.info.can_streaming_active = true;
+    }
+  }
+
+  if (client != nullptr && datalayer.system.info.can_streaming_active) {
+    if (!can_dump_ring_drain(client)) {
+      // Client is gone / the socket broke. Stop dumping until a new connection appears.
+      can_dump_client = nullptr;
+      datalayer.system.info.can_streaming_active = false;
+    }
+  }
+
+  // No active connection, so the stream has torn down (or never started). Now
+  // that the consumer is idle we may free the ring buffer. We only free when
+  // we can grab the busy lock (i.e. the CAN task is not mid-write); if we can't,
+  // defer and try again on the next tick. drain and this free both run on this
+  // same (timer-tick) thread, so they can never race each other.
+  if (can_dump_client == nullptr) {
+    if (!can_dump_ring_test_and_set()) {
+      if (can_dump_ring != nullptr) {
+        free(can_dump_ring);
+        can_dump_ring = nullptr;
+        can_dump_ring_head.store(0, std::memory_order_release);
+        can_dump_ring_tail.store(0, std::memory_order_release);
+      }
+      can_dump_ring_busy.clear(std::memory_order_release);
+    }
+  }
+
+  xSemaphoreGive(can_dump_mutex);
+}
+
+// Output a CAN frame to the active stream, if present. The line itself is
+// formatted by the shared format_can_frame() (see comm_can.h).
+void stream_can_frame(const CAN_frame& frame, CAN_Interface interface, frameDirection msgDir) {
+  if (!datalayer.system.info.can_streaming_active) {
+    return;
+  }
+
+  char line[230];
+  const size_t len = format_can_frame(line, sizeof(line), frame, interface, msgDir);
+  if (len > 0) {
+    // Lock-free enqueue into the ring; the drain task handles the actual socket I/O.
+    can_dump_ring_push(line, len);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming CAN dump
+// ---------------------------------------------------------------------------
+void register_dump_can_route(AsyncWebServer& server) {
+  if (can_dump_mutex == nullptr) {
+    can_dump_mutex = xSemaphoreCreateMutex();
+  }
+
+  server.on("/dump_can", HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (webserver_auth_is_ready() && !request->authenticate(http_username.c_str(), http_password.c_str())) {
+      return request->requestAuthentication(AsyncAuthType::AUTH_BASIC, WEB_AUTH_REALM);
+    }
+
+    // Only one concurrent stream is allowed: drop any previous one.
+    can_dump_close_current();
+
+    AsyncClient* client = request->client();
+
+    // Allocate the ring buffer for this stream, or reuse the existing one if an
+    // earlier stream is still being buffered while it is replaced. Taken under
+    // the busy lock so we never race an in-flight CAN write belonging to the
+    // previous tenant. In task context a short blocking wait is fine.
+    can_dump_ring_lock();
+    if (can_dump_ring == nullptr) {
+      can_dump_ring = static_cast<uint8_t*>(malloc(CAN_DUMP_RING_SIZE));
+    }
+    // Fresh stream starts with an empty ring.
+    can_dump_ring_head.store(0, std::memory_order_release);
+    can_dump_ring_tail.store(0, std::memory_order_release);
+
+    if (can_dump_ring == nullptr) {
+      // Out of memory - we cannot stand up a stream. Send a normal HTTP error
+      // response via the framework (the request was never "streamed", so the
+      // normal send path is still valid).
+      can_dump_ring_unlock();
+      request->send(503, "text/plain", "out of memory");
+      return;
+    }
+
+    // Install the new client while still holding the busy flag so the drain
+    // tick's free path cannot reclaim the ring between allocation and install.
+    // We leave can_streaming_active gated OFF until the drain task has dropped
+    // any stale bytes and re-opened the gate, so a fresh stream never inherits
+    // lines from the previous tenant.
+    can_dump_swap_client(client);
+    can_dump_reset_pending.store(true, std::memory_order_relaxed);
+    can_dump_ring_unlock();
+
+    // Tell the framework not to auto-send a response when this handler returns:
+    // otherwise it would inject "501 Not Implemented / Handler did not handle
+    // the request" once we deliberately skip request->send().
+    request->setStreamingResponse(true);
+
+    // Send the response headers ourselves and deliberately leave the connection
+    // open (we never call request->send()). The request/response machinery is
+    // bypassed entirely; we stream raw bytes on the socket from stream_can_frame().
+    const char headers[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/plain\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+    client->write(headers, sizeof(headers) - 1, ASYNC_WRITE_FLAG_COPY);
+
+    // On disconnect (browser closes, or this connection is replaced) this runs on
+    // the TCP task before the framework deletes the AsyncClient. We only clear our
+    // active-client pointer if it still refers to *this* connection, so replacing
+    // a stream doesn't clobber its successor.
+    request->onDisconnect([client]() {
+      AsyncClient* c = can_dump_swap_client(nullptr);
+      if (c != nullptr && c != client) {
+        // A newer connection has already taken over; restore it and leave logging on.
+        can_dump_swap_client(c);
+        return;
+      }
+      // This (or a now-cleared) client was the active stream, so tear everything down.
+      datalayer.system.info.can_streaming_active = false;
+    });
+  });
+}

--- a/Software/src/devboard/webserver/webserver_can_streaming.h
+++ b/Software/src/devboard/webserver/webserver_can_streaming.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "../../lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
+
+void can_dump_drain_tick();
+void register_dump_can_route(AsyncWebServer& server);
+void stream_can_frame(const CAN_frame& frame, CAN_Interface interface, frameDirection msgDir);

--- a/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h
+++ b/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h
@@ -198,6 +198,7 @@ private:
 
   bool _sent = false;                            // response is sent
   bool _paused = false;                          // request is paused (request continuation)
+  bool _streaming = false;                       // handler manages the raw connection itself (no auto response)
   std::shared_ptr<AsyncWebServerRequest> _this;  // shared pointer to this request
 
   String _temp;
@@ -270,6 +271,17 @@ public:
 
   AsyncClient *client() {
     return _client;
+  }
+  // Called by handlers that take over the raw TCP connection themselves (e.g.
+  // for long-lived streaming). Once enabled, the framework will not send an
+  // automatic response when the handler returns; the handler manages the
+  // connection lifecycle (headers, data, closing) and it is closed when the
+  // client disconnects.
+  void setStreamingResponse(bool streaming = true) {
+    _streaming = streaming;
+  }
+  bool isStreamingResponse() const {
+    return _streaming;
   }
   uint8_t version() const {
     return _version;

--- a/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebRequest.cpp
+++ b/Software/src/lib/ESP32Async-ESPAsyncWebServer/src/WebRequest.cpp
@@ -723,6 +723,13 @@ void AsyncWebServerRequest::_send() {
 
     // user did not create a response ?
     if (!_response) {
+      if (_streaming) {
+        // The handler has taken over the raw connection (e.g. for long-lived
+        // streaming) and manages headers/data/closing itself, so there is
+        // nothing to auto-send here. The connection stays open until the client
+        // disconnects (handled in _onDisconnect).
+        return;
+      }
       send(501, T_text_plain, "Handler did not handle the request");
     }
 


### PR DESCRIPTION
### What
Adds a `/dump_can` endpoint which retrieves endless streamed CAN logs. 

Can either consume in a browser window or use something like:
`while true; do curl http://192.168.4.1/dump_can >> can_log.txt; done`
to log forever.

Also makes the existing CAN logger and SD logger use the new CAN formatter (which is considerably faster). Note that I haven't tested the SD CAN logging (although it should now use the new bus numbering unlike before). One small addition is that FD frames are now distinguished: `rx0`/`tx1` for non-FD, `RX0`/`TX1` for FD.

One annoyance is that the stream is infinite, so a browser won't actually save it as a download - cancelling deletes the partial file. You can save it by starting a new stream in another tab, which will stop the current one and finish downloading. If we add a user interface, we could add a 'Stop' button which just starts/stops a stream to trigger this.

### Why
Was originally implemented in the TinyWebServer branch, then backported to the new-frontend-on-AsyncWebServer branch, and now backported to the current frontend.

Might be useful if it isn't too big.

Implementation mostly guided AI, there's some rather subtle locking going on (but I've checked through it a few times and also tested). Requires a tweak to the vendored AsyncWebServer but I don't think we're in a position to update that anyway.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
