### PR TITLE
Calculate uptime strings without ctime

### DIFF
--- a/Software/src/battery/BMW-IX-HTML.cpp
+++ b/Software/src/battery/BMW-IX-HTML.cpp
@@ -1,4 +1,5 @@
 #include "BMW-IX-HTML.h"
+#include "../devboard/utils/time_format.h"
 #include "BMW-IX-BATTERY.h"
 
 String BmwIXHtmlRenderer::get_status_html() {
@@ -176,15 +177,7 @@ String BmwIXHtmlRenderer::get_status_html() {
   content += "<h3 style='color: #757575; border-bottom: 2px solid #757575; padding-bottom: 5px;'>🔧 Diagnostics</h3>";
   content += "<div style='margin-left: 15px;'>";
 
-  // Convert uptime to days:hours:minutes:seconds format
-  unsigned long uptime_seconds = batt.get_bms_uptime();
-  unsigned long days = uptime_seconds / 86400;
-  unsigned long hours = (uptime_seconds % 86400) / 3600;
-  unsigned long minutes = (uptime_seconds % 3600) / 60;
-  unsigned long seconds = uptime_seconds % 60;
-
-  content += "<h4>BMS Uptime: " + String(days) + "d " + String(hours) + "h " + String(minutes) + "m " +
-             String(seconds) + "s</h4>";
+  content += "<h4>BMS Uptime: " + format_ms_string((uint64_t)batt.get_bms_uptime() * 1000) + "</h4>";
   content += "</div>";
 
   // Diagnostic Trouble Codes Section

--- a/Software/src/devboard/utils/time_format.cpp
+++ b/Software/src/devboard/utils/time_format.cpp
@@ -1,0 +1,39 @@
+#include <stdint.h>
+#include <cstdio>
+#ifdef UNIT_TEST
+#include "WString.h"
+#else
+#include <Arduino.h>
+#endif
+#include "time_format.h"
+
+struct TimeBreakdown {
+  unsigned long days;
+  unsigned long hours;
+  unsigned long minutes;
+  unsigned long seconds;
+};
+
+static TimeBreakdown ms_to_parts(uint64_t ms) {
+  uint64_t s = ms / 1000;
+  return {
+      .days = (unsigned long)(s / 86400),
+      .hours = (unsigned long)((s % 86400) / 3600),
+      .minutes = (unsigned long)((s % 3600) / 60),
+      .seconds = (unsigned long)(s % 60),
+  };
+}
+
+String format_ms_stamp(uint64_t ms) {
+  TimeBreakdown t = ms_to_parts(ms);
+  char buf[24];
+  snprintf(buf, sizeof(buf), "%lud%02luh%02lum%02lus", t.days, t.hours, t.minutes, t.seconds);
+  return buf;
+}
+
+String format_ms_string(uint64_t ms) {
+  TimeBreakdown t = ms_to_parts(ms);
+  char buf[64];
+  snprintf(buf, sizeof(buf), "%lu days, %lu hours, %lu minutes, %lu seconds", t.days, t.hours, t.minutes, t.seconds);
+  return buf;
+}

--- a/Software/src/devboard/utils/time_format.h
+++ b/Software/src/devboard/utils/time_format.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+
+String format_ms_stamp(uint64_t ms);
+String format_ms_string(uint64_t ms);

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1,6 +1,5 @@
 #include "webserver.h"
 #include <Preferences.h>
-#include <ctime>
 #include <vector>
 #include "../../battery/BATTERIES.h"
 #include "../../battery/Battery.h"
@@ -18,6 +17,8 @@
 #include "../sdcard/sdcard.h"
 #include "../utils/events.h"
 #include "../utils/led_handler.h"
+#include "../utils/millis64.h"
+#include "../utils/time_format.h"
 #include "../utils/timer.h"
 #include "esp_task_wdt.h"
 #include "favicon.h"
@@ -348,23 +349,11 @@ void init_webserver() {
         logs = "No logs available.";
       }
 
-      // Get the current time
-      time_t now = time(nullptr);
-      struct tm timeinfo;
-      localtime_r(&now, &timeinfo);
-
-      // Ensure time retrieval was successful
-      char filename[32];
-      if (strftime(filename, sizeof(filename), "canlog_%H-%M-%S.txt", &timeinfo)) {
-        // Valid filename created
-      } else {
-        // Fallback filename if automatic timestamping failed
-        strcpy(filename, "battery_emulator_can_log.txt");
-      }
+      String filename = "canlog_" + format_ms_stamp(millis64()) + ".txt";
 
       // Use request->send with dynamic headers
       AsyncWebServerResponse* response = request->beginResponse(200, "text/plain", logs);
-      response->addHeader("Content-Disposition", String("attachment; filename=\"") + String(filename) + "\"");
+      response->addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
       request->send(response);
     });
   }
@@ -393,23 +382,11 @@ void init_webserver() {
         logs = "No logs available.";
       }
 
-      // Get the current time
-      time_t now = time(nullptr);
-      struct tm timeinfo;
-      localtime_r(&now, &timeinfo);
-
-      // Ensure time retrieval was successful
-      char filename[32];
-      if (strftime(filename, sizeof(filename), "log_%H-%M-%S.txt", &timeinfo)) {
-        // Valid filename created
-      } else {
-        // Fallback filename if automatic timestamping failed
-        strcpy(filename, "battery_emulator_log.txt");
-      }
+      String filename = "log_" + format_ms_stamp(millis64()) + ".txt";
 
       // Use request->send with dynamic headers
       AsyncWebServerResponse* response = request->beginResponse(200, "text/plain", logs);
-      response->addHeader("Content-Disposition", String("attachment; filename=\"") + String(filename) + "\"");
+      response->addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
       request->send(response);
     });
   }
@@ -974,27 +951,6 @@ String get_firmware_info_processor(const String& var) {
   return String();
 }
 
-String get_uptime() {
-  uint64_t milliseconds;
-  uint32_t remaining_seconds_in_day;
-  uint32_t remaining_seconds;
-  uint32_t remaining_minutes;
-  uint32_t remaining_hours;
-  uint16_t total_days;
-
-  milliseconds = millis64();
-
-  //convert passed millis to days, hours, minutes, seconds
-  total_days = milliseconds / (1000 * 60 * 60 * 24);
-  remaining_seconds_in_day = (milliseconds / 1000) % (60 * 60 * 24);
-  remaining_hours = remaining_seconds_in_day / (60 * 60);
-  remaining_minutes = (remaining_seconds_in_day % (60 * 60)) / 60;
-  remaining_seconds = remaining_seconds_in_day % 60;
-
-  return (String)total_days + " days, " + (String)remaining_hours + " hours, " + (String)remaining_minutes +
-         " minutes, " + (String)remaining_seconds + " seconds";
-}
-
 String processor(const String& var) {
   if (var == "X") {
     String content = "";
@@ -1057,7 +1013,7 @@ String processor(const String& var) {
     } else {
       content += "</h4>";
     }
-    content += "<h4>Uptime: " + get_uptime() + "</h4>";
+    content += "<h4>Uptime: " + format_ms_string(millis64()) + "</h4>";
     if (datalayer.system.info.performance_measurement_active) {
       content +=
           "<h4>Free heap: " + String(ESP.getFreeHeap()) + ", max alloc: " + String(ESP.getMaxAllocHeap()) + "</h4>";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(tests
     ../Software/src/devboard/hal/hal.cpp
     ../Software/src/devboard/utils/types.cpp
     ../Software/src/devboard/utils/events.cpp
+    ../Software/src/devboard/utils/time_format.cpp
     ../Software/src/devboard/utils/common_functions.cpp
     ../Software/src/devboard/utils/led_handler.cpp
     ../Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp


### PR DESCRIPTION
### What
While looking into RTC support for #2722 I noticed that there was a `ctime` dependency even though the time is never synced. This meant the logs were implicitly named after uptime already. I replaced it with an smaller uptime based calculation.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
