### PR TITLE
Stellantis e-CMP: Triple battery support :battery: :battery: :battery: 

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -373,6 +373,7 @@ bool battery_supports_triple(BatteryType type) {
   switch (type) {
     case BatteryType::NissanLeaf:
     case BatteryType::CmfaEv:
+    case BatteryType::StellantisEcmp:
     case BatteryType::RelionBattery:
     case BatteryType::TestFake:
       return true;
@@ -480,6 +481,9 @@ void setup_battery() {
           break;
         case BatteryType::CmfaEv:
           battery3 = new CmfaEvBattery(&datalayer.battery3, can_config.battery_triple);
+          break;
+        case BatteryType::StellantisEcmp:
+          battery3 = new EcmpBattery(&datalayer.battery3, can_config.battery_triple);
           break;
         case BatteryType::RelionBattery:
           battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -9,7 +9,7 @@
 
 class EcmpBattery : public CanBattery {
  public:
-  // Use this constructor for the second battery.
+  // Use this constructor for the second/third battery.
   EcmpBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan) : CanBattery(targetCan) {
     datalayer_battery = datalayer_ptr;
     datalayer_ecmp = NULL;


### PR DESCRIPTION
### What
This PR implements Triple battery support for Stellantis eCMP

### Why
User requested feature. Fixes #2728

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
