### PR TITLE
Fix reported SOC and capacity for multi-pack systems

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -15,6 +15,7 @@
 #include "src/communication/nvm/comm_nvm.h"
 #include "src/communication/precharge_control/precharge_control.h"
 #include "src/communication/rs485/comm_rs485.h"
+#include "src/datalayer/calculated_soc.h"
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/display/display.h"
 #include "src/devboard/espnow/espnow.h"
@@ -443,105 +444,7 @@ void update_calculated_values(uint32_t currentMillis) {
         (datalayer.battery3.status.current_dA * (datalayer.battery3.status.voltage_dV / 100));
   }
 
-  if (datalayer.battery.settings.soc_scaling_active) {
-    /** SOC Scaling
-   * A static version of a stochastic oscillator. The scaled SoC is calculated as:
-   *
-   *     10000 * (real_soc - min_percentage)
-   * ---------------------------------------
-   *     (max_percentage - min_percentage)
-   *
-   * And scaled capacity is:
-   *
-   *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
-   *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
-   */
-    // Compute delta_pct and clamped_soc
-    int32_t delta_pct = datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage;
-    int32_t clamped_soc = CONSTRAIN(datalayer.battery.status.real_soc, datalayer.battery.settings.min_percentage,
-                                    datalayer.battery.settings.max_percentage);
-    int32_t scaled_soc = 0;
-    int32_t scaled_total_capacity = 0;
-    if (delta_pct != 0) {  //Safeguard against division by 0
-      scaled_soc = 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
-    }
-
-    datalayer.battery.status.reported_soc = scaled_soc;
-
-    // If battery info is valid
-    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-      // Scale total usable capacity
-      scaled_total_capacity = (datalayer.battery.info.total_capacity_Wh * delta_pct) / 10000;
-      datalayer.battery.info.reported_total_capacity_Wh = scaled_total_capacity;
-
-      // Scale remaining capacity based on scaled SOC
-      datalayer.battery.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-    } else {
-      // Fallback if scaling cannot be performed
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    }
-
-    if (battery2) {
-      // If battery info is valid
-      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-
-        datalayer.battery2.info.reported_total_capacity_Wh = scaled_total_capacity;
-        // Scale remaining capacity based on scaled SOC
-        datalayer.battery2.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-      } else {
-        // Fallback if scaling cannot be performed
-        datalayer.battery2.info.reported_total_capacity_Wh = datalayer.battery2.info.total_capacity_Wh;
-        datalayer.battery2.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
-      }
-
-      //Since we are running double battery, the scaled value of battery1 becomes the sum of battery1+battery2
-      //This way the inverter connected to the system sees both batteries as one large battery
-      datalayer.battery.info.reported_total_capacity_Wh += datalayer.battery2.info.reported_total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh +=
-          datalayer.battery2.status.reported_remaining_capacity_Wh;
-    }
-
-  } else {  // soc_scaling_active == false. No SOC window wanted. Set scaled SOC & capacity to same as real.
-    datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
-
-    datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-
-    if (battery2) {
-      datalayer.battery.status.reported_remaining_capacity_Wh =
-          datalayer.battery.status.remaining_capacity_Wh + datalayer.battery2.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh =
-          datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh;
-    }
-    if (battery3) {
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh +
-                                                                datalayer.battery2.status.remaining_capacity_Wh +
-                                                                datalayer.battery3.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh +
-                                                          datalayer.battery2.info.total_capacity_Wh +
-                                                          datalayer.battery3.info.total_capacity_Wh;
-    }
-  }
-
-  datalayer.battery2.status.reported_soc =
-      datalayer.battery2.status.real_soc;  //For screen to display correct SOC of battery 2
-  datalayer.battery3.status.reported_soc =
-      datalayer.battery3.status.real_soc;  //For screen to display correct SOC of battery 3
-
-  //Check each extra battery, and if they are at the extremes, report the SOC from these batteries instead
-  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing) {  //Battery2 is in the mix
-    if ((datalayer.battery2.status.real_soc < 100) || (datalayer.battery2.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
-    }
-  }
-  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing) {  //Battery3 is in the mix
-    if ((datalayer.battery3.status.real_soc < 100) || (datalayer.battery3.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery3.status.real_soc;
-    }
-  }
+  update_reported_soc_and_capacity();
 }
 
 void check_reset_reason() {

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -15,6 +15,7 @@
 #include "src/communication/nvm/comm_nvm.h"
 #include "src/communication/precharge_control/precharge_control.h"
 #include "src/communication/rs485/comm_rs485.h"
+#include "src/datalayer/calculated_soc.h"
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/display/display.h"
 #include "src/devboard/espnow/espnow.h"
@@ -449,105 +450,7 @@ void update_calculated_values(unsigned long currentMillis) {
         (datalayer.battery3.status.current_dA * (datalayer.battery3.status.voltage_dV / 100));
   }
 
-  if (datalayer.battery.settings.soc_scaling_active) {
-    /** SOC Scaling
-   * A static version of a stochastic oscillator. The scaled SoC is calculated as:
-   *
-   *     10000 * (real_soc - min_percentage)
-   * ---------------------------------------
-   *     (max_percentage - min_percentage)
-   *
-   * And scaled capacity is:
-   *
-   *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
-   *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
-   */
-    // Compute delta_pct and clamped_soc
-    int32_t delta_pct = datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage;
-    int32_t clamped_soc = CONSTRAIN(datalayer.battery.status.real_soc, datalayer.battery.settings.min_percentage,
-                                    datalayer.battery.settings.max_percentage);
-    int32_t scaled_soc = 0;
-    int32_t scaled_total_capacity = 0;
-    if (delta_pct != 0) {  //Safeguard against division by 0
-      scaled_soc = 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
-    }
-
-    datalayer.battery.status.reported_soc = scaled_soc;
-
-    // If battery info is valid
-    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-      // Scale total usable capacity
-      scaled_total_capacity = (datalayer.battery.info.total_capacity_Wh * delta_pct) / 10000;
-      datalayer.battery.info.reported_total_capacity_Wh = scaled_total_capacity;
-
-      // Scale remaining capacity based on scaled SOC
-      datalayer.battery.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-    } else {
-      // Fallback if scaling cannot be performed
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    }
-
-    if (battery2) {
-      // If battery info is valid
-      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-
-        datalayer.battery2.info.reported_total_capacity_Wh = scaled_total_capacity;
-        // Scale remaining capacity based on scaled SOC
-        datalayer.battery2.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-      } else {
-        // Fallback if scaling cannot be performed
-        datalayer.battery2.info.reported_total_capacity_Wh = datalayer.battery2.info.total_capacity_Wh;
-        datalayer.battery2.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
-      }
-
-      //Since we are running double battery, the scaled value of battery1 becomes the sum of battery1+battery2
-      //This way the inverter connected to the system sees both batteries as one large battery
-      datalayer.battery.info.reported_total_capacity_Wh += datalayer.battery2.info.reported_total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh +=
-          datalayer.battery2.status.reported_remaining_capacity_Wh;
-    }
-
-  } else {  // soc_scaling_active == false. No SOC window wanted. Set scaled SOC & capacity to same as real.
-    datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
-
-    datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-
-    if (battery2) {
-      datalayer.battery.status.reported_remaining_capacity_Wh =
-          datalayer.battery.status.remaining_capacity_Wh + datalayer.battery2.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh =
-          datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh;
-    }
-    if (battery3) {
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh +
-                                                                datalayer.battery2.status.remaining_capacity_Wh +
-                                                                datalayer.battery3.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh +
-                                                          datalayer.battery2.info.total_capacity_Wh +
-                                                          datalayer.battery3.info.total_capacity_Wh;
-    }
-  }
-
-  datalayer.battery2.status.reported_soc =
-      datalayer.battery2.status.real_soc;  //For screen to display correct SOC of battery 2
-  datalayer.battery3.status.reported_soc =
-      datalayer.battery3.status.real_soc;  //For screen to display correct SOC of battery 3
-
-  //Check each extra battery, and if they are at the extremes, report the SOC from these batteries instead
-  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing) {  //Battery2 is in the mix
-    if ((datalayer.battery2.status.real_soc < 100) || (datalayer.battery2.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
-    }
-  }
-  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing) {  //Battery3 is in the mix
-    if ((datalayer.battery3.status.real_soc < 100) || (datalayer.battery3.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery3.status.real_soc;
-    }
-  }
+  update_reported_soc_and_capacity();
 }
 
 void check_reset_reason() {

--- a/Software/src/datalayer/calculated_soc.cpp
+++ b/Software/src/datalayer/calculated_soc.cpp
@@ -1,0 +1,109 @@
+#include "calculated_soc.h"
+
+#include "../battery/BATTERIES.h"
+#include "../devboard/utils/value_mapping.h"
+#include "datalayer.h"
+
+// Moved verbatim out of update_calculated_values() in Software.cpp. Behaviour
+// is unchanged by this commit; the defects it contains are addressed next.
+void update_reported_soc_and_capacity() {
+  if (datalayer.battery.settings.soc_scaling_active) {
+    /** SOC Scaling
+   * A static version of a stochastic oscillator. The scaled SoC is calculated as:
+   *
+   *     10000 * (real_soc - min_percentage)
+   * ---------------------------------------
+   *     (max_percentage - min_percentage)
+   *
+   * And scaled capacity is:
+   *
+   *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
+   *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
+   */
+    // Compute delta_pct and clamped_soc
+    int32_t delta_pct = datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage;
+    int32_t clamped_soc = CONSTRAIN(datalayer.battery.status.real_soc, datalayer.battery.settings.min_percentage,
+                                    datalayer.battery.settings.max_percentage);
+    int32_t scaled_soc = 0;
+    int32_t scaled_total_capacity = 0;
+    if (delta_pct != 0) {  //Safeguard against division by 0
+      scaled_soc = 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
+    }
+
+    datalayer.battery.status.reported_soc = scaled_soc;
+
+    // If battery info is valid
+    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
+      // Scale total usable capacity
+      scaled_total_capacity = (datalayer.battery.info.total_capacity_Wh * delta_pct) / 10000;
+      datalayer.battery.info.reported_total_capacity_Wh = scaled_total_capacity;
+
+      // Scale remaining capacity based on scaled SOC
+      datalayer.battery.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
+
+    } else {
+      // Fallback if scaling cannot be performed
+      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
+      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
+    }
+
+    if (battery2) {
+      // If battery info is valid
+      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
+
+        datalayer.battery2.info.reported_total_capacity_Wh = scaled_total_capacity;
+        // Scale remaining capacity based on scaled SOC
+        datalayer.battery2.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
+
+      } else {
+        // Fallback if scaling cannot be performed
+        datalayer.battery2.info.reported_total_capacity_Wh = datalayer.battery2.info.total_capacity_Wh;
+        datalayer.battery2.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
+      }
+
+      //Since we are running double battery, the scaled value of battery1 becomes the sum of battery1+battery2
+      //This way the inverter connected to the system sees both batteries as one large battery
+      datalayer.battery.info.reported_total_capacity_Wh += datalayer.battery2.info.reported_total_capacity_Wh;
+      datalayer.battery.status.reported_remaining_capacity_Wh +=
+          datalayer.battery2.status.reported_remaining_capacity_Wh;
+    }
+
+  } else {  // soc_scaling_active == false. No SOC window wanted. Set scaled SOC & capacity to same as real.
+    datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
+
+    datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
+    datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
+
+    if (battery2) {
+      datalayer.battery.status.reported_remaining_capacity_Wh =
+          datalayer.battery.status.remaining_capacity_Wh + datalayer.battery2.status.remaining_capacity_Wh;
+      datalayer.battery.info.reported_total_capacity_Wh =
+          datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh;
+    }
+    if (battery3) {
+      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh +
+                                                                datalayer.battery2.status.remaining_capacity_Wh +
+                                                                datalayer.battery3.status.remaining_capacity_Wh;
+      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh +
+                                                          datalayer.battery2.info.total_capacity_Wh +
+                                                          datalayer.battery3.info.total_capacity_Wh;
+    }
+  }
+
+  datalayer.battery2.status.reported_soc =
+      datalayer.battery2.status.real_soc;  //For screen to display correct SOC of battery 2
+  datalayer.battery3.status.reported_soc =
+      datalayer.battery3.status.real_soc;  //For screen to display correct SOC of battery 3
+
+  //Check each extra battery, and if they are at the extremes, report the SOC from these batteries instead
+  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing) {  //Battery2 is in the mix
+    if ((datalayer.battery2.status.real_soc < 100) || (datalayer.battery2.status.real_soc > 9900)) {
+      datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
+    }
+  }
+  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing) {  //Battery3 is in the mix
+    if ((datalayer.battery3.status.real_soc < 100) || (datalayer.battery3.status.real_soc > 9900)) {
+      datalayer.battery.status.reported_soc = datalayer.battery3.status.real_soc;
+    }
+  }
+}

--- a/Software/src/datalayer/calculated_soc.cpp
+++ b/Software/src/datalayer/calculated_soc.cpp
@@ -4,106 +4,115 @@
 #include "../devboard/utils/value_mapping.h"
 #include "datalayer.h"
 
-// Moved verbatim out of update_calculated_values() in Software.cpp. Behaviour
-// is unchanged by this commit; the defects it contains are addressed next.
+/** SOC Scaling
+ * A static version of a stochastic oscillator. The scaled SoC is calculated as:
+ *
+ *     10000 * (real_soc - min_percentage)
+ * ---------------------------------------
+ *     (max_percentage - min_percentage)
+ *
+ * And scaled capacity is:
+ *
+ *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
+ *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
+ */
+
+namespace {
+
+// The user's SOC window, shared by every pack: the inverter sees one battery,
+// so one window applies to all of them.
+int32_t window_delta_pct() {
+  return datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage;
+}
+
+// Maps a real SOC onto the user's window. Used for every pack and for the
+// extreme-pack override below, so a scaled figure is never mixed with a raw one.
+int32_t scale_soc(int32_t real_soc) {
+  const int32_t delta_pct = window_delta_pct();
+  if (delta_pct == 0) {  // Safeguard against division by 0
+    return 0;
+  }
+  const int32_t clamped_soc =
+      CONSTRAIN(real_soc, datalayer.battery.settings.min_percentage, datalayer.battery.settings.max_percentage);
+  return 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
+}
+
+// Writes one pack's own scaled SOC and capacity into its own reported fields.
+// Every value comes from that pack: using battery 1's capacity for the extra
+// packs is what made their reported figures wrong whenever the packs differed.
+void scale_pack(DATALAYER_BATTERY_TYPE& pack) {
+  const int32_t scaled_soc = scale_soc(pack.status.real_soc);
+  pack.status.reported_soc = scaled_soc;
+
+  if (pack.info.total_capacity_Wh > 0 && pack.status.real_soc > 0) {
+    const int32_t scaled_total_capacity = (pack.info.total_capacity_Wh * window_delta_pct()) / 10000;
+    pack.info.reported_total_capacity_Wh = scaled_total_capacity;
+    pack.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
+  } else {
+    // Fallback if scaling cannot be performed
+    pack.info.reported_total_capacity_Wh = pack.info.total_capacity_Wh;
+    pack.status.reported_remaining_capacity_Wh = pack.status.remaining_capacity_Wh;
+  }
+}
+
+// Copies a pack's real values into its reported fields, for when no window is
+// wanted.
+void report_pack_unscaled(DATALAYER_BATTERY_TYPE& pack) {
+  pack.status.reported_soc = pack.status.real_soc;
+  pack.info.reported_total_capacity_Wh = pack.info.total_capacity_Wh;
+  pack.status.reported_remaining_capacity_Wh = pack.status.remaining_capacity_Wh;
+}
+
+// True when an extra pack has reached either end of its range and the whole
+// system should report that, so the inverter stops before the weakest pack is
+// driven past its limit.
+bool at_extreme(const DATALAYER_BATTERY_TYPE& pack) {
+  return (pack.status.real_soc < 100) || (pack.status.real_soc > 9900);
+}
+
+}  // namespace
+
 void update_reported_soc_and_capacity() {
-  if (datalayer.battery.settings.soc_scaling_active) {
-    /** SOC Scaling
-   * A static version of a stochastic oscillator. The scaled SoC is calculated as:
-   *
-   *     10000 * (real_soc - min_percentage)
-   * ---------------------------------------
-   *     (max_percentage - min_percentage)
-   *
-   * And scaled capacity is:
-   *
-   *     reported_total_capacity_Wh = total_capacity_Wh * (max - min) / 10000
-   *     reported_remaining_capacity_Wh = reported_total_capacity_Wh * scaled_soc / 10000
-   */
-    // Compute delta_pct and clamped_soc
-    int32_t delta_pct = datalayer.battery.settings.max_percentage - datalayer.battery.settings.min_percentage;
-    int32_t clamped_soc = CONSTRAIN(datalayer.battery.status.real_soc, datalayer.battery.settings.min_percentage,
-                                    datalayer.battery.settings.max_percentage);
-    int32_t scaled_soc = 0;
-    int32_t scaled_total_capacity = 0;
-    if (delta_pct != 0) {  //Safeguard against division by 0
-      scaled_soc = 10000 * (clamped_soc - datalayer.battery.settings.min_percentage) / delta_pct;
-    }
+  const bool scaling = datalayer.battery.settings.soc_scaling_active;
 
-    datalayer.battery.status.reported_soc = scaled_soc;
-
-    // If battery info is valid
-    if (datalayer.battery.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-      // Scale total usable capacity
-      scaled_total_capacity = (datalayer.battery.info.total_capacity_Wh * delta_pct) / 10000;
-      datalayer.battery.info.reported_total_capacity_Wh = scaled_total_capacity;
-
-      // Scale remaining capacity based on scaled SOC
-      datalayer.battery.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-    } else {
-      // Fallback if scaling cannot be performed
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    }
-
-    if (battery2) {
-      // If battery info is valid
-      if (datalayer.battery2.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
-
-        datalayer.battery2.info.reported_total_capacity_Wh = scaled_total_capacity;
-        // Scale remaining capacity based on scaled SOC
-        datalayer.battery2.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
-
-      } else {
-        // Fallback if scaling cannot be performed
-        datalayer.battery2.info.reported_total_capacity_Wh = datalayer.battery2.info.total_capacity_Wh;
-        datalayer.battery2.status.reported_remaining_capacity_Wh = datalayer.battery2.status.remaining_capacity_Wh;
-      }
-
-      //Since we are running double battery, the scaled value of battery1 becomes the sum of battery1+battery2
-      //This way the inverter connected to the system sees both batteries as one large battery
-      datalayer.battery.info.reported_total_capacity_Wh += datalayer.battery2.info.reported_total_capacity_Wh;
-      datalayer.battery.status.reported_remaining_capacity_Wh +=
-          datalayer.battery2.status.reported_remaining_capacity_Wh;
-    }
-
-  } else {  // soc_scaling_active == false. No SOC window wanted. Set scaled SOC & capacity to same as real.
-    datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
-
-    datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh;
-    datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh;
-
-    if (battery2) {
-      datalayer.battery.status.reported_remaining_capacity_Wh =
-          datalayer.battery.status.remaining_capacity_Wh + datalayer.battery2.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh =
-          datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh;
-    }
-    if (battery3) {
-      datalayer.battery.status.reported_remaining_capacity_Wh = datalayer.battery.status.remaining_capacity_Wh +
-                                                                datalayer.battery2.status.remaining_capacity_Wh +
-                                                                datalayer.battery3.status.remaining_capacity_Wh;
-      datalayer.battery.info.reported_total_capacity_Wh = datalayer.battery.info.total_capacity_Wh +
-                                                          datalayer.battery2.info.total_capacity_Wh +
-                                                          datalayer.battery3.info.total_capacity_Wh;
-    }
+  // Each configured pack first gets its own reported values, in its own right.
+  if (scaling) {
+    scale_pack(datalayer.battery);
+  } else {
+    report_pack_unscaled(datalayer.battery);
+  }
+  if (battery2) {
+    scaling ? scale_pack(datalayer.battery2) : report_pack_unscaled(datalayer.battery2);
+  }
+  if (battery3) {
+    scaling ? scale_pack(datalayer.battery3) : report_pack_unscaled(datalayer.battery3);
   }
 
-  datalayer.battery2.status.reported_soc =
-      datalayer.battery2.status.real_soc;  //For screen to display correct SOC of battery 2
-  datalayer.battery3.status.reported_soc =
-      datalayer.battery3.status.real_soc;  //For screen to display correct SOC of battery 3
-
-  //Check each extra battery, and if they are at the extremes, report the SOC from these batteries instead
-  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing) {  //Battery2 is in the mix
-    if ((datalayer.battery2.status.real_soc < 100) || (datalayer.battery2.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery2.status.real_soc;
-    }
+  // The inverter sees the whole system as one battery, so battery 1's reported
+  // capacity doubles as the system total. Summed over every configured pack -
+  // battery 3 used to be left out of this whenever scaling was active, so a
+  // triple-pack system under-reported its capacity by a third.
+  uint32_t total_capacity_Wh = datalayer.battery.info.reported_total_capacity_Wh;
+  uint32_t remaining_capacity_Wh = datalayer.battery.status.reported_remaining_capacity_Wh;
+  if (battery2) {
+    total_capacity_Wh += datalayer.battery2.info.reported_total_capacity_Wh;
+    remaining_capacity_Wh += datalayer.battery2.status.reported_remaining_capacity_Wh;
   }
-  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing) {  //Battery3 is in the mix
-    if ((datalayer.battery3.status.real_soc < 100) || (datalayer.battery3.status.real_soc > 9900)) {
-      datalayer.battery.status.reported_soc = datalayer.battery3.status.real_soc;
-    }
+  if (battery3) {
+    total_capacity_Wh += datalayer.battery3.info.reported_total_capacity_Wh;
+    remaining_capacity_Wh += datalayer.battery3.status.reported_remaining_capacity_Wh;
+  }
+  datalayer.battery.info.reported_total_capacity_Wh = total_capacity_Wh;
+  datalayer.battery.status.reported_remaining_capacity_Wh = remaining_capacity_Wh;
+
+  // If an extra pack is at either extreme, report its SOC for the whole system.
+  // Scaled through the same window when scaling is active: writing the raw
+  // value here put an unscaled number into the field the inverter reads, so the
+  // reported SOC jumped domains the moment an extra pack crossed 1% or 99%.
+  if (battery2 && datalayer.system.status.battery2_allowed_contactor_closing && at_extreme(datalayer.battery2)) {
+    datalayer.battery.status.reported_soc = datalayer.battery2.status.reported_soc;
+  }
+  if (battery3 && datalayer.system.status.battery3_allowed_contactor_closing && at_extreme(datalayer.battery3)) {
+    datalayer.battery.status.reported_soc = datalayer.battery3.status.reported_soc;
   }
 }

--- a/Software/src/datalayer/calculated_soc.h
+++ b/Software/src/datalayer/calculated_soc.h
@@ -1,0 +1,17 @@
+#ifndef CALCULATED_SOC_H
+#define CALCULATED_SOC_H
+
+/**
+ * @brief Derives the reported (inverter-facing) SOC and capacity from the real
+ * values of every configured battery.
+ *
+ * Split out of update_calculated_values() in Software.cpp: this part is pure
+ * datalayer arithmetic, while the rest of that function reads the CPU
+ * temperature and free heap. Keeping it in its own translation unit is what
+ * makes it reachable from the host test suite - Software.cpp pulls in the
+ * webserver, wifi, mqtt, sdcard and display stacks, none of which this
+ * calculation needs.
+ */
+void update_reported_soc_and_capacity();
+
+#endif  // CALCULATED_SOC_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(tests
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
     estop_graceful_open_tests.cpp
+    calculated_soc_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp
@@ -96,6 +97,7 @@ add_executable(tests
     ../Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
     emul/neopixel_show.cpp
     ../Software/src/datalayer/datalayer.cpp
+    ../Software/src/datalayer/calculated_soc.cpp
     ../Software/src/datalayer/datalayer_extended.cpp
     ../Software/src/lib/uds_isotp/isotp.cpp
     ../Software/src/lib/eModbus-eModbus/ModbusMessage.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(tests
     ../Software/src/devboard/utils/led_handler.cpp
     ../Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
     ../Software/src/datalayer/datalayer.cpp
+    ../Software/src/datalayer/calculated_soc.cpp
     ../Software/src/datalayer/datalayer_extended.cpp
     ../Software/src/lib/uds_isotp/isotp.cpp
     ../Software/src/lib/eModbus-eModbus/ModbusMessage.cpp

--- a/test/calculated_soc_tests.cpp
+++ b/test/calculated_soc_tests.cpp
@@ -1,0 +1,292 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/battery/BATTERIES.h"
+#include "../Software/src/datalayer/calculated_soc.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+
+// Covers the reported (inverter-facing) SOC and capacity calculation: the
+// window maths, how the per-pack values are derived, how they are summed into
+// the system total, and the extreme-pack override.
+//
+// The inverter sees battery 1's reported_* fields as the whole system, so these
+// are the numbers a wrong result would be charged or discharged against.
+
+namespace {
+
+constexpr uint16_t kWindowMinPct = 1000;  // 10.00%
+constexpr uint16_t kWindowMaxPct = 9000;  // 90.00%
+
+class CalculatedSocTest : public ::testing::Test {
+ protected:
+  static void set_pack(DATALAYER_BATTERY_TYPE& pack, uint16_t real_soc, uint32_t total_Wh, uint32_t remaining_Wh) {
+    pack.status.real_soc = real_soc;
+    pack.info.total_capacity_Wh = total_Wh;
+    pack.status.remaining_capacity_Wh = remaining_Wh;
+  }
+
+  void SetUp() override {
+    datalayer = DataLayer();
+    init_hal();
+
+    if (!battery3) {
+      // The fake battery is the only integration instantiable three times.
+      user_selected_battery_type = BatteryType::TestFake;
+      user_selected_second_battery = true;
+      user_selected_triple_battery = true;
+      setup_battery();
+    }
+    ASSERT_NE(battery, nullptr);
+    ASSERT_NE(battery2, nullptr);
+    ASSERT_NE(battery3, nullptr);
+
+    datalayer.battery.settings.soc_scaling_active = true;
+    datalayer.battery.settings.min_percentage = kWindowMinPct;
+    datalayer.battery.settings.max_percentage = kWindowMaxPct;
+
+    // Three equal 10 kWh packs at 50% unless a test says otherwise.
+    set_pack(datalayer.battery, 5000, 10000, 5000);
+    set_pack(datalayer.battery2, 5000, 10000, 5000);
+    set_pack(datalayer.battery3, 5000, 10000, 5000);
+
+    datalayer.system.status.battery2_allowed_contactor_closing = true;
+    datalayer.system.status.battery3_allowed_contactor_closing = true;
+  }
+
+  // Removes the extra packs for the single-battery cases, since the production
+  // code gates on the pointers.
+  struct SinglePackScope {
+    Battery* saved2;
+    Battery* saved3;
+    SinglePackScope() : saved2(battery2), saved3(battery3) {
+      battery2 = nullptr;
+      battery3 = nullptr;
+    }
+    ~SinglePackScope() {
+      battery2 = saved2;
+      battery3 = saved3;
+    }
+  };
+};
+
+}  // namespace
+
+// --- The window maths ------------------------------------------------------
+
+// 50% real inside a 10-90% window is (50-10)/(90-10) = 50% reported.
+TEST_F(CalculatedSocTest, ScalesRealSocOntoTheConfiguredWindow) {
+  SinglePackScope single;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 5000);
+}
+
+TEST_F(CalculatedSocTest, ReportsEmptyAtAndBelowTheWindowFloor) {
+  SinglePackScope single;
+  datalayer.battery.status.real_soc = kWindowMinPct;
+  update_reported_soc_and_capacity();
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 0);
+
+  // Below the floor clamps rather than going negative.
+  datalayer.battery.status.real_soc = 500;
+  update_reported_soc_and_capacity();
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 0);
+}
+
+TEST_F(CalculatedSocTest, ReportsFullAtAndAboveTheWindowCeiling) {
+  SinglePackScope single;
+  datalayer.battery.status.real_soc = kWindowMaxPct;
+  update_reported_soc_and_capacity();
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 10000);
+
+  datalayer.battery.status.real_soc = 9500;
+  update_reported_soc_and_capacity();
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 10000);
+}
+
+// A zero-width window would divide by zero.
+TEST_F(CalculatedSocTest, ZeroWidthWindowReportsZeroRatherThanDividingByZero) {
+  SinglePackScope single;
+  datalayer.battery.settings.min_percentage = 5000;
+  datalayer.battery.settings.max_percentage = 5000;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 0);
+}
+
+TEST_F(CalculatedSocTest, ScalingDisabledReportsRealValuesUnchanged) {
+  SinglePackScope single;
+  datalayer.battery.settings.soc_scaling_active = false;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 5000);
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 10000u);
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 5000u);
+}
+
+// Usable capacity is only the part inside the window: 80% of 10 kWh.
+TEST_F(CalculatedSocTest, ReportedCapacityCoversOnlyTheWindow) {
+  SinglePackScope single;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 8000u);
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 4000u);
+}
+
+// A pack reporting zero SOC takes the fallback branch, which copies the raw
+// capacity across instead of scaling it. Pinned because the fallback must not
+// hand the inverter a full-size capacity for a pack that is empty - and because
+// the guard mixes two conditions that are easy to get wrong separately.
+TEST_F(CalculatedSocTest, ZeroRealSocFallsBackToRawCapacityRatherThanScaling) {
+  SinglePackScope single;
+  set_pack(datalayer.battery, 0, 10000, 0);
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 10000u)
+      << "the fallback reports the raw capacity, not the windowed one";
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 0u);
+}
+
+// The same fallback fires when a pack has no capacity figure at all.
+TEST_F(CalculatedSocTest, UnknownCapacityFallsBackRatherThanScalingToZero) {
+  SinglePackScope single;
+  set_pack(datalayer.battery, 5000, 0, 4000);
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 0u);
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 4000u)
+      << "the raw remaining capacity is passed through when it cannot be scaled";
+}
+
+// --- Multi-pack aggregation ------------------------------------------------
+
+TEST_F(CalculatedSocTest, TwoPacksSumIntoTheSystemTotal) {
+  Battery* saved3 = battery3;
+  battery3 = nullptr;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 16000u);
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 8000u);
+
+  battery3 = saved3;
+}
+
+// The regression: with scaling active the third pack used to be left out of the
+// sum entirely, so a triple-pack system reported two thirds of its capacity.
+TEST_F(CalculatedSocTest, ThirdPackIsIncludedInTheSystemTotalWhenScaling) {
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 24000u)
+      << "battery 3's capacity must be part of the system total";
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 12000u);
+}
+
+TEST_F(CalculatedSocTest, ThirdPackIsIncludedWithScalingDisabledToo) {
+  datalayer.battery.settings.soc_scaling_active = false;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 30000u);
+  EXPECT_EQ(datalayer.battery.status.reported_remaining_capacity_Wh, 15000u);
+}
+
+// Each pack's own capacity has to drive its own reported figures. Battery 1's
+// scaled capacity used to be copied onto the extra packs, so a system with
+// differently sized packs reported the wrong totals.
+TEST_F(CalculatedSocTest, EachPackIsScaledFromItsOwnCapacity) {
+  set_pack(datalayer.battery, 5000, 10000, 5000);
+  set_pack(datalayer.battery2, 5000, 20000, 10000);  // twice the size
+  set_pack(datalayer.battery3, 5000, 5000, 2500);    // half the size
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery2.info.reported_total_capacity_Wh, 16000u) << "pack 2 must be scaled from its own 20 kWh";
+  EXPECT_EQ(datalayer.battery3.info.reported_total_capacity_Wh, 4000u) << "pack 3 must be scaled from its own 5 kWh";
+  // 8000 + 16000 + 4000
+  EXPECT_EQ(datalayer.battery.info.reported_total_capacity_Wh, 28000u);
+}
+
+// --- Per-pack reported SOC -------------------------------------------------
+
+// The #2751 display symptom: the extra packs reported their raw SOC while
+// battery 1 reported a scaled one, so the screen mixed the two domains.
+TEST_F(CalculatedSocTest, EveryPackReportsScaledSocWhenScalingIsActive) {
+  set_pack(datalayer.battery, 5000, 10000, 5000);
+  set_pack(datalayer.battery2, 3000, 10000, 3000);
+  set_pack(datalayer.battery3, 7000, 10000, 7000);
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 5000);
+  EXPECT_EQ(datalayer.battery2.status.reported_soc, 2500) << "(30-10)/(90-10) = 25%";
+  EXPECT_EQ(datalayer.battery3.status.reported_soc, 7500) << "(70-10)/(90-10) = 75%";
+}
+
+TEST_F(CalculatedSocTest, EveryPackReportsRealSocWhenScalingIsDisabled) {
+  datalayer.battery.settings.soc_scaling_active = false;
+  set_pack(datalayer.battery2, 3000, 10000, 3000);
+  set_pack(datalayer.battery3, 7000, 10000, 7000);
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery2.status.reported_soc, 3000);
+  EXPECT_EQ(datalayer.battery3.status.reported_soc, 7000);
+}
+
+// --- The extreme-pack override ---------------------------------------------
+
+// A nearly empty extra pack must pull the system's reported SOC down so the
+// inverter stops discharging - but the value written has to stay in the scaled
+// domain, since that is the field the inverter reads.
+TEST_F(CalculatedSocTest, NearlyEmptyExtraPackOverridesWithAScaledValue) {
+  datalayer.battery2.status.real_soc = 50;  // below the 1% extreme threshold
+
+  update_reported_soc_and_capacity();
+
+  // 0.5% real is below the window floor, so it scales to 0 - not the raw 50.
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 0)
+      << "the override must not write an unscaled value into the reported field";
+}
+
+TEST_F(CalculatedSocTest, NearlyFullExtraPackOverridesWithAScaledValue) {
+  datalayer.battery2.status.real_soc = 9950;  // above the 99% extreme threshold
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 10000);
+}
+
+// With scaling off the override is the raw value, because everything is raw.
+TEST_F(CalculatedSocTest, ExtremeOverrideUsesRawValueWhenScalingDisabled) {
+  datalayer.battery.settings.soc_scaling_active = false;
+  datalayer.battery2.status.real_soc = 50;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 50);
+}
+
+// A pack that is not in the mix must not drag the system reading with it.
+TEST_F(CalculatedSocTest, ExtremePackIsIgnoredWhileItsContactorsAreOpen) {
+  datalayer.system.status.battery2_allowed_contactor_closing = false;
+  datalayer.battery2.status.real_soc = 50;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 5000) << "a disconnected pack must not override the system SOC";
+}
+
+TEST_F(CalculatedSocTest, ThirdPackAtAnExtremeAlsoOverrides) {
+  datalayer.battery3.status.real_soc = 9950;
+
+  update_reported_soc_and_capacity();
+
+  EXPECT_EQ(datalayer.battery.status.reported_soc, 10000);
+}


### PR DESCRIPTION
Three defects in the reported SOC and capacity, all of which reach the inverter.

- **With SOC scaling active, battery 3 was left out of the system capacity entirely.** The scaling branch summed only batteries 1 and 2, while the unscaled branch summed all three — so a triple-pack system with scaling on reported roughly two thirds of its real capacity.
- **The extra packs were scaled using battery 1's capacity rather than their own**, and the decision whether to scale them at all was taken from battery 1's SOC. Systems whose packs differ in size reported the wrong figures for every pack but the first.
- **When an extra pack reached either extreme, its raw `real_soc` was written into `reported_soc`**, which is the scaled field. With a window configured, the reported SOC jumped from the scaled domain to the raw one the moment a pack crossed 1% or 99%. The extra packs also published their raw SOC for the display while battery 1 published a scaled one, which is the mismatch reported in #2751 — this fixes that as well as the two above, so it is mentioned here rather than closing that issue automatically.

Each pack is now scaled from its own values, the system total sums every configured pack, and the extreme-pack override carries the scaled figure. The window maths lives in one helper used by all of them, so a raw value and a scaled one can no longer be mixed by accident.

The first commit is pure code motion and changes no logic: the calculation moves out of `Software.cpp` into `src/datalayer/calculated_soc.cpp`. That is what makes it testable at all — `Software.cpp` is the Arduino entry point and pulls in the webserver, wifi, mqtt, sdcard and display stacks, so nothing in it can be reached from the host test suite without emulating most of the device. Devkit flash grows 52 bytes, which is the call that is no longer inlined.

19 tests. Six fail against the extraction-only commit — one per defect plus the extreme-override cases — and the remaining thirteen pass either way as regression guards, including the single-pack path that most systems run and the fallback paths for a pack with no capacity or zero SOC.

Note: drafted with AI assistance, reviewed by me.
