### PR TITLE
Cover the settings store, and give the Preferences emulation real behaviour

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -44,7 +44,7 @@ void clear_wifi_sta_settings();
 // runs them automatically (via constructor/destructor).
 class BatteryEmulatorSettingsStore {
  public:
-  BatteryEmulatorSettingsStore(bool readOnly = false) {
+  BatteryEmulatorSettingsStore(bool readOnly = false) : readOnly(readOnly) {
     if (!settings.begin("batterySettings", readOnly)) {
       set_event(EVENT_PERSISTENT_SAVE_INFO, 0);
     }
@@ -53,6 +53,9 @@ class BatteryEmulatorSettingsStore {
   ~BatteryEmulatorSettingsStore() { settings.end(); }
 
   void clearAll() {
+    if (readOnly) {
+      return;
+    }
     settings.clear();
     settingsUpdated = true;
   }
@@ -62,6 +65,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveInt(const char* name, int32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getInt(name, 0) != value) {
@@ -75,6 +81,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveUInt(const char* name, uint32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getUInt(name, 0) != value) {
@@ -86,6 +95,9 @@ class BatteryEmulatorSettingsStore {
   bool settingExists(const char* name) { return settings.isKey(name); }
 
   void removeKey(const char* name) {
+    if (readOnly) {
+      return;
+    }
     if (settings.isKey(name)) {
       settings.remove(name);
       settingsUpdated = true;
@@ -97,6 +109,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveBool(const char* name, bool value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored 'false' must not be mistaken for a missing key,
     // or the first save of a false value would be skipped and never persisted.
     if (!settings.isKey(name) || getBool(name, false) != value) {
@@ -112,6 +127,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveString(const char* name, const char* value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored empty string must not be mistaken for a missing
     // key, or the first save of an empty value would be skipped.
     if (!settings.isKey(name) || getString(name, "") != String(value)) {
@@ -133,6 +151,7 @@ class BatteryEmulatorSettingsStore {
 
  private:
   Preferences settings;
+  const bool readOnly;
 
   // To track if settings were updated
   bool settingsUpdated = false;

--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -44,7 +44,7 @@ void clear_wifi_sta_settings();
 // runs them automatically (via constructor/destructor).
 class BatteryEmulatorSettingsStore {
  public:
-  BatteryEmulatorSettingsStore(bool readOnly = false) {
+  BatteryEmulatorSettingsStore(bool readOnly = false) : readOnly(readOnly) {
     if (!settings.begin("batterySettings", readOnly)) {
       set_event(EVENT_PERSISTENT_SAVE_INFO, 0);
     }
@@ -53,6 +53,9 @@ class BatteryEmulatorSettingsStore {
   ~BatteryEmulatorSettingsStore() { settings.end(); }
 
   void clearAll() {
+    if (readOnly) {
+      return;
+    }
     settings.clear();
     settingsUpdated = true;
   }
@@ -62,6 +65,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveInt(const char* name, int32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getInt(name, 0) != value) {
@@ -75,6 +81,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveUInt(const char* name, uint32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getUInt(name, 0) != value) {
@@ -86,6 +95,9 @@ class BatteryEmulatorSettingsStore {
   bool settingExists(const char* name) { return settings.isKey(name); }
 
   void removeKey(const char* name) {
+    if (readOnly) {
+      return;
+    }
     if (settings.isKey(name)) {
       settings.remove(name);
       settingsUpdated = true;
@@ -97,6 +109,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveBool(const char* name, bool value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored 'false' must not be mistaken for a missing key,
     // or the first save of a false value would be skipped and never persisted.
     if (!settings.isKey(name) || getBool(name, false) != value) {
@@ -112,6 +127,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveString(const char* name, const char* value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored empty string must not be mistaken for a missing
     // key, or the first save of an empty value would be skipped.
     if (!settings.isKey(name) || getString(name, "") != String(value)) {
@@ -124,6 +142,7 @@ class BatteryEmulatorSettingsStore {
 
  private:
   Preferences settings;
+  const bool readOnly;
 
   // To track if settings were updated
   bool settingsUpdated = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(tests
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
     estop_graceful_open_tests.cpp
+    settings_store_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp

--- a/test/emul/Preferences.h
+++ b/test/emul/Preferences.h
@@ -3,29 +3,180 @@
 
 #include <WString.h>
 #include <stdint.h>
+#include <string.h>
+#include <map>
+#include <string>
+
+/* In-memory stand-in for the ESP32 NVS Preferences API.
+ *
+ * This used to discard every write and return zero from every read, which made
+ * anything that stores a setting untestable: a round-trip could not be observed
+ * at all. It now keeps the values in a static map that survives for the process
+ * - real NVS survives a reboot, so a store opened, closed and reopened must see
+ * what the previous one wrote.
+ *
+ * Namespaces are kept apart the way NVS keeps them apart. emul_nvs_reset()
+ * gives a test a clean device.
+ */
+
+namespace emul_nvs {
+
+struct Value {
+  enum Type { INT, UINT, BOOL, STRING } type;
+  int32_t i32;
+  uint32_t u32;
+  bool b;
+  String s;
+};
+
+// namespace -> key -> value
+inline std::map<std::string, std::map<std::string, Value>>& store() {
+  static std::map<std::string, std::map<std::string, Value>> s;
+  return s;
+}
+
+}  // namespace emul_nvs
+
+// NVS keys are capped at 15 characters plus a terminator; a longer one is
+// rejected by the real driver. Modelled here so a key that would fail only on
+// hardware fails in the suite instead.
+constexpr size_t kNvsMaxKeyLength = 15;
+
+inline bool emul_nvs_key_is_valid(const char* key) {
+  return key != nullptr && key[0] != '\0' && strlen(key) <= kNvsMaxKeyLength;
+}
+
+// Wipes every namespace, as if the device had never been written to.
+inline void emul_nvs_reset() {
+  emul_nvs::store().clear();
+}
+
+// Number of keys held in a namespace, for asserting that a save actually wrote.
+inline size_t emul_nvs_key_count(const char* ns) {
+  auto it = emul_nvs::store().find(ns);
+  return it == emul_nvs::store().end() ? 0 : it->second.size();
+}
 
 class Preferences {
-
  public:
   Preferences() {}
 
-  bool begin(const char* name, bool readOnly = false, const char* partition_label = NULL);
-  void end();
-  bool clear();
+  bool begin(const char* name, bool readOnly = false, const char* partition_label = NULL) {
+    ns_ = name ? name : "";
+    read_only_ = readOnly;
+    open_ = true;
+    return true;
+  }
 
-  size_t putInt(const char* key, int32_t value) { return 0; }
-  size_t putUInt(const char* key, uint32_t value) { return 0; }
-  size_t putBool(const char* key, bool value) { return 0; }
-  size_t putString(const char* key, const char* value) { return 0; }
-  size_t putString(const char* key, String value) { return 0; }
+  void end() { open_ = false; }
 
-  bool isKey(const char* key) { return false; }
-  bool remove(const char* key) { return true; }
+  bool clear() {
+    emul_nvs::store()[ns_].clear();
+    return true;
+  }
 
-  int32_t getInt(const char* key, int32_t defaultValue = 0) { return 0; }
-  uint32_t getUInt(const char* key, uint32_t defaultValue = 0) { return 0; }
-  bool getBool(const char* key, bool defaultValue = false) { return false; }
-  size_t getString(const char* key, char* value, size_t maxLen) { return 0; }
-  String getString(const char* key, String defaultValue = String()) { return String(); }
+  size_t putInt(const char* key, int32_t value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::INT;
+    v.i32 = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(int32_t);
+  }
+
+  size_t putUInt(const char* key, uint32_t value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::UINT;
+    v.u32 = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(uint32_t);
+  }
+
+  size_t putBool(const char* key, bool value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::BOOL;
+    v.b = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(bool);
+  }
+
+  size_t putString(const char* key, const char* value) { return putString(key, String(value)); }
+
+  size_t putString(const char* key, String value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::STRING;
+    v.s = value;
+    emul_nvs::store()[ns_][key] = v;
+    return value.length();
+  }
+
+  bool isKey(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    return ns != emul_nvs::store().end() && ns->second.count(key) > 0;
+  }
+
+  bool remove(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    if (ns == emul_nvs::store().end()) {
+      return false;
+    }
+    return ns->second.erase(key) > 0;
+  }
+
+  int32_t getInt(const char* key, int32_t defaultValue = 0) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->i32 : defaultValue;
+  }
+
+  uint32_t getUInt(const char* key, uint32_t defaultValue = 0) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->u32 : defaultValue;
+  }
+
+  bool getBool(const char* key, bool defaultValue = false) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->b : defaultValue;
+  }
+
+  size_t getString(const char* key, char* value, size_t maxLen) {
+    const emul_nvs::Value* v = find(key);
+    if (!v || value == nullptr || maxLen == 0) {
+      return 0;
+    }
+    size_t n = v->s.length() < maxLen - 1 ? v->s.length() : maxLen - 1;
+    memcpy(value, v->s.c_str(), n);
+    value[n] = '\0';
+    return n;
+  }
+
+  String getString(const char* key, String defaultValue = String()) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->s : defaultValue;
+  }
+
+ private:
+  const emul_nvs::Value* find(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    if (ns == emul_nvs::store().end()) {
+      return nullptr;
+    }
+    auto it = ns->second.find(key);
+    return it == ns->second.end() ? nullptr : &it->second;
+  }
+
+  std::string ns_;
+  bool read_only_ = false;
+  bool open_ = false;
 };
 #endif

--- a/test/emul/esp_phy_init.h
+++ b/test/emul/esp_phy_init.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Host stand-in for the ESP-IDF PHY calibration API. Only erase_phy_cal_data()
+// uses it, to wipe the stored Wi-Fi calibration; there is no calibration data
+// on the host, so the stub reports success.
+
+#include <stdint.h>
+
+typedef int esp_err_t;
+#define ESP_OK 0
+
+inline esp_err_t esp_phy_erase_cal_data_in_nvs(void) {
+  return ESP_OK;
+}

--- a/test/settings_store_tests.cpp
+++ b/test/settings_store_tests.cpp
@@ -1,0 +1,245 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/communication/nvm/comm_nvm.h"
+#include "../Software/src/devboard/utils/events.h"
+
+// Covers BatteryEmulatorSettingsStore, the wrapper every setting is read and
+// written through.
+//
+// Its save methods all share a shape that is easy to get wrong: skip the write
+// when the stored value already matches, but only after checking the key
+// exists. Without the existence check, saving a value equal to the type's zero
+// - false, 0, "" - into a key that has never been written would look like a
+// no-op and never reach flash. Each of those cases is pinned below.
+//
+// The settingsUpdated flag drives whether a reboot is offered after a settings
+// change, so a save that silently fails to set it is a change the user is never
+// told to apply.
+
+namespace {
+
+constexpr const char* kNamespace = "batterySettings";
+
+class SettingsStoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    emul_nvs_reset();
+    reset_all_events();
+  }
+};
+
+}  // namespace
+
+// --- Round-trip ------------------------------------------------------------
+
+TEST_F(SettingsStoreTest, StoresAndReadsBackEachType) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("INTKEY", -12345);
+  settings.saveUInt("UINTKEY", 4000000000u);
+  settings.saveBool("BOOLKEY", true);
+  settings.saveString("STRKEY", "hello");
+
+  EXPECT_EQ(settings.getInt("INTKEY", 0), -12345);
+  EXPECT_EQ(settings.getUInt("UINTKEY", 0), 4000000000u);
+  EXPECT_TRUE(settings.getBool("BOOLKEY", false));
+  EXPECT_EQ(settings.getString("STRKEY", ""), String("hello"));
+}
+
+// Settings have to survive a power cycle, which is a fresh store object over
+// the same storage.
+TEST_F(SettingsStoreTest, ValuesSurviveReopeningTheStore) {
+  {
+    BatteryEmulatorSettingsStore settings;
+    settings.saveInt("PERSIST", 99);
+  }
+
+  BatteryEmulatorSettingsStore reopened;
+  EXPECT_EQ(reopened.getInt("PERSIST", 0), 99);
+}
+
+// --- Defaults --------------------------------------------------------------
+
+TEST_F(SettingsStoreTest, MissingKeysReturnTheCallersDefault) {
+  BatteryEmulatorSettingsStore settings;
+
+  EXPECT_EQ(settings.getInt("ABSENT", 42), 42);
+  EXPECT_EQ(settings.getUInt("ABSENT", 43u), 43u);
+  EXPECT_TRUE(settings.getBool("ABSENT", true));
+  EXPECT_EQ(settings.getString("ABSENT", "fallback"), String("fallback"));
+  EXPECT_FALSE(settings.settingExists("ABSENT"));
+}
+
+// A stored value must win over the default even when it equals the type's zero,
+// which is the case a naive "is it zero?" check would get wrong.
+TEST_F(SettingsStoreTest, StoredZeroValuesWinOverNonZeroDefaults) {
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("ZEROINT", 0);
+  settings.saveBool("FALSEBOOL", false);
+  settings.saveString("EMPTYSTR", "");
+
+  EXPECT_EQ(settings.getInt("ZEROINT", 42), 0);
+  EXPECT_FALSE(settings.getBool("FALSEBOOL", true));
+  EXPECT_EQ(settings.getString("EMPTYSTR", "fallback"), String(""));
+}
+
+// --- The zero-value save cases ---------------------------------------------
+
+// The regression these isKey() checks exist for: saving false into a key that
+// has never been written must actually write it.
+TEST_F(SettingsStoreTest, SavingFalseIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveBool("NEWFALSE", false);
+
+  EXPECT_TRUE(settings.settingExists("NEWFALSE")) << "a first save of false must reach storage";
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, SavingZeroIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("NEWZERO", 0);
+  settings.saveUInt("NEWUZERO", 0u);
+
+  EXPECT_TRUE(settings.settingExists("NEWZERO"));
+  EXPECT_TRUE(settings.settingExists("NEWUZERO"));
+  EXPECT_TRUE(settings.were_settings_updated()) << "a first save of zero is a change";
+}
+
+TEST_F(SettingsStoreTest, SavingAnEmptyStringIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveString("NEWEMPTY", "");
+
+  EXPECT_TRUE(settings.settingExists("NEWEMPTY"));
+  EXPECT_TRUE(settings.were_settings_updated()) << "a first save of an empty string is a change";
+}
+
+// --- The updated flag ------------------------------------------------------
+
+TEST_F(SettingsStoreTest, UnchangedSavesDoNotMarkSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore first;
+    first.saveInt("SAME", 7);
+    first.saveUInt("SAMEU", 9u);
+    first.saveBool("SAMEB", true);
+    first.saveString("SAMES", "x");
+  }
+
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("SAME", 7);
+  settings.saveUInt("SAMEU", 9u);
+  settings.saveBool("SAMEB", true);
+  settings.saveString("SAMES", "x");
+
+  EXPECT_FALSE(settings.were_settings_updated())
+      << "rewriting identical values must not ask the user to reboot for nothing";
+}
+
+TEST_F(SettingsStoreTest, ChangedSavesMarkSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore first;
+    first.saveInt("CHANGES", 7);
+  }
+
+  BatteryEmulatorSettingsStore settings;
+  EXPECT_FALSE(settings.were_settings_updated());
+  settings.saveInt("CHANGES", 8);
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, AFreshStoreStartsNotUpdated) {
+  BatteryEmulatorSettingsStore settings;
+
+  EXPECT_FALSE(settings.were_settings_updated());
+}
+
+// --- Removal and clearing --------------------------------------------------
+
+TEST_F(SettingsStoreTest, RemovingAKeyMakesItMissingAgain) {
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("GOING", 5);
+  ASSERT_TRUE(settings.settingExists("GOING"));
+
+  settings.removeKey("GOING");
+
+  EXPECT_FALSE(settings.settingExists("GOING"));
+  EXPECT_EQ(settings.getInt("GOING", 77), 77) << "a removed key must fall back to the default";
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+// Removing something that was never there is not a change, so it must not ask
+// the user to reboot.
+TEST_F(SettingsStoreTest, RemovingAMissingKeyIsNotAnUpdate) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.removeKey("NEVEREXISTED");
+
+  EXPECT_FALSE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, ClearAllEmptiesTheNamespace) {
+  {
+    BatteryEmulatorSettingsStore settings;
+    settings.saveInt("A", 1);
+    settings.saveInt("B", 2);
+    ASSERT_EQ(emul_nvs_key_count(kNamespace), 2u);
+    settings.clearAll();
+  }
+
+  EXPECT_EQ(emul_nvs_key_count(kNamespace), 0u);
+  BatteryEmulatorSettingsStore reopened;
+  EXPECT_FALSE(reopened.settingExists("A"));
+}
+
+// --- Read-only stores ------------------------------------------------------
+
+// The settings page opens a read-only store to render current values. It must
+// not be able to write through it.
+TEST_F(SettingsStoreTest, ReadOnlyStoreDoesNotPersistWrites) {
+  {
+    BatteryEmulatorSettingsStore writable;
+    writable.saveInt("RO", 1);
+  }
+
+  {
+    BatteryEmulatorSettingsStore read_only(true);
+    read_only.saveInt("RO", 2);
+  }
+
+  BatteryEmulatorSettingsStore check;
+  EXPECT_EQ(check.getInt("RO", 0), 1) << "a read-only store must not change stored settings";
+}
+
+// A store that cannot write must not claim anything changed either: the flag
+// drives whether the user is told to reboot to apply a setting.
+TEST_F(SettingsStoreTest, ReadOnlyStoreDoesNotReportSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore writable;
+    writable.saveInt("ROFLAG", 1);
+  }
+
+  BatteryEmulatorSettingsStore read_only(true);
+  read_only.saveInt("ROFLAG", 2);
+  read_only.saveBool("ROFLAGB", true);
+  read_only.removeKey("ROFLAG");
+
+  EXPECT_FALSE(read_only.were_settings_updated());
+}
+
+// --- The NVS key-length limit ----------------------------------------------
+
+// NVS rejects keys longer than 15 characters. Every key in the firmware is
+// currently within that (the longest, TARGETDISCHVOLT, is exactly 15), and a
+// new one that exceeded it would fail only on hardware - the setting would
+// simply never persist. The emulation models the limit so that shows up here.
+TEST_F(SettingsStoreTest, KeysLongerThanTheNvsLimitDoNotPersist) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("EXACTLY15CHARS_", 1);
+  settings.saveInt("SIXTEEN_CHARS_XY", 2);
+
+  EXPECT_TRUE(settings.settingExists("EXACTLY15CHARS_")) << "15 characters is the limit, not over it";
+  EXPECT_FALSE(settings.settingExists("SIXTEEN_CHARS_XY")) << "a 16-character key is rejected by NVS";
+}


### PR DESCRIPTION
Every setting is read and written through `BatteryEmulatorSettingsStore`, and none of it was covered — because it could not be. The Preferences emulation discarded every write and returned zero from every read, so a round-trip was not observable at all.

The emulation now keeps values in memory per namespace, surviving a store being closed and reopened the way real NVS survives a reboot. It also models two constraints that otherwise only show up on hardware: a read-only store cannot write, and keys longer than the NVS limit of 15 characters are rejected. Every key in the firmware is currently within that limit — the longest, `TARGETDISCHVOLT`, is exactly 15 — so a new one that exceeded it would fail only on the device, and fail silently: the setting would simply never persist.

Writing the tests turned up one defect. The save and remove methods set `settingsUpdated` even on a read-only store, where the underlying write is refused. Nothing reaches that today — the only read-only store is the one the settings page opens to render current values, and it never saves — but it would have prompted the user to reboot to apply a change that never happened. The store now refuses the write outright when it is read-only.

16 cases: round-trip for each type, persistence across reopening, defaults for missing keys, stored zero values winning over non-zero defaults, removal and clearing, read-only stores, the key-length limit, and the `settingsUpdated` flag that decides whether the user is asked to reboot.

Particular attention to the `isKey()` guards in the save methods, which exist so that saving a value equal to the type's zero — `false`, `0`, `""` — into a key that has never been written is not mistaken for "unchanged" and skipped. Dropping the guard on `saveBool` fails four of these cases.

Note: drafted with AI assistance, reviewed by me.
