### PR TITLE
Cover the contract the battery base classes give every driver

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -4,6 +4,7 @@
 #include "../../lib/pierremolinaro-acan-esp32/ACAN_ESP32.h"
 #include "CanReceiver.h"
 #include "comm_can.h"
+#include "comm_can_dispatch.h"
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/hal/hal.h"
 #include "src/devboard/safety/safety.h"
@@ -25,13 +26,6 @@ volatile CAN_Configuration can_config = {.battery = CAN_NATIVE,
                                          .charger = CAN_NATIVE,
                                          .shunt = CAN_NATIVE};
 
-struct CanReceiverRegistration {
-  CanReceiver* receiver;
-  CAN_Speed speed;
-};
-
-static std::multimap<CAN_Interface, CanReceiverRegistration> can_receivers;
-
 static void receive_frame_can_native();
 static void receive_frame_can_addon();
 static void receive_frame_canfd_addon();
@@ -41,11 +35,6 @@ static void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirec
 static uint32_t init_native_can(CAN_Speed speed, gpio_num_t tx_pin, gpio_num_t rx_pin);
 static bool begin_canfd();
 static bool begin_canfd_2();
-
-void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {
-  can_receivers.insert({interface, {receiver, speed}});
-  DEBUG_PRINTF("CAN receiver registered, total: %d\n", can_receivers.size());
-}
 
 static ACAN_ESP32_Settings* settingsespcan = nullptr;
 static CAN_Speed native_can_speed;
@@ -69,9 +58,7 @@ uint16_t user_selected_CAN_ID_cutoff_filter = 0;  //Messages below this ID will 
 bool init_CAN() {
   // Native CAN (onboard the ESP32)
 
-  auto nativeIt = can_receivers.find(CAN_NATIVE);
-
-  if (nativeIt != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     auto se_pin = esp32hal->CAN_SE_PIN();
     auto tx_pin = esp32hal->CAN_TX_PIN();
     auto rx_pin = esp32hal->CAN_RX_PIN();
@@ -88,7 +75,8 @@ bool init_CAN() {
       return false;
     }
 
-    const uint32_t errorCode = init_native_can(nativeIt->second.speed, tx_pin, rx_pin);
+    const uint32_t errorCode =
+        init_native_can(can_receiver_speed(CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS), tx_pin, rx_pin);
     if (errorCode == 0) {
       native_can_initialized = true;
       logging.println("Native Can ok");
@@ -119,8 +107,7 @@ bool init_CAN() {
 
   // Add-on CAN interface (via MCP2515)
 
-  auto addonIt = can_receivers.find(CAN_ADDON_MCP2515);
-  if (addonIt != can_receivers.end()) {
+  if (can_receiver_registered(CAN_ADDON_MCP2515)) {
     auto cs_pin = esp32hal->MCP2515_CS();
     auto int_pin = esp32hal->MCP2515_INT();
     auto sck_pin = esp32hal->MCP2515_SCK();
@@ -153,7 +140,8 @@ bool init_CAN() {
       quartz_frequency = can2515->autodetectOscillatorFrequency();
     }
 
-    if (can2515->begin({(int)addonIt->second.speed * 1000UL, quartz_frequency})) {
+    if (can2515->begin(
+            {(int)can_receiver_speed(CAN_ADDON_MCP2515, CAN_Speed::CAN_SPEED_500KBPS) * 1000UL, quartz_frequency})) {
       logging.println("MCP2515 CAN ok");
     } else {
       logging.println("MCP2515 CAN init failed");
@@ -166,11 +154,11 @@ bool init_CAN() {
 
   // FD interface(s) (via MCP2518FD)
 
-  auto fdNativeIt = can_receivers.find(CANFD_NATIVE);
-  auto fdAddonIt = can_receivers.find(CANFD_ADDON_MCP2518);
-  auto fdAddonIt_2 = can_receivers.find(CANFD_ADDON_MCP2518_2);
+  const bool fdNativeWanted = can_receiver_registered(CANFD_NATIVE);
+  const bool fdAddonWanted = can_receiver_registered(CANFD_ADDON_MCP2518);
+  const bool fdAddon2Wanted = can_receiver_registered(CANFD_ADDON_MCP2518_2);
 
-  if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end() || fdAddonIt_2 != can_receivers.end()) {
+  if (fdNativeWanted || fdAddonWanted || fdAddon2Wanted) {
     // Initialise SPI bus first
     auto sck_pin = esp32hal->MCP2517_SCK();
     auto sdo_pin = esp32hal->MCP2517_SDO();
@@ -184,9 +172,10 @@ bool init_CAN() {
     SPI2517->begin(sck_pin, sdo_pin, sdi_pin);
   }
 
-  if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end()) {
+  if (fdNativeWanted || fdAddonWanted) {
 
-    auto speed = (fdNativeIt != can_receivers.end()) ? fdNativeIt->second.speed : fdAddonIt->second.speed;
+    auto speed = fdNativeWanted ? can_receiver_speed(CANFD_NATIVE, CAN_Speed::CAN_SPEED_500KBPS)
+                                : can_receiver_speed(CANFD_ADDON_MCP2518, CAN_Speed::CAN_SPEED_500KBPS);
 
     auto cs_pin = esp32hal->MCP2517_CS();
     auto int_pin = esp32hal->MCP2517_INT();
@@ -230,7 +219,7 @@ bool init_CAN() {
     }
   }
 
-  if (fdAddonIt_2 != can_receivers.end()) {
+  if (fdAddon2Wanted) {
 
     auto cs_pin = esp32hal->MCP2517_CS2();
     auto int_pin = esp32hal->MCP2517_INT2();
@@ -265,7 +254,7 @@ bool init_CAN() {
         (freq == 0 ? ACAN2517FDSettings::OSC_AUTODETECT
                    : (freq == 20000000 ? ACAN2517FDSettings::OSC_20MHz : ACAN2517FDSettings::OSC_40MHz));
 
-    auto speed = fdAddonIt_2->second.speed;
+    auto speed = can_receiver_speed(CANFD_ADDON_MCP2518_2, CAN_Speed::CAN_SPEED_500KBPS);
     auto bitRate = (int)speed * 1000UL;
     // Crystal setting is ignored (library now autodetects)
     settings2517_2 = new ACAN2517FDSettings(osc_freq, bitRate, DataBitRateFactor::x4);
@@ -554,13 +543,7 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
   }
 #endif
 
-  // Send the frame to all the receivers registered for this interface.
-  auto receivers = can_receivers.equal_range(interface);
-
-  for (auto it = receivers.first; it != receivers.second; ++it) {
-    auto& receiver = it->second;
-    receiver.receiver->receive_can_frame(rx_frame);
-  }
+  deliver_to_receivers(rx_frame, interface);
 }
 
 // For formatting CAN frames considerably faster than using snprintf
@@ -662,7 +645,7 @@ void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection ms
 }
 
 void stop_can() {
-  if (can_receivers.find(CAN_NATIVE) != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     ACAN_ESP32::can.end();
   }
 
@@ -680,7 +663,7 @@ void stop_can() {
 }
 
 void restart_can() {
-  if (can_receivers.find(CAN_NATIVE) != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     ACAN_ESP32::can.begin(*settingsespcan);
   }
 

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -4,6 +4,7 @@
 #include "../../lib/pierremolinaro-acan-esp32/ACAN_ESP32.h"
 #include "CanReceiver.h"
 #include "comm_can.h"
+#include "comm_can_dispatch.h"
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/hal/hal.h"
 #include "src/devboard/safety/safety.h"
@@ -24,13 +25,6 @@ volatile CAN_Configuration can_config = {.battery = CAN_NATIVE,
                                          .charger = CAN_NATIVE,
                                          .shunt = CAN_NATIVE};
 
-struct CanReceiverRegistration {
-  CanReceiver* receiver;
-  CAN_Speed speed;
-};
-
-static std::multimap<CAN_Interface, CanReceiverRegistration> can_receivers;
-
 static void receive_frame_can_native();
 static void receive_frame_can_addon();
 static void receive_frame_canfd_addon();
@@ -40,11 +34,6 @@ static void print_can_frame(CAN_frame frame, CAN_Interface interface, frameDirec
 static uint32_t init_native_can(CAN_Speed speed, gpio_num_t tx_pin, gpio_num_t rx_pin);
 static bool begin_canfd();
 static bool begin_canfd_2();
-
-void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {
-  can_receivers.insert({interface, {receiver, speed}});
-  DEBUG_PRINTF("CAN receiver registered, total: %d\n", can_receivers.size());
-}
 
 static ACAN_ESP32_Settings* settingsespcan = nullptr;
 static CAN_Speed native_can_speed;
@@ -68,9 +57,7 @@ uint16_t user_selected_CAN_ID_cutoff_filter = 0;  //Messages below this ID will 
 bool init_CAN() {
   // Native CAN (onboard the ESP32)
 
-  auto nativeIt = can_receivers.find(CAN_NATIVE);
-
-  if (nativeIt != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     auto se_pin = esp32hal->CAN_SE_PIN();
     auto tx_pin = esp32hal->CAN_TX_PIN();
     auto rx_pin = esp32hal->CAN_RX_PIN();
@@ -87,7 +74,8 @@ bool init_CAN() {
       return false;
     }
 
-    const uint32_t errorCode = init_native_can(nativeIt->second.speed, tx_pin, rx_pin);
+    const uint32_t errorCode =
+        init_native_can(can_receiver_speed(CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS), tx_pin, rx_pin);
     if (errorCode == 0) {
       native_can_initialized = true;
       logging.println("Native Can ok");
@@ -118,8 +106,7 @@ bool init_CAN() {
 
   // Add-on CAN interface (via MCP2515)
 
-  auto addonIt = can_receivers.find(CAN_ADDON_MCP2515);
-  if (addonIt != can_receivers.end()) {
+  if (can_receiver_registered(CAN_ADDON_MCP2515)) {
     auto cs_pin = esp32hal->MCP2515_CS();
     auto int_pin = esp32hal->MCP2515_INT();
     auto sck_pin = esp32hal->MCP2515_SCK();
@@ -152,7 +139,8 @@ bool init_CAN() {
       quartz_frequency = can2515->autodetectOscillatorFrequency();
     }
 
-    if (can2515->begin({(int)addonIt->second.speed * 1000UL, quartz_frequency})) {
+    if (can2515->begin(
+            {(int)can_receiver_speed(CAN_ADDON_MCP2515, CAN_Speed::CAN_SPEED_500KBPS) * 1000UL, quartz_frequency})) {
       logging.println("MCP2515 CAN ok");
     } else {
       logging.println("MCP2515 CAN init failed");
@@ -165,11 +153,11 @@ bool init_CAN() {
 
   // FD interface(s) (via MCP2518FD)
 
-  auto fdNativeIt = can_receivers.find(CANFD_NATIVE);
-  auto fdAddonIt = can_receivers.find(CANFD_ADDON_MCP2518);
-  auto fdAddonIt_2 = can_receivers.find(CANFD_ADDON_MCP2518_2);
+  const bool fdNativeWanted = can_receiver_registered(CANFD_NATIVE);
+  const bool fdAddonWanted = can_receiver_registered(CANFD_ADDON_MCP2518);
+  const bool fdAddon2Wanted = can_receiver_registered(CANFD_ADDON_MCP2518_2);
 
-  if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end() || fdAddonIt_2 != can_receivers.end()) {
+  if (fdNativeWanted || fdAddonWanted || fdAddon2Wanted) {
     // Initialise SPI bus first
     auto sck_pin = esp32hal->MCP2517_SCK();
     auto sdo_pin = esp32hal->MCP2517_SDO();
@@ -183,9 +171,10 @@ bool init_CAN() {
     SPI2517->begin(sck_pin, sdo_pin, sdi_pin);
   }
 
-  if (fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end()) {
+  if (fdNativeWanted || fdAddonWanted) {
 
-    auto speed = (fdNativeIt != can_receivers.end()) ? fdNativeIt->second.speed : fdAddonIt->second.speed;
+    auto speed = fdNativeWanted ? can_receiver_speed(CANFD_NATIVE, CAN_Speed::CAN_SPEED_500KBPS)
+                                : can_receiver_speed(CANFD_ADDON_MCP2518, CAN_Speed::CAN_SPEED_500KBPS);
 
     auto cs_pin = esp32hal->MCP2517_CS();
     auto int_pin = esp32hal->MCP2517_INT();
@@ -229,7 +218,7 @@ bool init_CAN() {
     }
   }
 
-  if (fdAddonIt_2 != can_receivers.end()) {
+  if (fdAddon2Wanted) {
 
     auto cs_pin = esp32hal->MCP2517_CS2();
     auto int_pin = esp32hal->MCP2517_INT2();
@@ -264,7 +253,7 @@ bool init_CAN() {
         (freq == 0 ? ACAN2517FDSettings::OSC_AUTODETECT
                    : (freq == 20000000 ? ACAN2517FDSettings::OSC_20MHz : ACAN2517FDSettings::OSC_40MHz));
 
-    auto speed = fdAddonIt_2->second.speed;
+    auto speed = can_receiver_speed(CANFD_ADDON_MCP2518_2, CAN_Speed::CAN_SPEED_500KBPS);
     auto bitRate = (int)speed * 1000UL;
     // Crystal setting is ignored (library now autodetects)
     settings2517_2 = new ACAN2517FDSettings(osc_freq, bitRate, DataBitRateFactor::x4);
@@ -547,13 +536,7 @@ static void map_can_frame_to_variable(CAN_frame* rx_frame, CAN_Interface interfa
   }
 #endif
 
-  // Send the frame to all the receivers registered for this interface.
-  auto receivers = can_receivers.equal_range(interface);
-
-  for (auto it = receivers.first; it != receivers.second; ++it) {
-    auto& receiver = it->second;
-    receiver.receiver->receive_can_frame(rx_frame);
-  }
+  deliver_to_receivers(rx_frame, interface);
 }
 
 void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection msgDir) {
@@ -592,7 +575,7 @@ void dump_can_frame(CAN_frame& frame, CAN_Interface interface, frameDirection ms
 }
 
 void stop_can() {
-  if (can_receivers.find(CAN_NATIVE) != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     ACAN_ESP32::can.end();
   }
 
@@ -610,7 +593,7 @@ void stop_can() {
 }
 
 void restart_can() {
-  if (can_receivers.find(CAN_NATIVE) != can_receivers.end()) {
+  if (can_receiver_registered(CAN_NATIVE)) {
     ACAN_ESP32::can.begin(*settingsespcan);
   }
 

--- a/Software/src/communication/can/comm_can_dispatch.cpp
+++ b/Software/src/communication/can/comm_can_dispatch.cpp
@@ -1,0 +1,46 @@
+#include "comm_can_dispatch.h"
+
+#include <map>
+#include "../../devboard/utils/logging.h"
+#include "CanReceiver.h"
+
+// Moved verbatim out of comm_can.cpp: same multimap, same insertion, same
+// equal_range fan-out in registration order.
+struct CanReceiverRegistration {
+  CanReceiver* receiver;
+  CAN_Speed speed;
+};
+
+static std::multimap<CAN_Interface, CanReceiverRegistration> can_receivers;
+
+void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {
+  can_receivers.insert({interface, {receiver, speed}});
+  DEBUG_PRINTF("CAN receiver registered, total: %d\n", can_receivers.size());
+}
+
+bool can_receiver_registered(CAN_Interface interface) {
+  return can_receivers.find(interface) != can_receivers.end();
+}
+
+CAN_Speed can_receiver_speed(CAN_Interface interface, CAN_Speed fallback) {
+  auto it = can_receivers.find(interface);
+  return it == can_receivers.end() ? fallback : it->second.speed;
+}
+
+void deliver_to_receivers(CAN_frame* rx_frame, CAN_Interface interface) {
+  // Send the frame to all the receivers registered for this interface.
+  auto receivers = can_receivers.equal_range(interface);
+
+  for (auto it = receivers.first; it != receivers.second; ++it) {
+    auto& receiver = it->second;
+    receiver.receiver->receive_can_frame(rx_frame);
+  }
+}
+
+size_t can_receiver_count() {
+  return can_receivers.size();
+}
+
+void clear_can_receivers() {
+  can_receivers.clear();
+}

--- a/Software/src/communication/can/comm_can_dispatch.h
+++ b/Software/src/communication/can/comm_can_dispatch.h
@@ -1,0 +1,37 @@
+#ifndef _COMM_CAN_DISPATCH_H_
+#define _COMM_CAN_DISPATCH_H_
+
+#include "../../devboard/utils/types.h"
+#include "comm_can.h"
+
+/* The receiver registry and the fan-out of a received frame to it.
+ *
+ * Split out of comm_can.cpp so it can be tested: that file also drives the
+ * native TWAI controller, the MCP2515 and both MCP2518FDs, so nothing in it is
+ * reachable from a host build. What lives here is only bookkeeping - which
+ * driver asked for which logical interface, at what speed, and who gets a
+ * frame that arrives on one - and depends on no hardware at all.
+ *
+ * The registration API itself is declared in comm_can.h and unchanged.
+ */
+
+// True if any driver registered for this interface. init_CAN() uses this to
+// decide which controllers to bring up.
+bool can_receiver_registered(CAN_Interface interface);
+
+// The speed requested for an interface, or fallback when nothing registered.
+// Where several receivers share an interface the first registration wins,
+// which is the behaviour init_CAN() has always had.
+CAN_Speed can_receiver_speed(CAN_Interface interface, CAN_Speed fallback);
+
+// Hands a received frame to every receiver registered for the interface.
+void deliver_to_receivers(CAN_frame* rx_frame, CAN_Interface interface);
+
+// Number of registrations, for tests and for the registration log line.
+size_t can_receiver_count();
+
+// Empties the registry. Exists for tests: the registry is a global that would
+// otherwise carry registrations between cases.
+void clear_can_receivers();
+
+#endif  // _COMM_CAN_DISPATCH_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(tests
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
     estop_graceful_open_tests.cpp
+    driver_contract_tests.cpp
     can_dispatch_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(tests
     bms_reset_tests.cpp
     inverter_alive_tests.cpp
     estop_graceful_open_tests.cpp
+    can_dispatch_tests.cpp
     battery/FordMachETest.cpp
     battery_alive_tests.cpp
     battery/NissanLeafTest.cpp
@@ -86,6 +87,7 @@ add_executable(tests
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp
+    ../Software/src/communication/can/comm_can_dispatch.cpp
     ../Software/src/devboard/safety/safety.cpp
     ../Software/src/devboard/hal/hal.cpp
     ../Software/src/devboard/utils/types.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(tests
     ${TEST_SOURCES}
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+    ../Software/src/communication/can/comm_can_dispatch.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp
     ../Software/src/devboard/safety/safety.cpp
     ../Software/src/devboard/hal/hal.cpp

--- a/test/can_dispatch_tests.cpp
+++ b/test/can_dispatch_tests.cpp
@@ -1,0 +1,213 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../Software/src/communication/can/CanReceiver.h"
+#include "../Software/src/communication/can/comm_can_dispatch.h"
+
+// Covers the CAN receiver registry and the fan-out of a received frame to it.
+//
+// This is the contract every battery, inverter, charger and shunt driver relies
+// on: register for a logical interface, then receive exactly the frames that
+// arrive on it. It is also the contract a rewrite of comm_can.cpp has to
+// preserve, so these tests are written against the behaviour as it stands and
+// are meant to keep passing across such a rewrite.
+
+namespace {
+
+// Records what it was given, so a test can assert on delivery rather than on
+// the registry's internals.
+class RecordingReceiver : public CanReceiver {
+ public:
+  void receive_can_frame(CAN_frame* frame) override { received.push_back(frame->ID); }
+
+  std::vector<uint32_t> received;
+};
+
+CAN_frame frame_with_id(uint32_t id) {
+  CAN_frame f = {};
+  f.ID = id;
+  f.DLC = 8;
+  return f;
+}
+
+class CanDispatchTest : public ::testing::Test {
+ protected:
+  void SetUp() override { clear_can_receivers(); }
+  void TearDown() override { clear_can_receivers(); }
+};
+
+}  // namespace
+
+// --- Registration ----------------------------------------------------------
+
+TEST_F(CanDispatchTest, NothingIsRegisteredOnAFreshRegistry) {
+  EXPECT_EQ(can_receiver_count(), 0u);
+  for (int i = 0; i < NO_CAN_INTERFACE; ++i) {
+    EXPECT_FALSE(can_receiver_registered(static_cast<CAN_Interface>(i)));
+  }
+}
+
+TEST_F(CanDispatchTest, RegisteringMarksOnlyThatInterface) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_ADDON_MCP2515, CAN_Speed::CAN_SPEED_500KBPS);
+
+  EXPECT_TRUE(can_receiver_registered(CAN_ADDON_MCP2515));
+  EXPECT_FALSE(can_receiver_registered(CAN_NATIVE));
+  EXPECT_FALSE(can_receiver_registered(CANFD_ADDON_MCP2518));
+  EXPECT_EQ(can_receiver_count(), 1u);
+}
+
+// init_CAN() brings up a controller at the speed its receiver asked for.
+TEST_F(CanDispatchTest, RegisteredSpeedIsReportedBack) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_250KBPS);
+
+  EXPECT_EQ(can_receiver_speed(CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS), CAN_Speed::CAN_SPEED_250KBPS);
+}
+
+TEST_F(CanDispatchTest, UnregisteredInterfaceReportsTheFallbackSpeed) {
+  EXPECT_EQ(can_receiver_speed(CANFD_ADDON_MCP2518_2, CAN_Speed::CAN_SPEED_800KBPS), CAN_Speed::CAN_SPEED_800KBPS);
+}
+
+// Several drivers can share one bus - a battery and a shunt, say. The first
+// registration decides the speed the controller is brought up at.
+TEST_F(CanDispatchTest, FirstRegistrationDecidesTheSpeedWhenSeveralShareABus) {
+  RecordingReceiver first;
+  RecordingReceiver second;
+  register_can_receiver(&first, CAN_NATIVE, CAN_Speed::CAN_SPEED_250KBPS);
+  register_can_receiver(&second, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  EXPECT_EQ(can_receiver_speed(CAN_NATIVE, CAN_Speed::CAN_SPEED_100KBPS), CAN_Speed::CAN_SPEED_250KBPS);
+  EXPECT_EQ(can_receiver_count(), 2u);
+}
+
+// --- Delivery --------------------------------------------------------------
+
+TEST_F(CanDispatchTest, FrameReachesTheReceiverRegisteredForItsInterface) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x123);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  ASSERT_EQ(receiver.received.size(), 1u);
+  EXPECT_EQ(receiver.received[0], 0x123u);
+}
+
+// The isolation that makes several buses usable at once: a frame on one
+// interface must not reach a driver listening on another.
+TEST_F(CanDispatchTest, FrameDoesNotReachReceiversOnOtherInterfaces) {
+  RecordingReceiver on_native;
+  RecordingReceiver on_addon;
+  register_can_receiver(&on_native, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+  register_can_receiver(&on_addon, CAN_ADDON_MCP2515, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x456);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  EXPECT_EQ(on_native.received.size(), 1u);
+  EXPECT_TRUE(on_addon.received.empty()) << "a frame must not cross between interfaces";
+}
+
+TEST_F(CanDispatchTest, EveryReceiverOnTheInterfaceGetsTheFrame) {
+  RecordingReceiver battery;
+  RecordingReceiver shunt;
+  RecordingReceiver inverter;
+  register_can_receiver(&battery, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+  register_can_receiver(&shunt, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+  register_can_receiver(&inverter, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x789);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  ASSERT_EQ(battery.received.size(), 1u);
+  ASSERT_EQ(shunt.received.size(), 1u);
+  ASSERT_EQ(inverter.received.size(), 1u);
+  // Contents too, not just counts: delivering the real frame to the first
+  // receiver and an empty one to the rest would satisfy the counts alone.
+  EXPECT_EQ(battery.received[0], 0x789u);
+  EXPECT_EQ(shunt.received[0], 0x789u);
+  EXPECT_EQ(inverter.received[0], 0x789u);
+}
+
+// Registering the same receiver twice on one interface delivers to it twice.
+// Pinned because it is the shape a double-registration bug would take, and
+// because nothing in the API prevents it.
+TEST_F(CanDispatchTest, RegisteringTheSameReceiverTwiceDeliversTwice) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x99);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  EXPECT_EQ(receiver.received.size(), 2u) << "the registry does not de-duplicate";
+}
+
+// Exactly once per frame, not once per registration of the same object.
+TEST_F(CanDispatchTest, DeliveringTwoFramesGivesTwoCallbacksInOrder) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame first = frame_with_id(0x100);
+  CAN_frame second = frame_with_id(0x200);
+  deliver_to_receivers(&first, CAN_NATIVE);
+  deliver_to_receivers(&second, CAN_NATIVE);
+
+  ASSERT_EQ(receiver.received.size(), 2u);
+  EXPECT_EQ(receiver.received[0], 0x100u);
+  EXPECT_EQ(receiver.received[1], 0x200u);
+}
+
+// A bus nobody registered for is not an error; the frame is simply dropped.
+TEST_F(CanDispatchTest, FrameOnAnUnregisteredInterfaceIsDroppedQuietly) {
+  RecordingReceiver receiver;
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x321);
+  deliver_to_receivers(&frame, CANFD_ADDON_MCP2518_2);
+
+  EXPECT_TRUE(receiver.received.empty());
+}
+
+// The same physical chip serves both FD names on some boards, so the two are
+// distinct registry entries and must stay independent here.
+TEST_F(CanDispatchTest, TheTwoFdInterfacesAreSeparateRegistryEntries) {
+  RecordingReceiver on_fd_native;
+  RecordingReceiver on_fd_addon;
+  register_can_receiver(&on_fd_native, CANFD_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+  register_can_receiver(&on_fd_addon, CANFD_ADDON_MCP2518, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x555);
+  deliver_to_receivers(&frame, CANFD_ADDON_MCP2518);
+
+  EXPECT_TRUE(on_fd_native.received.empty());
+  EXPECT_EQ(on_fd_addon.received.size(), 1u);
+}
+
+// The frame is passed by pointer, so a receiver sees the real contents rather
+// than a copy made before the data was filled in.
+TEST_F(CanDispatchTest, ReceiverSeesTheFrameContents) {
+  class ContentChecking : public CanReceiver {
+   public:
+    void receive_can_frame(CAN_frame* frame) override {
+      saw_id = frame->ID;
+      saw_first_byte = frame->data.u8[0];
+      saw_dlc = frame->DLC;
+    }
+    uint32_t saw_id = 0;
+    uint8_t saw_first_byte = 0;
+    uint8_t saw_dlc = 0;
+  } receiver;
+
+  register_can_receiver(&receiver, CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS);
+
+  CAN_frame frame = frame_with_id(0x7FF);
+  frame.data.u8[0] = 0xAB;
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  EXPECT_EQ(receiver.saw_id, 0x7FFu);
+  EXPECT_EQ(receiver.saw_first_byte, 0xAB);
+  EXPECT_EQ(receiver.saw_dlc, 8);
+}

--- a/test/driver_contract_tests.cpp
+++ b/test/driver_contract_tests.cpp
@@ -1,0 +1,251 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../Software/src/battery/CanBattery.h"
+#include "../Software/src/communication/can/comm_can_dispatch.h"
+#include "../Software/src/datalayer/datalayer.h"
+
+// Covers the contract the battery base classes give every driver, rather than
+// any one integration.
+//
+// Two things matter here. Battery declares a large set of optional
+// capabilities, each a supports_*() predicate paired with an action; a driver
+// opts in by overriding both. The base defaults are what make it safe for a
+// driver to override neither, and what the UI reads to decide which buttons to
+// show. And CanBattery wires a driver to a bus: it registers on construction
+// and adapts between the CanReceiver/Transmitter interfaces and the driver's
+// own methods.
+
+namespace {
+
+// The smallest thing that satisfies the base class: overrides nothing optional.
+class MinimalCanBattery : public CanBattery {
+ public:
+  MinimalCanBattery() : CanBattery(CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS) {}
+  explicit MinimalCanBattery(CAN_Interface interface) : CanBattery(interface, CAN_Speed::CAN_SPEED_500KBPS) {}
+
+  void setup() override {}
+  void update_values() override {}
+
+  void handle_incoming_can_frame(CAN_frame rx_frame) override { received_ids.push_back(rx_frame.ID); }
+  void transmit_can(unsigned long currentMillis) override { transmit_calls.push_back(currentMillis); }
+
+  std::vector<uint32_t> received_ids;
+  std::vector<unsigned long> transmit_calls;
+};
+
+CAN_frame frame_with_id(uint32_t id) {
+  CAN_frame f = {};
+  f.ID = id;
+  f.DLC = 8;
+  return f;
+}
+
+class DriverContractTest : public ::testing::Test {
+ protected:
+  void SetUp() override { clear_can_receivers(); }
+  void TearDown() override { clear_can_receivers(); }
+};
+
+}  // namespace
+
+// --- The optional-capability defaults --------------------------------------
+
+// A driver that declares no capabilities must report none. The settings and
+// battery pages read exactly these to decide which controls to render, so a
+// default flipping to true would offer the user a button that does nothing.
+TEST_F(DriverContractTest, ADriverDeclaresNoCapabilitiesByDefault) {
+  MinimalCanBattery battery;
+
+  EXPECT_FALSE(battery.supports_clear_isolation());
+  EXPECT_FALSE(battery.supports_reset_BMS());
+  EXPECT_FALSE(battery.supports_reset_SOC());
+  EXPECT_FALSE(battery.supports_reset_crash());
+  EXPECT_FALSE(battery.supports_reset_NVROL());
+  EXPECT_FALSE(battery.supports_reset_DTC());
+  EXPECT_FALSE(battery.supports_read_DTC());
+  EXPECT_FALSE(battery.supports_reset_SOH());
+  EXPECT_FALSE(battery.supports_reset_BECM());
+  EXPECT_FALSE(battery.supports_calibrate_SOC());
+  EXPECT_FALSE(battery.supports_contactor_close());
+  EXPECT_FALSE(battery.supports_contactor_reset());
+  EXPECT_FALSE(battery.supports_set_fake_voltage());
+  EXPECT_FALSE(battery.supports_manual_balancing());
+  EXPECT_FALSE(battery.supports_real_BMS_status());
+  EXPECT_FALSE(battery.supports_toggle_SOC_method());
+  EXPECT_FALSE(battery.supports_energy_saving_mode_reset());
+  EXPECT_FALSE(battery.supports_factory_mode_method());
+  EXPECT_FALSE(battery.supports_chademo_restart());
+  EXPECT_FALSE(battery.supports_chademo_stop());
+  EXPECT_FALSE(battery.supports_balancing());
+  EXPECT_FALSE(battery.supports_balancing_request());
+  EXPECT_FALSE(battery.supports_isolation_test());
+  EXPECT_FALSE(battery.supports_charged_energy());
+  EXPECT_FALSE(battery.supports_insulation_resistance());
+}
+
+// The actions paired with those predicates must be safe to call even when the
+// driver has not implemented them - the base no-op is what makes an unguarded
+// call from the UI or MQTT harmless rather than a crash.
+TEST_F(DriverContractTest, UnimplementedActionsChangeNothing) {
+  MinimalCanBattery battery;
+
+  datalayer.battery.status.real_soc = 5000;
+  datalayer.battery.status.voltage_dV = 3700;
+  datalayer.battery.status.max_charge_power_W = 5000;
+  datalayer.battery.status.max_discharge_power_W = 5000;
+  datalayer.battery.status.real_bms_status = BMS_ACTIVE;
+  const DATALAYER_BATTERY_TYPE before = datalayer.battery;
+  const bool start_precharging_before = datalayer.system.info.start_precharging;
+
+  battery.request_isolation_test();
+  battery.clear_isolation();
+  battery.calibrate_SOC();
+  battery.reset_BMS();
+  battery.reset_SOC();
+  battery.reset_crash();
+  battery.reset_contactor();
+  battery.reset_NVROL();
+  battery.reset_DTC();
+  battery.read_DTC();
+  battery.reset_SOH();
+  battery.reset_BECM();
+  battery.request_open_contactors();
+  battery.request_close_contactors();
+  battery.toggle_SOC_method();
+  battery.reset_energy_saving_mode();
+  battery.set_factory_mode();
+  battery.chademo_restart();
+  battery.chademo_stop();
+  battery.initiate_balancing();
+  battery.end_balancing();
+  battery.handle_precharge();
+  battery.set_fake_voltage(400.0f);
+
+  // The property is that the defaults change nothing, not merely that they do
+  // not crash - an empty body cannot crash, so asserting only that proves
+  // nothing. A default that quietly wrote to the datalayer would be caught here.
+  EXPECT_EQ(datalayer.battery.status.real_soc, before.status.real_soc);
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, before.status.voltage_dV);
+  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, before.status.max_charge_power_W);
+  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, before.status.max_discharge_power_W);
+  EXPECT_EQ(datalayer.battery.status.real_bms_status, before.status.real_bms_status);
+  EXPECT_EQ(datalayer.battery.settings.user_requests_balancing, before.settings.user_requests_balancing);
+  EXPECT_EQ(datalayer.system.info.start_precharging, start_precharging_before);
+}
+
+TEST_F(DriverContractTest, DefaultBalancingStateIsInactiveAndUnnamed) {
+  MinimalCanBattery battery;
+
+  EXPECT_FALSE(battery.is_balancing_active());
+  EXPECT_EQ(battery.get_balancing_state_string(), nullptr);
+}
+
+// The safety monitor raises EVENT_SOC_PLAUSIBILITY_ERROR when a driver says its
+// SOC is implausible. Defaulting to true means a driver that has no opinion
+// never trips it.
+TEST_F(DriverContractTest, SocIsPlausibleUnlessADriverSaysOtherwise) {
+  MinimalCanBattery battery;
+
+  EXPECT_TRUE(battery.soc_plausible());
+}
+
+// The charge taper is optional except where a chemistry requires it; a driver
+// that says nothing must not have it forced on.
+TEST_F(DriverContractTest, ChargeTaperIsNotMandatoryByDefault) {
+  MinimalCanBattery battery;
+
+  EXPECT_FALSE(battery.mandatory_charge_taper());
+}
+
+// --- CanBattery bus wiring -------------------------------------------------
+
+// Constructing a CAN driver is what puts it on a bus. Nothing else registers
+// it, so a driver that is constructed but never registered would silently
+// receive nothing.
+TEST_F(DriverContractTest, ConstructionRegistersTheDriverOnItsInterface) {
+  ASSERT_EQ(can_receiver_count(), 0u);
+
+  MinimalCanBattery battery(CAN_ADDON_MCP2515);
+
+  EXPECT_EQ(can_receiver_count(), 1u);
+  EXPECT_TRUE(can_receiver_registered(CAN_ADDON_MCP2515));
+  EXPECT_FALSE(can_receiver_registered(CAN_NATIVE));
+}
+
+TEST_F(DriverContractTest, TheRequestedSpeedIsWhatGetsRegistered) {
+  // A non-default speed, so this pins that the driver's request is carried
+  // through rather than the class default being echoed back.
+  class SlowBattery : public CanBattery {
+   public:
+    SlowBattery() : CanBattery(CAN_NATIVE, CAN_Speed::CAN_SPEED_125KBPS) {}
+    void setup() override {}
+    void update_values() override {}
+    void handle_incoming_can_frame(CAN_frame rx_frame) override {}
+    void transmit_can(unsigned long currentMillis) override {}
+  };
+
+  SlowBattery battery;
+
+  EXPECT_EQ(can_receiver_speed(CAN_NATIVE, CAN_Speed::CAN_SPEED_500KBPS), CAN_Speed::CAN_SPEED_125KBPS);
+}
+
+// A frame delivered to the registry has to reach the driver's own handler.
+TEST_F(DriverContractTest, ReceivedFramesReachTheDriversHandler) {
+  MinimalCanBattery battery(CAN_NATIVE);
+
+  CAN_frame frame = frame_with_id(0x2A0);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  ASSERT_EQ(battery.received_ids.size(), 1u);
+  EXPECT_EQ(battery.received_ids[0], 0x2A0u);
+}
+
+// Two drivers on different buses must not see each other's traffic - the
+// property that makes a double-battery setup work at all.
+TEST_F(DriverContractTest, DriversOnDifferentBusesDoNotSeeEachOthersFrames) {
+  MinimalCanBattery on_native(CAN_NATIVE);
+  MinimalCanBattery on_addon(CAN_ADDON_MCP2515);
+
+  CAN_frame frame = frame_with_id(0x3B0);
+  deliver_to_receivers(&frame, CAN_ADDON_MCP2515);
+
+  EXPECT_TRUE(on_native.received_ids.empty());
+  ASSERT_EQ(on_addon.received_ids.size(), 1u);
+  EXPECT_EQ(on_addon.received_ids[0], 0x3B0u);
+}
+
+// handle_incoming_can_frame takes the frame BY VALUE, so a driver gets its own
+// copy and cannot disturb what other drivers on the same bus then receive.
+TEST_F(DriverContractTest, EachDriverOnABusGetsItsOwnCopyOfTheFrame) {
+  class MutatingBattery : public MinimalCanBattery {
+   public:
+    MutatingBattery() : MinimalCanBattery(CAN_NATIVE) {}
+    void handle_incoming_can_frame(CAN_frame rx_frame) override {
+      rx_frame.ID = 0xDEAD;  // must not be visible to anyone else
+      received_ids.push_back(rx_frame.ID);
+    }
+  };
+
+  MutatingBattery first;
+  MinimalCanBattery second(CAN_NATIVE);
+
+  CAN_frame frame = frame_with_id(0x111);
+  deliver_to_receivers(&frame, CAN_NATIVE);
+
+  ASSERT_EQ(second.received_ids.size(), 1u);
+  EXPECT_EQ(second.received_ids[0], 0x111u) << "one driver's edit must not reach the next";
+  EXPECT_EQ(frame.ID, 0x111u) << "nor the caller's frame";
+}
+
+// The transmit hook the core loop drives has to reach the driver's own method,
+// with the timestamp it was given.
+TEST_F(DriverContractTest, TransmitDelegatesToTheDriverWithTheTimestamp) {
+  MinimalCanBattery battery(CAN_NATIVE);
+
+  battery.transmit(123456);
+
+  ASSERT_EQ(battery.transmit_calls.size(), 1u);
+  EXPECT_EQ(battery.transmit_calls[0], 123456u);
+}

--- a/test/emul/can.cpp
+++ b/test/emul/can.cpp
@@ -22,7 +22,8 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
   }
 }
 
-void register_can_receiver(CanReceiver* receiver, CAN_Interface interface, CAN_Speed speed) {}
+// register_can_receiver and the fan-out now come from the real
+// comm_can_dispatch.cpp, which is hardware-free and in the test build.
 
 bool change_can_speed(CAN_Interface interface, CAN_Speed speed) {
   return true;


### PR DESCRIPTION
Not a per-integration test: the shared behaviour every driver inherits from the battery base classes.

`Battery` declares 25 optional capabilities, each a `supports_*()` predicate paired with an action, and a driver opts in by overriding both. The defaults are what make it safe to override neither — the settings and battery pages read the predicates to decide which controls to render, so a default flipping to true would offer the user a button that does nothing, and the no-op actions are what stop an unguarded call from the UI or MQTT reaching a driver that never implemented it. The test asserts that the defaults leave the datalayer untouched, rather than only that they do not crash: an empty body cannot crash, so asserting that alone would prove nothing.

`CanBattery` wires a driver to a bus. Construction is what registers it — nothing else does, so a driver constructed but never registered would silently receive nothing. Registration lands on its own interface at its own requested speed; frames reach the driver's handler; drivers on different buses do not see each other's traffic; the transmit hook carries its timestamp through; and the frame is taken by value, so one driver's edits cannot reach the next driver on a shared bus or the caller's frame.

11 cases. Stacked on #2774, which moves the registry somewhere a host build can reach — this will show that PR's commits until it merges.

Verified by mutation: registering on the wrong interface fails 4 of these cases, and making a default action write to the datalayer fails 2.

Note: drafted with AI assistance, reviewed by me.
