### PR TITLE
Fix two test-order dependencies, and make CI able to see them

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,3 +29,19 @@ jobs:
       run: |
         cd test/build
         ctest
+
+    # ctest is not enough on its own. test/CMakeLists.txt uses
+    # gtest_discover_tests(), which registers every case as its own ctest test,
+    # so each one runs in a fresh process and no global or static can leak
+    # between them. That makes the step above structurally unable to see an
+    # order dependency. Running the binary directly puts every case in one
+    # process, the way a developer runs it, and shuffling then breaks any
+    # remaining reliance on definition order.
+    - name: Check order independence
+      run: |
+        cd test/build
+        ./tests
+        for seed in 1 7 42 1234 99999; do
+          echo "--- shuffled, seed $seed ---"
+          ./tests --gtest_shuffle --gtest_random_seed=$seed
+        done

--- a/test/inverter_alive_tests.cpp
+++ b/test/inverter_alive_tests.cpp
@@ -8,16 +8,19 @@
 
 // Tests for the inverter CAN aliveness handling in update_machineryprotection().
 //
-// NOTE on ordering: safety.cpp keeps a file-static inverter_detected latch with no
-// reset, so the detection test below must run before any other test in this suite
-// refreshes the counter to >= CAN_STILL_ALIVE. Google Test runs tests within a
-// suite in definition order (as long as shuffling is not enabled), so keep the
-// detection test first in this file.
+// The detection latch in safety.cpp has no reset of its own, so it used to have
+// to be the first test in the file and the suite could not be shuffled. The
+// fixture now clears it directly, the same way battery_alive_tests.cpp clears
+// the battery and charger latches, so these tests are order-independent.
+
+extern bool inverter_detected;
 
 namespace {
 
 void setup_can_inverter_test() {
   datalayer = DataLayer();
+  // Defined in safety.cpp; not exposed via safety.h like the battery latches are.
+  inverter_detected = false;
   reset_all_events();
   init_hal();
   // Avoid tripping the low-heap check (CPU_free_heap defaults to 0)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -7,6 +7,7 @@
 #include "../Software/src/devboard/hal/hal.h"
 #include "../Software/src/devboard/safety/safety.h"
 #include "../Software/src/devboard/utils/events.h"
+#include "../Software/src/inverter/INVERTERS.h"
 
 void RegisterCanLogTests(void);
 void RegisterStillAliveTests(void);
@@ -27,6 +28,12 @@ class DataLayerResetListener : public ::testing::EmptyTestEventListener {
     battery3 = nullptr;
     delete charger;
     charger = nullptr;
+    /* The inverter is the same kind of instance and was the one omission here.
+       It also decides behaviour by TYPE - needs_can_startup_grace() is true for
+       the SMA family and false for the rest - so a test inheriting the previous
+       test's inverter silently runs against the wrong protocol. */
+    delete inverter;
+    inverter = nullptr;
 
     // Selection globals must be owned by each test's own fixture.
     user_selected_second_battery = false;


### PR DESCRIPTION
### What

Two globals leak between test cases, and the unit-test CI cannot see either. Both are live on `main` today; the first fails on a clean checkout right now.

**1. The inverter is never destroyed between cases.** The reset listener in `test/tests.cpp` deletes `battery`, `battery2`, `battery3` and `charger` before every case — "every instance holds pointers into the datalayer we just replaced" — but not `inverter`. It is worse than the others because it decides behaviour by **type**: `needs_can_startup_grace()` is true for the SMA family and false for the rest.

`MillisWrapTest.InverterStartupGraceDoesNotRearmAfterWrap` builds an `SmaBydH` inverter behind an `if (!inverter)` guard, but `InverterAliveTests` has already built a `BydCan` one — its own comment calls it "a plain CAN inverter without the SMA startup grace window" — so the guard reuses it and the grace assertion fails. `setup_inverter()` also returns early when `inverter` is non-null, so nothing established the type either test needed.

**2. `inverter_detected` has no reset.** That is why `inverter_alive_tests.cpp` carried a note requiring its detection test to stay first in the file. The fixture now clears it, the same way `battery_alive_tests.cpp` clears the battery and charger latches, so the note goes away.

### Why CI never caught it

`test/CMakeLists.txt` uses `gtest_discover_tests()`, which registers **every case as its own ctest test**. Each therefore runs in a fresh process where no global can leak, so `ctest` is structurally unable to see an order dependency — a suite can be thoroughly order-dependent and still report green. That is how both of these reached main.

The new step runs the binary directly, once sequentially and then over five **fixed** seeds — fixed rather than random so a failure is reproducible from the log instead of a flake nobody can rerun. It costs about 120 ms.

### Neither fix is sufficient alone

| | sequential | shuffled |
|---|---|---|
| inverter teardown only | passes | fails `DetectionFires…`, 4 of 5 seeds |
| `inverter_detected` only | fails `MillisWrapTest` | + `EstopGracefulOpenTest` at seed 42 |
| **both** | **166 pass** | **166 pass, 8/8 seeds** |

The seed-42 `EstopGracefulOpenTest` failure needed no separate fix — same inverter leak, since SMA versus non-SMA changes contactor behaviour. Three symptoms, two causes.

### Notes

Split out of #2775, which keeps the machinery-protection coverage. The two are independent: verified that #2775 passes without these changes, and that merging them together is clean and green in either order.

@jonny5532 — flagging this to you since you reviewed #2783; this is the test-isolation half of that same ground, and it's small.

Note: drafted with AI assistance, reviewed by me.
