### PR TITLE
Autodetect build version

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -43,6 +43,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       name: Checkout code
+      with:
+        fetch-depth: 0 # To be able to determine the ancestor tag
+
+    - name: "Fetch upstream tags" # for forks
+      run: git fetch https://github.com/dalathegreat/Battery-Emulator.git --tags --no-recurse-submodules
 
     # The env cache should contain the PlatformIO installation, as well as our
     # previously built custom sdkconfig image. We can avoid redownloading
@@ -108,6 +113,10 @@ jobs:
 
     - name: Build image for ${{ matrix.board_name }}
       shell: bash
+      env:
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_PR: ${{ github.event.pull_request.number }}
+        GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -o pipefail
         pio run -e ${{ matrix.pio_env }} 2>&1 | tee checkprogsize.txt

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -28,6 +28,7 @@
 #include "src/devboard/utils/timer.h"
 #include "src/devboard/utils/types.h"
 #include "src/devboard/utils/value_mapping.h"
+#include "src/devboard/utils/version.h"
 #include "src/devboard/utils/watchdog.h"
 #include "src/devboard/webserver/webserver.h"
 #include "src/devboard/wifi/wifi.h"
@@ -39,7 +40,7 @@
 #endif
 
 // The current software version, shown on webserver
-const char* version_number = "12.3.dev";
+const char* version_number = BUILD_VERSION;
 
 // Interval timers. Time values are uint32_t on purpose: that is the width
 // millis() actually has on the target, so the wrap arithmetic is identical on

--- a/Software/src/devboard/utils/version.h
+++ b/Software/src/devboard/utils/version.h
@@ -1,0 +1,23 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+// Assembles BUILD_VERSION from raw macros set by tools/identify_build.py.
+// Each macro is defined only when its value is available.
+
+#if defined(GIT_TAG)
+#define BUILD_VERSION GIT_TAG
+
+#elif defined(GIT_ANCESTOR_TAG) && defined(GIT_SHORT_SHA)
+#if defined(GITHUB_PR) && defined(GITHUB_PR_HEAD_SHORT_SHA)
+#define BUILD_VERSION GIT_ANCESTOR_TAG "dev-" GITHUB_PR_HEAD_SHORT_SHA " (#" GITHUB_PR ")"
+#elif defined(GIT_BRANCH)
+#define BUILD_VERSION GIT_ANCESTOR_TAG "dev-" GIT_SHORT_SHA " (" GIT_BRANCH ")"
+#else
+#define BUILD_VERSION GIT_ANCESTOR_TAG "dev-" GIT_SHORT_SHA
+#endif
+
+#else
+#define BUILD_VERSION "unknown"
+#endif
+
+#endif  // VERSION_H

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -990,7 +990,18 @@ String processor(const String& var) {
     // Start content block
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";
     content += "<div id='bxUpd' style='text-align:center'></div>";
-    content += "<h4>Software: " + String(version_number);
+    content += "<h4>Software: ";
+#if defined(GIT_TAG) && defined(GITHUB_ORG) && defined(GITHUB_REPO)
+    content += "<a href='https://github.com/" GITHUB_ORG "/" GITHUB_REPO "/releases/tag/" GIT_TAG
+               "' target='_blank' style='color:#fff'>" +
+               String(version_number) + "</a>";
+#elif defined(GITHUB_PR) && defined(GITHUB_ORG) && defined(GITHUB_REPO)
+    content += "<a href='https://github.com/" GITHUB_ORG "/" GITHUB_REPO "/pull/" GITHUB_PR
+               "' target='_blank' style='color:#fff'>" +
+               String(version_number) + "</a>";
+#else
+    content += String(version_number);
+#endif
 
 // Show hardware used:
 #ifdef HW_LILYGO

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1685,7 +1685,11 @@ String processor(const String& var) {
     // In-UI update notification (browser-side; skips dev builds, 6h cached) - issue #1660
     content += "<script>";
     content += "(function(){var cur='" + String(version_number) + "';";
-    content += "if(cur.indexOf('dev')>=0)return;";
+#ifdef GIT_TAG
+    content += "if(false)return;";
+#else
+    content += "if(true)return;";
+#endif
     content += "var el=document.getElementById('bxUpd');if(!el)return;";
     content += "function p(v){return v.replace(/^v/,'').split('.').map(function(x){return parseInt(x,10)||0;});}";
     content +=

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ framework = arduino
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 monitor_speed = 115200
 monitor_filters = default, time, log2file, esp32_exception_decoder
+extra_scripts = pre:tools/identify_build.py
 custom_sdkconfig = file://sdkconfig.be_size.defaults
 custom_component_remove =
     espressif/esp_insights

--- a/tools/identify_build.py
+++ b/tools/identify_build.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+
+Import("env")
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL).decode().strip()
+
+
+def define_str(macro, value):
+    safe = value.replace("\\", "\\\\").replace('"', '\\"')
+    env.Append(CPPDEFINES=[(macro, f'\\"{safe}\\"')])
+
+
+# Exact tag (release build)
+try:
+    define_str("GIT_TAG", git("describe", "--tags", "--exact-match"))
+except subprocess.CalledProcessError:
+    pass
+
+# Ancestor tag (dev build base)
+try:
+    define_str("GIT_ANCESTOR_TAG", git("describe", "--tags", "--abbrev=0"))
+except subprocess.CalledProcessError:
+    pass
+
+# Full SHA + short form
+try:
+    sha = git("rev-parse", "HEAD")
+    define_str("GIT_SHA", sha)
+    define_str("GIT_SHORT_SHA", sha[:7])
+except subprocess.CalledProcessError:
+    pass
+
+# GitHub org + repo name (split from "owner/repo")
+if repo_full := os.environ.get("GITHUB_REPOSITORY", "").strip():
+    if "/" in repo_full:
+        org, repo = repo_full.split("/", 1)
+        define_str("GITHUB_ORG", org)
+        define_str("GITHUB_REPO", repo)
+
+# PR number (passed explicitly from workflow env)
+if pr := os.environ.get("GITHUB_PR", "").strip():
+    define_str("GITHUB_PR", pr)
+
+# PR head SHA (the actual PR commit, not the synthetic merge commit)
+if pr_head_sha := os.environ.get("GITHUB_PR_HEAD_SHA", "").strip():
+    define_str("GITHUB_PR_HEAD_SHA", pr_head_sha)
+    define_str("GITHUB_PR_HEAD_SHORT_SHA", pr_head_sha[:7])
+
+# Local branch (omit when detached HEAD)
+try:
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    if branch and branch != "HEAD":
+        define_str("GIT_BRANCH", branch)
+except subprocess.CalledProcessError:
+    pass


### PR DESCRIPTION
### Why
When switching between multiple debug builds the current versioning scheme with a static `12.3.dev` does not tell you what version you are actually running. This means it is possible to accidentially flash the wrong version to a board without a way to notice it.

### What
Therefore with this PR we now read the build information from the environment and pass that information along into our code. We can then use `ifdef`s to emit a build version. There are three main types of versions:
1. Release builds that are directly built from a tag -> we just use that
<img width="1600" height="450" alt="release_build" src="https://github.com/user-attachments/assets/0e177151-554c-497e-9ca8-cbe02956bc3d" />

2. PR builds where we reference the last tag in the history to determine the version. This is arguably more correct than the current statically incremented version since this tells you which changes are already included, whereas `12.3.dev` does not tell you anything about what changes after `12.2` are included. We also reference the bash sha instead of the default merge sha. This is less precise but in my opinion more useful since you can directly compare against the PR.
<img width="1600" height="346" alt="pr_build" src="https://github.com/user-attachments/assets/d11bec8f-c3e4-46ac-bb74-376acd2fc78b" />

3. All other builds like a push use a fallback pattern where we use whatever information is still avialable. As long as a full checkout is present `GIT_ANCESTOR_TAG "dev-" GIT_SHORT_SHA` should always work.

I also added a link so that you can directly go to the Release and PR builds, otherwise this change would even be flash negative.

### How
By adding a small python script that calls git and reads the environment vairables set in the Github workflow.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)