### PR TITLE
Move BMS Power to GPIO45 on T-2CAN FD to avoid pin conflict

### DIFF
--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -81,10 +81,11 @@ class LilyGo2CANHal : public Esp32Hal {
     if (user_selected_gpioopt1 == GPIOOPT1::ESTOP_BMS_POWER) {
       return GPIO_NUM_2;
     }
-    return GPIO_NUM_3;
+    // GPIO3 is used as INT1 on a T-2CAN FD (MCP2518), so use GPIO45 instead.
+    return is_fd() ? GPIO_NUM_45 : GPIO_NUM_3;
   }
-  // Pins to be latched across a reset/OTA reboot (RTC-capable pins only): BMS_POWER is either GPIO2, GPIO3
-  virtual std::vector<gpio_num_t> reset_hold_pins() { return {GPIO_NUM_2, GPIO_NUM_3}; }
+  // Pins to be latched across a reset/OTA reboot (RTC-capable pins only): BMS_POWER is either GPIO2, GPIO3, or GPIO45
+  virtual std::vector<gpio_num_t> reset_hold_pins() { return { GPIO_NUM_2, is_fd() ? GPIO_NUM_45 : GPIO_NUM_3 }; }
   virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_5; }
   virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_4; }
 

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -85,7 +85,7 @@ class LilyGo2CANHal : public Esp32Hal {
     return is_fd() ? GPIO_NUM_45 : GPIO_NUM_3;
   }
   // Pins to be latched across a reset/OTA reboot (RTC-capable pins only): BMS_POWER is either GPIO2, GPIO3, or GPIO45
-  virtual std::vector<gpio_num_t> reset_hold_pins() { return { GPIO_NUM_2, is_fd() ? GPIO_NUM_45 : GPIO_NUM_3 }; }
+  virtual std::vector<gpio_num_t> reset_hold_pins() { return {GPIO_NUM_2, is_fd() ? GPIO_NUM_45 : GPIO_NUM_3}; }
   virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_5; }
   virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_4; }
 


### PR DESCRIPTION
### What
This PR moves the BMS Power pin from GPIO3 to GPIO45 on T2-CAN FD devices.

### Why
Currently the BMS Power pin is not usable on the T2-CAN FD due to a pin conflict on IO3.   Attempting to use it gives the following error:

       0.225 2CAN FD detected (ret=0)
       0.225 GPIO conflict for pin 3 between CANFD and BMS power.
       0.226 Event: GPIO Pin Conflict: The pin used by 'CANFD' is already allocated by 'BMS power'.

Even if the second CAN is configured off and this error is bypassed, the BMS Power pin on GPIO3 never signals high and is unusable.

GPIO45 was chosen because it is unused by any other code on the T2-CAN FD (Chademo support uses a number of the other pins not currently labelled on the wiki).

### How
There is existing code to detect FD devices is_fd(), this code reuses that method to assign GPIO45 rather than GPIO3 on FD devices only.

Tested locally using an SSR connected to GPIO45 and confirmed it signals correctly.

Note: The wiki will need to be updated to reflect the pin assignment on the FD here https://github.com/dalathegreat/Battery-Emulator/wiki/Hardware:-LilyGo-T%E2%80%902CAN#expansion-header,  and in the second bullet point here https://github.com/dalathegreat/Battery-Emulator/wiki/Hardware:-LilyGo-T%E2%80%902CAN#hardware-basics to remove the TODO.    Happy to do this if/when this is merged in and released.

