### PR TITLE
Nissan LEAF🔋: fix Hx on ZE0/AZE0; expose Hx over MQTT; add QC & AC charge count; remove BMS ID; faster startup; cosmetics

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -1125,7 +1125,10 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
     }
 
     //Send 10s CAN messages
-    if (currentMillis - previousMillis10s >= INTERVAL_10_S) {
+    //The first pass through the group list runs at the faster burst interval, so the battery info
+    //page is populated within seconds of startup rather than over the following minute.
+    if (currentMillis - previousMillis10s >=
+        (poll_burst_remaining ? POLL_BURST_INTERVAL_MS : (unsigned long)INTERVAL_10_S)) {
       previousMillis10s = currentMillis;
 
       //Every 10s, ask diagnostic data from the battery. Don't ask if someone is already polling on the bus (Leafspy?),
@@ -1135,15 +1138,21 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
           UserRequestDTCreadout || UserRequestDTCreset || dtc_read_in_progress || dtc_clear_in_progress;
       if (!stop_battery_query && !dtc_operation_pending) {
 
-        // Move to the next group
-        // Advance to the next group. Group 0x62 is asked for only until it answers: the lifetime
-        // charge counters cannot change in a stationary setup, so dropping it out of the rotation
-        // keeps the recurring groups at the same spacing they had before it was added.
+        // Move to the next group, skipping the static ones that already answered. The charge
+        // counters and the two identity strings cannot change while the pack is powered, so each
+        // is asked for only until its data is in, after which the recurring groups come round
+        // faster. Testing the data itself rather than a "seen" flag means a reply that arrived
+        // while another tool was polling the bus counts just as well.
         do {
           PIDindex = (PIDindex + 1) % (sizeof(PIDgroups) / sizeof(PIDgroups[0]));
-        } while (PIDgroups[PIDindex] == 0x62 && battery_charge_count_l1l2 != 0);
+        } while ((PIDgroups[PIDindex] == 0x62 && battery_charge_count_l1l2 != 0) ||
+                 (PIDgroups[PIDindex] == 0x84 && BatterySerialNumber[0] != 0) ||
+                 (PIDgroups[PIDindex] == 0x83 && BatteryPartNumber[0] != 0));
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
+        if (poll_burst_remaining) {
+          poll_burst_remaining--;
+        }
         uds_busy = true;
         uds_request_millis = currentMillis;
         transmit_can_frame(&LEAF_GROUP_REQUEST);

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -302,6 +302,8 @@ void NissanLeafBattery::
     datalayer_nissan->HeatingStart = battery_Heating_Start;
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
     datalayer_nissan->battery_HX_pptt = battery_HX_pptt;
+    datalayer_nissan->ChargeCountQC = battery_charge_count_qc;
+    datalayer_nissan->ChargeCountL1L2 = battery_charge_count_l1l2;
     datalayer_nissan->temperature1 = ((Temp_fromRAW_to_F(battery_temp_raw_1) - 320) * 5) / 9;  //Convert from F to C
     datalayer_nissan->temperature2 = ((Temp_fromRAW_to_F(battery_temp_raw_2) - 320) * 5) / 9;  //Convert from F to C
     datalayer_nissan->temperature3 = ((Temp_fromRAW_to_F(battery_temp_raw_3) - 320) * 5) / 9;  //Convert from F to C
@@ -739,6 +741,21 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
       }
 
+      if (group_7bb == 0x62) {              //Lifetime charge counters
+        if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 76 61 62 08 00 01 5A)
+          //Both counters are carried in the first frame, no need to walk the rest of the reply:
+          //payload[0..1] holds the L1/L2 (AC) charges, payload[2..3] the quick (CHAdeMO) charges.
+          //A counter the LBC has no value for reads back as 0xFFFF. A used pack always has AC
+          //charges, so a zero L1/L2 count means "not read yet" and keeps the group in the rotation.
+          uint16_t count_l1l2 = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          uint16_t count_qc = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
+          if (count_l1l2 != 0xFFFF && count_qc != 0xFFFF) {
+            battery_charge_count_l1l2 = count_l1l2;
+            battery_charge_count_qc = count_qc;
+          }
+        }
+      }
+
       if (group_7bb == 0x83)  //BatteryPartNumber
       {
         if (rx_frame.data.u8[0] == 0x10) {  //First frame (101A6183334E4B32)
@@ -1135,7 +1152,12 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       if (!stop_battery_query && !dtc_operation_pending) {
 
         // Move to the next group
-        PIDindex = (PIDindex + 1) % 7;  // 7 = amount of elements in the PIDgroups[]
+        // Advance to the next group. Group 0x62 is asked for only until it answers: the lifetime
+        // charge counters cannot change in a stationary setup, so dropping it out of the rotation
+        // keeps the recurring groups at the same spacing they had before it was added.
+        do {
+          PIDindex = (PIDindex + 1) % (sizeof(PIDgroups) / sizeof(PIDgroups[0]));
+        } while (PIDgroups[PIDindex] == 0x62 && battery_charge_count_l1l2 != 0);
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];
 
         uds_busy = true;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -279,7 +279,6 @@ void NissanLeafBattery::
   if (datalayer_nissan) {
     memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
     memcpy(datalayer_nissan->BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
-    memcpy(datalayer_nissan->BMSIDcode, BMSIDcode, sizeof(BMSIDcode));
     datalayer_nissan->LEAF_gen = LEAF_battery_Type;
     if (allows_contactor_closing) {  //Only the main battery names the protocol shown on the status page
       //setup() already wrote Name, so only the "battery" part gets replaced by the detected generation
@@ -798,21 +797,6 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           BatterySerialNumber[14] = rx_frame.data.u8[7];
         }
         if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23 00 00 00 00 00 00 00)
-        }
-      }
-
-      if (group_7bb == 0x90) {              //BMSIDcode
-        if (rx_frame.data.u8[0] == 0x10) {  //First frame (100A619044434131)
-          BMSIDcode[0] = rx_frame.data.u8[4];
-          BMSIDcode[1] = rx_frame.data.u8[5];
-          BMSIDcode[2] = rx_frame.data.u8[6];
-          BMSIDcode[3] = rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second frame (2130303535FFFFFF)
-          BMSIDcode[4] = rx_frame.data.u8[1];
-          BMSIDcode[5] = rx_frame.data.u8[2];
-          BMSIDcode[6] = rx_frame.data.u8[3];
-          BMSIDcode[7] = rx_frame.data.u8[4];
         }
       }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -295,7 +295,7 @@ void NissanLeafBattery::
     datalayer_nissan->HeatingStop = battery_Heating_Stop;
     datalayer_nissan->HeatingStart = battery_Heating_Start;
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
-    datalayer_nissan->battery_HX = battery_HX;
+    datalayer_nissan->battery_HX_pptt = battery_HX_pptt;
     datalayer_nissan->temperature1 = ((Temp_fromRAW_to_F(battery_temp_raw_1) - 320) * 5) / 9;  //Convert from F to C
     datalayer_nissan->temperature2 = ((Temp_fromRAW_to_F(battery_temp_raw_2) - 320) * 5) / 9;  //Convert from F to C
     datalayer_nissan->temperature3 = ((Temp_fromRAW_to_F(battery_temp_raw_3) - 320) * 5) / 9;  //Convert from F to C
@@ -553,6 +553,9 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       //First check which group data we are getting
       if (rx_frame.data.u8[0] == 0x10) {  //First message of a group
         group_7bb = rx_frame.data.u8[3];
+        //Remember how long the reply is. The group 1 layout differs between LEAF generations, and
+        //the announced length is what identifies which one the LBC just sent.
+        group_7bb_length = rx_frame.data.u8[1];
       }
 
       transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Request the next frame for the group
@@ -575,7 +578,19 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
 
         if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame
-          battery_HX = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 102.4;
+          // Hx sits at a different payload offset and uses a different scale depending on which
+          // layout the LBC answered with, so the reply length decides how to read it:
+          //   0x29 (ZE0 24kWh) / 0x2B (AZE0 30kWh) -> payload[26..27], already in hundredths of a %
+          //   0x35 (ZE1 40/62kWh)                  -> payload[28..29], raw / 102.4 = percent
+          // This frame carries payload[25..31] in u8[1..7]. Any other length is a layout we do not
+          // know (a ZE1 answers 0x2C shortly after wakeup), so leave the last good value in place.
+          if (group_7bb_length == 0x35) {  //ZE1
+            uint16_t battery_HX_raw = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+            //raw / 102.4 * 100 == raw * 125 / 128, rounded to nearest
+            battery_HX_pptt = (uint16_t)(((uint32_t)battery_HX_raw * 125u + 64u) / 128u);
+          } else if (group_7bb_length == 0x29 || group_7bb_length == 0x2B) {  //ZE0 / AZE0
+            battery_HX_pptt = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+          }
         }
       }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -137,8 +137,10 @@ class NissanLeafBattery : public CanBattery {
                         .ID = 0x626,
                         .data = {0x02, 0x00, 0xff, 0x1d, 0x20, 0x00}};
   // Active polling messages
-  uint8_t PIDgroups[8] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x90, 0x62};
-  uint8_t PIDindex = 0;
+  uint8_t PIDgroups[7] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x62};
+  //Start on the last entry so the first rotation step wraps to group 0x01, which carries the
+  //values the rest of the emulator waits for (precise SOC, Hx, insulation).
+  uint8_t PIDindex = sizeof(PIDgroups) / sizeof(PIDgroups[0]) - 1;
   CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
                                   .ext_ID = false,
                                   .DLC = 8,
@@ -247,9 +249,11 @@ class NissanLeafBattery : public CanBattery {
   //shorter than 256 bytes, so the low length byte of the first frame is enough to hold it.
   uint8_t group_7bb_length = 0;
   bool stop_battery_query = true;
-  uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
-  uint16_t battery_cell_voltages[96];           //array with all the cellvoltages
-  bool battery_balancing_shunts[96];            //array with all the balancing resistors
+  //Counted down once per 10s tick, and polling only starts on the tick after it reaches zero,
+  //so the first group request goes out 30 seconds after startup.
+  uint8_t hold_off_with_polling_10seconds = 1;
+  uint16_t battery_cell_voltages[96];  //array with all the cellvoltages
+  bool battery_balancing_shunts[96];   //array with all the balancing resistors
   //Balancing classification state, see update_values()
   //The classifier tracks how often a group 0x06 read comes back with the shunt set completely
   //unchanged, over a sliding window of the most recent reads.
@@ -299,7 +303,6 @@ class NissanLeafBattery : public CanBattery {
   int16_t battery_temp_polled_min = 0;
   uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
   uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
-  uint8_t BMSIDcode[8] = {0};
   uint8_t stateMachineClearSOH = 0xFF;
 
 #ifndef SMALL_FLASH_DEVICE

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -243,6 +243,9 @@ class NissanLeafBattery : public CanBattery {
   // Nissan LEAF battery data from polled CAN messages
   uint8_t battery_request_idx = 0;
   uint8_t group_7bb = 0;
+  //ISO-TP payload length of the group reply currently being received. Leaf group replies are all
+  //shorter than 256 bytes, so the low length byte of the first frame is enough to hold it.
+  uint8_t group_7bb_length = 0;
   bool stop_battery_query = true;
   uint8_t hold_off_with_polling_10seconds = 2;  //Paused for 20 seconds on startup
   uint16_t battery_cell_voltages[96];           //array with all the cellvoltages
@@ -281,7 +284,7 @@ class NissanLeafBattery : public CanBattery {
   void set_balancing_status(balancing_status_enum new_status);
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-  uint16_t battery_HX = 0;              //Internal resistance
+  uint16_t battery_HX_pptt = 0;         //Pack conductance estimate (Hx), in hundredths of a percent
   uint16_t battery_insulation = 0;      //Insulation resistance
   uint16_t battery_temp_raw_1 = 718;
   uint8_t battery_temp_raw_2_highnibble = 0;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -250,8 +250,8 @@ class NissanLeafBattery : public CanBattery {
   uint8_t group_7bb_length = 0;
   bool stop_battery_query = true;
   //Counted down once per 10s tick, and polling only starts on the tick after it reaches zero,
-  //so the first group request goes out 30 seconds after startup.
-  uint8_t hold_off_with_polling_10seconds = 1;
+  //the first group request goes out 0 seconds after startup.
+  uint8_t hold_off_with_polling_10seconds = 0;
   uint16_t battery_cell_voltages[96];  //array with all the cellvoltages
   bool battery_balancing_shunts[96];   //array with all the balancing resistors
   //Balancing classification state, see update_values()

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -137,7 +137,7 @@ class NissanLeafBattery : public CanBattery {
                         .ID = 0x626,
                         .data = {0x02, 0x00, 0xff, 0x1d, 0x20, 0x00}};
   // Active polling messages
-  uint8_t PIDgroups[7] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x90};
+  uint8_t PIDgroups[8] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x90, 0x62};
   uint8_t PIDindex = 0;
   CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
                                   .ext_ID = false,
@@ -283,9 +283,11 @@ class NissanLeafBattery : public CanBattery {
   //Applies a new balancing status, raising the start/end events on the ACTIVE edges
   void set_balancing_status(balancing_status_enum new_status);
   uint8_t battery_cellcounter = 0;
-  uint16_t battery_min_max_voltage[2];  //contains cell min[0] and max[1] values in mV
-  uint16_t battery_HX_pptt = 0;         //Pack conductance estimate (Hx), in hundredths of a percent
-  uint16_t battery_insulation = 0;      //Insulation resistance
+  uint16_t battery_min_max_voltage[2];     //contains cell min[0] and max[1] values in mV
+  uint16_t battery_HX_pptt = 0;            //Pack conductance estimate (Hx), in hundredths of a percent
+  uint16_t battery_insulation = 0;         //Insulation resistance
+  uint16_t battery_charge_count_qc = 0;    //Lifetime number of quick (CHAdeMO) charges
+  uint16_t battery_charge_count_l1l2 = 0;  //Lifetime number of L1/L2 (AC) charges
   uint16_t battery_temp_raw_1 = 718;
   uint8_t battery_temp_raw_2_highnibble = 0;
   uint16_t battery_temp_raw_2 = 718;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -87,10 +87,14 @@ class NissanLeafBattery : public CanBattery {
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was send
   unsigned long previousMillis500 = 0;  // will store last time a 500ms CAN Message was send
   unsigned long previousMillis10s = 0;  // will store last time a 1s CAN Message was send
-  uint8_t mprun10r = 0;                 //counter 0-20 for 0x1F2 message
-  uint8_t mprun10 = 0;                  //counter 0-3
-  uint8_t mprun100 = 0;                 //counter 0-3
-  uint8_t counter_3B8 = 0;              //counter 0-14
+  //Startup burst: the first pass through PIDgroups[] is polled at this faster rate so the battery
+  //info page fills in within seconds instead of over a minute. Counted down per request actually
+  //sent, so it always terminates and the steady state polling rate is left untouched.
+  static const unsigned long POLL_BURST_INTERVAL_MS = 2000;
+  uint8_t mprun10r = 0;     //counter 0-20 for 0x1F2 message
+  uint8_t mprun10 = 0;      //counter 0-3
+  uint8_t mprun100 = 0;     //counter 0-3
+  uint8_t counter_3B8 = 0;  //counter 0-14
   bool flip_3B8 = false;
 
   static const uint8_t ZE0_BATTERY = 0;
@@ -137,10 +141,13 @@ class NissanLeafBattery : public CanBattery {
                         .ID = 0x626,
                         .data = {0x02, 0x00, 0xff, 0x1d, 0x20, 0x00}};
   // Active polling messages
-  uint8_t PIDgroups[7] = {0x01, 0x02, 0x04, 0x06, 0x83, 0x84, 0x62};
-  //Start on the last entry so the first rotation step wraps to group 0x01, which carries the
-  //values the rest of the emulator waits for (precise SOC, Hx, insulation).
+  //Ordered so the values that identify an unknown pack come out first. The three static groups
+  //(0x62 charge counters, 0x84 serial number, 0x83 part number) are read once and then skipped,
+  //leaving 0x04/0x01/0x02/0x06 as the recurring rotation.
+  uint8_t PIDgroups[7] = {0x62, 0x84, 0x04, 0x01, 0x02, 0x06, 0x83};
+  //Start on the last entry so the first rotation step wraps to index 0.
   uint8_t PIDindex = sizeof(PIDgroups) / sizeof(PIDgroups[0]) - 1;
+  uint8_t poll_burst_remaining = sizeof(PIDgroups) / sizeof(PIDgroups[0]);
   CAN_frame LEAF_GROUP_REQUEST = {.FD = false,
                                   .ext_ID = false,
                                   .DLC = 8,

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -184,7 +184,7 @@ class NissanLeafBattery : public CanBattery {
   // group polling, so it is intercepted separately while a readout is in flight.
   static const uint16_t DTC_BUFFER_SIZE = 3 + 4 * DATALAYER_BATTERY_DTC_TYPE::MAX_DTC_COUNT;
   static const unsigned long DTC_TIMEOUT_MS = 2000;
-  uint8_t dtc_buffer[DTC_BUFFER_SIZE];
+  uint8_t dtc_buffer[DTC_BUFFER_SIZE] = {0};
   uint16_t dtc_rx_total = 0;   // Total payload length announced by the ISO-TP first frame
   uint16_t dtc_rx_seen = 0;    // Bytes received so far, counted even when past our storage capacity
   uint16_t dtc_rx_len = 0;     // Bytes actually stored, capped at DTC_BUFFER_SIZE
@@ -259,8 +259,8 @@ class NissanLeafBattery : public CanBattery {
   //Counted down once per 10s tick, and polling only starts on the tick after it reaches zero,
   //the first group request goes out 0 seconds after startup.
   uint8_t hold_off_with_polling_10seconds = 0;
-  uint16_t battery_cell_voltages[96];  //array with all the cellvoltages
-  bool battery_balancing_shunts[96];   //array with all the balancing resistors
+  uint16_t battery_cell_voltages[96] = {0};     //array with all the cellvoltages
+  bool battery_balancing_shunts[96] = {false};  //array with all the balancing resistors
   //Balancing classification state, see update_values()
   //The classifier tracks how often a group 0x06 read comes back with the shunt set completely
   //unchanged, over a sliding window of the most recent reads.
@@ -276,7 +276,7 @@ class NissanLeafBattery : public CanBattery {
   //momentarily read as all-clear, so a single low read is not enough to declare balancing finished.
   static const uint8_t BALANCING_READY_DEBOUNCE_READS = 3;
   //Previous group 0x06 shunt bitmap (96 bits packed into 3 words), for change detection
-  uint32_t balancing_bitmap_prev[3];
+  uint32_t balancing_bitmap_prev[3] = {0};
   //true once balancing_bitmap_prev holds a real reading
   bool balancing_bitmap_valid = false;
   //One bit per recent read, set if that read came back with the shunt set unchanged
@@ -294,11 +294,11 @@ class NissanLeafBattery : public CanBattery {
   //Applies a new balancing status, raising the start/end events on the ACTIVE edges
   void set_balancing_status(balancing_status_enum new_status);
   uint8_t battery_cellcounter = 0;
-  uint16_t battery_min_max_voltage[2];     //contains cell min[0] and max[1] values in mV
-  uint16_t battery_HX_pptt = 0;            //Pack conductance estimate (Hx), in hundredths of a percent
-  uint16_t battery_insulation = 0;         //Insulation resistance
-  uint16_t battery_charge_count_qc = 0;    //Lifetime number of quick (CHAdeMO) charges
-  uint16_t battery_charge_count_l1l2 = 0;  //Lifetime number of L1/L2 (AC) charges
+  uint16_t battery_min_max_voltage[2] = {0};  //contains cell min[0] and max[1] values in mV
+  uint16_t battery_HX_pptt = 0;               //Pack conductance estimate (Hx), in hundredths of a percent
+  uint16_t battery_insulation = 0;            //Insulation resistance
+  uint16_t battery_charge_count_qc = 0;       //Lifetime number of quick (CHAdeMO) charges
+  uint16_t battery_charge_count_l1l2 = 0;     //Lifetime number of L1/L2 (AC) charges
   uint16_t battery_temp_raw_1 = 718;
   uint8_t battery_temp_raw_2_highnibble = 0;
   uint16_t battery_temp_raw_2 = 718;
@@ -317,7 +317,7 @@ class NissanLeafBattery : public CanBattery {
   // Clear SOH values
 
   uint32_t incomingChallenge = 0xFFFFFFFF;
-  uint8_t solvedChallenge[8];
+  uint8_t solvedChallenge[8] = {0};
   bool challengeFailed = false;
 
   CAN_frame LEAF_CLEAR_SOH = {.FD = false,

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -46,7 +46,10 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     readableBMSID[8] = '\0';  // Null terminate the string
     content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
     content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
-    content += "<h4>HX: " + String(nissan_dl->battery_HX) + "</h4>";
+    content +=
+        "<h4>HX: " +
+        (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
+        "</h4>";
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
     content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -71,8 +71,16 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
     content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
     content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
-    content += "<h4>CryptoChallenge: " + String(nissan_dl->CryptoChallenge) + "</h4>";
-    content += "<h4>SolvedChallenge: " + String(nissan_dl->SolvedChallengeMSB) + String(nissan_dl->SolvedChallengeLSB) +
+    //Both challenge values only ever get filled by the Reset degradation data sequence. Until that
+    //has run, incomingChallenge still holds its 0xFFFFFFFF default and the solved halves are zero,
+    //so say so rather than printing placeholder numbers that look like readings.
+    content += "<h4>CryptoChallenge: " +
+               (nissan_dl->CryptoChallenge != 0xFFFFFFFF ? String(nissan_dl->CryptoChallenge) : String("Not run")) +
+               "</h4>";
+    content += "<h4>SolvedChallenge: " +
+               ((nissan_dl->SolvedChallengeMSB || nissan_dl->SolvedChallengeLSB)
+                    ? String(nissan_dl->SolvedChallengeMSB) + "-" + String(nissan_dl->SolvedChallengeLSB)
+                    : String("Not run")) +
                "</h4>";
     content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
 

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -50,6 +50,13 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         "<h4>Hx: " +
         (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
         "</h4>";
+    //A used pack always has AC charges on it, so a zero L1/L2 count means the group was not read yet.
+    //The QC count itself may legitimately be zero on a pack that was never quick charged.
+    content +=
+        "<h4>QC charge count: " + (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountQC) : String("Unknown")) +
+        "</h4>";
+    content += "<h4>AC charge count: " +
+               (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountL1L2) : String("Unknown")) + "</h4>";
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
     content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -41,10 +41,6 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     memcpy(readablePartNumber, nissan_dl->BatteryPartNumber, sizeof(nissan_dl->BatteryPartNumber));
     readablePartNumber[7] = '\0';  // Null terminate the string
     content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
-    char readableBMSID[9];  // One extra space for null terminator
-    memcpy(readableBMSID, nissan_dl->BMSIDcode, sizeof(nissan_dl->BMSIDcode));
-    readableBMSID[8] = '\0';  // Null terminate the string
-    content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
     content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
     content +=
         "<h4>Hx: " +

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -54,23 +54,23 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
                (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountL1L2) : String("Unknown")) + "</h4>";
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
-    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
-    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
-    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
-    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
-    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
-    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
-    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
-    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
-    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
-    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
-    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
     content += "<h4>Temperature 1: " + String(nissan_dl->temperature1 / 10.0) + " &deg;C</h4>";
     content += "<h4>Temperature 2: " + String(nissan_dl->temperature2 / 10.0) + " &deg;C</h4>";
     if (nissan_dl->LEAF_gen == 0) {
       content += "<h4>Temperature 3: " + String(nissan_dl->temperature3 / 10.0) + " &deg;C</h4>";
     }
     content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
+    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
+    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
+    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
+    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
+    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
+    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
+    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
+    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
+    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
+    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
+    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
     content += "<h4>CryptoChallenge: " + String(nissan_dl->CryptoChallenge) + "</h4>";
     content += "<h4>SolvedChallenge: " + String(nissan_dl->SolvedChallengeMSB) + String(nissan_dl->SolvedChallengeLSB) +
                "</h4>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -51,7 +51,6 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
         "</h4>";
     //A used pack always has AC charges on it, so a zero L1/L2 count means the group was not read yet.
-    //The QC count itself may legitimately be zero on a pack that was never quick charged.
     content +=
         "<h4>QC charge count: " + (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountQC) : String("Unknown")) +
         "</h4>";
@@ -60,7 +59,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
     content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
-    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + "</h4>";
+    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
     content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
     content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
     content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -47,7 +47,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>BMS ID: " + String(readableBMSID) + "</h4>";
     content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
     content +=
-        "<h4>HX: " +
+        "<h4>Hx: " +
         (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
         "</h4>";
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -762,8 +762,8 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   uint16_t GIDS;
   /** Max regen power in kW */
   uint16_t ChargePowerLimit;
-  /** Internal resistance in percentage */
-  uint16_t battery_HX;
+  /** Pack conductance estimate (LeafSpy "Hx"), in hundredths of a percent */
+  uint16_t battery_HX_pptt;
   /** Insulation resistance, most likely kOhm */
   uint16_t Insulation;
 

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -808,7 +808,6 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** Battery info, stores raw HEX values for ASCII chars */
   uint8_t BatterySerialNumber[15];
   uint8_t BatteryPartNumber[7];
-  uint8_t BMSIDcode[8];
 };
 
 struct DATALAYER_INFO_MEB {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -766,6 +766,10 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   uint16_t battery_HX_pptt;
   /** Insulation resistance, most likely kOhm */
   uint16_t Insulation;
+  /** Lifetime number of quick (CHAdeMO) charges, 0 until read from the battery */
+  uint16_t ChargeCountQC;
+  /** Lifetime number of L1/L2 (AC) charges, 0 until read from the battery */
+  uint16_t ChargeCountL1L2;
 
   /** Max charge power in kW */
   int16_t MaxPowerForCharger;

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -140,6 +140,9 @@ static bool supports_byd_metrics(Battery* b) {
 static bool supports_insulation(Battery* b) {
   return b != nullptr && b->supports_insulation_resistance();
 }
+static bool supports_leaf_metrics(Battery* b) {
+  return b != nullptr && user_selected_battery_type == BatteryType::NissanLeaf;
+}
 
 static const SensorConfig batterySensorConfigTemplate[] = {
     {"SOC", "SOC (Scaled)", "%", "battery", always},
@@ -172,7 +175,8 @@ static const SensorConfig batterySensorConfigTemplate[] = {
     {"autocal_cooldown_ready", "BYD Auto-cal: Cooldown Ready", "", "", supports_byd_autocal_metrics},
     {"autocal_soc_drift", "BYD Auto-cal: SOC Drift", "%", "battery", supports_byd_autocal_metrics},
     {"min_cell_number", "Min Cell Number", "", "", supports_byd_metrics},
-    {"max_cell_number", "Max Cell Number", "", "", supports_byd_metrics}};
+    {"max_cell_number", "Max Cell Number", "", "", supports_byd_metrics},
+    {"leaf_hx", "Hx", "%", "", supports_leaf_metrics}};
 
 static const SensorConfig globalSensorConfigTemplate[] = {
     {"bms_status", "BMS Status", "", "", always},
@@ -367,6 +371,16 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
     doc["min_cell_number"] = byd.BMS_min_cell_voltage_number;
     doc["max_cell_number"] = byd.BMS_max_cell_voltage_number;
   }
+  if (supports_leaf_metrics(::battery)) {
+    const DATALAYER_INFO_NISSAN_LEAF& leaf = (battery_index == 3)   ? datalayer_extended.nissanleaf_3
+                                             : (battery_index == 2) ? datalayer_extended.nissanleaf_2
+                                                                    : datalayer_extended.nissanleaf;
+    // Omit until a group 1 reply with a known layout has been decoded, so HA shows "unknown"
+    // instead of a false 0 % before the first poll completes.
+    if (leaf.battery_HX_pptt != 0u) {
+      doc["leaf_hx"] = ((float)leaf.battery_HX_pptt) / 100.0f;
+    }
+  }
 }
 
 static std::vector<EventData> order_events;
@@ -384,6 +398,9 @@ static const char* sensor_discovery_icon(const char* entity_id, const char* devi
     }
     if (strcmp(entity_id, "insulation_resistance") == 0) {
       return "mdi:resistor";
+    }
+    if (strcmp(entity_id, "leaf_hx") == 0) {
+      return "mdi:battery-heart-variant";
     }
     if (strcmp(entity_id, "charging_state") == 0) {
       return "mdi:home-battery";
@@ -462,6 +479,12 @@ static bool publish_sensor_discovery(const SensorConfig& config, const char* id_
   if (strcmp(config.entity_id, "insulation_resistance") == 0) {
     doc["state_class"] = "measurement";
     doc["suggested_display_precision"] = 0;
+  }
+  // "leaf_hx" is a percentage with no matching device_class, so it misses the state_class
+  // assignment above too. Mark it as a measurement and show two decimals, like LeafSpy does.
+  if (strcmp(config.entity_id, "leaf_hx") == 0) {
+    doc["state_class"] = "measurement";
+    doc["suggested_display_precision"] = 2;
   }
   // "energy" device_class is only valid with state_class total / total_increasing, never
   // "measurement" — HA rejects the combination. The capacity sensors represent a current

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -145,8 +145,8 @@ static bool supports_leaf_metrics(Battery* b) {
 }
 
 static const SensorConfig batterySensorConfigTemplate[] = {
-    {"SOC", "SOC (Scaled)", "%", "battery", always},
-    {"SOC_real", "SOC (real)", "%", "battery", always},
+    {"SOC", "SoC (scaled)", "%", "battery", always},
+    {"SOC_real", "SoC (real)", "%", "battery", always},
     {"state_of_health", "State of Health", "%", "battery", always},
     {"temperature_min", "Temperature Min", "°C", "temperature", always},
     {"temperature_max", "Temperature Max", "°C", "temperature", always},


### PR DESCRIPTION
### What
This PR fixes the Nissan LEAF HX value, which always reported 0 on ZE0 and AZE0 packs, and exposes it as a new Leaf-specific MQTT sensor with Home Assistant autodiscovery.

<img width="298" height="316" alt="image" src="https://github.com/user-attachments/assets/75c9ab3b-03c5-44b9-9ed5-37a74ac3dd02" />

Home Assistant:
<img width="406" height="56" alt="image" src="https://github.com/user-attachments/assets/a1debd70-d01a-4aec-ba06-d0ed31f578cd" />

Charge counts:
<img width="365" height="111" alt="image" src="https://github.com/user-attachments/assets/bc49f9b3-47d6-4a0a-9d42-ac5df9a08660" />
<img width="196" height="30" alt="image" src="https://github.com/user-attachments/assets/92c9697b-01a1-4b81-b9f0-5505e5cc7aed" />

### Why
The decoder only ever implemented the ZE1 layout of the LBC group 1 reply. ZE0 (24 kWh) and AZE0 (30 kWh) answer with a two-byte-shorter layout, so those packs read the high half of the following field - a value small enough that the `/102.4` scaling always truncated to 0. LeafSpy reports a real Hx on the same packs.

### How
The announced ISO-TP length of the group 1 reply identifies the layout (`0x29` ZE0, `0x2B` AZE0, `0x35` ZE1), so the offset and scale are picked from that: payload 26..27 already in hundredths of a percent for ZE0/AZE0, payload 28..29 scaled by `125/128` for ZE1. The value is stored as `battery_HX_pptt` to keep LeafSpy's two decimals, rendered with a `%` on the battery info page, and published as `leaf_hx` (`state_class: measurement`, precision 2). Unknown reply lengths and the pre-first-poll state leave the sensor unpublished rather than reporting a false 0.

Renamed 'HX' to 'Hx' for consistency and parity with Leafspy ui.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
