### PR TITLE
MQTT: log publish failures once per outage, fix mislabelled event log

### DIFF
--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -64,6 +64,22 @@ static bool publish_common_info(void);
 static bool publish_cell_voltages(void);
 static bool publish_events(void);
 
+// A dropped broker connection makes every publish fail (QoS 0 returns -1 while the client
+// is not connected), and publish_values() runs again every mqtt_publish_interval_ms, so
+// logging each failure unconditionally repeats the same line for the whole outage. Pending
+// events make it worse: they are deliberately retried until they go out, so publish_events()
+// fails on every cycle from the moment EVENT_MQTT_DISCONNECT is raised until reconnect.
+// Log the first failure of an outage only; publish_values() re-arms the latch after a
+// complete successful cycle.
+static bool publish_failure_logged = false;
+
+static void log_publish_failure(const char* what) {
+  if (!publish_failure_logged) {
+    publish_failure_logged = true;
+    logging.printf("%s MQTT msg could not be sent\n", what);
+  }
+}
+
 /** Publish global values and call callbacks for specific modules */
 static void publish_values(void) {
 
@@ -86,6 +102,9 @@ static void publish_values(void) {
       return;
     }
   }
+
+  // Whole cycle went out: arm the failure log again so the next outage is reported.
+  publish_failure_logged = false;
 }
 
 static bool ha_common_info_published = false;
@@ -556,7 +575,7 @@ static bool publish_common_info(void) {
 
       serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
       if (mqtt_publish(info_topics[0].c_str(), mqtt_msg, false) == false) {
-        // logging.println("Common info MQTT msg could not be sent");
+        log_publish_failure("Common info");
         return false;
       }
     }
@@ -575,7 +594,7 @@ static bool publish_common_info(void) {
         set_battery_attributes(shared_doc, *target.data, target.index, bat->supports_charged_energy());
         serializeJson(shared_doc, mqtt_msg, sizeof(mqtt_msg));
         if (mqtt_publish(info_topics[target.index - 1].c_str(), mqtt_msg, false) == false) {
-          logging.println("Common info MQTT msg could not be sent");
+          log_publish_failure("Common info");
           return false;
         }
       }
@@ -633,7 +652,7 @@ static bool publish_cell_data_state(const DATALAYER_BATTERY_TYPE& battery_data, 
   len += snprintf(mqtt_msg + len, sizeof(mqtt_msg) - len, "]}");
 
   if (!mqtt_publish(state_topic.c_str(), mqtt_msg, false)) {
-    logging.println("Cell data MQTT msg could not be sent");
+    log_publish_failure("Cell data");
     return false;
   }
   return true;
@@ -775,7 +794,7 @@ bool publish_events() {
 
       serializeJson(doc, mqtt_msg, sizeof(mqtt_msg));
       if (!mqtt_publish(state_topic.c_str(), mqtt_msg, false)) {
-        logging.println("Common info MQTT msg could not be sent");
+        log_publish_failure("Event");
         return false;
       } else {
         set_event_MQTTpublished(event_handle);


### PR DESCRIPTION
## What

This PR makes MQTT publish failures log once per outage instead of once per publish cycle, and corrects the event publisher's failure message, which was mislabelled as "Common info MQTT msg could not be sent".

## Why

A pending `EVENT_MQTT_DISCONNECT` is retried on every publish cycle until it goes out, and with QoS 0 every publish fails while the client is down, so the same line repeated every `mqtt_publish_interval_ms` for the whole outage. All of those lines came from `publish_events()`, not from the common info publisher — `publish_values()` returns on the first failure, so `publish_common_info()` is never reached during an outage, making the log actively misleading about which stage failed.

```
    6569.834 Event: MQTT disconnected.
    6569.834 MQTT disconnected!
    6569.834 Cell data MQTT msg could not be sent
    6573.134 Common info MQTT msg could not be sent
    6578.734 Common info MQTT msg could not be sent
    6579.852 Event: MQTT connected.
    9937.467 Event: Wifi disconnected.
    9937.467 Wi-Fi disconnected.
    9937.478 Event: MQTT disconnected.
    9937.478 MQTT disconnected!
    9937.490 Wi-Fi disconnected.
    9938.357 Wi-Fi not connected (status=4), attempting to reconnect
    9938.357 Wi-Fi reconnect attempt...
    9938.358 Wi-Fi reconnect attempt sucess...
    9938.882 Event: Wifi connected.
    9938.882 Wi-Fi connected. status: 0, RSSI: 65 dBm, IP address: x.x.x.x, SSID: XXXXX
    9938.883 Wi-Fi Got IP. IP address: x.x.x.x
    9942.031 Common info MQTT msg could not be sent
    9947.727 Common info MQTT msg could not be sent
```

## How

All four failure sites now route through a latched helper that logs only the first failure; `publish_values()` clears the latch after a complete successful cycle, so the next outage is reported again. The event site is relabelled "Event", and the battery #1 common info log that was commented out for this same flooding reason is re-enabled.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
