### PR TITLE
Nissan LEAF 🔋: show detected generation on the main status page

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -281,6 +281,12 @@ void NissanLeafBattery::
     memcpy(datalayer_nissan->BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
     memcpy(datalayer_nissan->BMSIDcode, BMSIDcode, sizeof(BMSIDcode));
     datalayer_nissan->LEAF_gen = LEAF_battery_Type;
+    if (allows_contactor_closing) {  //Only the main battery names the protocol shown on the status page
+      //setup() already wrote Name, so only the "battery" part gets replaced by the detected generation
+      static_assert(Name[sizeof("Nissan LEAF ") - 1] == 'b', "Name must start with \"Nissan LEAF \"");
+      static const char LEAF_gen_name[3][5] = {"ZE0", "AZE0", "ZE1"};
+      strcpy(datalayer.system.info.battery_protocol + sizeof("Nissan LEAF ") - 1, LEAF_gen_name[LEAF_battery_Type]);
+    }
     datalayer_nissan->GIDS = battery_GIDS;
     datalayer_nissan->ChargePowerLimit = battery_Charge_Power_Limit;
     datalayer_nissan->MaxPowerForCharger = battery_MAX_POWER_FOR_CHARGER;


### PR DESCRIPTION
### What
This PR implements showing the detected LEAF generation on the main status page, so the battery protocol line reads like "Battery protocol: Nissan LEAF AZE0" instead of the generic (and double batteryed)  "Battery protocol: Nissan LEAF battery".

### Why
The battery generation wasn't visible at a glance. It displays it only on the More Battery Info page. Plus it's about the protocol, which is more than just LEAF.

### How
In `update_values()`, next to the existing `LEAF_gen` assignment, only the "battery" suffix of the name `setup()` already wrote into `battery_protocol` is replaced with ZE0/AZE0/ZE1.
Costs 15 bytes of rodata with no pointer table, and only the main battery writes the shared field so double/triple setups don't fight over it.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
