### PR TITLE
Logging: Remove duplicate log entries and add syslog notice severity

### DIFF
--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -509,7 +509,6 @@ void BmwPhevBattery::update_values() {  //This function maps all the values fetc
     datalayer.battery.status.cell_min_voltage_mV = 9999;  //Stale values force stop
     datalayer.battery.status.cell_max_voltage_mV = 9999;  //Stale values force stop
     set_event(EVENT_STALE_VALUE, 0);
-    logging.println("Stale Min/Max voltage values detected during charge/discharge sending - 9999mV...");
   } else {
 
     datalayer.battery.status.cell_min_voltage_mV = min_cell_voltage;  //Value is alive

--- a/Software/src/battery/BMW-PHEV-BATTERY.cpp
+++ b/Software/src/battery/BMW-PHEV-BATTERY.cpp
@@ -508,7 +508,7 @@ void BmwPhevBattery::update_values() {  //This function maps all the values fetc
       battery_current != 0) {                             //Ignore stale values if there is no current flowing
     datalayer.battery.status.cell_min_voltage_mV = 9999;  //Stale values force stop
     datalayer.battery.status.cell_max_voltage_mV = 9999;  //Stale values force stop
-    set_event(EVENT_STALE_VALUE, 0);
+    set_event(EVENT_STALE_VALUE, 0);                      // also printing a log entry
   } else {
 
     datalayer.battery.status.cell_min_voltage_mV = min_cell_voltage;  //Value is alive

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -586,7 +586,7 @@ void TeslaBattery::
     } else {
       stateMachineBMSReset = 0xFF;
       datalayer_battery->settings.user_requests_tesla_bms_reset = false;
-      set_event(EVENT_BMS_RESET_REQ_FAIL, 0);
+      set_event(EVENT_BMS_RESET_REQ_FAIL, 0);  // also printing a log entry
       clear_event(EVENT_BMS_RESET_REQ_FAIL);
     }
   }
@@ -600,7 +600,7 @@ void TeslaBattery::
     } else {
       stateMachineSOCReset = 0xFF;
       datalayer_battery->settings.user_requests_tesla_soc_reset = false;
-      set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);
+      set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);  // also printing a log entry
       clear_event(EVENT_BATTERY_SOC_RESET_FAIL);
     }
   }
@@ -2322,16 +2322,16 @@ void TeslaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         logging.println("CAN UDS: BMS ECU reset request successful but ECU busy, response pending");
       }
       if (memcmp(rx_frame.data.u8, "\x02\x51\x01\xAA\xAA\xAA\xAA\xAA", 8) == 0) {
-        set_event(EVENT_BMS_RESET_REQ_SUCCESS, 0);
+        set_event(EVENT_BMS_RESET_REQ_SUCCESS, 0);  // also printing a log entry
         clear_event(EVENT_BMS_RESET_REQ_SUCCESS);
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x01\xAA\xAA", 8) == 0) {
-        set_event(EVENT_BATTERY_SOC_RESET_SUCCESS, 0);
+        set_event(EVENT_BATTERY_SOC_RESET_SUCCESS, 0);  // also printing a log entry
         clear_event(EVENT_BATTERY_SOC_RESET_SUCCESS);
         stateMachineBMSReset = 6;  // BMS ECU already unlocked etc. so we jump straight to reset
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x00\xAA\xAA", 8) == 0) {
-        set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);
+        set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);  // also printing a log entry
         clear_event(EVENT_BATTERY_SOC_RESET_FAIL);
       }
       break;

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -584,7 +584,6 @@ void TeslaBattery::
       datalayer_battery->settings.user_requests_tesla_bms_reset = false;
       logging.println("INFO: BMS reset requested");
     } else {
-      logging.println("ERROR: BMS reset failed due to contactors not being open, or BMS ECU not allowing it");
       stateMachineBMSReset = 0xFF;
       datalayer_battery->settings.user_requests_tesla_bms_reset = false;
       set_event(EVENT_BMS_RESET_REQ_FAIL, 0);
@@ -599,7 +598,6 @@ void TeslaBattery::
       datalayer_battery->settings.user_requests_tesla_soc_reset = false;
       logging.println("INFO: SOC reset requested");
     } else {
-      logging.println("ERROR: SOC reset failed, SOC not < 15 or > 90, or contactors not open");
       stateMachineSOCReset = 0xFF;
       datalayer_battery->settings.user_requests_tesla_soc_reset = false;
       set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);
@@ -2324,18 +2322,15 @@ void TeslaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         logging.println("CAN UDS: BMS ECU reset request successful but ECU busy, response pending");
       }
       if (memcmp(rx_frame.data.u8, "\x02\x51\x01\xAA\xAA\xAA\xAA\xAA", 8) == 0) {
-        logging.println("CAN UDS: BMS ECU reset positive response, 1 second downtime");
         set_event(EVENT_BMS_RESET_REQ_SUCCESS, 0);
         clear_event(EVENT_BMS_RESET_REQ_SUCCESS);
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x01\xAA\xAA", 8) == 0) {
-        logging.println("CAN UDS: BMS SOC reset accepted, resetting BMS ECU");
         set_event(EVENT_BATTERY_SOC_RESET_SUCCESS, 0);
         clear_event(EVENT_BATTERY_SOC_RESET_SUCCESS);
         stateMachineBMSReset = 6;  // BMS ECU already unlocked etc. so we jump straight to reset
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x00\xAA\xAA", 8) == 0) {
-        logging.println("CAN UDS: BMS SOC reset failed");
         set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0);
         clear_event(EVENT_BATTERY_SOC_RESET_FAIL);
       }

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -530,7 +530,7 @@ void handle_BMSpower() {
         // There's still current, and we don't want to weld the contactors, so give up.
 
         datalayer.system.status.bms_reset_status = BMS_RESET_IDLE;
-        set_event(EVENT_PERIODIC_BMS_RESET_FAILURE, 0);
+        set_event(EVENT_PERIODIC_BMS_RESET_FAILURE, 0);  // also printing a log entry
         clear_event(EVENT_PERIODIC_BMS_RESET_FAILURE);
       }
     } else if (datalayer.system.status.bms_reset_status == BMS_RESET_POWERED_OFF) {

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -259,6 +259,7 @@ void handle_contactors() {
         bool timed_out = (now - estop_open_wait_start_ms) > ESTOP_OPEN_TIMEOUT_MS;
         if (paused || timed_out) {
           if (timed_out) {
+            LOG_SET_NEXT_SEVERITY(4);  // warning
             logging.printf("Contactors: Equipment stop wait timed out, opening under load\n");
             set_event(EVENT_ERROR_OPEN_CONTACTOR, 1);
           }
@@ -527,8 +528,6 @@ void handle_BMSpower() {
         datalayer.system.status.bms_reset_status = BMS_RESET_POWERED_OFF;
       } else if (currentTime - lastPowerRemovalTime >= 10000) {
         // There's still current, and we don't want to weld the contactors, so give up.
-
-        logging.printf("BMS reset: Aborting, contactors are still under load.\n");
 
         datalayer.system.status.bms_reset_status = BMS_RESET_IDLE;
         set_event(EVENT_PERIODIC_BMS_RESET_FAILURE, 0);

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -119,7 +119,7 @@ void handle_precharge_control(unsigned long currentMillis) {
         digitalWrite(hia4v1_pin, LOW);
         digitalWrite(inverter_disconnect_contactor_pin, CONTACTOR_ON);
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_FAILURE;
-        set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);
+        set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);  // also printing a log entry
         // Force stop any further precharge attempts
         datalayer.system.info.start_precharging = false;
       } else if ((datalayer.battery.status.real_bms_status != BMS_STANDBY &&

--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -119,7 +119,6 @@ void handle_precharge_control(unsigned long currentMillis) {
         digitalWrite(hia4v1_pin, LOW);
         digitalWrite(inverter_disconnect_contactor_pin, CONTACTOR_ON);
         datalayer.system.status.precharge_status = AUTO_PRECHARGE_FAILURE;
-        logging.printf("Precharge: CRITICAL FAILURE (timeout/BMS fault) -> REQUIRES REBOOT\n");
         set_event(EVENT_AUTOMATIC_PRECHARGE_FAILURE, 0);
         // Force stop any further precharge attempts
         datalayer.system.info.start_precharging = false;

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -46,9 +46,10 @@ class Esp32Hal {
 
     for (gpio_num_t pin : requested_pins) {
       if (pin < 0) {
-        set_event(EVENT_GPIO_NOT_DEFINED, (int)pin);
+        // Must be set BEFORE set_event(): set_event() logs the event message immediately,
+        // and get_event_message_string() reads it back via failed_allocator().
         allocator_name = name;
-        DEBUG_PRINTF("%s attempted to allocate pin %d that wasn't defined for the selected HW.\n", name, (int)pin);
+        set_event(EVENT_GPIO_NOT_DEFINED, (int)pin);
         return false;
       }
 
@@ -56,7 +57,6 @@ class Esp32Hal {
       if (it != allocated_pins.end()) {
         allocator_name = name;
         allocated_name = it->second.c_str();
-        DEBUG_PRINTF("GPIO conflict for pin %d between %s and %s.\n", (int)pin, name, it->second.c_str());
         set_event(EVENT_GPIO_CONFLICT, (int)pin);
         return false;
       }

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -49,7 +49,7 @@ class Esp32Hal {
         // Must be set BEFORE set_event(): set_event() logs the event message immediately,
         // and get_event_message_string() reads it back via failed_allocator().
         allocator_name = name;
-        set_event(EVENT_GPIO_NOT_DEFINED, (int)pin);
+        set_event(EVENT_GPIO_NOT_DEFINED, (int)pin);  // also printing a log entry
         return false;
       }
 
@@ -57,7 +57,7 @@ class Esp32Hal {
       if (it != allocated_pins.end()) {
         allocator_name = name;
         allocated_name = it->second.c_str();
-        set_event(EVENT_GPIO_CONFLICT, (int)pin);
+        set_event(EVENT_GPIO_CONFLICT, (int)pin);  // also printing a log entry
         return false;
       }
     }

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -953,7 +953,6 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_
       break;
     case MQTT_EVENT_DISCONNECTED:
       set_event(EVENT_MQTT_DISCONNECT, 0);
-      logging.println("MQTT disconnected!");
       break;
     case MQTT_EVENT_DATA:
       mqtt_message_received(event->topic, event->topic_len, event->data, event->data_len);

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -975,7 +975,7 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_
       subscribe();
       break;
     case MQTT_EVENT_DISCONNECTED:
-      set_event(EVENT_MQTT_DISCONNECT, 0);
+      set_event(EVENT_MQTT_DISCONNECT, 0);  // also printing a log entry
       break;
     case MQTT_EVENT_DATA:
       mqtt_message_received(event->topic, event->topic_len, event->data, event->data_len);

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -219,7 +219,6 @@ bool init_sdcard() {
 
   if (!SD.begin(cs_pin, sd_spi, SD_SPI_FREQ, "/root", SD_MAX_OPEN_FILES, FORMAT_IF_EMPTY)) {
     set_event_latched(EVENT_SD_INIT_FAILED, 0);
-    logging.println("SD Card initialization failed!");
     return false;
   }
 

--- a/Software/src/devboard/sdcard/sdcard.cpp
+++ b/Software/src/devboard/sdcard/sdcard.cpp
@@ -218,7 +218,7 @@ bool init_sdcard() {
   constexpr bool FORMAT_IF_EMPTY = true;
 
   if (!SD.begin(cs_pin, sd_spi, SD_SPI_FREQ, "/root", SD_MAX_OPEN_FILES, FORMAT_IF_EMPTY)) {
-    set_event_latched(EVENT_SD_INIT_FAILED, 0);
+    set_event_latched(EVENT_SD_INIT_FAILED, 0);  // also printing a log entry
     return false;
   }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -1,5 +1,6 @@
 #include "events.h"
 #include <Arduino.h>
+#include <string.h>  // memchr, for the notice_events lookup
 #include "../../datalayer/datalayer.h"
 #include "../../devboard/hal/hal.h"
 #include "../../devboard/utils/logging.h"
@@ -73,6 +74,63 @@ static uint8_t event_level_to_syslog(EVENTS_LEVEL_TYPE lvl) {
     default:
       return 6;
   }
+}
+
+/* Operational milestones that a syslog server should show at its default verbosity:
+   one-shot-per-boot lifecycle transitions and deliberate operator actions.
+
+   This is deliberately NOT expressed by raising the event's EVENTS_LEVEL_TYPE.
+   EVENT_LEVEL_UPDATE is the only level that already maps to notice, but it is a state
+   level, not a logging level: update_bms_status() turns it into system_status = UPDATING,
+   which drives the LED pattern, the web UI status and inverter behaviour. Marking, say,
+   EVENT_MQTT_CONNECT as UPDATE would park the emulator in UPDATING forever.
+
+   Stored as a flat uint8_t table so it costs one byte per entry and a single memchr,
+   rather than the ~8 bytes of compare-and-branch per case a switch would emit. */
+static_assert(EVENT_NOF_EVENTS <= 256, "notice_events[] indexes events as uint8_t");
+static const uint8_t notice_events[] = {
+    // Peer detection - latched in check_can_component_alive(), so one line per boot
+    EVENT_CAN_BATTERY_DETECTED,
+    EVENT_CAN_BATTERY2_DETECTED,
+    EVENT_CAN_BATTERY3_DETECTED,
+    EVENT_CAN_INVERTER_DETECTED,
+    EVENT_MODBUS_INVERTER_DETECTED,
+    EVENT_CAN_CHARGER_DETECTED,
+    // Connectivity - the "down" halves are listed so a syslog view never shows an
+    // unterminated session. Wi-Fi/battery/inverter loss is already >= warning.
+    EVENT_MQTT_CONNECT,
+    EVENT_MQTT_DISCONNECT,
+    EVENT_WIFI_DISCONNECT,
+    // Deliberate state changes. PAUSE_BEGIN is already warning; without PAUSE_END the
+    // pause window never appears to close.
+    EVENT_PAUSE_END,
+    EVENT_WIFI_AP_PROVISION_TIMEOUT,
+    EVENT_WIFI_AP_PASSWORD_DEFAULT,
+    EVENT_PERIODIC_BMS_RESET,
+    EVENT_BMS_RESET_REQ_SUCCESS,
+    // Reset cause - fires exactly once per boot and answers "why did it come back".
+    // The WDT/panic/lockup causes are already warning.
+    EVENT_RESET_UNKNOWN,
+    EVENT_RESET_POWERON,
+    EVENT_RESET_EXT,
+    EVENT_RESET_SW,
+    EVENT_RESET_DEEPSLEEP,
+    EVENT_RESET_SDIO,
+    EVENT_RESET_USB,
+    EVENT_RESET_JTAG,
+    EVENT_RESET_EFUSE,
+    EVENT_RESET_PWR_GLITCH,
+};
+
+// Syslog severity for an event: its level, raised to notice for the milestones above.
+// The sev > 5 test means the table can only ever raise severity, so re-levelling an
+// event to warning or error later cannot be silently undone here.
+static uint8_t event_syslog_severity(EVENTS_ENUM_TYPE event) {
+  uint8_t sev = event_level_to_syslog(effective_level(event));
+  if (sev > 5 && memchr(notice_events, (uint8_t)event, sizeof(notice_events)) != nullptr) {
+    sev = 5;  // notice
+  }
+  return sev;
 }
 
 /* Initialization function */
@@ -208,9 +266,11 @@ void init_events(void) {
   events.entries[EVENT_BMS_RESET_REQ_SUCCESS].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BMS_RESET_REQ_FAIL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_REQUESTS_HEAT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_WARMED_UP].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_PERIODIC_BMS_RESET_FAILURE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_GPIO_CONFLICT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_GPIO_NOT_DEFINED].level = EVENT_LEVEL_ERROR;
-  events.entries[EVENT_BATTERY_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
 }
 
 void set_event(EVENTS_ENUM_TYPE event, uint8_t data) {
@@ -612,7 +672,7 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched) {
       (events.entries[event].state != EVENT_STATE_ACTIVE_LATCHED)) {
     events.entries[event].MQTTpublished = false;
 
-    LOG_SET_NEXT_SEVERITY(event_level_to_syslog(effective_level(event)));
+    LOG_SET_NEXT_SEVERITY(event_syslog_severity(event));
     DEBUG_PRINTF("Event: %s\n", get_event_message_string(event).c_str());
   }
 

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -673,7 +673,7 @@ static void set_event(EVENTS_ENUM_TYPE event, uint8_t data, bool latched) {
     events.entries[event].MQTTpublished = false;
 
     LOG_SET_NEXT_SEVERITY(event_syslog_severity(event));
-    DEBUG_PRINTF("Event: %s\n", get_event_message_string(event).c_str());
+    DEBUG_PRINTF("%s (event)\n", get_event_message_string(event).c_str());
   }
 
   // We should set the event, update event info

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -417,6 +417,7 @@ void init_webserver() {
     BatteryEmulatorSettingsStore settings;
     settings.clearAll();
     erase_phy_cal_data();
+    LOG_SET_NEXT_SEVERITY(5);  // notice
     logging.println("Factory reset performed from the web interface.");
     request->send(200, "text/html", "OK");
   });
@@ -1760,10 +1761,12 @@ void onOTAEnd(bool success) {
 
   // Log when OTA has finished
   if (success) {
+    LOG_SET_NEXT_SEVERITY(5);  // notice
     logging.println("OTA update finished successfully!");
     hold_pins_across_reset();
     graceful_restart();
   } else {
+    LOG_SET_NEXT_SEVERITY(3);  // err
     logging.println("There was an error during OTA update!");
     // Unpause battery (preserving equipment stop if set)
     setBatteryPause(false, false, EquipmentStop::UNCHANGED, false);

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -400,7 +400,7 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
   // One call, not three: severity and the syslogLine[] assembly buffer are shared
   // globals, so a concurrent logger in another task can otherwise split the line.
   LOG_SET_NEXT_SEVERITY(5);  // notice
-  logging.printf("Wi-Fi Got IP, address: %s\n", WiFi.localIP().toString().c_str());
+  logging.printf("Wi-Fi got IP address: %s\n", WiFi.localIP().toString().c_str());
 
   // One-shot boot notice — fires once per boot, not on every reconnect.
   static bool boot_logged = false;

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -397,8 +397,6 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 
   //clear disconnects events if we got a IP
   clear_event(EVENT_WIFI_DISCONNECT);
-  // One call, not three: severity and the syslogLine[] assembly buffer are shared
-  // globals, so a concurrent logger in another task can otherwise split the line.
   LOG_SET_NEXT_SEVERITY(5);  // notice
   logging.printf("Wi-Fi got IP address: %s\n", WiFi.localIP().toString().c_str());
 

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -419,7 +419,7 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
   if (connected_once) {
-    set_event(EVENT_WIFI_DISCONNECT, 0);
+    set_event(EVENT_WIFI_DISCONNECT, 0);  // also printing a log entry
   }
   //we dont do anything here, the reconnect will be handled by the monitor
   //too many events received when the connection is lost

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -91,7 +91,7 @@ static void check_ap_provisioning_window() {
   }
   // Direct log so EVERY expiry produces a log/syslog line, not just the first per
   // boot (set_event only emits its log line on the inactive->active transition).
-  LOG_SET_NEXT_SEVERITY(6);  // info
+  LOG_SET_NEXT_SEVERITY(5);  // notice
   logging.println("AP provisioning window expired (factory-default AP password), disabling access point.");
   WiFi.softAPdisconnect(true);  // stop the AP and drop the AP bit from the WiFi mode; STA stays up
   ap_active = false;
@@ -242,11 +242,13 @@ static void check_ap_button() {
     if (held >= AP_BUTTON_FACTORY_RESET_MS) {
       BatteryEmulatorSettingsStore settings;
       settings.clearAll();
+      LOG_SET_NEXT_SEVERITY(5);  // notice
       logging.println("Factory reset performed from the board button.");
       erase_phy_cal_data();
       graceful_restart();
     } else if (held >= AP_BUTTON_STA_WIPE_MS) {
       clear_wifi_sta_settings();
+      LOG_SET_NEXT_SEVERITY(5);  // notice
       logging.println("Network settings wiped from the board button.");
       erase_phy_cal_data();
       hold_pins_across_reset();
@@ -395,9 +397,10 @@ void onWifiGotIP(WiFiEvent_t event, WiFiEventInfo_t info) {
 
   //clear disconnects events if we got a IP
   clear_event(EVENT_WIFI_DISCONNECT);
-  logging.print("Wi-Fi Got IP. ");
-  logging.print("IP address: ");
-  logging.println(WiFi.localIP().toString());
+  // One call, not three: severity and the syslogLine[] assembly buffer are shared
+  // globals, so a concurrent logger in another task can otherwise split the line.
+  LOG_SET_NEXT_SEVERITY(5);  // notice
+  logging.printf("Wi-Fi Got IP, address: %s\n", WiFi.localIP().toString().c_str());
 
   // One-shot boot notice — fires once per boot, not on every reconnect.
   static bool boot_logged = false;
@@ -420,7 +423,6 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
   if (connected_once) {
     set_event(EVENT_WIFI_DISCONNECT, 0);
   }
-  logging.println("Wi-Fi disconnected.");
   //we dont do anything here, the reconnect will be handled by the monitor
   //too many events received when the connection is lost
   //normal reconnect retry start at first 2 seconds

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -237,7 +237,6 @@ void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x5E7:  //Message originating from SMA inverter - Pairing request
       /* FALLTHROUGH */
     case 0x660:  //Message originating from SMA inverter - Pairing request
-      logging.println("Received SMA pairing request");
       pairing_events++;
       set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;

--- a/Software/src/inverter/SMA-BYD-H-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-H-CAN.cpp
@@ -238,7 +238,7 @@ void SmaBydHInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       /* FALLTHROUGH */
     case 0x660:  //Message originating from SMA inverter - Pairing request
       pairing_events++;
-      set_event(EVENT_SMA_PAIRING, pairing_events);
+      set_event(EVENT_SMA_PAIRING, pairing_events);  // also printing a log entry
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;
       transmit_can_init = true;
       break;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -133,7 +133,7 @@ void SmaBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       /* FALLTHROUGH */
     case 0x660:  //Message originating from SMA inverter - Pairing request
       pairing_events++;
-      set_event(EVENT_SMA_PAIRING, pairing_events);
+      set_event(EVENT_SMA_PAIRING, pairing_events);  // also printing a log entry
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;
       transmit_can_init();
       break;

--- a/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
+++ b/Software/src/inverter/SMA-BYD-HVS-CAN.cpp
@@ -132,7 +132,6 @@ void SmaBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x5E7:  //Message originating from SMA inverter - Pairing request
       /* FALLTHROUGH */
     case 0x660:  //Message originating from SMA inverter - Pairing request
-      logging.println("Received SMA pairing request");
       pairing_events++;
       set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;

--- a/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
+++ b/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
@@ -219,7 +219,7 @@ void SmaSBSBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
     case 0x5E7:  //Message originating from SMA inverter - Pairing request
     case 0x660:  //Message originating from SMA inverter - Pairing request
       pairing_events++;
-      set_event(EVENT_SMA_PAIRING, pairing_events);
+      set_event(EVENT_SMA_PAIRING, pairing_events);  // also printing a log entry
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;
       transmit_can_init = true;
       break;

--- a/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
+++ b/Software/src/inverter/SMA-SBS-BYD-CAN.cpp
@@ -218,7 +218,6 @@ void SmaSBSBydHvsInverter::map_can_frame_to_variable(CAN_frame rx_frame) {
       break;
     case 0x5E7:  //Message originating from SMA inverter - Pairing request
     case 0x660:  //Message originating from SMA inverter - Pairing request
-      logging.println("Received SMA pairing request");
       pairing_events++;
       set_event(EVENT_SMA_PAIRING, pairing_events);
       datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE * 3;


### PR DESCRIPTION
### What
Removes 20 direct `logging.*` calls that duplicated the line `set_event()` already emits.
Adds a notice-severity table so lifecycle milestones reach RFC 5424 severity 5, and attaches severities to 9 standalone log lines that had none.
Fixes a GPIO event that logged an empty component name, and three events that never had a `.level` assigned. 

### Why
`set_event()` already logs `Event: <message>`, so any adjacent direct log line ships the same news twice — often at two different severities, so they don't even collapse in a syslog view.
Only `EVENT_LEVEL_UPDATE` mapped to notice, and it is a state level, not a logging level: it forces `system_status = UPDATING`, which drives the LED, the web UI status and inverter behaviour. It cannot be reused to promote log lines.
The result is that a syslog server filtering at notice sees "Bootup complete" and nothing else — no connectivity, peer detection or reset cause.

### How
Deletes the direct line wherever the event message is equal or richer; keeps both only where the direct line carries data the event's fixed string plus one `uint8_t` cannot (CAN-FD error codes, precharge trigger detail).
Adds `event_syslog_severity()` backed by a flat `uint8_t` table and a single `memchr` — one byte per entry, against roughly eight bytes of compare-and-branch per case for a switch. The `sev > 5` test means the table can only ever raise severity, so re-levelling an event to warning or error later cannot be silently undone.
`hal.h` now assigns `allocator_name` before `set_event()`, since `set_event()` renders the message synchronously via `failed_allocator()`.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
