### PR TITLE
Performance 📈: Gate time measurement macros on the profiling setting

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -625,36 +625,22 @@ void core_loop(void*) {
         set_event(EVENT_TASK_OVERRUN, (currentMillis - previousMillis10ms));
       }
       previousMillis10ms = currentMillis;
-      if (datalayer.system.info.performance_measurement_active) {
-        START_TIME_MEASUREMENT(10ms);
-        monitor_equipment_stop_button();
-        led_exe();
-        handle_contactors();  // Take care of startup precharge/contactor closing
-        if (precharge_control_enabled) {
-          handle_precharge_control(currentMillis);  //Drive the hia4v1 via PWM
-        }
-        if (battery) {
-          battery->handle_precharge();
-        }
-        END_TIME_MEASUREMENT_MAX(10ms, datalayer.system.status.time_10ms_us);
-      } else {  //Run 10ms tasks without timing it
-        monitor_equipment_stop_button();
-        led_exe();
-        handle_contactors();  // Take care of startup precharge/contactor closing
-        if (precharge_control_enabled) {
-          handle_precharge_control(currentMillis);  //Drive the hia4v1 via PWM
-        }
-        if (battery) {
-          battery->handle_precharge();
-        }
+      START_TIME_MEASUREMENT(10ms);
+      monitor_equipment_stop_button();
+      led_exe();
+      handle_contactors();  // Take care of startup precharge/contactor closing
+      if (precharge_control_enabled) {
+        handle_precharge_control(currentMillis);  //Drive the hia4v1 via PWM
       }
+      if (battery) {
+        battery->handle_precharge();
+      }
+      END_TIME_MEASUREMENT_MAX(10ms, datalayer.system.status.time_10ms_us);
     }
 
     if (currentMillis - previousMillisUpdateVal >= INTERVAL_1_S && loopPhase == 1) {
       previousMillisUpdateVal = currentMillis;  // Order matters on the update_loop!
-      if (datalayer.system.info.performance_measurement_active) {
-        START_TIME_MEASUREMENT(values);
-      }
+      START_TIME_MEASUREMENT(values);
       update_pause_state();  // Check if we are OK to send CAN or need to pause
 
       // Fetch battery values
@@ -682,26 +668,18 @@ void core_loop(void*) {
 
       update_restart_progress();  // Check if we need to restart the ESP32
 
-      if (datalayer.system.info.performance_measurement_active) {
-        END_TIME_MEASUREMENT_MAX(values, datalayer.system.status.time_values_us);
-      }
+      END_TIME_MEASUREMENT_MAX(values, datalayer.system.status.time_values_us);
     }
-    if (datalayer.system.info.performance_measurement_active) {
-      START_TIME_MEASUREMENT(cantx);
+    START_TIME_MEASUREMENT(cantx);
 
-      for (auto& transmitter : transmitters) {
-        transmitter->transmit(currentMillis);
-      }
-
-      END_TIME_MEASUREMENT_MAX(cantx, datalayer.system.status.time_cantx_us);
-    } else {
-      for (auto& transmitter : transmitters) {
-        transmitter->transmit(currentMillis);
-      }
+    for (auto& transmitter : transmitters) {
+      transmitter->transmit(currentMillis);
     }
 
+    END_TIME_MEASUREMENT_MAX(cantx, datalayer.system.status.time_cantx_us);
+
+    END_TIME_MEASUREMENT_MAX(all, datalayer.system.status.core_task_10s_max_us);
     if (datalayer.system.info.performance_measurement_active) {
-      END_TIME_MEASUREMENT_MAX(all, datalayer.system.status.core_task_10s_max_us);
       if (datalayer.system.status.core_task_10s_max_us > datalayer.system.status.core_task_max_us) {
         // Update worst case total time
         datalayer.system.status.core_task_max_us = datalayer.system.status.core_task_10s_max_us;

--- a/Software/src/devboard/utils/time_meas.h
+++ b/Software/src/devboard/utils/time_meas.h
@@ -1,23 +1,51 @@
 #ifndef TIME_MEAS_H_
 #define TIME_MEAS_H_
 
+#include "../../datalayer/datalayer.h"
 #include "esp_timer.h"
+
+/* The measurement macros below are gated on the "Performance profiling on main
+ * page" setting (datalayer.system.info.performance_measurement_active, read once
+ * from NVS at boot). Gating inside the macros instead of at every call site keeps
+ * the timestamping out of the time critical loops when profiling is disabled:
+ * esp_timer_get_time() is a real function call with a hardware poll inside, and
+ * it is not declared pure, so the compiler cannot elide it even when the result
+ * is never used.
+ */
 
 /** Start time measurement in microseconds
  * Input parameter must be a unique "tag", e.g: START_TIME_MEASUREMENT(wifi);
+ * Takes no timestamp when performance profiling is disabled.
  */
-#define START_TIME_MEASUREMENT(x) int64_t start_time_##x __attribute__((unused)) = esp_timer_get_time()
+#define START_TIME_MEASUREMENT(x)                  \
+  int64_t start_time_##x __attribute__((unused)) = \
+      datalayer.system.info.performance_measurement_active ? esp_timer_get_time() : 0
 /** End time measurement in microseconds
  * Input parameters are the unique tag and the name of the ALREADY EXISTING
  * destination variable (int64_t), e.g: END_TIME_MEASUREMENT(wifi, my_wifi_time_int64_t);
+ * The destination is left untouched when performance profiling is disabled.
  */
-#define END_TIME_MEASUREMENT(x, y) y = esp_timer_get_time() - start_time_##x
+#define END_TIME_MEASUREMENT(x, y)                              \
+  do {                                                          \
+    if (datalayer.system.info.performance_measurement_active) { \
+      (y) = esp_timer_get_time() - start_time_##x;              \
+    }                                                           \
+  } while (0)
 /** End time measurement in microseconds, log maximum
  * Input parameters are the unique tag and the name of the ALREADY EXISTING
  * destination variable (int64_t), e.g: END_TIME_MEASUREMENT_MAX(wifi, my_wifi_time_int64_t);
- * 
+ *
  * This will log the maximum value in the destination variable.
+ * The destination is left untouched when performance profiling is disabled.
  */
-#define END_TIME_MEASUREMENT_MAX(x, y) y = MAX(y, esp_timer_get_time() - start_time_##x)
+#define END_TIME_MEASUREMENT_MAX(x, y)                             \
+  do {                                                             \
+    if (datalayer.system.info.performance_measurement_active) {    \
+      int64_t elapsed_##x = esp_timer_get_time() - start_time_##x; \
+      if (elapsed_##x > (y)) {                                     \
+        (y) = elapsed_##x;                                         \
+      }                                                            \
+    }                                                              \
+  } while (0)
 
 #endif


### PR DESCRIPTION
## What
Moves the profiling gate inside the `START_/END_TIME_MEASUREMENT*` macros, so no timestamp is taken at all when "Performance profiling on main page" is off.
Evaluates the end timestamp once instead of twice — the `MAX` macro re-evaluated `esp_timer_get_time()` on every new maximum.
Lets the duplicated timed/untimed copies of the 10 ms task block and the CAN transmit loop in `core_loop` collapse into one copy each.

## Why
Removes 3-4 `esp_timer_get_time()` calls per millisecond from the core task and 2 per connectivity loop iteration that every device paid regardless of the setting, on values nothing reads while profiling is off.
Each of those calls polls a hardware counter — on the classic ESP32 LAC path it spins on `COUNT_LO` until the register latches — so this is real headroom returned to the loop where a 10 ms task drifting to 13 ms can open contactors.
The reported worst case also gets more accurate, since the recorded maximum no longer includes an extra timer read taken after the measured section already ended.

## How
`time_meas.h` gates on `datalayer.system.info.performance_measurement_active` and stores the elapsed time in a local before comparing; no call site needs to change.
`core_loop` keeps a single gate around the snapshot/reset bookkeeping only, which drops the duplicated blocks and saves a little flash on the 4 MB targets.
Side effect: with profiling off, `time_comm_us` / `wifi_task_10s_max_us` / `mqtt_task_10s_max_us` now stay at 0 instead of accumulating a since-boot maximum that nothing resets or displays.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
