### PR TITLE
UI and Logs enhancements around how Wi-Fi information is displayed

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -546,13 +546,13 @@ String get_event_message_string(EVENTS_ENUM_TYPE event) {
     case EVENT_PID_FAILED:
       return "Failed to write PID request to battery";
     case EVENT_WIFI_CONNECT:
-      return "Wifi connected.";
+      return "Wi-Fi connected.";
     case EVENT_WIFI_DISCONNECT:
-      return "Wifi disconnected.";
+      return "Wi-Fi disconnected.";
     case EVENT_WIFI_AP_PASSWORD_DEFAULT:
       return "The AP will be disabled after 5 idle minutes. Change default password to keep AP constantly on!";
     case EVENT_WIFI_AP_PROVISION_TIMEOUT:
-      return "Wifi AP disabled due to cybersecurity concern. Change default password to keep AP "
+      return "Wi-Fi AP disabled due to cybersecurity concern. Change default password to keep AP "
              "constantly on! Reboot/Hold BOOT button 5-15 seconds to re-enable AP temporarily.";
     case EVENT_MQTT_CONNECT:
       return "MQTT connected.";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -445,8 +445,8 @@ void init_webserver() {
       "SYSLOGFAC",  "PERBMSRESETH",
   };
 
-  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD",
-                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",  "SUBNET",
+  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER",  "MQTTPASSWORD",
+                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",   "SUBNET",
                                       "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS"};
 
   // Handles the form POST from UI to save settings of the common image

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1071,7 +1071,9 @@ String processor(const String& var) {
       content += "<h4>Hostname: " + html_escape(WiFi.getHostname()) + "</h4>";
       // MAC is the station address, which is also the source address of the ESPNow
       // frames - handy when filling in the ESPNow receiver MAC list on another node.
-      content += "<h4>IP: " + WiFi.localIP().toString() + " MAC: " + WiFi.macAddress().toLowerCase() + "</h4>";
+      String mac = WiFi.macAddress();
+      mac.toLowerCase();
+      content += "<h4>IP: " + WiFi.localIP().toString() + " MAC: " + mac + "</h4>";
     } else {
       content += "<h4>Wifi state: " + getConnectResultString(status) + "</h4>";
     }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -445,8 +445,8 @@ void init_webserver() {
       "SYSLOGFAC",  "PERBMSRESETH",
   };
 
-  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER",  "MQTTPASSWORD",
-                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",   "SUBNET",
+  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD",
+                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",  "SUBNET",
                                       "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWS"};
 
   // Handles the form POST from UI to save settings of the common image

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -447,7 +447,7 @@ void init_webserver() {
 
   const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD",
                                       "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",  "SUBNET",
-                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWS"};
+                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -447,7 +447,7 @@ void init_webserver() {
 
   const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER",  "MQTTPASSWORD",
                                       "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",   "SUBNET",
-                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS"};
+                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWS"};
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,
@@ -1071,7 +1071,7 @@ String processor(const String& var) {
       content += "<h4>Hostname: " + html_escape(WiFi.getHostname()) + "</h4>";
       // MAC is the station address, which is also the source address of the ESPNow
       // frames - handy when filling in the ESPNow receiver MAC list on another node.
-      content += "<h4>IP: " + WiFi.localIP().toString() + " MAC: " + WiFi.macAddress() + "</h4>";
+      content += "<h4>IP: " + WiFi.localIP().toString() + " MAC: " + WiFi.macAddress().toLowerCase() + "</h4>";
     } else {
       content += "<h4>Wifi state: " + getConnectResultString(status) + "</h4>";
     }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -427,7 +427,7 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 void init_WiFi_AP() {
 
   DEBUG_PRINTF("Creating Wi-Fi AP: %s (password set with %u chars)\n", ssidAP.c_str(), (unsigned)passwordAP.length());
-  
+
   if (!ap_active) {
     // (Re)start the provisioning window timer only on an off->on transition, so
     // repeated re-inits from the STA reconnect fallback don't keep extending it.

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -350,7 +350,6 @@ void connectToWiFi() {
 
   if (WiFi.status() != WL_CONNECTED) {
     lastReconnectAttempt = millis();  // Reset the reconnect attempt timer
-    logging.println("Connecting to Wi-Fi...");
     if (wifi_channel > 14) {
       wifi_channel = 0;
     }  //prevent users going out of bounds

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -127,7 +127,7 @@ static void init_mDNS() {
 }
 
 void init_WiFi() {
-  DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
+  //DEBUG_PRINTF("init_Wifi enabled=%d, ap=%d, ssid=%s\n", wifi_enabled, wifiap_enabled, ssid.c_str());
 
   // Keep the WiFi driver's mode/config changes in RAM instead of NVS. Credentials
   // are stored in our own Preferences and reapplied at boot, so driver-level
@@ -294,12 +294,11 @@ void wifi_monitor() {
       if (current_check_interval + STEP_WIFI_CHECK_INTERVAL <= MAX_STEP_WIFI_CHECK_INTERVAL) {
         current_check_interval += STEP_WIFI_CHECK_INTERVAL;
       }
-      DEBUG_PRINTF("Wi-Fi not connected (%d), attempting to reconnect\n", status);
+      DEBUG_PRINTF("Wi-Fi not connected(%d), reconnect attempt\n", status);
 
       // Try WiFi.reconnect() if it was successfully connected at least once
       if (hasConnectedBefore) {
         lastReconnectAttempt = currentMillis;  // Reset reconnection attempt timer
-        logging.println("Wi-Fi reconnect attempt...");
         if (WiFi.reconnect()) {
           logging.println("Wi-Fi reconnect attempt sucess...");
           reconnectAttempts = 0;  // Reset the attempt counter on successful reconnect
@@ -368,7 +367,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
   // SSID and BSSID are taken from the event payload. The BSSID identifies which AP we landed on when
   // several of them share the SSID.
   const wifi_event_sta_connected_t& ap = info.wifi_sta_connected;
-  DEBUG_PRINTF("Wi-Fi connected (%d), RSSI: %d dBm, SSID: %.*s, BSSID: %02x:%02x:%02x:%02x:%02x:%02x\n", WiFi.status(),
+  DEBUG_PRINTF("Wi-Fi connected(%d), RSSI: %d dBm, SSID: %.*s, BSSID: %02x:%02x:%02x:%02x:%02x:%02x\n", WiFi.status(),
                WiFi.RSSI(), ap.ssid_len, (const char*)ap.ssid, ap.bssid[0], ap.bssid[1], ap.bssid[2], ap.bssid[3],
                ap.bssid[4], ap.bssid[5]);
   hasConnectedBefore = true;                                            // Mark as successfully connected at least once
@@ -427,9 +426,8 @@ void onWifiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 
 void init_WiFi_AP() {
 
-  DEBUG_PRINTF("Creating Access Point: %s\n", ssidAP.c_str());
-  DEBUG_PRINTF("Access Point password set (%u characters)\n", (unsigned)passwordAP.length());
-
+  DEBUG_PRINTF("Creating Wi-Fi AP: %s (password set with %u chars)\n", ssidAP.c_str(), (unsigned)passwordAP.length());
+  
   if (!ap_active) {
     // (Re)start the provisioning window timer only on an off->on transition, so
     // repeated re-inits from the STA reconnect fallback don't keep extending it.
@@ -445,10 +443,10 @@ void init_WiFi_AP() {
     // every AP start; the event additionally shows on the web UI / MQTT (set_event
     // emits its own log line only on the first inactive->active transition per boot).
     LOG_SET_NEXT_SEVERITY(6);  // info
-    logging.println("AP using default password.");
+    logging.println("Access Point using default password!");
     set_event(EVENT_WIFI_AP_PASSWORD_DEFAULT, 0);
   }
   IPAddress IP = WiFi.softAPIP();
 
-  DEBUG_PRINTF("Access Point created, IP address: %s\n", IP.toString().c_str());
+  DEBUG_PRINTF("Access Point IP address: %s\n", IP.toString().c_str());
 }

--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -196,10 +196,10 @@ void init_WiFi() {
   }
 
   // Start Wi-Fi connection
-  DEBUG_PRINTF("start Wifi\n");
+  //DEBUG_PRINTF("start Wifi\n");
   connectToWiFi();
 
-  DEBUG_PRINTF("init_Wifi complete\n");
+  //DEBUG_PRINTF("init_Wifi complete\n");
 }
 
 // Board button (usually BOOT/GPIO0):
@@ -294,7 +294,7 @@ void wifi_monitor() {
       if (current_check_interval + STEP_WIFI_CHECK_INTERVAL <= MAX_STEP_WIFI_CHECK_INTERVAL) {
         current_check_interval += STEP_WIFI_CHECK_INTERVAL;
       }
-      DEBUG_PRINTF("Wi-Fi not connected (status=%d), attempting to reconnect\n", status);
+      DEBUG_PRINTF("Wi-Fi not connected (%d), attempting to reconnect\n", status);
 
       // Try WiFi.reconnect() if it was successfully connected at least once
       if (hasConnectedBefore) {
@@ -380,7 +380,7 @@ void onWifiConnect(WiFiEvent_t event, WiFiEventInfo_t info) {
 }
 
 static void log_ap_sta_event(const char* verb, const uint8_t* mac) {
-  logging.printf("AP: %02X:%02X:%02X:%02X:%02X:%02X %s\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], verb);
+  logging.printf("AP: %02x:%02x:%02x:%02x:%02x:%02x %s\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], verb);
 }
 
 void onApStaConnected(WiFiEvent_t event, WiFiEventInfo_t info) {


### PR DESCRIPTION
### What
- Remove verbose log messages around wifi
- Make consistent usage of "Wifi" and "Wi-Fi" names
- show MAC addresses in lowercase

### Why
- save some flash
- redundant log prints about wifi stuff
- use consistent naming
- easier to read, less clutter

### How
- string corrections

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
