### PR TITLE
Github: Speedup by removing compiler build, move werror to all builds

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -120,7 +120,6 @@ jobs:
         pio run -e ${{ matrix.pio_env }} 2>&1 | tee checkprogsize.txt
 
     - name: Capture size report for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
       run: |
         cat checkprogsize.txt | python .github/scripts/parse_size.py \
           --pio-env "${{ matrix.pio_env }}" \
@@ -131,7 +130,6 @@ jobs:
 
     - name: Compute artifact prefix
       id: name
-      if: matrix.pio_env != 'compiler_warning_check'
       uses: actions/github-script@v9
       env:
         RELEASE_VERSION: ${{ inputs.release_version }}
@@ -157,7 +155,6 @@ jobs:
           core.setOutput('prefix', `BE_${context_seg}_${board}`);
 
     - name: Rename release artifacts for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
       env:
         PREFIX: ${{ steps.name.outputs.prefix }}
         PIO_ENV: ${{ matrix.pio_env }}
@@ -167,7 +164,6 @@ jobs:
         mv ".pio/build/${PIO_ENV}/firmware.bin"         "${PREFIX}.ota.bin"
 
     - name: Upload factory image for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
       uses: actions/upload-artifact@v7
       with:
         path: ${{ steps.name.outputs.prefix }}.factory.bin
@@ -175,7 +171,6 @@ jobs:
         if-no-files-found: error
 
     - name: Upload OTA image for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
       uses: actions/upload-artifact@v7
       with:
         path: ${{ steps.name.outputs.prefix }}.ota.bin
@@ -183,7 +178,6 @@ jobs:
         if-no-files-found: error
 
     - name: Upload size report for ${{ matrix.board_name }}
-      if: matrix.pio_env != 'compiler_warning_check'
       uses: actions/upload-artifact@v7
       with:
         path: ${{ steps.name.outputs.prefix }}.size.json

--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -37,8 +37,6 @@ jobs:
             pio_env: "waveshare_330"
           - board_name: "DFRobot Edge101"
             pio_env: "dfrobot_edge101_330"
-          - board_name: "Compiler warning check"
-            pio_env: "compiler_warning_check"
 
     steps:
     - uses: actions/checkout@v7

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,7 +44,6 @@ build_flags =
     -Wimplicit-fallthrough
     -Wextra
     -Wall
-    -Werror
     -fno-exceptions
     -ffunction-sections
     -fdata-sections
@@ -59,6 +58,7 @@ board_build.partitions = min_spiffs.csv
 lib_deps =
 build_flags =
     ${env.build_flags}
+    -Werror
 
 [common_esp32s3]
 board = esp32s3_flash_16MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ build_flags =
     -Wimplicit-fallthrough
     -Wextra
     -Wall
+    -Werror
     -fno-exceptions
     -ffunction-sections
     -fdata-sections
@@ -73,15 +74,6 @@ build_flags =
     -D ARDUINO_EVENT_RUNNING_CORE=1
 
 ; ── Environments ─────────────────────────────────────────────────────────────
-
-[env:compiler_warning_check]
-extends = common_esp32
-build_flags =
-    ${common_esp32.build_flags}
-    -D HW_LILYGO
-    -D SMALL_FLASH_DEVICE
-    -Werror
-    -D SDCARD
 
 [env:esp32devkit_330]
 extends = common_esp32


### PR DESCRIPTION
### What
This PR speeds up the build system by removing the specific compiler build

### Why
Slow to build

### How
The only thing it did was use -Werror , we can now run -Werror on all builds and skip a separate compiler warning build

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
