### PR TITLE
Link the status page title to the documentation site

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -991,7 +991,8 @@ String processor(const String& var) {
     content += "</style>";
 
     // Compact header
-    content += "<h2>Battery Emulator</h2>";
+    content += "<h2><a href='https://dalathegreat.github.io/Battery-Emulator-Wiki/' target='_blank' "
+               "rel='noopener' style='color:inherit'>Battery Emulator</a></h2>";
 
     // Start content block
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -991,8 +991,9 @@ String processor(const String& var) {
     content += "</style>";
 
     // Compact header
-    content += "<h2><a href='https://dalathegreat.github.io/Battery-Emulator-Wiki/' target='_blank' "
-               "rel='noopener' style='color:inherit'>Battery Emulator</a></h2>";
+    content +=
+        "<h2><a href='https://dalathegreat.github.io/Battery-Emulator-Wiki/' target='_blank' "
+        "rel='noopener' style='color:inherit'>Battery Emulator</a></h2>";
 
     // Start content block
     content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>";


### PR DESCRIPTION
## What
The "Battery Emulator" heading on the status page is now a link to https://dalathegreat.github.io/Battery-Emulator-Wiki/, opening in a new tab.

## Why
Gives users a one-click route from the running device to the documentation, without hunting for the URL.

## How
Wraps the existing `<h2>` text in an anchor in `processor()` in `webserver.cpp`, using `color:inherit` so the heading keeps its current colour while showing the standard underline.