### PR TITLE
BYD-Modbus: report scaled capacity in the p301 block

### DIFF
--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -110,7 +110,7 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   mbPV[304] =
       std::min(datalayer.battery.info.reported_total_capacity_Wh, static_cast<uint32_t>(57960u));  //Cap to 58kWh
   mbPV[305] = std::min(datalayer.battery.status.reported_remaining_capacity_Wh,
-                       static_cast<uint32_t>(57960u));  //Cap to 58kWh
+                       static_cast<uint32_t>(57960u));                        //Cap to 58kWh
   mbPV[306] = std::min(max_discharge_W, static_cast<uint32_t>(30000u));       //Cap to 30000 if exceeding
   mbPV[307] = std::min(max_charge_W, static_cast<uint32_t>(30000u));          //Cap to 30000 if exceeding
   mbPV[310] = datalayer.battery.status.voltage_dV;                            // DC inner voltage.

--- a/Software/src/inverter/BYD-MODBUS.cpp
+++ b/Software/src/inverter/BYD-MODBUS.cpp
@@ -104,20 +104,13 @@ void BydModbusInverter::handle_update_data_modbusp301_byd() {
   } else {
     mbPV[303] = datalayer.battery.status.reported_soc;
   }
-  if (battery2) {
-    mbPV[304] = std::min(datalayer.battery.info.total_capacity_Wh + datalayer.battery2.info.total_capacity_Wh,
-                         static_cast<uint32_t>(57960u));  //Cap to 58kWh
-  } else {
-    mbPV[304] = std::min(datalayer.battery.info.total_capacity_Wh, static_cast<uint32_t>(57960u));  //Cap to 58kWh
-  }
-  if (battery2) {
-    mbPV[305] = std::min(datalayer.battery.status.reported_remaining_capacity_Wh +
-                             datalayer.battery2.status.reported_remaining_capacity_Wh,
-                         static_cast<uint32_t>(57960u));  //Cap to 58kWh
-  } else {
-    mbPV[305] = std::min(datalayer.battery.status.reported_remaining_capacity_Wh,
-                         static_cast<uint32_t>(57960u));  //Cap to 58kWh
-  }
+  // Both capacity registers report the scaled (reported_) values, matching mbPV[202] in the p201 block.
+  // update_calculated_values() already sums battery 2 and 3 into the reported_ fields of battery 1,
+  // so no per-battery addition is needed here.
+  mbPV[304] =
+      std::min(datalayer.battery.info.reported_total_capacity_Wh, static_cast<uint32_t>(57960u));  //Cap to 58kWh
+  mbPV[305] = std::min(datalayer.battery.status.reported_remaining_capacity_Wh,
+                       static_cast<uint32_t>(57960u));  //Cap to 58kWh
   mbPV[306] = std::min(max_discharge_W, static_cast<uint32_t>(30000u));       //Cap to 30000 if exceeding
   mbPV[307] = std::min(max_charge_W, static_cast<uint32_t>(30000u));          //Cap to 30000 if exceeding
   mbPV[310] = datalayer.battery.status.voltage_dV;                            // DC inner voltage.


### PR DESCRIPTION
## What
`mbPV[304]` now sends `reported_total_capacity_Wh` instead of the real `total_capacity_Wh`, matching `mbPV[202]` and `mbPV[305]`. The local double-battery addition is dropped from both p301 capacity registers.

## Why
With Rescale SOC active the inverter keeps sending power despite the Emulator sets limits to 0. With my AZE0 The inverter read a remaining/total ratio far below the SOC in `mbPV[303]` - a 28.9 kWh pack scaled to 19.6 kWh reported 19.6 of 28.9 kWh, so a full pack still showed 9.3 kWh of headroom. The inverter probably thinks it's still allowed to charge.
To be on the safe side. Also it's better to see the "Max­imum Ca­pa­city" reflected in the Fronius UI to the scaled one. The factory battery system can be expanded with modules too, so an occasional changing value for maximum capacity should be supported.

## How
`update_calculated_values()` already aggregates battery 2 and 3 into battery 1's `reported_` fields, so the driver-side addition was also double counting on `mbPV[305]`. Follows the same change c0adf567 made for `mbPV[202]`.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
