### PR TITLE
Add OTA progress percentage

### DIFF
--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1755,7 +1755,11 @@ void onOTAStart() {
 void onOTAProgress(size_t current, size_t final) {
   // Log every 1 second
   if (ota_progress_timer.elapsed()) {
-    logging.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
+    if (final > 0) {
+      constexpr float BYTES_PER_KB = 1024.0f;
+      float percent = (float)current * 100.0f / (float) final;
+      logging.printf("OTA progress: %.1f%% (%.1f / %.1f KB)\n", percent, current / BYTES_PER_KB, final / BYTES_PER_KB);
+    }
     // Reset the "watchdog"
     ota_timeout_timer.reset();
   }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -38,7 +38,7 @@ AsyncWebServer server(80);
 AsyncAuthenticationMiddleware web_auth_middleware;
 
 // Measure OTA progress
-unsigned long ota_progress_millis = 0;
+static MyTimer ota_progress_timer = MyTimer(1000);
 
 #include "advanced_battery_html.h"
 #include "can_logging_html.h"
@@ -1754,8 +1754,7 @@ void onOTAStart() {
 
 void onOTAProgress(size_t current, size_t final) {
   // Log every 1 second
-  if (millis() - ota_progress_millis > 1000) {
-    ota_progress_millis = millis();
+  if (ota_progress_timer.elapsed()) {
     logging.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
     // Reset the "watchdog"
     ota_timeout_timer.reset();

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1774,7 +1774,7 @@ void onOTAEnd(bool success) {
     graceful_restart();
   } else {
     LOG_SET_NEXT_SEVERITY(3);  // err
-    logging.println("There was an error during OTA update!");
+    logging.println("OTA update failed.");
     // Unpause battery (preserving equipment stop if set)
     setBatteryPause(false, false, EquipmentStop::UNCHANGED, false);
   }


### PR DESCRIPTION
### Why
Current OTA logs are not very readable:
```
172.055 OTA update started! (event)
172.076 OTA Progress Current: 706 bytes, Final: 1904800 bytes
172.324 Task took too long to complete. CPU load might be too high. Info message, no action required. (event)
173.080 OTA Progress Current: 106074 bytes, Final: 1904800 bytes
174.082 OTA Progress Current: 211426 bytes, Final: 1904800 bytes
175.154 OTA Progress Current: 333130 bytes, Final: 1904800 bytes
176.307 OTA Progress Current: 463154 bytes, Final: 1904800 bytes
177.423 OTA Progress Current: 594834 bytes, Final: 1904800 bytes
178.567 OTA Progress Current: 726126 bytes, Final: 1904800 bytes
179.708 OTA Progress Current: 856886 bytes, Final: 1904800 bytes
180.811 OTA Progress Current: 987182 bytes, Final: 1904800 bytes
181.924 OTA Progress Current: 1119386 bytes, Final: 1904800 bytes
183.047 OTA Progress Current: 1250062 bytes, Final: 1904800 bytes
184.162 OTA Progress Current: 1381202 bytes, Final: 1904800 bytes
185.298 OTA Progress Current: 1511470 bytes, Final: 1904800 bytes
186.453 OTA Progress Current: 1643834 bytes, Final: 1904800 bytes
187.596 OTA Progress Current: 1774230 bytes, Final: 1904800 bytes
189.107 OTA update finished successfully!
```

### What
This PR changes the format to:
```
549.353 OTA update started! (event)
549.370 OTA progress: 0.0% (0.7 / 1913.9 KB)
549.597 Task took too long to complete. CPU load might be too high. Info message, no action required. (event)
550.372 OTA progress: 5.5% (105.1 / 1913.9 KB)
551.374 OTA progress: 10.9% (208.7 / 1913.9 KB)
552.406 OTA progress: 17.0% (325.0 / 1913.9 KB)
553.498 OTA progress: 23.7% (452.7 / 1913.9 KB)
554.600 OTA progress: 30.3% (580.8 / 1913.9 KB)
555.695 OTA progress: 37.0% (708.6 / 1913.9 KB)
556.772 OTA progress: 43.7% (836.4 / 1913.9 KB)
557.869 OTA progress: 50.4% (964.1 / 1913.9 KB)
558.959 OTA progress: 57.1% (1092.7 / 1913.9 KB)
560.058 OTA progress: 63.8% (1221.3 / 1913.9 KB)
561.163 OTA progress: 70.5% (1349.0 / 1913.9 KB)
562.261 OTA progress: 77.2% (1477.2 / 1913.9 KB)
563.360 OTA progress: 83.8% (1604.1 / 1913.9 KB)
564.444 OTA progress: 90.5% (1732.8 / 1913.9 KB)
565.549 OTA progress: 97.3% (1861.3 / 1913.9 KB)
566.199 OTA update finished successfully!
```

### Alternative
We could also reduce instead of increase flash if we use slightly uglier integer formatting(9c1c7d11218bfc99cfa65b8be43bd9d58b7cc385):
```
 14.453 OTA update started! (event)
 14.472 OTA progress: 0% (0 / 1913 KB)
 14.713 Task took too long to complete. CPU load might be too high. Info message, no action required. (event)
 15.480 OTA progress: 5% (104 / 1913 KB)
 16.481 OTA progress: 10% (204 / 1913 KB)
 17.588 OTA progress: 16% (325 / 1913 KB)
 18.724 OTA progress: 23% (452 / 1913 KB)
 19.857 OTA progress: 30% (580 / 1913 KB)
 20.991 OTA progress: 37% (708 / 1913 KB)
 22.101 OTA progress: 43% (836 / 1913 KB)
 23.226 OTA progress: 50% (964 / 1913 KB)
 24.372 OTA progress: 57% (1093 / 1913 KB)
 25.491 OTA progress: 63% (1220 / 1913 KB)
 26.606 OTA progress: 70% (1349 / 1913 KB)
 27.722 OTA progress: 77% (1476 / 1913 KB)
 28.859 OTA progress: 83% (1604 / 1913 KB)
 30.000 OTA progress: 90% (1732 / 1913 KB)
 31.143 OTA progress: 97% (1860 / 1913 KB)
 31.807 OTA update finished successfully!
```

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
