### PR TITLE
Glob the test sources so adding a test does not mean editing CMakeLists

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,26 +65,23 @@ include_directories(emul)
 # For eModBus
 add_compile_definitions(ESP32 HW_LILYGO COMMON_IMAGE)
 
+# Test sources are globbed so that adding a test does not mean editing this
+# list. Naming every file here means two branches that each add a test conflict
+# on the same line, always with the same resolution. CONFIGURE_DEPENDS re-globs
+# at build time, so a new file is picked up without re-running cmake by hand.
+# The production sources below stay explicit: they are a curated set, and not
+# everything under Software/src builds against the host emulation.
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*_tests.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/battery/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/can_log_based/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utils/*.cpp"
+)
+
 # add the executable
 add_executable(tests 
     tests.cpp
-    voltage_sync_tests.cpp
-    offgrid_downgrade_tests.cpp
-    bms_reset_tests.cpp
-    inverter_alive_tests.cpp
-    millis_wrap_tests.cpp
-    estop_graceful_open_tests.cpp
-    contactor_sequence_tests.cpp
-    battery/FordMachETest.cpp
-    battery_alive_tests.cpp
-    battery/NissanLeafTest.cpp
-    battery/BydAtto3Test.cpp
-    battery/foxess_tests.cpp
-    battery/still_alive_tests.cpp
-    battery/VolvoSPATest.cpp
-    battery/UdsCanBatteryTest.cpp
-    can_log_based/canlog_safety_tests.cpp
-    utils/utils.cpp
+    ${TEST_SOURCES}
     ../Software/src/devboard/safety/parallel_safety.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp


### PR DESCRIPTION
`add_executable(tests ...)` names every test file explicitly, so adding a test means adding a line — and two branches that each add a test conflict on that line even though the resolution is always "keep both". It is the most frequent merge conflict in the test suite and it carries no information.

This globs the test sources only: `*_tests.cpp` at the top level, plus the `battery/`, `can_log_based/` and `utils/` directories, which contain nothing else. `CONFIGURE_DEPENDS` means a new file is picked up on the next build without re-running cmake by hand.

The production sources and the `emul/` shims stay listed explicitly. Those genuinely are a curated set — not everything under `Software/src` builds against the host emulation — so globbing them would be a different and riskier change.

The usual objection to globbing is stale file lists, which `CONFIGURE_DEPENDS` addresses for local builds; CI configures from scratch on every run in any case.

Verification: the four patterns were expanded and compared against the list they replace — the same 17 files, nothing added and nothing dropped. The suite itself is what CI runs here, so a mistake in this change shows up as a red build rather than as silently missing coverage.

Note: drafted with AI assistance, reviewed by me.
