### PR TITLE
VoltageSync tests: drain the drift counters so the suite is idempotent

### DIFF
--- a/test/voltage_sync_tests.cpp
+++ b/test/voltage_sync_tests.cpp
@@ -9,6 +9,20 @@ class VoltageSyncTest : public ::testing::Test {
  protected:
   void SetUp() override {
     init_events();
+    // The drift counters in check_parallel_battery_safety() are function-local
+    // statics, so a preceding run of the timeout tests leaves them latched at
+    // 10 and the next run in the same process starts mid-fault - a plain
+    // --gtest_repeat=2 fails without this. They are not reachable from a
+    // fixture; one in-sync pass through the public API is the reset (the
+    // <=1.5V branch zeroes the counter). 3750 dodges the 3700-startup-default
+    // guard, which returns before touching the counter.
+    battery2_detected = true;
+    battery3_detected = true;
+    datalayer.battery.status.voltage_dV = 3750;
+    datalayer.battery2.status.voltage_dV = 3750;
+    datalayer.battery3.status.voltage_dV = 3750;
+    check_parallel_battery_safety(2);
+    check_parallel_battery_safety(3);
     // Reset datalayer to known state
     datalayer.battery.status.voltage_dV = 3700;   // 370.0V
     datalayer.battery2.status.voltage_dV = 3700;  // 370.0V


### PR DESCRIPTION
The voltage-drift counters in `check_parallel_battery_safety()` are function-local statics. The two timeout tests deliberately count them up to 10 and leave them latched there, so a second run of the suite in the same process starts mid-fault: a plain `--gtest_repeat=2` fails deterministically today, and any repeated invocation of the new one-process shuffle CI step fails the same way. (Single shuffled passes stay green only because no other suite touches these counters.)

The counters are not reachable from a fixture, so the reset goes through the public API instead: one in-sync pass per battery in `SetUp()` zeroes the counter via the `<=1.5V` branch. The pass uses 3750 rather than 3700, because the startup-default guard returns before touching the counter.

Test-only; no production change. Verified: `--gtest_repeat=5` green, and `--gtest_shuffle --gtest_repeat=3` green across seeds 1, 7, 42, 1234, 99999.