### PR TITLE
Settings page: render and save the Tesla GTW settings with the defaults they boot with

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -329,20 +329,23 @@ String settings_processor(const String& var, BatteryEmulatorSettingsStore& setti
                             name_for_comm_interface);
   }
 
+  // The GTW keys must render with the same fallbacks init_stored_settings()
+  // boots with (the driver globals), or a device that never saved them shows
+  // values the firmware is not running.
   if (var == "GTWCOUNTRY") {
-    return options_from_map(settings.getUInt("GTWCOUNTRY", 0), tesla_countries);
+    return options_from_map(settings.getUInt("GTWCOUNTRY", user_selected_tesla_GTW_country), tesla_countries);
   }
 
   if (var == "GTWMAPREG") {
-    return options_from_map(settings.getUInt("GTWMAPREG", 0), tesla_mapregion);
+    return options_from_map(settings.getUInt("GTWMAPREG", user_selected_tesla_GTW_mapRegion), tesla_mapregion);
   }
 
   if (var == "GTWCHASSIS") {
-    return options_from_map(settings.getUInt("GTWCHASSIS", 0), tesla_chassis);
+    return options_from_map(settings.getUInt("GTWCHASSIS", user_selected_tesla_GTW_chassisType), tesla_chassis);
   }
 
   if (var == "GTWPACK") {
-    return options_from_map(settings.getUInt("GTWPACK", 0), tesla_pack);
+    return options_from_map(settings.getUInt("GTWPACK", user_selected_tesla_GTW_packEnergy), tesla_pack);
   }
 
   if (var == "LEDMODE") {
@@ -1033,7 +1036,8 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   }
 
   if (var == "GTWRHD") {
-    return settings.getBool("GTWRHD") ? "checked" : "";
+    // Boots true when unset, so it must also render checked when unset.
+    return settings.getBool("GTWRHD", user_selected_tesla_GTW_rightHandDrive) ? "checked" : "";
   }
 
   if (var == "CTOFFSET") {

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -576,7 +576,16 @@ void init_webserver() {
 
               for (auto& boolSetting : boolSettingNames) {
                 auto p = request->getParam(boolSetting, true);
-                const bool default_value = (std::string(boolSetting) == std::string("WIFIAPENABLED"));
+                // The comparison default must match what the firmware boots with when the
+                // key is unset, or saving that state writes nothing and the page keeps
+                // disagreeing with the firmware. Only two bools boot true: WIFIAPENABLED
+                // and GTWRHD (whose boot fallback is the driver global).
+                bool default_value = false;
+                if (std::string(boolSetting) == std::string("WIFIAPENABLED")) {
+                  default_value = true;
+                } else if (std::string(boolSetting) == std::string("GTWRHD")) {
+                  default_value = user_selected_tesla_GTW_rightHandDrive;
+                }
                 const bool value = p != nullptr && p->value() == "on";
                 if (settings.getBool(boolSetting, default_value) != value) {
                   settings.saveBool(boolSetting, value);


### PR DESCRIPTION
Follow-up to #2724, which moved the boot fallbacks for the five Tesla gateway keys to the driver globals (country 17477 "DE", right-hand-drive `true`, map region 2, chassis 2, pack 1). The render and save sides did not move with it: the settings page still read the keys with a `0`/`false` default, so a device that never saved them showed country 0 / unchecked RHD while the firmware was running the driver defaults.

The right-hand-drive checkbox was also sticky: the save loop compared against `getBool("GTWRHD", false)`, so leaving the box unchecked and pressing Save wrote nothing at all, and the page kept disagreeing with the firmware.

Fix: all three surfaces (boot fallback, page render, save comparison) now read the same `user_selected_tesla_GTW_*` globals, so a future default change moves them together. A host test pins the five defaults so changing one is a deliberate act.

Devices with stored settings are unaffected (stored keys win, as before).

Note: drafted with AI assistance, reviewed by me.
