### PR TITLE
Refuse FD-length frames on the classic CAN transmit paths

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -324,6 +324,13 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
 
   switch (interface) {
     case CAN_NATIVE: {
+      if (tx_frame->DLC > sizeof(CANMessage::data)) {
+        // An FD-length frame cannot be sent on a classic CAN interface (a CAN-FD
+        // battery configured on it produces these), and copying it below would
+        // overflow frame.data on the stack.
+        datalayer.system.info.can_native_send_fail = true;
+        break;
+      }
       CANMessage frame;
       frame.id = tx_frame->ID;
       frame.ext = tx_frame->ext_ID;
@@ -337,6 +344,11 @@ void transmit_can_frame_to_interface(const CAN_frame* tx_frame, CAN_Interface in
       }
     } break;
     case CAN_ADDON_MCP2515: {
+      if (tx_frame->DLC > sizeof(MCP2515_Lite_Frame::data)) {
+        // Same as CAN_NATIVE: an FD-length frame cannot travel over the MCP2515.
+        datalayer.system.info.can_2515_send_fail = true;
+        break;
+      }
       MCP2515_Lite_Frame mcp2515_frame;
       copy_can_frame_to_mcp2515_lite_frame(*tx_frame, mcp2515_frame);
 


### PR DESCRIPTION
The settings UI allows configuring a CAN-FD battery on a classic CAN interface. When that happens, the battery driver hands 32/48-byte frames to `transmit_can_frame_to_interface()`, and the `CAN_NATIVE` case copies `DLC` bytes into `CANMessage`'s 8-byte on-stack data array — memory corruption on every poll, plus malformed DLCs on the wire. On my bench this produced `CAN_NATIVE_BUS_ERROR` + `CAN_NATIVE_BUFFER_FULL` from one second after every boot and made the channel unusable for every node on the bus. The MCP2515 path has no overflow (fixed-size memcpy) but forwarded the oversize DLC to the controller.

Both classic paths now refuse frames whose DLC exceeds the target frame's data buffer (`sizeof` of the actual member, not a literal) and raise the existing send-fail flag, so the misconfiguration surfaces as a persistent CAN-failure event instead of corruption.

Note: drafted with AI assistance, reviewed by me.
