### PR TITLE
Fix ESPNow only configurations not triggering WiFi activation

### DIFF
--- a/Software/src/devboard/wifi/wifi.cpp
+++ b/Software/src/devboard/wifi/wifi.cpp
@@ -100,10 +100,12 @@ static bool wifi_sta_configured() {
   return !ssid.empty() && !password.empty();
 }
 
-// The WiFi radio only needs to come up if either the AP is broadcast or STA
-// credentials are configured
+// The WiFi radio only needs to come up when
+// AP is enabled
+// STA credentials are configured
+// ESPNow is enabled
 static bool wifi_required() {
-  return wifiap_enabled || wifi_sta_configured();
+  return wifiap_enabled || wifi_sta_configured() || espnow_enabled;
 }
 
 void init_WiFi() {


### PR DESCRIPTION
### What
In #2827 I made Wifi startup conditional so that it only starts up when it´s actually configured. This missed the fact that ESPNow is also a user. Just configuring ESPNow without STA credentials and a disabled AP skipped the WiFi init and thus aborted the ESPNow init. Thus we also need to check for ESPNow.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
