### PR TITLE
Make the long-CAN-timeout comment and test match the code

### DIFF
--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -359,11 +359,13 @@ void update_machineryprotection() {
       // Inverter frames received recently - clear any previously raised missing-event
       // regardless of which timeout mode is active
       clear_event(EVENT_CAN_INVERTER_MISSING);
-      // If the inverter is a slow starter, only decrement the counter every 2 seconds to give it more time to start up before we report it as missing
+      // If the inverter is a slow starter, only decrement the counter every third second,
+      // tripling the timeout (60 s -> 180 s) to give it more time to start up before we
+      // report it as missing
       if (user_selected_inverter_long_CAN_timeout) {
         static uint8_t slow_start_counter = 0;
         slow_start_counter++;
-        if (slow_start_counter > 2) {  // Only decrement every 2 seconds
+        if (slow_start_counter > 2) {  // Counts 1, 2, 3: the decrement runs on every third pass
           datalayer.system.status.CAN_inverter_still_alive--;
           slow_start_counter = 0;
         }

--- a/test/inverter_alive_tests.cpp
+++ b/test/inverter_alive_tests.cpp
@@ -93,17 +93,26 @@ TEST(InverterAliveTests, MissingEventClearsOnRecoveryWithNormalTimeout) {
 
 // The long-timeout decrement runs at half rate (every 2nd call); make sure the
 // hoisted clear_event did not change that behavior.
-TEST(InverterAliveTests, LongTimeoutStillDecrementsAtHalfRate) {
+TEST(InverterAliveTests, LongTimeoutDecrementsOnEveryThirdPass) {
   setup_can_inverter_test();
   user_selected_inverter_long_CAN_timeout = true;
 
+  // The pass counter is a function-local static, so its phase carries over from
+  // whatever ran before. Tick until one decrement is observed: that leaves the
+  // phase at a known zero.
   datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
-  // 6 calls at half rate -> the counter must drop by at most 3
+  for (int guard = 0; datalayer.system.status.CAN_inverter_still_alive == CAN_STILL_ALIVE && guard < 4; guard++) {
+    update_machineryprotection();
+  }
+  ASSERT_EQ(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE - 1) << "phase sync failed";
+
+  // From a known phase: six passes are exactly two full 3-tick periods.
+  datalayer.system.status.CAN_inverter_still_alive = CAN_STILL_ALIVE;
   for (int i = 0; i < 6; i++) {
     update_machineryprotection();
   }
-  EXPECT_GE(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE - 3);
-  EXPECT_LT(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE);
+  EXPECT_EQ(datalayer.system.status.CAN_inverter_still_alive, CAN_STILL_ALIVE - 2)
+      << "the long timeout decrements on every third pass - a 3x window, not the 2x the old comment claimed";
 
   user_selected_inverter_long_CAN_timeout = false;
 }


### PR DESCRIPTION
The comment on the slow-starter branch in `update_machineryprotection()` says the still-alive counter is decremented every 2 seconds; the code decrements on every third pass, which is a 3x longer timeout (60 s → 180 s), not 2x. This states the real cadence and the effective timeout in the comment. Comment and test only, no behaviour change.

This is the concrete half of #2684 (question 2): whether the mismatch was in the comment or the code is resolved here as "the code is the intent" — and the belief was load-bearing enough to have named the test covering this branch (`...AtHalfRate`, with bounds that passed under either cadence). The test is renamed and now pins the real cadence exactly, verified by mutation: switching the code to every-2nd fails it. The other half of that issue — whether the driver-side refresh multipliers and this option should stack (SMA + option = 540 s) — is a design question this PR deliberately does not touch.

Note: drafted with AI assistance, reviewed by me.
