### PR TITLE
Restore the battery's veto to the contactor-closing gate

### DIFF
--- a/Software/src/battery/CHARGEBYTE-CCS.cpp
+++ b/Software/src/battery/CHARGEBYTE-CCS.cpp
@@ -221,6 +221,11 @@ void ChargebyteCCSBattery::setup() {
 
   strncpy(datalayer.system.info.battery_protocol, "CCS using chargebyte CME/CCF", 63);
   datalayer.system.info.battery_protocol[63] = '\0';
+  // Vacuous allow, declared: this driver does not yet derive a contactor veto from
+  // module state, so it grants permission unconditionally at setup like the other
+  // setup-granting drivers. Without the write the flag stays at its false default
+  // and the contactor gate never opens for this battery.
+  datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.min_design_voltage_dV = 1000;
   datalayer.battery.info.max_design_voltage_dV = 5000;
   datalayer.battery.info.max_cell_voltage_mV = 4200;

--- a/Software/src/battery/GEELY-SEA-BATTERY.cpp
+++ b/Software/src/battery/GEELY-SEA-BATTERY.cpp
@@ -351,6 +351,11 @@ void GeelySeaBattery::transmit_can(unsigned long currentMillis) {
 void GeelySeaBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
+  // Vacuous allow, declared: this driver does not yet derive a contactor veto from
+  // BMS state, so it grants permission unconditionally at setup like the other
+  // setup-granting drivers. Without the write the flag stays at its false default
+  // and the contactor gate never opens for this battery.
+  datalayer.system.status.battery_allows_contactor_closing = true;
   datalayer.battery.info.total_capacity_Wh = MAX_CAPACITY_NCM_110S_WH;          //Startout in NCM mode
   datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_NCM_110S_DV;  //Startout with max allowed range
   datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_NCM_110S_DV;  //Startout with min allowed range

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -234,7 +234,12 @@ void handle_contactors() {
       set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
       datalayer.system.status.contactors_engaged = 0;
 
-      if (datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active) {
+      // The battery's veto is part of this gate: drivers whose protocol has a
+      // handshake (CHAdeMO's EVSE session being the archetype) hold the flag
+      // false until the vehicle side has granted permission. It was lost in
+      // 1645c5b3, after which contactors closed on inverter say-so alone.
+      if (datalayer.system.status.battery_allows_contactor_closing &&
+          datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active) {
         contactorStatus = START_PRECHARGE;
       }
     }

--- a/test/contactor_sequence_tests.cpp
+++ b/test/contactor_sequence_tests.cpp
@@ -53,6 +53,7 @@ class ContactorSequenceTest : public ::testing::Test {
     emulator_pause_status = NORMAL;
     battery_detected = true;
     datalayer.system.status.system_status = ACTIVE;
+    datalayer.system.status.battery_allows_contactor_closing = true;
     datalayer.system.status.inverter_allows_contactor_closing = true;
     datalayer.system.info.equipment_stop_active = false;
 
@@ -138,6 +139,19 @@ TEST_F(ContactorSequenceTest, LeavesDisconnectedOncePermittedAndNoStop) {
 
   EXPECT_EQ(contactorStatus, PRECHARGE);
   EXPECT_EQ(datalayer.system.status.contactors_engaged, kEngagedClosing);
+}
+
+// The battery's veto is half of the permission gate. Handshake protocols
+// (CHAdeMO's EVSE session) hold it false until the vehicle side has granted
+// permission; losing this check is what let contactors close on inverter
+// say-so alone with nothing plugged in (the 1645c5b3 regression).
+TEST_F(ContactorSequenceTest, StaysDisconnectedWhileTheBatteryWithholdsPermission) {
+  datalayer.system.status.battery_allows_contactor_closing = false;
+
+  tick_at(kBootMs);
+
+  EXPECT_EQ(contactorStatus, DISCONNECTED);
+  EXPECT_EQ(datalayer.system.status.contactors_engaged, 0);
 }
 
 // --- The closing ladder ----------------------------------------------------

--- a/test/contactor_sequence_tests.cpp
+++ b/test/contactor_sequence_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>  // Emul: set_millis64() to control the test clock
 
+#include "../Software/src/battery/BATTERIES.h"
 #include "../Software/src/communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../Software/src/datalayer/datalayer.h"
 #include "../Software/src/devboard/hal/hal.h"
@@ -151,6 +152,45 @@ TEST_F(ContactorSequenceTest, StaysDisconnectedWhileTheBatteryWithholdsPermissio
   tick_at(kBootMs);
 
   EXPECT_EQ(contactorStatus, DISCONNECTED);
+  EXPECT_EQ(datalayer.system.status.contactors_engaged, 0);
+}
+
+// Pinned semantics, stated deliberately: the battery's veto gates CLOSING
+// only. A battery that withdraws permission mid-session does NOT open the
+// contactors from COMPLETED - opening under load is the arc/weld hazard the
+// e-stop path exists to sequence properly, and protocol teardowns (CHAdeMO
+// A.7.2.x) manage their own current-drop ordering before contactors open.
+// If this behavior is ever changed, it must be changed on purpose: this test
+// is the tripwire, not an endorsement of either semantic.
+TEST_F(ContactorSequenceTest, CompletedIsNotReopenedByBatteryRevocation) {
+  contactorStatus = COMPLETED;
+  datalayer.system.status.battery_allows_contactor_closing = false;
+
+  tick_at(kBootMs);
+  tick_at(kBootMs + 1000);
+
+  EXPECT_EQ(contactorStatus, COMPLETED);
+}
+
+// The end-to-end #1863 scenario, through the REAL driver: a CHAdeMO
+// integration with nothing plugged in must not close contactors at boot.
+// The driver withholds battery_allows_contactor_closing until the EVSE
+// handshake grants it (that half never regressed); this asserts the GATE
+// reads the veto - the half 1645c5b3 dropped, which let contactors close on
+// inverter say-so alone with no vehicle present.
+TEST_F(ContactorSequenceTest, ChademoWithNothingPluggedInNeverClosesAtBoot) {
+  user_selected_battery_type = BatteryType::Chademo;
+  setup_battery();
+  ASSERT_NE(battery, nullptr);
+  // The driver owns the veto now; the fixture's blanket grant must not stand
+  // in for it.
+  datalayer.system.status.battery_allows_contactor_closing = false;
+  battery->update_values();  // IDLE tick: unplugged EVSE, no grant
+
+  for (int t = 0; t < 5; ++t) {
+    tick_at(kBootMs + t * 1000);
+    ASSERT_EQ(contactorStatus, DISCONNECTED) << "contactors left DISCONNECTED with no vehicle present (t=" << t << ")";
+  }
   EXPECT_EQ(datalayer.system.status.contactors_engaged, 0);
 }
 

--- a/test/contactor_veto_contract_tests.cpp
+++ b/test/contactor_veto_contract_tests.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <cctype>
+#include <string>
+
+#include "../Software/src/battery/BATTERIES.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+#include "../Software/src/devboard/utils/events.h"
+
+/* The contactor-veto contract, per driver.
+ *
+ * battery_allows_contactor_closing is each battery's veto over contactor
+ * closure, and the closing gate honors it again (it was lost in 1645c5b3).
+ * Restoring the gate means every driver must either drive the veto from real
+ * BMS state or grant it deliberately - a driver that never writes the flag
+ * leaves it at its false default and can never close contactors.
+ *
+ * These tests run EVERY supported battery driver through construction and a
+ * few benign update ticks on the host, and assert the flag lands where that
+ * driver's declared behavior says. A driver that grants at setup or under
+ * benign conditions must show true - a never-writer fails here, which is the
+ * point. A handshake- or CAN-gated driver must show false - granting with no
+ * vehicle data would be the unsafe direction for it.
+ *
+ * A new driver fails until a row is added below, which forces its author to
+ * decide the veto question explicitly. What this cannot distinguish is a
+ * correctly-withholding driver from a never-writer wrongly declared as
+ * withholding - that judgment lives in the veto census and, eventually, the
+ * provides_contactor_veto capability declaration.
+ */
+
+namespace {
+
+// Drivers that must WITHHOLD permission under benign host conditions (no
+// vehicle CAN, default datalayer): their grant comes from decoded vehicle
+// state or a scheduled CAN path that plain update_values() ticks never run.
+// Everyone else must have granted by the time setup + a few ticks are done.
+bool expected_to_withhold(BatteryType type) {
+  switch (type) {
+    case BatteryType::BmwIX:       // grants 2 s after boot, from transmit_can()
+    case BatteryType::BydAtto3:    // grants from system state in transmit_can()
+    case BatteryType::Chademo:     // grants only in CHADEMO_EVSE_START, after the vehicle handshake
+    case BatteryType::Meb:         // grants only in HV-active BMS modes
+    case BatteryType::VAGMqbEvo:   // MEB subclass, same veto
+    case BatteryType::MgGen1:      // grants from decoded BMS state frames
+    case BatteryType::NissanLeaf:  // grants once battery CAN is alive
+    case BatteryType::VolvoSpa:    // grants from system state in transmit_can()
+    case BatteryType::VolvoSpaHybrid:
+      return true;
+    default:
+      return false;
+  }
+}
+
+class ContactorVetoContract : public ::testing::TestWithParam<BatteryType> {};
+
+TEST_P(ContactorVetoContract, DeclaredVetoBehaviorHolds) {
+  const BatteryType type = GetParam();
+
+  datalayer.system.status.system_status = ACTIVE;
+  user_selected_battery_type = type;
+  setup_battery();
+  ASSERT_NE(battery, nullptr) << "create_battery() returned nothing for " << name_for_battery_type(type);
+
+  for (int i = 0; i < 3; ++i) {
+    battery->update_values();
+  }
+
+  if (expected_to_withhold(type)) {
+    EXPECT_FALSE(datalayer.system.status.battery_allows_contactor_closing)
+        << name_for_battery_type(type)
+        << " granted contactor permission with no vehicle data - its veto is supposed to wait for the vehicle";
+  } else {
+    EXPECT_TRUE(datalayer.system.status.battery_allows_contactor_closing)
+        << name_for_battery_type(type)
+        << " never granted contactor permission - under the restored gate this driver cannot close contactors";
+  }
+}
+
+std::string test_name_for(const ::testing::TestParamInfo<BatteryType>& info) {
+  const char* raw = name_for_battery_type(info.param);
+  std::string name = raw ? raw : "";
+  std::string out;
+  for (char c : name) {
+    if (std::isalnum(static_cast<unsigned char>(c))) {
+      out += c;
+    }
+  }
+  return out.empty() ? std::to_string(static_cast<int>(info.param)) : out;
+}
+
+// supported_battery_types() spans the raw enum range, including None and the
+// two unassigned values; only entries with a name are constructible drivers.
+std::vector<BatteryType> constructible_battery_types() {
+  std::vector<BatteryType> out;
+  for (BatteryType type : supported_battery_types()) {
+    if (type != BatteryType::None && name_for_battery_type(type) != nullptr) {
+      out.push_back(type);
+    }
+  }
+  return out;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllBatteryDrivers, ContactorVetoContract, ::testing::ValuesIn(constructible_battery_types()),
+                         test_name_for);
+
+}  // namespace


### PR DESCRIPTION
`battery_allows_contactor_closing` was half of the contactor FSM's DISCONNECTED gate until `1645c5b3` ("Further improve dialogue boxes and texts", #1433, first shipped in v9.0.RC3) dropped it from the condition. Since then contactors close on inverter say-so alone: the gate reads `inverter_allows_contactor_closing && !equipment_stop_active`, and the battery's flag is written by every driver but read by nothing.

That matters for the protocols with a handshake. CHAdeMO holds the flag false from setup and only grants it in `CHADEMO_EVSE_START`, after the CAN session, the pin-4 permission and a valid target voltage. With the gate gone the whole EVSE sequence is bypassed and contactors close at boot with nothing plugged in — the symptom in #1863 and #1662. The same applies, less visibly, to every driver that withholds until it has seen the BMS: MEB/MQB, BMW iX, Atto 3, MG Gen1, LEAF, the Volvos. Their withholding still runs; it just no longer holds anything.

This PR restores the flag to the gate and fixes the two drivers the restoration would otherwise brick. The flag defaults to false, so a driver that never writes it would never close contactors. A census of all 51 driver TUs on current main: 11 drive the veto from real BMS/handshake state, 38 grant unconditionally at setup, and two — **CHARGEBYTE-CCS** and **GEELY-SEA** — never write it at all. Both now grant at setup with the vacuous allow stated in a comment, the same contract as the other 38. No driver's behaviour changes otherwise; the diff to the gate is one added condition.

**Tests.** `contactor_veto_contract_tests` runs every constructible battery driver through setup plus benign update ticks and asserts the flag lands where that driver's declared behaviour says: setup-granting drivers must have granted, handshake- and CAN-gated drivers must still be withholding. A driver that never writes the flag fails, and a new driver fails until its author declares which kind it is — so the two-missing-writers case cannot silently recur. Two scenario tests in `contactor_sequence_tests`: `ChademoWithNothingPluggedInNeverClosesAtBoot` (the #1863 report, through the real driver: five seconds of contactor ticks, DISCONNECTED throughout) and `CompletedIsNotReopenedByBatteryRevocation`, which pins the existing semantics on purpose — the veto gates *closing* only; a battery revoking mid-session does not open contactors from COMPLETED (opening under load is the e-stop path's sequenced job). If that is ever changed, it becomes a decision instead of an accident.

**What this does and does not claim.** It restores the gate that v8 had and that #1863 lost; it is the contactor half of making CHAdeMO usable on main again. The CHAdeMO driver's other regressions (ISA shunt frames routed past the ID filter, the unconditional still-alive kick) are a separate PR so this safety change can be judged on its own. No hardware leg was possible for CHAdeMO itself; the gate change is exercised on the host through the real drivers, and the suite plus the CI shuffle gate are green.

Refs #1863, #1662.

Note: drafted with AI assistance, reviewed by me.
