### PR TITLE
Keep battery 1 events unsuffixed for backwards compatibility

### DIFF
--- a/Software/src/battery/BMW-IX-BATTERY.cpp
+++ b/Software/src/battery/BMW-IX-BATTERY.cpp
@@ -707,7 +707,7 @@ void BmwIXBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         if ((rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]) == 10000 ||
             (rx_frame.data.u8[8] << 8 | rx_frame.data.u8[9]) == 10000) {  //Qualifier Invalid Mode - Request Reboot
           logging.println("Cell MinMax Qualifier Invalid - Requesting BMS Reset");
-          //set_event(EVENT_BATTERY1_VALUE_UNAVAILABLE, (millis()), battery_index); //Eventually need new Info level event type
+          //set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, (millis()), battery_index); //Eventually need new Info level event type
           transmit_can_frame(&BMWiX_6F4_REQUEST_HARD_RESET);
         } else {  //Only ingest values if they are not the 10V Error state
           min_cell_voltage = (rx_frame.data.u8[6] << 8 | rx_frame.data.u8[7]);

--- a/Software/src/battery/CMFA-EV-BATTERY.cpp
+++ b/Software/src/battery/CMFA-EV-BATTERY.cpp
@@ -247,7 +247,7 @@ uint16_t CmfaEvBattery::handle_pid(uint16_t pid, uint32_t value, const uint8_t* 
         if (cellvoltage_reading == 0) {
           //Blown fuse/celltap. Force value to 10mV so user sees this in cellmonitor page. Also fire event
           cellvoltage_reading = 10;
-          set_event(EVENT_BATTERY1_FUSE, cellnumber, battery_index);
+          set_event(EVENT_BATTERY_FUSE, cellnumber, battery_index);
         }
         datalayer_battery->status.cell_voltages_mV[cellnumber] = (uint16_t)(cellvoltage_reading * 0.976563f);
       }

--- a/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
+++ b/Software/src/battery/JAGUAR-IPACE-BATTERY.cpp
@@ -93,9 +93,9 @@ void JaguarIpaceBattery::update_values() {
   }
 
   if (HVILBattIsolationError) {  // Alert user incase battery reports isolation error
-    set_event(EVENT_BATTERY1_ISOLATION, 0, battery_index);
+    set_event(EVENT_BATTERY_ISOLATION, 0, battery_index);
   } else {
-    clear_event(EVENT_BATTERY1_ISOLATION, battery_index);
+    clear_event(EVENT_BATTERY_ISOLATION, battery_index);
   }
 }
 

--- a/Software/src/battery/MG-5-BATTERY.cpp
+++ b/Software/src/battery/MG-5-BATTERY.cpp
@@ -244,10 +244,10 @@ void Mg5Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
       if (rx_frame.data.u8[1] == 0xf && previousState != 0xf) {
         // Isolation fault, set event
-        set_event(EVENT_BATTERY1_ISOLATION, rx_frame.data.u8[0], battery_index);
+        set_event(EVENT_BATTERY_ISOLATION, rx_frame.data.u8[0], battery_index);
       } else if (rx_frame.data.u8[1] != 0xf && previousState == 0xf) {
         // Isolation fault has cleared, clear event
-        clear_event(EVENT_BATTERY1_ISOLATION, battery_index);
+        clear_event(EVENT_BATTERY_ISOLATION, battery_index);
       }
 
       if (rx_frame.data.u8[1] == 0x03 && previousState != 0x03) {

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -95,29 +95,29 @@ void NissanLeafBattery::
   /*Extra safety functions below*/
   if (battery_GIDS < 10)  //700Wh left in battery!
   {                       //Battery is running abnormally low, some discharge logic might have failed. Zero it all out.
-    set_event(EVENT_BATTERY1_EMPTY, 0, battery_index);
+    set_event(EVENT_BATTERY_EMPTY, 0, battery_index);
     datalayer_battery->status.real_soc = 0;
     datalayer_battery->status.max_discharge_power_W = 0;
   }
 
   if (battery_Full_CHARGE_flag) {  //Battery reports that it is fully charged stop all further charging incase it hasn't already
-    set_event(EVENT_BATTERY1_FULL, 0, battery_index);
+    set_event(EVENT_BATTERY_FULL, 0, battery_index);
     datalayer_battery->status.max_charge_power_W = 0;
   } else {
-    clear_event(EVENT_BATTERY1_FULL, battery_index);
+    clear_event(EVENT_BATTERY_FULL, battery_index);
   }
 
   if (battery_Capacity_Empty) {  //Battery reports that it is fully discharged. Stop all further discharging incase it hasn't already
-    set_event(EVENT_BATTERY1_EMPTY, 0, battery_index);
+    set_event(EVENT_BATTERY_EMPTY, 0, battery_index);
     datalayer_battery->status.max_discharge_power_W = 0;
   } else {
-    clear_event(EVENT_BATTERY1_EMPTY, battery_index);
+    clear_event(EVENT_BATTERY_EMPTY, battery_index);
   }
 
   if (battery_Total_Voltage2 == 0x3FF) {  //Battery reports critical measurement unavailable
-    set_event(EVENT_BATTERY1_VALUE_UNAVAILABLE, 0, battery_index);
+    set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, 0, battery_index);
   } else {
-    clear_event(EVENT_BATTERY1_VALUE_UNAVAILABLE, battery_index);
+    clear_event(EVENT_BATTERY_VALUE_UNAVAILABLE, battery_index);
   }
 
   if (battery_Relay_Cut_Request) {  //battery_FAIL, BMS requesting shutdown and contactors to be opened
@@ -143,27 +143,27 @@ void NissanLeafBattery::
         break;
       case (4):
         //Caution Lamp Request
-        set_event(EVENT_BATTERY1_CAUTION, 0, battery_index);
+        set_event(EVENT_BATTERY_CAUTION, 0, battery_index);
         break;
       case (5):
         //Caution Lamp Request & Normal Stop Request
-        set_event(EVENT_BATTERY1_DISCHG_STOP_REQ, 0, battery_index);
+        set_event(EVENT_BATTERY_DISCHG_STOP_REQ, 0, battery_index);
         break;
       case (6):
         //Caution Lamp Request & Charging Mode Stop Request
-        set_event(EVENT_BATTERY1_CHG_STOP_REQ, 0, battery_index);
+        set_event(EVENT_BATTERY_CHG_STOP_REQ, 0, battery_index);
         break;
       case (7):
         //Caution Lamp Request & Charging Mode Stop Request & Normal Stop Request
-        set_event(EVENT_BATTERY1_CHG_DISCHG_STOP_REQ, 0, battery_index);
+        set_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, 0, battery_index);
         break;
       default:
         break;
     }
   } else {  //battery_Failsafe_Status == 0
-    clear_event(EVENT_BATTERY1_DISCHG_STOP_REQ, battery_index);
-    clear_event(EVENT_BATTERY1_CHG_STOP_REQ, battery_index);
-    clear_event(EVENT_BATTERY1_CHG_DISCHG_STOP_REQ, battery_index);
+    clear_event(EVENT_BATTERY_DISCHG_STOP_REQ, battery_index);
+    clear_event(EVENT_BATTERY_CHG_STOP_REQ, battery_index);
+    clear_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, battery_index);
   }
 
   if (user_selected_LEAF_interlock_mandatory) {
@@ -184,10 +184,10 @@ void NissanLeafBattery::
 
   if (battery_HeatExist) {
     if (battery_Heating_Stop) {
-      set_event(EVENT_BATTERY1_WARMED_UP, 0, battery_index);
+      set_event(EVENT_BATTERY_WARMED_UP, 0, battery_index);
     }
     if (battery_Heating_Start) {
-      set_event(EVENT_BATTERY1_REQUESTS_HEAT, 0, battery_index);
+      set_event(EVENT_BATTERY_REQUESTS_HEAT, 0, battery_index);
     }
   }
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -60,10 +60,10 @@ uint16_t RenaultZoeGen1Battery::handle_pid(uint16_t pid, uint32_t value, const u
         }
         // Cell 47 measurement is inbetween pack halves. If low, fuse blown
         if (datalayer_battery->status.cell_voltages_mV[47] < 100) {
-          set_event(EVENT_BATTERY1_FUSE, datalayer_battery->status.cell_voltages_mV[47], battery_index);
+          set_event(EVENT_BATTERY_FUSE, datalayer_battery->status.cell_voltages_mV[47], battery_index);
 
         } else {
-          clear_event(EVENT_BATTERY1_FUSE, battery_index);
+          clear_event(EVENT_BATTERY_FUSE, battery_index);
         }
       }
       break;

--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -96,9 +96,9 @@ void RenaultZoeGen2Battery::update_values() {
 
   /* Removed until we have a way to clear failures
   if (battery_slave_failures > 0) {
-    set_event(EVENT_BATTERY1_CAUTION, 0, battery_index);
+    set_event(EVENT_BATTERY_CAUTION, 0, battery_index);
   } else {
-    clear_event(EVENT_BATTERY1_CAUTION, battery_index);
+    clear_event(EVENT_BATTERY_CAUTION, battery_index);
   }*/
 
   // Update webserver datalayer

--- a/Software/src/battery/RJXZS-BMS.cpp
+++ b/Software/src/battery/RJXZS-BMS.cpp
@@ -201,22 +201,22 @@ void RjxzsBms::handle_incoming_can_frame(CAN_frame rx_frame) {
           set_event(EVENT_DISCHARGE_LIMIT_EXCEEDED, 0);  // could also be EVENT_CHARGE_LIMIT_EXCEEDED
         } else if (protecting_historical_logs == 0x02) {
           // over discharge protection
-          set_event(EVENT_BATTERY1_UNDERVOLTAGE, 0, battery_index);
+          set_event(EVENT_BATTERY_UNDERVOLTAGE, 0, battery_index);
         } else if (protecting_historical_logs == 0x03) {
           // overcharge protection
-          set_event(EVENT_BATTERY1_OVERVOLTAGE, 0, battery_index);
+          set_event(EVENT_BATTERY_OVERVOLTAGE, 0, battery_index);
         } else if (protecting_historical_logs == 0x04) {
           // Over temperature protection
-          set_event(EVENT_BATTERY1_OVERHEAT, 0, battery_index);
+          set_event(EVENT_BATTERY_OVERHEAT, 0, battery_index);
         } else if (protecting_historical_logs == 0x05) {
           // Battery string error protection
-          set_event(EVENT_BATTERY1_CAUTION, 0, battery_index);
+          set_event(EVENT_BATTERY_CAUTION, 0, battery_index);
         } else if (protecting_historical_logs == 0x06) {
           // Damaged charging relay
-          set_event(EVENT_BATTERY1_CHG_STOP_REQ, 0, battery_index);
+          set_event(EVENT_BATTERY_CHG_STOP_REQ, 0, battery_index);
         } else if (protecting_historical_logs == 0x07) {
           // Damaged discharge relay
-          set_event(EVENT_BATTERY1_DISCHG_STOP_REQ, 0, battery_index);
+          set_event(EVENT_BATTERY_DISCHG_STOP_REQ, 0, battery_index);
         } else if (protecting_historical_logs == 0x08) {
           // Low voltage power outage protection
           set_event(EVENT_12V_LOW, 0);
@@ -225,7 +225,7 @@ void RjxzsBms::handle_incoming_can_frame(CAN_frame rx_frame) {
           set_event(EVENT_VOLTAGE_DIFFERENCE_BAT2, differential_pressure_setting_value);
         } else if (protecting_historical_logs == 0x0A) {
           // Low temperature protection
-          set_event(EVENT_BATTERY1_FROZEN, low_temperature_protection_setting_value, battery_index);
+          set_event(EVENT_BATTERY_FROZEN, low_temperature_protection_setting_value, battery_index);
         }
       } else if (mux == 0x54) {
         hall_sensor_type = (rx_frame.data.u8[1] << 8) | rx_frame.data.u8[2];

--- a/Software/src/battery/TESLA-BATTERY.cpp
+++ b/Software/src/battery/TESLA-BATTERY.cpp
@@ -514,17 +514,17 @@ void TeslaBattery::
   }
   //Voltage between 0.5-5.0V, pyrofuse most likely blown
   if (datalayer_battery->status.voltage_dV >= 5 && datalayer_battery->status.voltage_dV <= 50) {
-    set_event(EVENT_BATTERY1_FUSE, 0, battery_index);
+    set_event(EVENT_BATTERY_FUSE, 0, battery_index);
   } else {
-    clear_event(EVENT_BATTERY1_FUSE, battery_index);
+    clear_event(EVENT_BATTERY_FUSE, battery_index);
   }
   // Raise any Tesla BMS events in BE
   // Events: Informational
   if (BMS_a145_SW_SOC_Change) {  // BMS has newly recalibrated pack SOC
-    set_event_latched(EVENT_BATTERY1_SOC_RECALIBRATION, 0,
+    set_event_latched(EVENT_BATTERY_SOC_RECALIBRATION, 0,
                       battery_index);  // Latcched as BMS_a145 can be active for a while
   } else if (!BMS_a145_SW_SOC_Change) {
-    clear_event(EVENT_BATTERY1_SOC_RECALIBRATION, battery_index);
+    clear_event(EVENT_BATTERY_SOC_RECALIBRATION, battery_index);
   }
   // Events: Warning
   if (BMS_contactorState == 5) {  // BMS has detected welded contactor(s)
@@ -601,8 +601,8 @@ void TeslaBattery::
     } else {
       stateMachineSOCReset = 0xFF;
       datalayer_battery->settings.user_requests_tesla_soc_reset = false;
-      set_event(EVENT_BATTERY1_SOC_RESET_FAIL, 0, battery_index);  // also printing a log entry
-      clear_event(EVENT_BATTERY1_SOC_RESET_FAIL, battery_index);
+      set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0, battery_index);  // also printing a log entry
+      clear_event(EVENT_BATTERY_SOC_RESET_FAIL, battery_index);
     }
   }
 
@@ -2327,13 +2327,13 @@ void TeslaBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         clear_event(EVENT_BMS_RESET_REQ_SUCCESS);
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x01\xAA\xAA", 8) == 0) {
-        set_event(EVENT_BATTERY1_SOC_RESET_SUCCESS, 0, battery_index);  // also printing a log entry
-        clear_event(EVENT_BATTERY1_SOC_RESET_SUCCESS, battery_index);
+        set_event(EVENT_BATTERY_SOC_RESET_SUCCESS, 0, battery_index);  // also printing a log entry
+        clear_event(EVENT_BATTERY_SOC_RESET_SUCCESS, battery_index);
         stateMachineBMSReset = 6;  // BMS ECU already unlocked etc. so we jump straight to reset
       }
       if (memcmp(rx_frame.data.u8, "\x05\x71\x01\x04\x07\x00\xAA\xAA", 8) == 0) {
-        set_event(EVENT_BATTERY1_SOC_RESET_FAIL, 0, battery_index);  // also printing a log entry
-        clear_event(EVENT_BATTERY1_SOC_RESET_FAIL, battery_index);
+        set_event(EVENT_BATTERY_SOC_RESET_FAIL, 0, battery_index);  // also printing a log entry
+        clear_event(EVENT_BATTERY_SOC_RESET_FAIL, battery_index);
       }
       break;
     default:

--- a/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
+++ b/Software/src/battery/TESLA-LEGACY-BATTERY.cpp
@@ -90,7 +90,7 @@ void TeslaLegacyBattery::update_values() {
       datalayer.battery.info.total_capacity_Wh = 70000;
       break;
     default:  //Unknown hwID. Raise event
-      set_event(EVENT_BATTERY1_VALUE_UNAVAILABLE, battery_hwID, battery_index);
+      set_event(EVENT_BATTERY_VALUE_UNAVAILABLE, battery_hwID, battery_index);
       break;
   }
 

--- a/Software/src/battery/VOLVO-SPA-BATTERY.cpp
+++ b/Software/src/battery/VOLVO-SPA-BATTERY.cpp
@@ -57,7 +57,7 @@ void VolvoSpaBattery::
   if (BECMsupplyVoltage < 10700) {  //10.7V,
     //If 12V voltage goes under this, latch battery OFF to prevent contactors from swinging between on/off
     set_event(EVENT_12V_LOW, (BECMsupplyVoltage / 100));
-    set_event(EVENT_BATTERY1_CHG_DISCHG_STOP_REQ, 0, battery_index);
+    set_event(EVENT_BATTERY_CHG_DISCHG_STOP_REQ, 0, battery_index);
   }
 
   // Update diagnostic requests from webserver

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -83,24 +83,24 @@ static void check_battery_temperatures(void) {
 
     // Battery is overheated!
     if (max_dC > BATTERY_MAXTEMPERATURE) {
-      set_event(EVENT_BATTERY1_OVERHEAT, max_dC, number);
+      set_event(EVENT_BATTERY_OVERHEAT, max_dC, number);
     } else {
-      clear_event(EVENT_BATTERY1_OVERHEAT, number);
+      clear_event(EVENT_BATTERY_OVERHEAT, number);
     }
 
     // Battery is too cold to operate optimally
     if (min_dC < BATTERY_MINTEMPERATURE) {
-      set_event(EVENT_BATTERY1_FROZEN, min_dC, number);
+      set_event(EVENT_BATTERY_FROZEN, min_dC, number);
     } else {
-      clear_event(EVENT_BATTERY1_FROZEN, number);
+      clear_event(EVENT_BATTERY_FROZEN, number);
     }
 
     /* Not latched: the else branch below could never release a latched event, since
        clear_event() only acts on EVENT_STATE_ACTIVE. The warning now follows the pack. */
     if (deviation_dC > BATTERY_MAX_TEMPERATURE_DEVIATION) {
-      set_event(EVENT_BATTERY1_TEMP_DEVIATION_HIGH, deviation_dC, number);
+      set_event(EVENT_BATTERY_TEMP_DEVIATION_HIGH, deviation_dC, number);
     } else {
-      clear_event(EVENT_BATTERY1_TEMP_DEVIATION_HIGH, number);
+      clear_event(EVENT_BATTERY_TEMP_DEVIATION_HIGH, number);
     }
   }
 }
@@ -197,18 +197,18 @@ void update_machineryprotection() {
 
     // Battery voltage is over designed max voltage!
     if (datalayer.battery.status.voltage_dV > datalayer.battery.info.max_design_voltage_dV) {
-      set_event(EVENT_BATTERY1_OVERVOLTAGE, datalayer.battery.status.voltage_dV, 1);
+      set_event(EVENT_BATTERY_OVERVOLTAGE, datalayer.battery.status.voltage_dV, 1);
       datalayer.battery.status.max_charge_power_W = 0;
     } else {
-      clear_event(EVENT_BATTERY1_OVERVOLTAGE, 1);
+      clear_event(EVENT_BATTERY_OVERVOLTAGE, 1);
     }
 
     // Battery voltage is under designed min voltage!
     if (datalayer.battery.status.voltage_dV < datalayer.battery.info.min_design_voltage_dV) {
-      set_event(EVENT_BATTERY1_UNDERVOLTAGE, datalayer.battery.status.voltage_dV, 1);
+      set_event(EVENT_BATTERY_UNDERVOLTAGE, datalayer.battery.status.voltage_dV, 1);
       datalayer.battery.status.max_discharge_power_W = 0;
     } else {
-      clear_event(EVENT_BATTERY1_UNDERVOLTAGE, 1);
+      clear_event(EVENT_BATTERY_UNDERVOLTAGE, 1);
     }
 
     // Cell overvoltage, further charging not possible. Battery might be imbalanced.
@@ -273,12 +273,12 @@ void update_machineryprotection() {
         datalayer.battery.status.real_soc == 10000)  //Either Scaled OR Real SOC% value is 100.00%
     {
       if (!battery_full_event_fired) {
-        set_event(EVENT_BATTERY1_FULL, 0, 1);
+        set_event(EVENT_BATTERY_FULL, 0, 1);
         battery_full_event_fired = true;
       }
       datalayer.battery.status.max_charge_power_W = 0;
     } else {
-      clear_event(EVENT_BATTERY1_FULL, 1);
+      clear_event(EVENT_BATTERY_FULL, 1);
       battery_full_event_fired = false;
     }
 
@@ -288,12 +288,12 @@ void update_machineryprotection() {
       if (datalayer.battery.status.reported_soc == 0 ||
           datalayer.battery.status.real_soc == 0) {  //Either Scaled OR Real SOC% value is 0.00%, time to stop
         if (!battery_empty_event_fired) {
-          set_event(EVENT_BATTERY1_EMPTY, 0, 1);
+          set_event(EVENT_BATTERY_EMPTY, 0, 1);
           battery_empty_event_fired = true;
         }
         datalayer.battery.status.max_discharge_power_W = 0;
       } else {
-        clear_event(EVENT_BATTERY1_EMPTY, 1);
+        clear_event(EVENT_BATTERY_EMPTY, 1);
         battery_empty_event_fired = false;
       }
     }

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -177,46 +177,46 @@ void init_events(void) {
   events.entries[EVENT_KWH_PLAUSIBILITY_ERROR].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BALANCING_START].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BALANCING_END].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_EMPTY].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_EMPTY].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_EMPTY].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_EMPTY].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_FULL].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_FULL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_FULL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_FULL].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_FUSE].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_FUSE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_FUSE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_FUSE].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_FROZEN].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_FROZEN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_FROZEN].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_FROZEN].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_CAUTION].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_CAUTION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_CAUTION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_CAUTION].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_BATTERY_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY2_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY3_CHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
-  events.entries[EVENT_BATTERY1_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_BATTERY_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY2_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY3_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
-  events.entries[EVENT_BATTERY1_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_BATTERY_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY2_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY3_CHG_DISCHG_STOP_REQ].level = EVENT_LEVEL_ERROR;
-  events.entries[EVENT_BATTERY1_OVERHEAT].level = EVENT_LEVEL_ERROR;
+  events.entries[EVENT_BATTERY_OVERHEAT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY2_OVERHEAT].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BATTERY3_OVERHEAT].level = EVENT_LEVEL_ERROR;
-  events.entries[EVENT_BATTERY1_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_OVERVOLTAGE].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_UNDERVOLTAGE].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_VALUE_UNAVAILABLE].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_VALUE_UNAVAILABLE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_VALUE_UNAVAILABLE].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_VALUE_UNAVAILABLE].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_ISOLATION].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_ISOLATION].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_ISOLATION].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_ISOLATION].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_SOC_RECALIBRATION].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_SOC_RECALIBRATION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_SOC_RECALIBRATION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_SOC_RECALIBRATION].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BYD_AUTO_SOC_CALIBRATION].level = EVENT_LEVEL_INFO;
@@ -224,10 +224,10 @@ void init_events(void) {
   events.entries[EVENT_BYD_CONTACTOR_FORCE_OPEN].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_BYD_CONTACTOR_OPEN_REQ].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BYD_CONTACTOR_CLOSE_REQ].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_SOC_RESET_SUCCESS].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_SOC_RESET_SUCCESS].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_SOC_RESET_SUCCESS].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_SOC_RESET_SUCCESS].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_SOC_RESET_FAIL].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_SOC_RESET_FAIL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_SOC_RESET_FAIL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_SOC_RESET_FAIL].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_VOLTAGE_DIFFERENCE_BAT2].level = EVENT_LEVEL_INFO;
@@ -297,13 +297,13 @@ void init_events(void) {
   events.entries[EVENT_PERIODIC_BMS_RESET].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BMS_RESET_REQ_SUCCESS].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BMS_RESET_REQ_FAIL].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BATTERY_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY2_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_BATTERY3_TEMP_DEVIATION_HIGH].level = EVENT_LEVEL_WARNING;
-  events.entries[EVENT_BATTERY1_REQUESTS_HEAT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_REQUESTS_HEAT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_REQUESTS_HEAT].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_REQUESTS_HEAT].level = EVENT_LEVEL_INFO;
-  events.entries[EVENT_BATTERY1_WARMED_UP].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_BATTERY_WARMED_UP].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY2_WARMED_UP].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_BATTERY3_WARMED_UP].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_PERIODIC_BMS_RESET_FAILURE].level = EVENT_LEVEL_WARNING;
@@ -316,38 +316,38 @@ void set_event(EVENTS_ENUM_TYPE event, int16_t data) {
 }
 
 /* The per-battery event variants are laid out as contiguous 1,2,3 triplets, so the concrete
-   event for a pack is the EVENT_BATTERY1_* variant plus (battery - 1). Nothing about that
+   event for a pack is the EVENT_BATTERY_* variant plus (battery - 1). Nothing about that
    layout is enforced by the type system, so lock it at compile time: inserting or reordering
    an entry inside the block fails the build here rather than silently misdirecting events at
    runtime. Checking the two ends plus one interior triplet is enough, because the block is
    generated as whole triplets and its length is checked too. */
-static_assert(EVENT_BATTERY2_EMPTY == EVENT_BATTERY1_EMPTY + 1 && EVENT_BATTERY3_EMPTY == EVENT_BATTERY1_EMPTY + 2,
+static_assert(EVENT_BATTERY2_EMPTY == EVENT_BATTERY_EMPTY + 1 && EVENT_BATTERY3_EMPTY == EVENT_BATTERY_EMPTY + 2,
               "Per-battery event variants must stay contiguous and in 1,2,3 order");
-static_assert(EVENT_BATTERY2_OVERHEAT == EVENT_BATTERY1_OVERHEAT + 1 &&
-                  EVENT_BATTERY3_OVERHEAT == EVENT_BATTERY1_OVERHEAT + 2,
+static_assert(EVENT_BATTERY2_OVERHEAT == EVENT_BATTERY_OVERHEAT + 1 &&
+                  EVENT_BATTERY3_OVERHEAT == EVENT_BATTERY_OVERHEAT + 2,
               "Per-battery event variants must stay contiguous and in 1,2,3 order");
-static_assert(EVENT_BATTERY2_TEMP_DEVIATION_HIGH == EVENT_BATTERY1_TEMP_DEVIATION_HIGH + 1 &&
-                  EVENT_BATTERY3_TEMP_DEVIATION_HIGH == EVENT_BATTERY1_TEMP_DEVIATION_HIGH + 2,
+static_assert(EVENT_BATTERY2_TEMP_DEVIATION_HIGH == EVENT_BATTERY_TEMP_DEVIATION_HIGH + 1 &&
+                  EVENT_BATTERY3_TEMP_DEVIATION_HIGH == EVENT_BATTERY_TEMP_DEVIATION_HIGH + 2,
               "Per-battery event variants must stay contiguous and in 1,2,3 order");
-static_assert((EVENT_BATTERY3_TEMP_DEVIATION_HIGH - EVENT_BATTERY1_EMPTY + 1) % 3 == 0,
+static_assert((EVENT_BATTERY3_TEMP_DEVIATION_HIGH - EVENT_BATTERY_EMPTY + 1) % 3 == 0,
               "The per-battery event block must consist of whole 1,2,3 triplets");
 
 /* Returns the pack a battery specific event belongs to (1/2/3), or 0 when the event is not
    battery specific. Derived from the enum, so it cannot disagree with the event that was set. */
 static uint8_t event_battery_number(EVENTS_ENUM_TYPE event) {
-  if (event < EVENT_BATTERY1_EMPTY || event > EVENT_BATTERY3_TEMP_DEVIATION_HIGH) {
+  if (event < EVENT_BATTERY_EMPTY || event > EVENT_BATTERY3_TEMP_DEVIATION_HIGH) {
     return 0;
   }
-  return static_cast<uint8_t>((event - EVENT_BATTERY1_EMPTY) % 3 + 1);
+  return static_cast<uint8_t>((event - EVENT_BATTERY_EMPTY) % 3 + 1);
 }
 
-/* Resolve the EVENT_BATTERY1_* variant plus a pack number into the concrete event.
+/* Resolve the EVENT_BATTERY_* variant plus a pack number into the concrete event.
    Resolution is index arithmetic over the enum, so a bad argument would quietly land on an
-   unrelated event. Anything that is not a EVENT_BATTERY1_* base with a pack number of 1..3
+   unrelated event. Anything that is not a EVENT_BATTERY_* base with a pack number of 1..3
    returns EVENT_NOF_EVENTS, which callers report rather than acting on. */
 static EVENTS_ENUM_TYPE resolve_battery_event(EVENTS_ENUM_TYPE event, uint8_t battery) {
-  const bool valid_base = (event >= EVENT_BATTERY1_EMPTY && event <= EVENT_BATTERY3_TEMP_DEVIATION_HIGH &&
-                           (event - EVENT_BATTERY1_EMPTY) % 3 == 0);
+  const bool valid_base = (event >= EVENT_BATTERY_EMPTY && event <= EVENT_BATTERY3_TEMP_DEVIATION_HIGH &&
+                           (event - EVENT_BATTERY_EMPTY) % 3 == 0);
   if (!valid_base || battery < 1 || battery > 3) {
     DEBUG_PRINTF("Bad battery event %d for battery %u\n", (int)event, (unsigned)battery);
     return EVENT_NOF_EVENTS;
@@ -478,71 +478,71 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
       return "Balancing has started";
     case EVENT_BALANCING_END:
       return "Balancing has ended";
-    case EVENT_BATTERY1_EMPTY:
+    case EVENT_BATTERY_EMPTY:
     case EVENT_BATTERY2_EMPTY:
     case EVENT_BATTERY3_EMPTY:
       return "Battery is completely discharged";
-    case EVENT_BATTERY1_FULL:
+    case EVENT_BATTERY_FULL:
     case EVENT_BATTERY2_FULL:
     case EVENT_BATTERY3_FULL:
       return "Battery is fully charged";
-    case EVENT_BATTERY1_FUSE:
+    case EVENT_BATTERY_FUSE:
     case EVENT_BATTERY2_FUSE:
     case EVENT_BATTERY3_FUSE:
       return "Battery internal fuse blown. Inspect battery";
-    case EVENT_BATTERY1_FROZEN:
+    case EVENT_BATTERY_FROZEN:
     case EVENT_BATTERY2_FROZEN:
     case EVENT_BATTERY3_FROZEN:
       return "Battery is too cold to operate optimally. Consider warming it up!";
-    case EVENT_BATTERY1_CAUTION:
+    case EVENT_BATTERY_CAUTION:
     case EVENT_BATTERY2_CAUTION:
     case EVENT_BATTERY3_CAUTION:
       return "Battery has raised a general caution flag. Might want to inspect it closely.";
-    case EVENT_BATTERY1_CHG_STOP_REQ:
+    case EVENT_BATTERY_CHG_STOP_REQ:
     case EVENT_BATTERY2_CHG_STOP_REQ:
     case EVENT_BATTERY3_CHG_STOP_REQ:
       return "Battery raised caution indicator AND requested charge stop. Inspect battery status!";
-    case EVENT_BATTERY1_DISCHG_STOP_REQ:
+    case EVENT_BATTERY_DISCHG_STOP_REQ:
     case EVENT_BATTERY2_DISCHG_STOP_REQ:
     case EVENT_BATTERY3_DISCHG_STOP_REQ:
       return "Battery raised caution indicator AND requested discharge stop. Inspect battery status!";
-    case EVENT_BATTERY1_CHG_DISCHG_STOP_REQ:
+    case EVENT_BATTERY_CHG_DISCHG_STOP_REQ:
     case EVENT_BATTERY2_CHG_DISCHG_STOP_REQ:
     case EVENT_BATTERY3_CHG_DISCHG_STOP_REQ:
       return "Battery raised caution indicator AND requested charge/discharge stop. Inspect battery status!";
-    case EVENT_BATTERY1_REQUESTS_HEAT:
+    case EVENT_BATTERY_REQUESTS_HEAT:
     case EVENT_BATTERY2_REQUESTS_HEAT:
     case EVENT_BATTERY3_REQUESTS_HEAT:
       return "COLD BATTERY! Battery requesting heating pads to activate!";
-    case EVENT_BATTERY1_WARMED_UP:
+    case EVENT_BATTERY_WARMED_UP:
     case EVENT_BATTERY2_WARMED_UP:
     case EVENT_BATTERY3_WARMED_UP:
       return "Battery requesting heating pads to stop. The battery is now warm enough.";
-    case EVENT_BATTERY1_OVERHEAT:
+    case EVENT_BATTERY_OVERHEAT:
     case EVENT_BATTERY2_OVERHEAT:
     case EVENT_BATTERY3_OVERHEAT:
       return "Battery overheated. Shutting down to prevent thermal runaway!";
-    case EVENT_BATTERY1_OVERVOLTAGE:
+    case EVENT_BATTERY_OVERVOLTAGE:
     case EVENT_BATTERY2_OVERVOLTAGE:
     case EVENT_BATTERY3_OVERVOLTAGE:
       return "Battery exceeding maximum design voltage. Discharge battery to prevent damage!";
-    case EVENT_BATTERY1_UNDERVOLTAGE:
+    case EVENT_BATTERY_UNDERVOLTAGE:
     case EVENT_BATTERY2_UNDERVOLTAGE:
     case EVENT_BATTERY3_UNDERVOLTAGE:
       return "Battery under minimum design voltage. Charge battery to prevent damage!";
-    case EVENT_BATTERY1_VALUE_UNAVAILABLE:
+    case EVENT_BATTERY_VALUE_UNAVAILABLE:
     case EVENT_BATTERY2_VALUE_UNAVAILABLE:
     case EVENT_BATTERY3_VALUE_UNAVAILABLE:
       return "Battery measurement unavailable. Check 12V power supply and battery wiring!";
-    case EVENT_BATTERY1_TEMP_DEVIATION_HIGH:
+    case EVENT_BATTERY_TEMP_DEVIATION_HIGH:
     case EVENT_BATTERY2_TEMP_DEVIATION_HIGH:
     case EVENT_BATTERY3_TEMP_DEVIATION_HIGH:
       return "Battery temperature sensors reporting large difference between hottest and coldest cell!";
-    case EVENT_BATTERY1_ISOLATION:
+    case EVENT_BATTERY_ISOLATION:
     case EVENT_BATTERY2_ISOLATION:
     case EVENT_BATTERY3_ISOLATION:
       return "Battery reports isolation error. High voltage might be leaking to ground. Check battery!";
-    case EVENT_BATTERY1_SOC_RECALIBRATION:
+    case EVENT_BATTERY_SOC_RECALIBRATION:
     case EVENT_BATTERY2_SOC_RECALIBRATION:
     case EVENT_BATTERY3_SOC_RECALIBRATION:
       return "The BMS updated the HV battery State of Charge (SOC) by more than 3pct based on SocByOcv.";
@@ -560,11 +560,11 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
     case EVENT_BYD_CONTACTOR_CLOSE_REQ:
       return "Contactor close commanded. The battery precharges and closes its contactors. Data: 1 = cancelled a "
              "pending open.";
-    case EVENT_BATTERY1_SOC_RESET_SUCCESS:
+    case EVENT_BATTERY_SOC_RESET_SUCCESS:
     case EVENT_BATTERY2_SOC_RESET_SUCCESS:
     case EVENT_BATTERY3_SOC_RESET_SUCCESS:
       return "SOC reset routine was successful.";
-    case EVENT_BATTERY1_SOC_RESET_FAIL:
+    case EVENT_BATTERY_SOC_RESET_FAIL:
     case EVENT_BATTERY2_SOC_RESET_FAIL:
     case EVENT_BATTERY3_SOC_RESET_FAIL:
       return "SOC reset routine failed - check SOC is < 15 or > 90, and contactors are open.";

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -10,12 +10,18 @@
 #define GENERATE_STRING(STRING) #STRING,
 
 /* NOTE ON THE PER-BATTERY EVENTS BELOW
-   Every EVENT_BATTERY<n>_* event exists once per pack. The three variants of an event MUST stay
-   contiguous and in 1,2,3 order: set_event(event, data, battery) resolves the concrete event by
-   adding (battery - 1) to the EVENT_BATTERY1_* variant. Inserting anything between them, or
-   reordering them, silently misdirects events -- the static_asserts in events.cpp fail the build
-   if that happens. Keep EVENT_BATTERY1_EMPTY first and EVENT_BATTERY3_TEMP_DEVIATION_HIGH last;
-   set_event() uses both as range bounds. */
+   Every battery specific event exists once per pack. Pack 1 carries no digit and packs 2 and 3
+   are suffixed, matching EVENT_CANFD_BUFFER_FULL / EVENT_CANFD_2_BUFFER_FULL and
+   EVENT_VOLTAGE_DIFFERENCE_BAT2 elsewhere in this enum. So EVENT_BATTERY_OVERHEAT means battery
+   1 specifically, not "some battery" -- these names are published verbatim over MQTT, ESP-NOW
+   and the events page, and single battery installations are the overwhelmingly common case, so
+   keeping pack 1 unsuffixed keeps existing integrations working.
+
+   The three variants of an event MUST stay contiguous and in 1,2,3 order: set_event(event, data,
+   battery) resolves the concrete event by adding (battery - 1) to the unsuffixed variant.
+   Inserting anything between them, or reordering them, silently misdirects events -- the
+   static_asserts in events.cpp fail the build if that happens. Keep EVENT_BATTERY_EMPTY first and
+   EVENT_BATTERY3_TEMP_DEVIATION_HIGH last; set_event() uses both as range bounds. */
 #define EVENTS_ENUM_TYPE(XX)             \
   XX(EVENT_CANMCP2518FD_INIT_FAILURE)    \
   XX(EVENT_CANMCP2515_INIT_FAILURE)      \
@@ -50,61 +56,61 @@
   XX(EVENT_KWH_PLAUSIBILITY_ERROR)       \
   XX(EVENT_BALANCING_START)              \
   XX(EVENT_BALANCING_END)                \
-  XX(EVENT_BATTERY1_EMPTY)               \
+  XX(EVENT_BATTERY_EMPTY)                \
   XX(EVENT_BATTERY2_EMPTY)               \
   XX(EVENT_BATTERY3_EMPTY)               \
-  XX(EVENT_BATTERY1_FULL)                \
+  XX(EVENT_BATTERY_FULL)                 \
   XX(EVENT_BATTERY2_FULL)                \
   XX(EVENT_BATTERY3_FULL)                \
-  XX(EVENT_BATTERY1_FUSE)                \
+  XX(EVENT_BATTERY_FUSE)                 \
   XX(EVENT_BATTERY2_FUSE)                \
   XX(EVENT_BATTERY3_FUSE)                \
-  XX(EVENT_BATTERY1_FROZEN)              \
+  XX(EVENT_BATTERY_FROZEN)               \
   XX(EVENT_BATTERY2_FROZEN)              \
   XX(EVENT_BATTERY3_FROZEN)              \
-  XX(EVENT_BATTERY1_CAUTION)             \
+  XX(EVENT_BATTERY_CAUTION)              \
   XX(EVENT_BATTERY2_CAUTION)             \
   XX(EVENT_BATTERY3_CAUTION)             \
-  XX(EVENT_BATTERY1_CHG_STOP_REQ)        \
+  XX(EVENT_BATTERY_CHG_STOP_REQ)         \
   XX(EVENT_BATTERY2_CHG_STOP_REQ)        \
   XX(EVENT_BATTERY3_CHG_STOP_REQ)        \
-  XX(EVENT_BATTERY1_DISCHG_STOP_REQ)     \
+  XX(EVENT_BATTERY_DISCHG_STOP_REQ)      \
   XX(EVENT_BATTERY2_DISCHG_STOP_REQ)     \
   XX(EVENT_BATTERY3_DISCHG_STOP_REQ)     \
-  XX(EVENT_BATTERY1_CHG_DISCHG_STOP_REQ) \
+  XX(EVENT_BATTERY_CHG_DISCHG_STOP_REQ)  \
   XX(EVENT_BATTERY2_CHG_DISCHG_STOP_REQ) \
   XX(EVENT_BATTERY3_CHG_DISCHG_STOP_REQ) \
-  XX(EVENT_BATTERY1_OVERHEAT)            \
+  XX(EVENT_BATTERY_OVERHEAT)             \
   XX(EVENT_BATTERY2_OVERHEAT)            \
   XX(EVENT_BATTERY3_OVERHEAT)            \
-  XX(EVENT_BATTERY1_OVERVOLTAGE)         \
+  XX(EVENT_BATTERY_OVERVOLTAGE)          \
   XX(EVENT_BATTERY2_OVERVOLTAGE)         \
   XX(EVENT_BATTERY3_OVERVOLTAGE)         \
-  XX(EVENT_BATTERY1_UNDERVOLTAGE)        \
+  XX(EVENT_BATTERY_UNDERVOLTAGE)         \
   XX(EVENT_BATTERY2_UNDERVOLTAGE)        \
   XX(EVENT_BATTERY3_UNDERVOLTAGE)        \
-  XX(EVENT_BATTERY1_VALUE_UNAVAILABLE)   \
+  XX(EVENT_BATTERY_VALUE_UNAVAILABLE)    \
   XX(EVENT_BATTERY2_VALUE_UNAVAILABLE)   \
   XX(EVENT_BATTERY3_VALUE_UNAVAILABLE)   \
-  XX(EVENT_BATTERY1_ISOLATION)           \
+  XX(EVENT_BATTERY_ISOLATION)            \
   XX(EVENT_BATTERY2_ISOLATION)           \
   XX(EVENT_BATTERY3_ISOLATION)           \
-  XX(EVENT_BATTERY1_REQUESTS_HEAT)       \
+  XX(EVENT_BATTERY_REQUESTS_HEAT)        \
   XX(EVENT_BATTERY2_REQUESTS_HEAT)       \
   XX(EVENT_BATTERY3_REQUESTS_HEAT)       \
-  XX(EVENT_BATTERY1_WARMED_UP)           \
+  XX(EVENT_BATTERY_WARMED_UP)            \
   XX(EVENT_BATTERY2_WARMED_UP)           \
   XX(EVENT_BATTERY3_WARMED_UP)           \
-  XX(EVENT_BATTERY1_SOC_RECALIBRATION)   \
+  XX(EVENT_BATTERY_SOC_RECALIBRATION)    \
   XX(EVENT_BATTERY2_SOC_RECALIBRATION)   \
   XX(EVENT_BATTERY3_SOC_RECALIBRATION)   \
-  XX(EVENT_BATTERY1_SOC_RESET_SUCCESS)   \
+  XX(EVENT_BATTERY_SOC_RESET_SUCCESS)    \
   XX(EVENT_BATTERY2_SOC_RESET_SUCCESS)   \
   XX(EVENT_BATTERY3_SOC_RESET_SUCCESS)   \
-  XX(EVENT_BATTERY1_SOC_RESET_FAIL)      \
+  XX(EVENT_BATTERY_SOC_RESET_FAIL)       \
   XX(EVENT_BATTERY2_SOC_RESET_FAIL)      \
   XX(EVENT_BATTERY3_SOC_RESET_FAIL)      \
-  XX(EVENT_BATTERY1_TEMP_DEVIATION_HIGH) \
+  XX(EVENT_BATTERY_TEMP_DEVIATION_HIGH)  \
   XX(EVENT_BATTERY2_TEMP_DEVIATION_HIGH) \
   XX(EVENT_BATTERY3_TEMP_DEVIATION_HIGH) \
   XX(EVENT_BYD_AUTO_SOC_CALIBRATION)     \
@@ -244,10 +250,10 @@ void set_event_latched(EVENTS_ENUM_TYPE event, int16_t data);
 void set_event(EVENTS_ENUM_TYPE event, int16_t data);
 // Battery-aware variant. battery is 1/2/3, or 0 when the event is not tied to one specific pack.
 // A non-zero value appends " (Battery N)" to the event message everywhere it is rendered.
-/* Raise a battery specific event for pack 1, 2 or 3. Pass the EVENT_BATTERY1_* variant as
+/* Raise a battery specific event for pack 1, 2 or 3. Pass the unsuffixed EVENT_BATTERY_* variant as
    `event` and the pack number as `battery`; the concrete event is resolved from the two.
    A driver instance passes its own battery_index, so the same driver code serves every pack.
-   Out of range arguments raise EVENT_BATTERY1_VALUE_UNAVAILABLE rather than corrupting an
+   Out of range arguments raise EVENT_BATTERY_VALUE_UNAVAILABLE rather than corrupting an
    unrelated event, since the resolution is index arithmetic over the enum. */
 void set_event(EVENTS_ENUM_TYPE event, int16_t data, uint8_t battery);
 void set_event_latched(EVENTS_ENUM_TYPE event, int16_t data, uint8_t battery);

--- a/test/can_log_based/canlog_safety_tests.cpp
+++ b/test/can_log_based/canlog_safety_tests.cpp
@@ -181,8 +181,8 @@ class BaseValuesPresentTest : public CanLogTestFixture {
     EXPECT_NE(datalayer.battery.status.temperature_max_dC, INT16_MIN);
     EXPECT_NE(datalayer.battery.status.temperature_min_dC, INT16_MIN);
 
-    EXPECT_EQ(get_event_pointer(EVENT_BATTERY1_OVERVOLTAGE)->occurences, 0);
-    EXPECT_EQ(get_event_pointer(EVENT_BATTERY1_UNDERVOLTAGE)->occurences, 0);
+    EXPECT_EQ(get_event_pointer(EVENT_BATTERY_OVERVOLTAGE)->occurences, 0);
+    EXPECT_EQ(get_event_pointer(EVENT_BATTERY_UNDERVOLTAGE)->occurences, 0);
   }
 };
 
@@ -193,7 +193,7 @@ class OverVoltageTest : public CanLogTestFixture {
   void TestBody() override {
     HandleFramesAndUpdateValues();
 
-    EXPECT_EQ(get_event_pointer(EVENT_BATTERY1_OVERVOLTAGE)->occurences, 1);
+    EXPECT_EQ(get_event_pointer(EVENT_BATTERY_OVERVOLTAGE)->occurences, 1);
   }
 };
 

--- a/test/offgrid_downgrade_tests.cpp
+++ b/test/offgrid_downgrade_tests.cpp
@@ -35,6 +35,6 @@ TEST_F(OffgridDowngradeTest, InverterMissingIsAWarningWhenOffgrid) {
 // that is still a real fault when standalone.
 TEST_F(OffgridDowngradeTest, OffgridDoesNotDowngradeUnlistedEvents) {
   user_selected_inverter_offgrid = true;
-  set_event(EVENT_BATTERY1_OVERHEAT, 0, 1);
+  set_event(EVENT_BATTERY_OVERHEAT, 0, 1);
   EXPECT_EQ(get_event_level(), EVENT_LEVEL_ERROR);
 }


### PR DESCRIPTION
### What
This PR renames the per-battery events added in #2799 so pack 1 carries no digit: `EVENT_BATTERY_OVERHEAT` / `EVENT_BATTERY2_OVERHEAT` / `EVENT_BATTERY3_OVERHEAT` instead of `EVENT_BATTERY1/2/3_*`.
Pure rename across 19 events and 137 references — no enum entries added or removed.

### Why
Those names go out verbatim through `get_event_enum_string()` to the MQTT `event_type` field, the ESP-NOW `EVENT_NAME` field, the events page and the display, so #2799 broke Home Assistant automations, MQTT subscribers and log parsers on every single-battery install.
No release has shipped with the suffixed names yet (`v12.2.0` predates #2799), so this lands before anyone has adapted to them.

### How
Pack 1 unsuffixed with 2 and 3 suffixed matches `EVENT_CANFD_BUFFER_FULL` / `EVENT_CANFD_2_BUFFER_FULL` and `EVENT_VOLTAGE_DIFFERENCE_BAT2` already in the same enum, and `set_event(EVENT_BATTERY_OVERHEAT, data, 2)` no longer reads as passing 1 to mean 2.
The triplet layout, resolver arithmetic and `static_assert`s are untouched; the accepted trade-off is that `EVENT_BATTERY_OVERHEAT` now means battery 1 specifically, documented at the enum and the same ambiguity the CANFD events already carry.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
