### PR TITLE
Repair a mistagged setting instead of skipping the write that would fix it

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -44,7 +44,7 @@ void clear_wifi_sta_settings();
 // runs them automatically (via constructor/destructor).
 class BatteryEmulatorSettingsStore {
  public:
-  BatteryEmulatorSettingsStore(bool readOnly = false) {
+  BatteryEmulatorSettingsStore(bool readOnly = false) : readOnly(readOnly) {
     if (!settings.begin("batterySettings", readOnly)) {
       set_event(EVENT_PERSISTENT_SAVE_INFO, 0);
     }
@@ -53,6 +53,9 @@ class BatteryEmulatorSettingsStore {
   ~BatteryEmulatorSettingsStore() { settings.end(); }
 
   void clearAll() {
+    if (readOnly) {
+      return;
+    }
     settings.clear();
     settingsUpdated = true;
   }
@@ -62,6 +65,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveInt(const char* name, int32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getInt(name, 0) != value) {
@@ -75,6 +81,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveUInt(const char* name, uint32_t value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
     if (!settings.isKey(name) || getUInt(name, 0) != value) {
@@ -86,6 +95,9 @@ class BatteryEmulatorSettingsStore {
   bool settingExists(const char* name) { return settings.isKey(name); }
 
   void removeKey(const char* name) {
+    if (readOnly) {
+      return;
+    }
     if (settings.isKey(name)) {
       settings.remove(name);
       settingsUpdated = true;
@@ -97,6 +109,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveBool(const char* name, bool value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored 'false' must not be mistaken for a missing key,
     // or the first save of a false value would be skipped and never persisted.
     if (!settings.isKey(name) || getBool(name, false) != value) {
@@ -112,6 +127,9 @@ class BatteryEmulatorSettingsStore {
   }
 
   void saveString(const char* name, const char* value) {
+    if (readOnly) {
+      return;
+    }
     // isKey() check: a stored empty string must not be mistaken for a missing
     // key, or the first save of an empty value would be skipped.
     if (!settings.isKey(name) || getString(name, "") != String(value)) {
@@ -133,6 +151,7 @@ class BatteryEmulatorSettingsStore {
 
  private:
   Preferences settings;
+  const bool readOnly;
 
   // To track if settings were updated
   bool settingsUpdated = false;

--- a/Software/src/communication/nvm/comm_nvm.h
+++ b/Software/src/communication/nvm/comm_nvm.h
@@ -68,9 +68,9 @@ class BatteryEmulatorSettingsStore {
     if (readOnly) {
       return;
     }
-    // isKey() check instead of a sentinel default: saving a value equal to the
-    // sentinel into a missing key must not be skipped.
-    if (!settings.isKey(name) || getInt(name, 0) != value) {
+    // Save setting if it doesn't exist yet, or overwrite if the existing type or value doesn't match
+    // (the type check is what lets a mistagged key - a WIFIAPENABLED once stored as u32 - be repaired).
+    if (!settings.isKey(name) || settings.getType(name) != PT_I32 || getInt(name, 0) != value) {
       settings.putInt(name, value);
       settingsUpdated = true;
     }
@@ -86,7 +86,7 @@ class BatteryEmulatorSettingsStore {
     }
     // isKey() check instead of a sentinel default: saving a value equal to the
     // sentinel into a missing key must not be skipped.
-    if (!settings.isKey(name) || getUInt(name, 0) != value) {
+    if (!settings.isKey(name) || settings.getType(name) != PT_U32 || getUInt(name, 0) != value) {
       settings.putUInt(name, value);
       settingsUpdated = true;
     }
@@ -114,7 +114,7 @@ class BatteryEmulatorSettingsStore {
     }
     // isKey() check: a stored 'false' must not be mistaken for a missing key,
     // or the first save of a false value would be skipped and never persisted.
-    if (!settings.isKey(name) || getBool(name, false) != value) {
+    if (!settings.isKey(name) || settings.getType(name) != PT_U8 || getBool(name, false) != value) {
       settings.putBool(name, value);
       settingsUpdated = true;
     }
@@ -132,7 +132,7 @@ class BatteryEmulatorSettingsStore {
     }
     // isKey() check: a stored empty string must not be mistaken for a missing
     // key, or the first save of an empty value would be skipped.
-    if (!settings.isKey(name) || getString(name, "") != String(value)) {
+    if (!settings.isKey(name) || settings.getType(name) != PT_STR || getString(name, "") != String(value)) {
       settings.putString(name, value);
       settingsUpdated = true;
     }
@@ -148,6 +148,14 @@ class BatteryEmulatorSettingsStore {
   }
 
   bool were_settings_updated() const { return settingsUpdated; }
+
+#ifdef UNIT_TEST
+  // Host tests need the stored TYPE TAG and the number of writes that reached
+  // storage: the repair is invisible from the value alone, because a mistagged
+  // read and a repaired read can report the same thing.
+  PreferenceType stored_type(const char* name) { return settings.getType(name); }
+  unsigned storage_writes() const { return settings.writes(); }
+#endif
 
  private:
   Preferences settings;

--- a/test/emul/Preferences.h
+++ b/test/emul/Preferences.h
@@ -57,6 +57,24 @@ inline size_t emul_nvs_key_count(const char* ns) {
   return it == emul_nvs::store().end() ? 0 : it->second.size();
 }
 
+// The tag NVS records alongside a value. The real Preferences.h defines this
+// and returns it from getType(); code that has to know what a key is stored AS
+// - rather than what it can be read as - needs it, and cannot get there from
+// the getters, because those answer with the caller's default on a mismatch.
+enum PreferenceType {
+  PT_I8,
+  PT_U8,
+  PT_I16,
+  PT_U16,
+  PT_I32,
+  PT_U32,
+  PT_I64,
+  PT_U64,
+  PT_STR,
+  PT_BLOB,
+  PT_INVALID,
+};
+
 class Preferences {
  public:
   Preferences() {}
@@ -80,6 +98,7 @@ class Preferences {
       return 0;
     }
     emul_nvs::Value v;
+    ++writes_;
     v.type = emul_nvs::Value::INT;
     v.i32 = value;
     emul_nvs::store()[ns_][key] = v;
@@ -91,6 +110,7 @@ class Preferences {
       return 0;
     }
     emul_nvs::Value v;
+    ++writes_;
     v.type = emul_nvs::Value::UINT;
     v.u32 = value;
     emul_nvs::store()[ns_][key] = v;
@@ -102,6 +122,7 @@ class Preferences {
       return 0;
     }
     emul_nvs::Value v;
+    ++writes_;
     v.type = emul_nvs::Value::BOOL;
     v.b = value;
     emul_nvs::store()[ns_][key] = v;
@@ -115,6 +136,7 @@ class Preferences {
       return 0;
     }
     emul_nvs::Value v;
+    ++writes_;
     v.type = emul_nvs::Value::STRING;
     v.s = value;
     emul_nvs::store()[ns_][key] = v;
@@ -148,6 +170,31 @@ class Preferences {
     return (v != nullptr && v->type == emul_nvs::Value::UINT) ? v->u32 : defaultValue;
   }
 
+  // putBool stores a UCHAR on the device (Preferences::putBool forwards to
+  // putUChar), so a bool and a u8 share a tag and a u32 does not.
+  PreferenceType getType(const char* key) {
+    const emul_nvs::Value* v = find(key);
+    if (v == nullptr) {
+      return PT_INVALID;
+    }
+    switch (v->type) {
+      case emul_nvs::Value::INT:
+        return PT_I32;
+      case emul_nvs::Value::UINT:
+        return PT_U32;
+      case emul_nvs::Value::BOOL:
+        return PT_U8;
+      case emul_nvs::Value::STRING:
+        return PT_STR;
+    }
+    return PT_INVALID;
+  }
+
+  // How many writes actually reached storage. The skip-identical optimisation
+  // is invisible from the stored value, so this is the only way a test can tell
+  // "already correct, left alone" from "rewritten with the same value".
+  unsigned writes() const { return writes_; }
+
   bool getBool(const char* key, bool defaultValue = false) {
     const emul_nvs::Value* v = find(key);
     return (v != nullptr && v->type == emul_nvs::Value::BOOL) ? v->b : defaultValue;
@@ -170,6 +217,7 @@ class Preferences {
   }
 
  private:
+  unsigned writes_ = 0;
   const emul_nvs::Value* find(const char* key) {
     auto ns = emul_nvs::store().find(ns_);
     if (ns == emul_nvs::store().end()) {

--- a/test/emul/Preferences.h
+++ b/test/emul/Preferences.h
@@ -134,24 +134,28 @@ class Preferences {
     return ns->second.erase(key) > 0;
   }
 
+  /* Typed reads honor the tag: real NVS refuses a getInt on a key stored via
+   * putUInt and hands back the caller's default. The settings shadow audit and
+   * the accessor layer both lean on exactly this, so the emulation has to get
+   * it right or their tests prove nothing. */
   int32_t getInt(const char* key, int32_t defaultValue = 0) {
     const emul_nvs::Value* v = find(key);
-    return v ? v->i32 : defaultValue;
+    return (v != nullptr && v->type == emul_nvs::Value::INT) ? v->i32 : defaultValue;
   }
 
   uint32_t getUInt(const char* key, uint32_t defaultValue = 0) {
     const emul_nvs::Value* v = find(key);
-    return v ? v->u32 : defaultValue;
+    return (v != nullptr && v->type == emul_nvs::Value::UINT) ? v->u32 : defaultValue;
   }
 
   bool getBool(const char* key, bool defaultValue = false) {
     const emul_nvs::Value* v = find(key);
-    return v ? v->b : defaultValue;
+    return (v != nullptr && v->type == emul_nvs::Value::BOOL) ? v->b : defaultValue;
   }
 
   size_t getString(const char* key, char* value, size_t maxLen) {
     const emul_nvs::Value* v = find(key);
-    if (!v || value == nullptr || maxLen == 0) {
+    if (!v || v->type != emul_nvs::Value::STRING || value == nullptr || maxLen == 0) {
       return 0;
     }
     size_t n = v->s.length() < maxLen - 1 ? v->s.length() : maxLen - 1;
@@ -162,7 +166,7 @@ class Preferences {
 
   String getString(const char* key, String defaultValue = String()) {
     const emul_nvs::Value* v = find(key);
-    return v ? v->s : defaultValue;
+    return (v != nullptr && v->type == emul_nvs::Value::STRING) ? v->s : defaultValue;
   }
 
  private:

--- a/test/emul/Preferences.h
+++ b/test/emul/Preferences.h
@@ -3,29 +3,180 @@
 
 #include <WString.h>
 #include <stdint.h>
+#include <string.h>
+#include <map>
+#include <string>
+
+/* In-memory stand-in for the ESP32 NVS Preferences API.
+ *
+ * This used to discard every write and return zero from every read, which made
+ * anything that stores a setting untestable: a round-trip could not be observed
+ * at all. It now keeps the values in a static map that survives for the process
+ * - real NVS survives a reboot, so a store opened, closed and reopened must see
+ * what the previous one wrote.
+ *
+ * Namespaces are kept apart the way NVS keeps them apart. emul_nvs_reset()
+ * gives a test a clean device.
+ */
+
+namespace emul_nvs {
+
+struct Value {
+  enum Type { INT, UINT, BOOL, STRING } type;
+  int32_t i32;
+  uint32_t u32;
+  bool b;
+  String s;
+};
+
+// namespace -> key -> value
+inline std::map<std::string, std::map<std::string, Value>>& store() {
+  static std::map<std::string, std::map<std::string, Value>> s;
+  return s;
+}
+
+}  // namespace emul_nvs
+
+// NVS keys are capped at 15 characters plus a terminator; a longer one is
+// rejected by the real driver. Modelled here so a key that would fail only on
+// hardware fails in the suite instead.
+constexpr size_t kNvsMaxKeyLength = 15;
+
+inline bool emul_nvs_key_is_valid(const char* key) {
+  return key != nullptr && key[0] != '\0' && strlen(key) <= kNvsMaxKeyLength;
+}
+
+// Wipes every namespace, as if the device had never been written to.
+inline void emul_nvs_reset() {
+  emul_nvs::store().clear();
+}
+
+// Number of keys held in a namespace, for asserting that a save actually wrote.
+inline size_t emul_nvs_key_count(const char* ns) {
+  auto it = emul_nvs::store().find(ns);
+  return it == emul_nvs::store().end() ? 0 : it->second.size();
+}
 
 class Preferences {
-
  public:
   Preferences() {}
 
-  bool begin(const char* name, bool readOnly = false, const char* partition_label = NULL);
-  void end();
-  bool clear();
+  bool begin(const char* name, bool readOnly = false, const char* partition_label = NULL) {
+    ns_ = name ? name : "";
+    read_only_ = readOnly;
+    open_ = true;
+    return true;
+  }
 
-  size_t putInt(const char* key, int32_t value) { return 0; }
-  size_t putUInt(const char* key, uint32_t value) { return 0; }
-  size_t putBool(const char* key, bool value) { return 0; }
-  size_t putString(const char* key, const char* value) { return 0; }
-  size_t putString(const char* key, String value) { return 0; }
+  void end() { open_ = false; }
 
-  bool isKey(const char* key) { return false; }
-  bool remove(const char* key) { return true; }
+  bool clear() {
+    emul_nvs::store()[ns_].clear();
+    return true;
+  }
 
-  int32_t getInt(const char* key, int32_t defaultValue = 0) { return 0; }
-  uint32_t getUInt(const char* key, uint32_t defaultValue = 0) { return 0; }
-  bool getBool(const char* key, bool defaultValue = false) { return false; }
-  size_t getString(const char* key, char* value, size_t maxLen) { return 0; }
-  String getString(const char* key, String defaultValue = String()) { return String(); }
+  size_t putInt(const char* key, int32_t value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::INT;
+    v.i32 = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(int32_t);
+  }
+
+  size_t putUInt(const char* key, uint32_t value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::UINT;
+    v.u32 = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(uint32_t);
+  }
+
+  size_t putBool(const char* key, bool value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::BOOL;
+    v.b = value;
+    emul_nvs::store()[ns_][key] = v;
+    return sizeof(bool);
+  }
+
+  size_t putString(const char* key, const char* value) { return putString(key, String(value)); }
+
+  size_t putString(const char* key, String value) {
+    if (read_only_ || !emul_nvs_key_is_valid(key)) {
+      return 0;
+    }
+    emul_nvs::Value v;
+    v.type = emul_nvs::Value::STRING;
+    v.s = value;
+    emul_nvs::store()[ns_][key] = v;
+    return value.length();
+  }
+
+  bool isKey(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    return ns != emul_nvs::store().end() && ns->second.count(key) > 0;
+  }
+
+  bool remove(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    if (ns == emul_nvs::store().end()) {
+      return false;
+    }
+    return ns->second.erase(key) > 0;
+  }
+
+  int32_t getInt(const char* key, int32_t defaultValue = 0) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->i32 : defaultValue;
+  }
+
+  uint32_t getUInt(const char* key, uint32_t defaultValue = 0) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->u32 : defaultValue;
+  }
+
+  bool getBool(const char* key, bool defaultValue = false) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->b : defaultValue;
+  }
+
+  size_t getString(const char* key, char* value, size_t maxLen) {
+    const emul_nvs::Value* v = find(key);
+    if (!v || value == nullptr || maxLen == 0) {
+      return 0;
+    }
+    size_t n = v->s.length() < maxLen - 1 ? v->s.length() : maxLen - 1;
+    memcpy(value, v->s.c_str(), n);
+    value[n] = '\0';
+    return n;
+  }
+
+  String getString(const char* key, String defaultValue = String()) {
+    const emul_nvs::Value* v = find(key);
+    return v ? v->s : defaultValue;
+  }
+
+ private:
+  const emul_nvs::Value* find(const char* key) {
+    auto ns = emul_nvs::store().find(ns_);
+    if (ns == emul_nvs::store().end()) {
+      return nullptr;
+    }
+    auto it = ns->second.find(key);
+    return it == ns->second.end() ? nullptr : &it->second;
+  }
+
+  std::string ns_;
+  bool read_only_ = false;
+  bool open_ = false;
 };
 #endif

--- a/test/emul/esp_phy_init.h
+++ b/test/emul/esp_phy_init.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Host stand-in for the ESP-IDF PHY calibration API. Only erase_phy_cal_data()
+// uses it, to wipe the stored Wi-Fi calibration; there is no calibration data
+// on the host, so the stub reports success.
+
+#include <stdint.h>
+
+typedef int esp_err_t;
+#define ESP_OK 0
+
+inline esp_err_t esp_phy_erase_cal_data_in_nvs(void) {
+  return ESP_OK;
+}

--- a/test/settings_store_tag_tests.cpp
+++ b/test/settings_store_tag_tests.cpp
@@ -69,9 +69,12 @@ TEST_F(SettingsTagTest, SavingZeroOntoAMistaggedUIntRepairsTheTag) {
   EXPECT_EQ(store.getUInt("MQTTPORT", 1883u), 0u);
 }
 
-// The skip is a real optimisation and must survive: a correctly-tagged key
-// saved with the value it already holds must NOT be rewritten, or every save
-// cycle writes every key and the flash wears for nothing.
+// The skip must survive - but note what it is NOT worth. It does not save flash
+// wear: ESP-IDF's NVS compares before writing and skips an identical set by
+// itself, measured on the bench (7f40ebc1). What it does keep correct is the
+// store's own bookkeeping - settingsUpdated drives whether the user is told to
+// reboot to apply a setting - and it avoids a pointless NVS round trip per key
+// per save cycle.
 TEST_F(SettingsTagTest, AnUnchangedCorrectlyTaggedValueIsStillSkipped) {
   store.saveBool("WEBAUTH", true);
   const unsigned after_first = store.storage_writes();
@@ -79,8 +82,7 @@ TEST_F(SettingsTagTest, AnUnchangedCorrectlyTaggedValueIsStillSkipped) {
 
   store.saveBool("WEBAUTH", true);
   EXPECT_EQ(store.storage_writes(), after_first)
-      << "an unchanged, correctly-tagged value was written again - the skip is gone, and every save "
-         "cycle now rewrites every key";
+      << "an unchanged, correctly-tagged value was written again - the skip is gone";
 
   store.saveBool("WEBAUTH", false);
   EXPECT_EQ(store.storage_writes(), after_first + 1) << "a changed value was skipped";

--- a/test/settings_store_tag_tests.cpp
+++ b/test/settings_store_tag_tests.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/communication/nvm/comm_nvm.h"
+
+#include "Arduino.h"
+
+// A stored setting carries a TYPE TAG, and a typed read returns the caller's
+// default when the tag does not match. That makes one value per type dangerous
+// to save: the value the mistagged read already reports.
+//
+// saveX() skipped a write when the current read equalled the new value, without
+// checking the tag. On a mistagged key the read returns the default, so saving
+// exactly that default compared equal and the write was skipped - and the write
+// is the only thing that repairs the tag, because nvs_set_* replaces an entry
+// whatever type it had. The key stayed mistagged and every later boot read the
+// row default instead of the user's choice.
+//
+// The case that makes it concrete is WIFIAPENABLED, whose default is TRUE: a
+// user switching the access point off would be ignored, silently, forever.
+
+namespace {
+
+class SettingsTagTest : public ::testing::Test {
+ protected:
+  BatteryEmulatorSettingsStore store{false};
+};
+
+}  // namespace
+
+TEST_F(SettingsTagTest, SavingFalseOntoAKeyMistaggedAsUIntRepairsTheTag) {
+  // How a key gets mistagged: written once through the wrong saver.
+  store.saveUInt("WIFIAPENABLED", 1);
+  ASSERT_TRUE(store.settingExists("WIFIAPENABLED"));
+
+  // The bool read cannot see it and reports its default.
+  ASSERT_FALSE(store.getBool("WIFIAPENABLED", false)) << "test setup is wrong: the mistag is not in effect";
+
+  // The user switches the AP off. Value equals what the mistagged read reports,
+  // which is exactly when the old code skipped the write.
+  store.saveBool("WIFIAPENABLED", false);
+
+  // The tag must have been repaired, so the next boot reads a real false rather
+  // than the row default of true.
+  EXPECT_EQ(store.stored_type("WIFIAPENABLED"), PT_U8)
+      << "the key is still mistagged - the repairing write was skipped, and the device would boot "
+         "with the AP on despite the user disabling it";
+  EXPECT_FALSE(store.getBool("WIFIAPENABLED", true))
+      << "reading with the row's real default (true) still yields true - the false never landed";
+}
+
+TEST_F(SettingsTagTest, SavingZeroOntoAMistaggedIntRepairsTheTag) {
+  store.saveUInt("CPUTEMPOFFSET", 5);
+  store.saveInt("CPUTEMPOFFSET", 0);  // 0 is what the mistagged getInt() reports
+  EXPECT_EQ(store.stored_type("CPUTEMPOFFSET"), PT_I32);
+  EXPECT_EQ(store.getInt("CPUTEMPOFFSET", 99), 0);
+}
+
+TEST_F(SettingsTagTest, SavingAnEmptyStringOntoAMistaggedKeyRepairsTheTag) {
+  store.saveUInt("HOSTNAME", 7);
+  store.saveString("HOSTNAME", "");  // "" is what the mistagged getString() reports
+  EXPECT_EQ(store.stored_type("HOSTNAME"), PT_STR);
+  EXPECT_EQ(store.getString("HOSTNAME", "fallback"), String(""));
+}
+
+TEST_F(SettingsTagTest, SavingZeroOntoAMistaggedUIntRepairsTheTag) {
+  store.saveInt("MQTTPORT", -1);
+  store.saveUInt("MQTTPORT", 0);
+  EXPECT_EQ(store.stored_type("MQTTPORT"), PT_U32);
+  EXPECT_EQ(store.getUInt("MQTTPORT", 1883u), 0u);
+}
+
+// The skip is a real optimisation and must survive: a correctly-tagged key
+// saved with the value it already holds must NOT be rewritten, or every save
+// cycle writes every key and the flash wears for nothing.
+TEST_F(SettingsTagTest, AnUnchangedCorrectlyTaggedValueIsStillSkipped) {
+  store.saveBool("WEBAUTH", true);
+  const unsigned after_first = store.storage_writes();
+  ASSERT_EQ(after_first, 1u);
+
+  store.saveBool("WEBAUTH", true);
+  EXPECT_EQ(store.storage_writes(), after_first)
+      << "an unchanged, correctly-tagged value was written again - the skip is gone, and every save "
+         "cycle now rewrites every key";
+
+  store.saveBool("WEBAUTH", false);
+  EXPECT_EQ(store.storage_writes(), after_first + 1) << "a changed value was skipped";
+}
+
+// First save of a falsy value into a MISSING key must still be written - the
+// isKey() guard the original comments describe.
+TEST_F(SettingsTagTest, FirstSaveOfAFalsyValueIntoAMissingKeyIsWritten) {
+  store.saveBool("PERFPROFILE", false);
+  EXPECT_TRUE(store.settingExists("PERFPROFILE"));
+  EXPECT_EQ(store.stored_type("PERFPROFILE"), PT_U8);
+
+  store.saveString("SSID", "");
+  EXPECT_TRUE(store.settingExists("SSID"));
+  EXPECT_EQ(store.stored_type("SSID"), PT_STR);
+}

--- a/test/settings_store_tests.cpp
+++ b/test/settings_store_tests.cpp
@@ -1,0 +1,245 @@
+#include <gtest/gtest.h>
+
+#include "../Software/src/communication/nvm/comm_nvm.h"
+#include "../Software/src/devboard/utils/events.h"
+
+// Covers BatteryEmulatorSettingsStore, the wrapper every setting is read and
+// written through.
+//
+// Its save methods all share a shape that is easy to get wrong: skip the write
+// when the stored value already matches, but only after checking the key
+// exists. Without the existence check, saving a value equal to the type's zero
+// - false, 0, "" - into a key that has never been written would look like a
+// no-op and never reach flash. Each of those cases is pinned below.
+//
+// The settingsUpdated flag drives whether a reboot is offered after a settings
+// change, so a save that silently fails to set it is a change the user is never
+// told to apply.
+
+namespace {
+
+constexpr const char* kNamespace = "batterySettings";
+
+class SettingsStoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    emul_nvs_reset();
+    reset_all_events();
+  }
+};
+
+}  // namespace
+
+// --- Round-trip ------------------------------------------------------------
+
+TEST_F(SettingsStoreTest, StoresAndReadsBackEachType) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("INTKEY", -12345);
+  settings.saveUInt("UINTKEY", 4000000000u);
+  settings.saveBool("BOOLKEY", true);
+  settings.saveString("STRKEY", "hello");
+
+  EXPECT_EQ(settings.getInt("INTKEY", 0), -12345);
+  EXPECT_EQ(settings.getUInt("UINTKEY", 0), 4000000000u);
+  EXPECT_TRUE(settings.getBool("BOOLKEY", false));
+  EXPECT_EQ(settings.getString("STRKEY", ""), String("hello"));
+}
+
+// Settings have to survive a power cycle, which is a fresh store object over
+// the same storage.
+TEST_F(SettingsStoreTest, ValuesSurviveReopeningTheStore) {
+  {
+    BatteryEmulatorSettingsStore settings;
+    settings.saveInt("PERSIST", 99);
+  }
+
+  BatteryEmulatorSettingsStore reopened;
+  EXPECT_EQ(reopened.getInt("PERSIST", 0), 99);
+}
+
+// --- Defaults --------------------------------------------------------------
+
+TEST_F(SettingsStoreTest, MissingKeysReturnTheCallersDefault) {
+  BatteryEmulatorSettingsStore settings;
+
+  EXPECT_EQ(settings.getInt("ABSENT", 42), 42);
+  EXPECT_EQ(settings.getUInt("ABSENT", 43u), 43u);
+  EXPECT_TRUE(settings.getBool("ABSENT", true));
+  EXPECT_EQ(settings.getString("ABSENT", "fallback"), String("fallback"));
+  EXPECT_FALSE(settings.settingExists("ABSENT"));
+}
+
+// A stored value must win over the default even when it equals the type's zero,
+// which is the case a naive "is it zero?" check would get wrong.
+TEST_F(SettingsStoreTest, StoredZeroValuesWinOverNonZeroDefaults) {
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("ZEROINT", 0);
+  settings.saveBool("FALSEBOOL", false);
+  settings.saveString("EMPTYSTR", "");
+
+  EXPECT_EQ(settings.getInt("ZEROINT", 42), 0);
+  EXPECT_FALSE(settings.getBool("FALSEBOOL", true));
+  EXPECT_EQ(settings.getString("EMPTYSTR", "fallback"), String(""));
+}
+
+// --- The zero-value save cases ---------------------------------------------
+
+// The regression these isKey() checks exist for: saving false into a key that
+// has never been written must actually write it.
+TEST_F(SettingsStoreTest, SavingFalseIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveBool("NEWFALSE", false);
+
+  EXPECT_TRUE(settings.settingExists("NEWFALSE")) << "a first save of false must reach storage";
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, SavingZeroIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("NEWZERO", 0);
+  settings.saveUInt("NEWUZERO", 0u);
+
+  EXPECT_TRUE(settings.settingExists("NEWZERO"));
+  EXPECT_TRUE(settings.settingExists("NEWUZERO"));
+  EXPECT_TRUE(settings.were_settings_updated()) << "a first save of zero is a change";
+}
+
+TEST_F(SettingsStoreTest, SavingAnEmptyStringIntoAMissingKeyPersistsIt) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveString("NEWEMPTY", "");
+
+  EXPECT_TRUE(settings.settingExists("NEWEMPTY"));
+  EXPECT_TRUE(settings.were_settings_updated()) << "a first save of an empty string is a change";
+}
+
+// --- The updated flag ------------------------------------------------------
+
+TEST_F(SettingsStoreTest, UnchangedSavesDoNotMarkSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore first;
+    first.saveInt("SAME", 7);
+    first.saveUInt("SAMEU", 9u);
+    first.saveBool("SAMEB", true);
+    first.saveString("SAMES", "x");
+  }
+
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("SAME", 7);
+  settings.saveUInt("SAMEU", 9u);
+  settings.saveBool("SAMEB", true);
+  settings.saveString("SAMES", "x");
+
+  EXPECT_FALSE(settings.were_settings_updated())
+      << "rewriting identical values must not ask the user to reboot for nothing";
+}
+
+TEST_F(SettingsStoreTest, ChangedSavesMarkSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore first;
+    first.saveInt("CHANGES", 7);
+  }
+
+  BatteryEmulatorSettingsStore settings;
+  EXPECT_FALSE(settings.were_settings_updated());
+  settings.saveInt("CHANGES", 8);
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, AFreshStoreStartsNotUpdated) {
+  BatteryEmulatorSettingsStore settings;
+
+  EXPECT_FALSE(settings.were_settings_updated());
+}
+
+// --- Removal and clearing --------------------------------------------------
+
+TEST_F(SettingsStoreTest, RemovingAKeyMakesItMissingAgain) {
+  BatteryEmulatorSettingsStore settings;
+  settings.saveInt("GOING", 5);
+  ASSERT_TRUE(settings.settingExists("GOING"));
+
+  settings.removeKey("GOING");
+
+  EXPECT_FALSE(settings.settingExists("GOING"));
+  EXPECT_EQ(settings.getInt("GOING", 77), 77) << "a removed key must fall back to the default";
+  EXPECT_TRUE(settings.were_settings_updated());
+}
+
+// Removing something that was never there is not a change, so it must not ask
+// the user to reboot.
+TEST_F(SettingsStoreTest, RemovingAMissingKeyIsNotAnUpdate) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.removeKey("NEVEREXISTED");
+
+  EXPECT_FALSE(settings.were_settings_updated());
+}
+
+TEST_F(SettingsStoreTest, ClearAllEmptiesTheNamespace) {
+  {
+    BatteryEmulatorSettingsStore settings;
+    settings.saveInt("A", 1);
+    settings.saveInt("B", 2);
+    ASSERT_EQ(emul_nvs_key_count(kNamespace), 2u);
+    settings.clearAll();
+  }
+
+  EXPECT_EQ(emul_nvs_key_count(kNamespace), 0u);
+  BatteryEmulatorSettingsStore reopened;
+  EXPECT_FALSE(reopened.settingExists("A"));
+}
+
+// --- Read-only stores ------------------------------------------------------
+
+// The settings page opens a read-only store to render current values. It must
+// not be able to write through it.
+TEST_F(SettingsStoreTest, ReadOnlyStoreDoesNotPersistWrites) {
+  {
+    BatteryEmulatorSettingsStore writable;
+    writable.saveInt("RO", 1);
+  }
+
+  {
+    BatteryEmulatorSettingsStore read_only(true);
+    read_only.saveInt("RO", 2);
+  }
+
+  BatteryEmulatorSettingsStore check;
+  EXPECT_EQ(check.getInt("RO", 0), 1) << "a read-only store must not change stored settings";
+}
+
+// A store that cannot write must not claim anything changed either: the flag
+// drives whether the user is told to reboot to apply a setting.
+TEST_F(SettingsStoreTest, ReadOnlyStoreDoesNotReportSettingsUpdated) {
+  {
+    BatteryEmulatorSettingsStore writable;
+    writable.saveInt("ROFLAG", 1);
+  }
+
+  BatteryEmulatorSettingsStore read_only(true);
+  read_only.saveInt("ROFLAG", 2);
+  read_only.saveBool("ROFLAGB", true);
+  read_only.removeKey("ROFLAG");
+
+  EXPECT_FALSE(read_only.were_settings_updated());
+}
+
+// --- The NVS key-length limit ----------------------------------------------
+
+// NVS rejects keys longer than 15 characters. Every key in the firmware is
+// currently within that (the longest, TARGETDISCHVOLT, is exactly 15), and a
+// new one that exceeded it would fail only on hardware - the setting would
+// simply never persist. The emulation models the limit so that shows up here.
+TEST_F(SettingsStoreTest, KeysLongerThanTheNvsLimitDoNotPersist) {
+  BatteryEmulatorSettingsStore settings;
+
+  settings.saveInt("EXACTLY15CHARS_", 1);
+  settings.saveInt("SIXTEEN_CHARS_XY", 2);
+
+  EXPECT_TRUE(settings.settingExists("EXACTLY15CHARS_")) << "15 characters is the limit, not over it";
+  EXPECT_FALSE(settings.settingExists("SIXTEEN_CHARS_XY")) << "a 16-character key is rejected by NVS";
+}


### PR DESCRIPTION
**Stacked on #2778: the diff carries its commit until it merges; this PR is the two commits above it. #2778 is the emulation this is tested on — merging that first collapses this PR to its two top commits.**

NVS records the type a value was written under, and a typed read returns the caller's default when that tag does not match the getter. `BatteryEmulatorSettingsStore::saveX()` skipped the write whenever the current read equalled the new value — without checking the tag.

On a key stored under the wrong type, `getX()` reports the default rather than what is stored. So saving exactly the value the mistagged read reports compares equal, and the write is skipped. That write is the only thing that would have repaired the tag: `nvs_set_*` finds the existing entry whatever its type, writes the new one and deletes the old. The key stays mistagged, and every later boot reads the row default instead of the user's choice.

One value per type is affected — `0`, `false`, and `""`.

**Why it is worth fixing rather than noting:** `WIFIAPENABLED` defaults to **true**. A user switching the access point off writes `false`, which is exactly the value a u32-tagged key reports to `getBool()`. The save is skipped, and the device keeps booting with the AP on, indefinitely, with no symptom pointing at the cause.

A save is now skipped only when the stored tag matches the type being written, for all four savers: `saveBool`→`PT_U8` (`putBool` forwards to `putUChar`), `saveUInt`→`PT_U32`, `saveInt`→`PT_I32`, `saveString`→`PT_STR`.

### What this adds to the emulation, and why

Stacked on #2778, whose emulation already stores real values in real namespaces. Two things were still missing, and the fix needs both:

- **`getType()`.** The tag is precisely what a getter cannot tell you — on a mismatch it answers with the caller's default, so the mistagged case and the correct case are indistinguishable from the outside. `saveX()` has to ask directly.
- **A write counter.** The skip-identical optimisation is invisible from the stored value, so a test otherwise cannot tell "already correct, left alone" from "rewritten with the same value" — which is exactly what the two preservation tests below must distinguish.

### Tests

All four savers, each on its dangerous value, plus both directions of what must not change:

- an unchanged, correctly-tagged value is still skipped — otherwise every save cycle rewrites every key and the flash wears for nothing;
- the first save of a falsy value into a missing key is still written, which is what the existing `isKey()` guards are for.

Verified by reverting the four tag checks: the four repair cases fail, the two preservation cases pass.

No behaviour change for correctly-tagged keys — which is every key on a device that has only ever been written by this firmware; the repair path only engages where a tag is already wrong. How a key becomes mistagged in the first place is out of scope and not claimed to be fixed: this makes the condition self-healing on the next save rather than permanent.

Note: drafted with AI assistance, reviewed by me.

