### PR TITLE
BYD Vehicle: Fix incorrect voltage on some packs (VM7 + more)

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -238,7 +238,8 @@ void BydAttoBattery::
   if (datalayer_bydatto) {
     datalayer_bydatto->SOC_highprec = battery_highprecision_SOC;
     datalayer_bydatto->SOC_polled = BMS_SOC;
-    datalayer_bydatto->pack_voltage_dV = battery_voltage_dV;
+    //Resolved voltage, not raw 0x438, so the page matches the main view when 0x438 is rejected
+    datalayer_bydatto->pack_voltage_dV = datalayer_battery->status.voltage_dV;
     datalayer_bydatto->insulation_ohm_per_volt = battery_insulation_ohm_per_volt;
     datalayer_bydatto->insulation_valid = battery_insulation_valid;
     datalayer_bydatto->iso_status_valid = (last_35E_ms != 0) && ((millis() - last_35E_ms) < 3000);
@@ -502,7 +503,15 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x438:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
-        battery_voltage_dV = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[5];
+        //b5..b6 is not pack voltage on every pack family (142S decodes to thousands of volts).
+        //Only a resolution upgrade on 0x444, so adopt it once seen and the two agree.
+        const uint16_t candidate_dV = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[5];
+        if (BMS_voltage_available) {
+          const uint16_t reference_dV = battery_voltage * 10;
+          const uint16_t deviation_dV =
+              (candidate_dV > reference_dV) ? (candidate_dV - reference_dV) : (reference_dV - candidate_dV);
+          battery_voltage_dV = (deviation_dV <= VOLTAGE_CROSSCHECK_TOLERANCE_DV) ? candidate_dV : 0;
+        }
       } else {
         datalayer_battery->status.CAN_error_counter++;
       }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -142,6 +142,9 @@ class BydAttoBattery : public CanBattery {
   static const uint16_t MAX_CELL_VOLTAGE_MV = 3650;  //Charging stops if one cell exceeds this value
   static const uint16_t MIN_CELL_VOLTAGE_MV = 2800;  //Discharging stops if one cell goes below this value
 
+  //Max 0x438-vs-0x444 disagreement before 0x438 is treated as not carrying pack voltage
+  static const uint16_t VOLTAGE_CROSSCHECK_TOLERANCE_DV = 50;
+
   uint16_t rampdown_power = 0;
   uint16_t poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
   uint16_t pid_reply = 0;

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -183,10 +183,11 @@ TEST(BydAtto3Tests, ShouldIgnore0x438UntilAReference0x444HasArrived) {
   battery->setup();
 
   // No 0x444 yet, so there is nothing to cross-check against and 0x438 must not be adopted.
+  const uint16_t initial_voltage_dV = datalayer.battery.status.voltage_dV;
   battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x05, 0xFF, 0x00, 0x00, 0x8E}));
   battery->update_values();
 
-  EXPECT_EQ(datalayer.battery.status.voltage_dV, 0);
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, initial_voltage_dV);
 
   // Once the reference arrives, the same 0x438 is judged and rejected.
   battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xD2, 0x01, 0x88, 0x13, 0x64, 0x1C, 0x4E}));

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -50,6 +50,7 @@ void reset_byd_state() {
   datalayer_extended.bydAtto3.SOC_highprec = 0;
   datalayer_extended.bydAtto3.BMS_min_temp_module_number = 0;
   datalayer_extended.bydAtto3.BMS_max_temp_module_number = 0;
+  datalayer_extended.bydAtto3.pack_voltage_dV = 0;
 }
 
 // Coldest sensor 9 at 8C, hottest sensor 1 at 24C, SOC 99.2%, average 16C.
@@ -141,4 +142,75 @@ TEST(BydAtto3Tests, ShouldDecode0x444WholePercentSocAndRejectBadChecksum) {
   EXPECT_EQ(datalayer_extended.bydAtto3.SOC_polled, 31);
   EXPECT_EQ(datalayer.battery.status.soh_pptt, 9300);
   EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 1);
+}
+
+TEST(BydAtto3Tests, ShouldPrefer0x438VoltageWhenItAgreesWith0x444) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // Atto payload: 0x444 says 420V whole-volt, 0x438 says 4203 dV. Real captures peak at 8 dV apart.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xA4, 0x01, 0x88, 0x13, 0x5D, 0x1F, 0x00}));
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x01, 0xD6, 0x47, 0x6B, 0x10}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 4203);
+  EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4203);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 0);
+}
+
+TEST(BydAtto3Tests, ShouldFallBackTo0x444WhenPackDoesNotCarryVoltageIn0x438) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // Real 142S VM7 payloads. b5:b6 there is not voltage and decodes to 36352 dV (3635.2V), which
+  // used to win over 0x444 and trip EVENT_BATTERY_OVERVOLTAGE.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xD2, 0x01, 0x88, 0x13, 0x64, 0x1C, 0x4E}));
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x05, 0xFF, 0x00, 0x00, 0x8E}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 4660);
+  // The detail page must show the resolved voltage too, not the rejected 0x438 value.
+  EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4660);
+  // A rejected pack family is not a bus error.
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 0);
+}
+
+TEST(BydAtto3Tests, ShouldIgnore0x438UntilAReference0x444HasArrived) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // No 0x444 yet, so there is nothing to cross-check against and 0x438 must not be adopted.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x05, 0xFF, 0x00, 0x00, 0x8E}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 0);
+
+  // Once the reference arrives, the same 0x438 is judged and rejected.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xD2, 0x01, 0x88, 0x13, 0x64, 0x1C, 0x4E}));
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x05, 0xFF, 0x00, 0x00, 0x8E}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 4660);
+}
+
+TEST(BydAtto3Tests, ShouldStopTrusting0x438OnceItDivergesFrom0x444) {
+  reset_byd_state();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xA4, 0x01, 0x88, 0x13, 0x5D, 0x1F, 0x00}));
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x01, 0xD6, 0x47, 0x6B, 0x10}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 4203);
+
+  // 0x438 now reads 4260 dV against 420V, 60 dV apart and past the tolerance. No stale value latches.
+  battery->handle_incoming_can_frame(byd_checksummed_frame(0x438, {0x55, 0x55, 0x01, 0xD6, 0x47, 0xA4, 0x10}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.voltage_dV, 4200);
+  EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4200);
 }


### PR DESCRIPTION
### What
Makes BYD voltage decoding work with packs that use 0x438 differently.

### Why
A VM7 142S pack reports the correct 466 V in 0x444, but its 0x438 payload was being interpreted as 3635.2 V. That false reading triggered the overvoltage protection.

### How
0x438 is now accepted only when a valid 0x444 voltage has already been received and both readings are within 5 V of each other. If they do not match, the emulator safely uses 0x444. The detailed battery page now shows this resolved voltage as well.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
