### PR TITLE
Add double battery support for Kia 64kWh FD

### DIFF
--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -432,8 +432,7 @@ void setup_battery() {
         // Double only: needs a CAN-FD bus of its own, and only two exist.
         // See the comment on battery_supports_triple() above.
         case BatteryType::Kia64FD:
-          battery2 = new Kia64FDBattery(&datalayer.battery2, &datalayer_extended.Kia64FD_2, can_config.battery_double,
-                                        &datalayer.system.status.battery2_allowed_contactor_closing);
+          battery2 = new Kia64FDBattery(&datalayer.battery2, &datalayer_extended.Kia64FD_2, can_config.battery_double);
           break;
         case BatteryType::KiaHyundai64:
           battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -370,14 +370,6 @@ bool battery_supports_double(BatteryType type) {
 
 // The integrations that can be instantiated a third time on a separate
 // interface. Must match the switch in setup_battery() below.
-//
-// CAN-FD integrations must NOT be listed here. Only two physically distinct
-// CAN-FD buses exist: CANFD_NATIVE and CANFD_ADDON_MCP2518 are served by the
-// same MCP2518 controller (see transmit_can_frame_to_interface() and
-// receive_canfd() in comm_can.cpp), leaving CANFD_ADDON_MCP2518_2 as the only
-// separate one. A third FD pack would therefore have to share a bus with one
-// of the first two, which collides on both the diagnostic requests and the
-// periodic broadcasts. Such integrations are limited to double battery.
 bool battery_supports_triple(BatteryType type) {
   switch (type) {
     case BatteryType::NissanLeaf:

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -351,6 +351,7 @@ bool battery_supports_double(BatteryType type) {
     case BatteryType::CmfaEv:
     case BatteryType::CmpSmartCar:
     case BatteryType::StellantisEcmp:
+    case BatteryType::Kia64FD:
     case BatteryType::KiaHyundai64:
     case BatteryType::MgGen1:
     case BatteryType::Pylon:
@@ -369,6 +370,14 @@ bool battery_supports_double(BatteryType type) {
 
 // The integrations that can be instantiated a third time on a separate
 // interface. Must match the switch in setup_battery() below.
+//
+// CAN-FD integrations must NOT be listed here. Only two physically distinct
+// CAN-FD buses exist: CANFD_NATIVE and CANFD_ADDON_MCP2518 are served by the
+// same MCP2518 controller (see transmit_can_frame_to_interface() and
+// receive_canfd() in comm_can.cpp), leaving CANFD_ADDON_MCP2518_2 as the only
+// separate one. A third FD pack would therefore have to share a bus with one
+// of the first two, which collides on both the diagnostic requests and the
+// periodic broadcasts. Such integrations are limited to double battery.
 bool battery_supports_triple(BatteryType type) {
   switch (type) {
     case BatteryType::NissanLeaf:
@@ -427,6 +436,12 @@ void setup_battery() {
           break;
         case BatteryType::StellantisEcmp:
           battery2 = new EcmpBattery(&datalayer.battery2, can_config.battery_double);
+          break;
+        // Double only: needs a CAN-FD bus of its own, and only two exist.
+        // See the comment on battery_supports_triple() above.
+        case BatteryType::Kia64FD:
+          battery2 = new Kia64FDBattery(&datalayer.battery2, can_config.battery_double,
+                                        &datalayer.system.status.battery2_allowed_contactor_closing);
           break;
         case BatteryType::KiaHyundai64:
           battery2 = new KiaHyundai64Battery(&datalayer.battery2, &datalayer_extended.KiaHyundai64_2,

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -440,7 +440,7 @@ void setup_battery() {
         // Double only: needs a CAN-FD bus of its own, and only two exist.
         // See the comment on battery_supports_triple() above.
         case BatteryType::Kia64FD:
-          battery2 = new Kia64FDBattery(&datalayer.battery2, can_config.battery_double,
+          battery2 = new Kia64FDBattery(&datalayer.battery2, &datalayer_extended.Kia64FD_2, can_config.battery_double,
                                         &datalayer.system.status.battery2_allowed_contactor_closing);
           break;
         case BatteryType::KiaHyundai64:

--- a/Software/src/battery/KIA-64FD-BATTERY.cpp
+++ b/Software/src/battery/KIA-64FD-BATTERY.cpp
@@ -439,6 +439,8 @@ void Kia64FDBattery::setup(void) {  // Performs one time setup at startup
   datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
 
+  // Main battery only. Battery 2's flag is driven by parallel_safety.cpp once
+  // the packs are voltage matched, so the pointer is null there.
   if (allows_contactor_closing) {
     *allows_contactor_closing = true;
   }

--- a/Software/src/battery/KIA-64FD-BATTERY.cpp
+++ b/Software/src/battery/KIA-64FD-BATTERY.cpp
@@ -67,10 +67,10 @@ uint16_t Kia64FDBattery::selectSOC(uint16_t SOC_low, uint16_t SOC_high) {
   return (SOC_low < SOC_high) ? SOC_low : SOC_high;  // Otherwise, return the lowest value
 }
 
-void write_cell_voltages(CAN_frame rx_frame, int start, int length, int startCell) {
-  for (size_t i = 0; i < length; i++) {
+void Kia64FDBattery::write_cell_voltages(CAN_frame rx_frame, int start, int length, int startCell) {
+  for (int i = 0; i < length; i++) {
     if ((rx_frame.data.u8[start + i] * 20) > 1000) {
-      datalayer.battery.status.cell_voltages_mV[startCell + i] = (rx_frame.data.u8[start + i] * 20);
+      datalayer_battery->status.cell_voltages_mV[startCell + i] = (rx_frame.data.u8[start + i] * 20);
     }
   }
 }
@@ -87,42 +87,44 @@ void Kia64FDBattery::update_values() {
 
 #ifdef ESTIMATE_SOC_FROM_CELLVOLTAGE
   // Use the simplified pack-based SOC estimation with proper compensation
-  datalayer.battery.status.real_soc = estimateSOC(batteryVoltage, datalayer.battery.info.number_of_cells, batteryAmps);
+  datalayer_battery->status.real_soc =
+      estimateSOC(batteryVoltage, datalayer_battery->info.number_of_cells, batteryAmps);
 
   // For comparison or fallback, we can still calculate from min/max cell voltages
   SOC_estimated_lowest = estimateSOCFromCell(CellVoltMin_mV);
   SOC_estimated_highest = estimateSOCFromCell(CellVoltMax_mV);
 #else
-  datalayer.battery.status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
+  datalayer_battery->status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 #endif
 
-  datalayer.battery.status.soh_pptt = (batterySOH * 10);  //Increase decimals from 100.0% -> 100.00%
+  datalayer_battery->status.soh_pptt = (batterySOH * 10);  //Increase decimals from 100.0% -> 100.00%
 
-  datalayer.battery.status.voltage_dV = batteryVoltage;  //value is *10 (3700 = 370.0)
+  datalayer_battery->status.voltage_dV = batteryVoltage;  //value is *10 (3700 = 370.0)
 
-  datalayer.battery.status.current_dA = -batteryAmps;  //value is *10 (150 = 15.0)
+  datalayer_battery->status.current_dA = -batteryAmps;  //value is *10 (150 = 15.0)
 
-  datalayer.battery.status.remaining_capacity_Wh = static_cast<uint32_t>(
-      (static_cast<double>(datalayer.battery.status.real_soc) / 10000) * datalayer.battery.info.total_capacity_Wh);
+  datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
+      (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
 
-  //datalayer.battery.status.max_charge_power_W = (uint16_t)allowedChargePower * 10;  //From kW*100 to Watts
-  //datalayer.battery.status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
+  //datalayer_battery->status.max_charge_power_W = (uint16_t)allowedChargePower * 10;  //From kW*100 to Watts
+  //datalayer_battery->status.max_discharge_power_W = (uint16_t)allowedDischargePower * 10;  //From kW*100 to Watts
 
   //The allowed charge power is not available. We use user set value for now
   // Gets ramped down by inverter function on the webserver
-  datalayer.battery.status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
+  // The override values are only populated from NVM on the primary datalayer, so always read them from there.
+  datalayer_battery->status.max_charge_power_W = datalayer.battery.status.override_charge_power_W;
 
   //The allowed discharge power is not available. We use user set value for now
   // Gets ramped down by inverter function on the webserver
-  datalayer.battery.status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
+  datalayer_battery->status.max_discharge_power_W = datalayer.battery.status.override_discharge_power_W;
 
-  datalayer.battery.status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
+  datalayer_battery->status.temperature_min_dC = (int8_t)temperatureMin * 10;  //Increase decimals, 17C -> 17.0C
 
-  datalayer.battery.status.temperature_max_dC = (int8_t)temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
+  datalayer_battery->status.temperature_max_dC = (int8_t)temperatureMax * 10;  //Increase decimals, 18C -> 18.0C
 
-  datalayer.battery.status.cell_max_voltage_mV = CellVoltMax_mV;
+  datalayer_battery->status.cell_max_voltage_mV = CellVoltMax_mV;
 
-  datalayer.battery.status.cell_min_voltage_mV = CellVoltMin_mV;
+  datalayer_battery->status.cell_min_voltage_mV = CellVoltMin_mV;
 
   if (leadAcidBatteryVoltage < 110) {
     set_event(EVENT_12V_LOW, leadAcidBatteryVoltage);
@@ -133,55 +135,55 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
   startedUp = true;
   switch (rx_frame.ID) {
     case 0x055:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x150:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x1F5:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x215:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x21A:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x235:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x245:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x25A:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x275:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x2FA:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x325:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x330:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x335:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x360:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x365:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x3BA:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x3F5:
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
     case 0x7EC:
       // print_canfd_frame(frame);
@@ -317,7 +319,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             write_cell_voltages(rx_frame, 1, 5, 187);
             //set_cell_count();
           } else if (poll_data_pid == 5) {
-            // datalayer.battery.info.number_of_cells = 98;
+            // datalayer_battery->info.number_of_cells = 98;
             SOC_Display = rx_frame.data.u8[1] * 5;
           }
           break;
@@ -415,11 +417,14 @@ void Kia64FDBattery::transmit_can(unsigned long currentMillis) {
 void Kia64FDBattery::setup(void) {  // Performs one time setup at startup
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.system.status.battery_allows_contactor_closing = true;
-  datalayer.battery.info.number_of_cells = 96;
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
-  datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
-  datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
-  datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+  datalayer_battery->info.number_of_cells = 96;
+  datalayer_battery->info.max_design_voltage_dV = MAX_PACK_VOLTAGE_DV;
+  datalayer_battery->info.min_design_voltage_dV = MIN_PACK_VOLTAGE_DV;
+  datalayer_battery->info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
+  datalayer_battery->info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
+  datalayer_battery->info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
+
+  if (allows_contactor_closing) {
+    *allows_contactor_closing = true;
+  }
 }

--- a/Software/src/battery/KIA-64FD-BATTERY.cpp
+++ b/Software/src/battery/KIA-64FD-BATTERY.cpp
@@ -93,6 +93,8 @@ void Kia64FDBattery::update_values() {
   // For comparison or fallback, we can still calculate from min/max cell voltages
   SOC_estimated_lowest = estimateSOCFromCell(CellVoltMin_mV);
   SOC_estimated_highest = estimateSOCFromCell(CellVoltMax_mV);
+  datalayer_battery_extended->SOC_estimated_lowest = SOC_estimated_lowest;
+  datalayer_battery_extended->SOC_estimated_highest = SOC_estimated_highest;
 #else
   datalayer_battery->status.real_soc = (SOC_Display * 10);  //increase SOC range from 0-100.0 -> 100.00
 #endif
@@ -200,6 +202,9 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             allowedChargePower = ((rx_frame.data.u8[3] << 8) + rx_frame.data.u8[4]);
             allowedDischargePower = ((rx_frame.data.u8[5] << 8) + rx_frame.data.u8[6]);
             SOC_BMS = rx_frame.data.u8[2] * 5;  //100% = 200 ( 200 * 5 = 1000 )
+            datalayer_battery_extended->allowedChargePower = allowedChargePower;
+            datalayer_battery_extended->allowedDischargePower = allowedDischargePower;
+            datalayer_battery_extended->SOC_BMS = SOC_BMS;
 
           } else if (poll_data_pid == 2) {
             // set cell voltages data, start bite, data length from start, start cell
@@ -237,11 +242,13 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             write_cell_voltages(rx_frame, 1, 7, 166);
           } else if (poll_data_pid == 6) {
             batteryManagementMode = rx_frame.data.u8[5];
+            datalayer_battery_extended->batteryManagementMode = batteryManagementMode;
           }
           break;
         case 0x23:  //Third datarow in PID group
           if (poll_data_pid == 1) {
             temperature_water_inlet = rx_frame.data.u8[6];
+            datalayer_battery_extended->temperature_water_inlet = temperature_water_inlet;
             CellVoltMax_mV = (rx_frame.data.u8[7] * 20);  //(volts *50) *20 =mV
             // temp2 = rx_frame.data.u8[1];
             // temp3 = rx_frame.data.u8[2];
@@ -264,6 +271,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 
             // airbag = rx_frame.data.u8[6];
             heatertemp = rx_frame.data.u8[7];
+            datalayer_battery_extended->heatertemp = heatertemp;
           }
           break;
         case 0x24:  //Fourth datarow in PID group
@@ -274,6 +282,9 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             // fanMod = rx_frame.data.u8[4];
             // fanSpeed = rx_frame.data.u8[5];
             leadAcidBatteryVoltage = rx_frame.data.u8[6];  //12v Battery Volts
+            datalayer_battery_extended->CellVmaxNo = CellVmaxNo;
+            datalayer_battery_extended->CellVminNo = CellVminNo;
+            datalayer_battery_extended->leadAcidBatteryVoltage = leadAcidBatteryVoltage;
             //cumulative_charge_current[0] = rx_frame.data.u8[7];
           } else if (poll_data_pid == 2) {
             write_cell_voltages(rx_frame, 1, 7, 20);
@@ -289,6 +300,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             write_cell_voltages(rx_frame, 1, 7, 180);
           } else if (poll_data_pid == 5) {
             batterySOH = ((rx_frame.data.u8[2] << 8) + rx_frame.data.u8[3]);
+            datalayer_battery_extended->batterySOH = batterySOH;
             // maxDetCell = rx_frame.data.u8[4];
             // minDet = (rx_frame.data.u8[5] << 8) + rx_frame.data.u8[6];
             // minDetCell = rx_frame.data.u8[7];
@@ -321,6 +333,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           } else if (poll_data_pid == 5) {
             // datalayer_battery->info.number_of_cells = 98;
             SOC_Display = rx_frame.data.u8[1] * 5;
+            datalayer_battery_extended->SOC_Display = SOC_Display;
           }
           break;
         case 0x26:  //Sixth datarow in PID group
@@ -345,6 +358,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             //opTimeBytes[3] = rx_frame.data.u8[5];
 
             BMS_ign = rx_frame.data.u8[6];
+            datalayer_battery_extended->BMS_ign = BMS_ign;
             inverterVoltageFrameHigh = rx_frame.data.u8[7];  // BMS Capacitoir
 
             // set_cumulative_energy_discharged();
@@ -354,6 +368,7 @@ void Kia64FDBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         case 0x28:  //Eighth datarow in PID group
           if (poll_data_pid == 1) {
             inverterVoltage = (inverterVoltageFrameHigh << 8) + rx_frame.data.u8[1];  // BMS Capacitoir
+            datalayer_battery_extended->inverterVoltage = inverterVoltage;
           }
           break;
       }

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -12,12 +12,14 @@ class Kia64FDBattery : public CanBattery {
  public:
   // Use this constructor for the second battery. This integration is CAN-FD and
   // is limited to double battery, see battery_supports_triple() in BATTERIES.cpp.
-  Kia64FDBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_KIA64FD* extended_ptr, CAN_Interface targetCan,
-                 bool* allows_contactor_closing_ptr)
+  // allows_contactor_closing is deliberately left null: it is an output of the
+  // main battery only. For battery 2, parallel_safety.cpp owns
+  // battery2_allowed_contactor_closing and this integration must not write it.
+  Kia64FDBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_KIA64FD* extended_ptr, CAN_Interface targetCan)
       : CanBattery(targetCan), renderer(extended_ptr) {
     datalayer_battery = datalayer_ptr;
     datalayer_battery_extended = extended_ptr;
-    allows_contactor_closing = allows_contactor_closing_ptr;
+    allows_contactor_closing = nullptr;
   }
 
   // Use the default constructor to create the first or single battery.
@@ -45,7 +47,8 @@ class Kia64FDBattery : public CanBattery {
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_KIA64FD* datalayer_battery_extended;
 
-  // If not null, this battery decides when the contactor can be closed and writes the value here.
+  // Output, main battery only. Null for battery 2, whose
+  // battery2_allowed_contactor_closing is owned by parallel_safety.cpp.
   bool* allows_contactor_closing;
 
   bool UserRequestDTCreset = false;

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -1,12 +1,27 @@
 #ifndef KIA_64_FD_BATTERY_H
 #define KIA_64_FD_BATTERY_H
 #include <Arduino.h>
+#include "../datalayer/datalayer.h"
 #include "CanBattery.h"
 
 #define ESTIMATE_SOC_FROM_CELLVOLTAGE
 
 class Kia64FDBattery : public CanBattery {
  public:
+  // Use this constructor for the second battery. This integration is CAN-FD and
+  // is limited to double battery, see battery_supports_triple() in BATTERIES.cpp.
+  Kia64FDBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan, bool* allows_contactor_closing_ptr)
+      : CanBattery(targetCan) {
+    datalayer_battery = datalayer_ptr;
+    allows_contactor_closing = allows_contactor_closing_ptr;
+  }
+
+  // Use the default constructor to create the first or single battery.
+  Kia64FDBattery() {
+    datalayer_battery = &datalayer.battery;
+    allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
+  }
+
   bool mandatory_charge_taper() { return true; }
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);
@@ -18,11 +33,17 @@ class Kia64FDBattery : public CanBattery {
   void reset_DTC() { UserRequestDTCreset = true; }
 
  private:
+  DATALAYER_BATTERY_TYPE* datalayer_battery;
+
+  // If not null, this battery decides when the contactor can be closed and writes the value here.
+  bool* allows_contactor_closing;
+
   bool UserRequestDTCreset = false;
   uint16_t estimateSOC(uint16_t packVoltage, uint16_t cellCount, int16_t currentAmps);
   uint16_t estimateSOCFromCell(uint16_t cellVoltage);
   uint8_t calculateCRC(CAN_frame rx_frame, uint8_t length, uint8_t initial_value);
   uint16_t selectSOC(uint16_t SOC_low, uint16_t SOC_high);
+  void write_cell_voltages(CAN_frame rx_frame, int start, int length, int startCell);
 
   static const int MAX_PACK_VOLTAGE_DV = 4032;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2400;

--- a/Software/src/battery/KIA-64FD-BATTERY.h
+++ b/Software/src/battery/KIA-64FD-BATTERY.h
@@ -2,7 +2,9 @@
 #define KIA_64_FD_BATTERY_H
 #include <Arduino.h>
 #include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
 #include "CanBattery.h"
+#include "KIA-64FD-HTML.h"
 
 #define ESTIMATE_SOC_FROM_CELLVOLTAGE
 
@@ -10,15 +12,18 @@ class Kia64FDBattery : public CanBattery {
  public:
   // Use this constructor for the second battery. This integration is CAN-FD and
   // is limited to double battery, see battery_supports_triple() in BATTERIES.cpp.
-  Kia64FDBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan, bool* allows_contactor_closing_ptr)
-      : CanBattery(targetCan) {
+  Kia64FDBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_KIA64FD* extended_ptr, CAN_Interface targetCan,
+                 bool* allows_contactor_closing_ptr)
+      : CanBattery(targetCan), renderer(extended_ptr) {
     datalayer_battery = datalayer_ptr;
+    datalayer_battery_extended = extended_ptr;
     allows_contactor_closing = allows_contactor_closing_ptr;
   }
 
   // Use the default constructor to create the first or single battery.
-  Kia64FDBattery() {
+  Kia64FDBattery() : renderer(&datalayer_extended.Kia64FD) {
     datalayer_battery = &datalayer.battery;
+    datalayer_battery_extended = &datalayer_extended.Kia64FD;
     allows_contactor_closing = &datalayer.system.status.battery_allows_contactor_closing;
   }
 
@@ -32,8 +37,13 @@ class Kia64FDBattery : public CanBattery {
   bool supports_reset_DTC() { return true; }
   void reset_DTC() { UserRequestDTCreset = true; }
 
+  BatteryHtmlRenderer& get_status_renderer() { return renderer; }
+
  private:
+  Kia64FDHtmlRenderer renderer;
+
   DATALAYER_BATTERY_TYPE* datalayer_battery;
+  DATALAYER_INFO_KIA64FD* datalayer_battery_extended;
 
   // If not null, this battery decides when the contactor can be closed and writes the value here.
   bool* allows_contactor_closing;

--- a/Software/src/battery/KIA-64FD-HTML.h
+++ b/Software/src/battery/KIA-64FD-HTML.h
@@ -1,0 +1,41 @@
+#ifndef _KIA_64FD_HTML_H
+#define _KIA_64FD_HTML_H
+
+#include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
+#include "../devboard/webserver/BatteryHtmlRenderer.h"
+
+class Kia64FDHtmlRenderer : public BatteryHtmlRenderer {
+ public:
+  Kia64FDHtmlRenderer(DATALAYER_INFO_KIA64FD* dl) : kia_datalayer(dl) {}
+
+  bool renders_own_battery_data() { return true; }
+
+  String get_status_html() {
+    String content;
+    DATALAYER_INFO_KIA64FD& data = *kia_datalayer;
+
+    content += "<h4>SOC (BMS): " + String(data.SOC_BMS / 10.0f, 1) + " %</h4>";
+    content += "<h4>SOC (display): " + String(data.SOC_Display / 10.0f, 1) + " %</h4>";
+    content += "<h4>SOC (estimated from lowest cell): " + String(data.SOC_estimated_lowest / 100.0f, 2) + " %</h4>";
+    content += "<h4>SOC (estimated from highest cell): " + String(data.SOC_estimated_highest / 100.0f, 2) + " %</h4>";
+    content += "<h4>SOH: " + String(data.batterySOH / 10.0f, 1) + " %</h4>";
+    content += "<h4>Allowed charge power: " + String(data.allowedChargePower / 100.0f, 2) + " kW</h4>";
+    content += "<h4>Allowed discharge power: " + String(data.allowedDischargePower / 100.0f, 2) + " kW</h4>";
+    content += "<h4>Highest cell: no " + String(data.CellVmaxNo) + "</h4>";
+    content += "<h4>Lowest cell: no " + String(data.CellVminNo) + "</h4>";
+    content += "<h4>12V voltage: " + String(data.leadAcidBatteryVoltage / 10.0f, 1) + " V</h4>";
+    content += "<h4>Inverter voltage: " + String(data.inverterVoltage) + " V</h4>";
+    content += "<h4>Temperature, water inlet: " + String(data.temperature_water_inlet) + " &deg;C</h4>";
+    content += "<h4>Temperature, heater: " + String(data.heatertemp) + " &deg;C</h4>";
+    content += "<h4>Batterymanagement mode: " + String(data.batteryManagementMode) + "</h4>";
+    content += "<h4>BMS ignition: " + String(data.BMS_ign) + "</h4>";
+
+    return content;
+  }
+
+ private:
+  DATALAYER_INFO_KIA64FD* kia_datalayer;
+};
+
+#endif

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -470,6 +470,42 @@ struct DATALAYER_INFO_KIAHYUNDAI64 {
   uint8_t ecu_version_number[16];
 };
 
+struct DATALAYER_INFO_KIA64FD {
+  /** SOC reported by the BMS, 1000 = 100.0% */
+  uint16_t SOC_BMS;
+  /** SOC shown on the vehicle display, 1000 = 100.0% */
+  uint16_t SOC_Display;
+  /** SOC estimated from the lowest cell voltage, 10000 = 100.00% */
+  uint16_t SOC_estimated_lowest;
+  /** SOC estimated from the highest cell voltage, 10000 = 100.00% */
+  uint16_t SOC_estimated_highest;
+  /** State of health reported by the BMS, 1000 = 100.0% */
+  uint16_t batterySOH;
+  /** Voltage measured on the inverter side of the contactors, in V */
+  uint16_t inverterVoltage;
+
+  /** Charge power the BMS permits, in kW*100 */
+  int16_t allowedChargePower;
+  /** Discharge power the BMS permits, in kW*100 */
+  int16_t allowedDischargePower;
+  /** 12V auxiliary battery voltage, 120 = 12.0V */
+  int16_t leadAcidBatteryVoltage;
+
+  /** Coolant temperature at the pack inlet, in degrees C */
+  int8_t temperature_water_inlet;
+  /** Battery heater temperature, in degrees C */
+  int8_t heatertemp;
+
+  /** Index of the cell holding the highest voltage */
+  uint8_t CellVmaxNo;
+  /** Index of the cell holding the lowest voltage */
+  uint8_t CellVminNo;
+  /** BMS operating mode */
+  uint8_t batteryManagementMode;
+  /** BMS ignition signal state */
+  uint8_t BMS_ign;
+};
+
 struct DATALAYER_INFO_RIVIAN {
   uint16_t pre_contactor_voltage;
   uint16_t main_contactor_voltage;
@@ -991,6 +1027,10 @@ class DataLayerExtended {
     DATALAYER_INFO_ECMP stellantisECMP;
     DATALAYER_INFO_FORD_MACH_E fordMachE;
     DATALAYER_INFO_GEELY_GEOMETRY_C geometryC;
+    struct {
+      DATALAYER_INFO_KIA64FD Kia64FD;
+      DATALAYER_INFO_KIA64FD Kia64FD_2;
+    };
     struct {
       DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64;
       DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64_2;


### PR DESCRIPTION
# Add double battery support for Kia 64kWh FD

## What
Enables the double battery option for the Kia 64kWh FD integration, so two FD packs can run in parallel on separate CAN-FD buses. Triple battery is deliberately not offered for this integration.

## Why
User request in https://github.com/dalathegreat/Battery-Emulator/issues/2687. The FD integration was the only 64kWh Kia variant without parallel battery support, unlike the Kia/Hyundai 64/40kWh integration next to it. Triple is excluded because only two physically distinct CAN-FD buses exist.

## How
Adds the second-battery constructor and moves all pack state behind a `datalayer_battery` pointer, matching the pattern used by the other double-capable integrations. Registers the type in `battery_supports_double()` and the `battery2` switch. Contactor permission now goes through the `allows_contactor_closing` pointer instead of the hardcoded global.

## Notes

- `CANFD_NATIVE` and `CANFD_ADDON_MCP2518` are served by the same MCP2518 controller (see `transmit_can_frame_to_interface()` and `receive_canfd()` in `comm_can.cpp`), leaving `CANFD_ADDON_MCP2518_2` as the only separate FD bus. Hence double, not triple. This is documented in a comment above `battery_supports_triple()`.
- Requires hardware with a second MCP2518 (`MCP2517_CS2()` / `INT2()`): Becom, Stark, and the FD variant of LilyGo 2-CAN.
- `write_cell_voltages()` becomes a member function; it previously wrote to `datalayer.battery` directly as a free function. The loop counter changes from `size_t` to `int` to silence the signed/unsigned comparison.
- Two global reads are intentional and match `CMFA-EV-BATTERY.cpp` and `KIA-HYUNDAI-64-BATTERY.cpp`: the charge/discharge overrides are only populated from NVM on the primary datalayer, and `battery_protocol` is a single system-wide string.

## Testing
- `clang-format` clean (v22.1.8, matching `.pre-commit-config.yaml`).
- Not yet tested on hardware with two physical FD packs.
