### PR TITLE
Only the full settings form may treat an absent checkbox as unchecked

### DIFF
--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1622,6 +1622,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
 <div style='background-color: #404E47; padding: 10px; margin-bottom: 10px; border-radius: 50px'>
         <form action='saveSettings' method='post' onsubmit='return validateWebAuthPassword()'>
+        <!-- Marks the full settings form: only with this marker may the server
+             treat an absent checkbox as unchecked. Partial POSTs lack it and
+             leave unmentioned booleans alone. -->
+        <input type='hidden' name='FULLFORM' value='on'>
 
         <div style='grid-column: span 2; text-align: center; padding-top: 10px;' class="%SAVEDCLASS%">
           <p>Settings saved. Reboot to take the new settings into use.<p> <button type='button' onclick='askReboot()'>Reboot</button>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -574,8 +574,18 @@ void init_webserver() {
                 }
               }
 
+              // Checkboxes are absent from a POST when unchecked, so absent-means-false
+              // is correct ONLY for the full settings form, which marks itself with a
+              // hidden FULLFORM field. A partial POST - curl, a script, an API client
+              // setting one field - must not silently wipe every boolean it did not
+              // mention; without the marker a boolean is applied only when its field is
+              // present ('on' = true, anything else = false).
+              const bool full_form = request->getParam("FULLFORM", true) != nullptr;
               for (auto& boolSetting : boolSettingNames) {
                 auto p = request->getParam(boolSetting, true);
+                if (!full_form && p == nullptr) {
+                  continue;
+                }
                 // The comparison default must match what the firmware boots with when the
                 // key is unset, or saving that state writes nothing and the page keeps
                 // disagreeing with the firmware. Only two bools boot true: WIFIAPENABLED


### PR DESCRIPTION
`POST /saveSettings` treats an absent checkbox as unchecked and saves false — correct for the full settings page, since an unchecked HTML checkbox vanishes from the submission. But the handler applies that rule to every POST it receives, and #2852 is about to make that assumption false from the UI itself: it splits the page into per-section forms, and a section's POST omits every checkbox outside its section — under today's logic, saving the inverter section would wipe `WIFIAPENABLED`, `MQTTENABLED` and three dozen other booleans it never mentioned.

The same applies to every non-page client already: a partial POST — curl, a script, any API client setting one field — silently clears the booleans it doesn't carry. (Found while scripting a single-field settings change; the safe workaround today is knowing every currently-checked box and re-sending them all.)

The settings form now marks itself with one hidden `FULLFORM` field and keeps its exact behaviour. Without the marker, a boolean is applied only when its field is present (`on` = true, anything else = false) — so a partial client, or a sectioned form, can set, clear, or leave any setting alone with no coordination needed. The double/triple capability clamp is unchanged — it enforces a stored invariant, not a form field.

Suite 184/184 + shuffle; `-Werror` devkit and Stark builds green.

Note: drafted with AI assistance, reviewed by me.
