### PR TITLE
Zoe Gen2: hand UDS replies to the superclass; make the can-log harness speak 29-bit UDS

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN2-BATTERY.cpp
@@ -242,8 +242,11 @@ void RenaultZoeGen2Battery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x612:
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
-    case 0x18DAF1DB:  // LBC Reply from active polling (Handled in handle_pid())
+    case 0x18DAF1DB:  // LBC Reply from active polling
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      // Hand the reply to the UDS superclass: ISO-TP reassembly, then handle_pid()
+      // for PID scan responses and the DTC handlers for the rest.
+      handle_incoming_uds_can_frame(rx_frame);
       break;
     default:
       break;

--- a/test/can_log_based/can_logs/29_RenaultZoe2_cv88.txt
+++ b/test/can_log_based/can_logs/29_RenaultZoe2_cv88.txt
@@ -1,4 +1,6 @@
 # Update cell voltage 88 via a faked poll response
 # (this is synthetic, please update with a real log!)
+# ISO-TP single frame (len 5): UDS 0x62 ReadDataByIdentifier positive response, DID 0x907B
+# (cell 88), value 0x0C7E = 3198 * 0.9765625 = 3123 mV.
 
-(84215.921) RX0 18DAF1DB [8] 00 00 90 7B 0C 7E AA AA
+(84215.921) RX0 18DAF1DB [8] 05 62 90 7B 0C 7E AA AA

--- a/test/can_log_based/canlog_safety_tests.cpp
+++ b/test/can_log_based/canlog_safety_tests.cpp
@@ -79,21 +79,34 @@ class CanLogTestFixture : public testing::Test {
     UdsCanBattery* udsBattery = dynamic_cast<UdsCanBattery*>(battery);
     const auto& tx_frames = get_transmitted_frames();
 
-    // Does this message looks like a UDS/KWP2000 poll response?
-    if (udsBattery != nullptr && msg.ID >= 0x780 && msg.ID <= 0x7EF && (msg.data.u8[0] & 0xF0) == 0x10) {
-      // Extract the SID from the poll response
-      const uint8_t resp_sid = msg.data.u8[2];
-      uint16_t target_pid = msg.data.u8[3];
+    // Does this message look like a UDS/KWP2000 poll response? Responses come
+    // from an 11-bit physical response ID (0x780-0x7EF) or, for batteries that
+    // speak UDS over 29-bit addressing (0x18DAxxyy), any extended ID. Both the
+    // ISO-TP first frame of a multi-frame response (PCI 0x1N: SID at byte 2)
+    // and a single-frame response (PCI 0x0N: SID at byte 1) must prime the
+    // battery, otherwise the superclass drops the reply as "nothing in flight".
+    const bool uds_response_id = (msg.ID >= 0x780 && msg.ID <= 0x7EF) || msg.ID > 0x7FF;
+    const uint8_t pci_type = msg.data.u8[0] & 0xF0;
+    const bool is_first_frame = (pci_type == 0x10);
+    const bool is_single_frame = (pci_type == 0x00);
+    const uint8_t sid_offset = is_first_frame ? 2 : 1;
+    const uint8_t resp_sid = msg.data.u8[sid_offset];
+    if (udsBattery != nullptr && uds_response_id && (is_first_frame || is_single_frame) &&
+        (resp_sid == 0x61 || resp_sid == 0x62)) {
+      uint16_t target_pid = msg.data.u8[sid_offset + 1];
       if (resp_sid == 0x62) {
         // Is a UDS two-byte PID response (as opposed to a one-byte KWP2000 one).
-        target_pid = (target_pid << 8) | msg.data.u8[4];
+        target_pid = (target_pid << 8) | msg.data.u8[sid_offset + 2];
       }
 
-      // Now we keep hammering transmit_can up to 3000 times until we detect
-      // that it has sent a poll to the SID we're responding for.
+      // Now we keep hammering transmit_can until we detect that it has sent a
+      // poll for the PID we are responding for. Batteries with long scan lists
+      // (Zoe Gen2: ~190 DIDs, 10 retries x 200 ms each when nothing answers)
+      // need minutes of emulated time to reach a late PID, so the deadline is
+      // generous.
 
       const size_t tx_start = tx_frames.size();
-      const unsigned long deadline = now + 30000;  // 30 s of emulated time
+      const unsigned long deadline = now + 600000;  // 600 s of emulated time
       bool poll_found = false;
       while (now < deadline && !poll_found) {
         now += 10;


### PR DESCRIPTION
### What
Fixes the red `build` job on #2824 (it is the unit-test run: `CanLogSafetyTests.TestCellVoltage29RenaultZoe2Cv88`), and with it the reason nothing polled could arrive.

### Why
`RenaultZoeGen2Battery::handle_incoming_can_frame` never called `handle_incoming_uds_can_frame()` (the `UdsCanBattery` contract), so 0x18DAF1DB replies never reached ISO-TP: `handle_pid()` never ran, DTC read could not complete, and the polled-voltage fallback had no value to fall back to. The test was the first thing to notice — but it could not pass on its own either: the synthetic frame `00 00 90 7B 0C 7E` is not an ISO-TP single frame (PCI 0x00 = length 0), and the harness only primed UDS batteries for 11-bit multi-frame replies within 30 s of emulated time, while Zoe2 answers on a 29-bit ID in single frames and needs ~5 min of emulated scan time to reach cell 88.

### How
- `RENAULT-ZOE-GEN2-BATTERY.cpp`: call `handle_incoming_uds_can_frame(rx_frame)` in the `0x18DAF1DB` case (alive stamp kept).
- `29_RenaultZoe2_cv88.txt`: frame is now a real reply, `05 62 90 7B 0C 7E AA AA` (0x0C7E × 0.9765625 = 3123 mV).
- `canlog_safety_tests.cpp`: the pump accepts 29-bit response IDs and ISO-TP single frames (SID 0x61/0x62 only), deadline 600 s emulated.

Host suite 184/184. Also checked on hardware: a board running this head with Zoe Gen2 selected, polling a second board that answers the full scan list + one DTC over a real CAN link — SoC/SoH/cell voltages decode and Read DTC shows the code; the same run without this change counts the 29-bit requests on the bus but decodes nothing. That proves the superclass path on real controllers, not Renault LBC timing or value encoding — that part still needs your pack.

Two things noticed while in there, left untouched: `POLL_BALANCE_SWITCHES` decode is commented out but `update_values()` still copies `balancing_status_cell[]`, so balancing status is frozen at zero (the old bit-walk can run over the reassembled `data` in `handle_pid()`); and `battery_temporisation = (bool)(value)` reads differently from the old "bit 7 of byte 4".

Note: drafted with AI assistance, reviewed by me.
