### PR TITLE
CHAdeMO: bias the plug-detect and vehicle-permission inputs

### DIFF
--- a/Software/src/battery/CHADEMO-BATTERY.cpp
+++ b/Software/src/battery/CHADEMO-BATTERY.cpp
@@ -904,8 +904,15 @@ void ChademoBattery::setup(void) {  // Performs one time setup at startup
   digitalWrite(pin10, LOW);
   pinMode(pin_lock, OUTPUT);
   digitalWrite(pin_lock, LOW);
-  pinMode(pin4, INPUT);
-  pinMode(pin7, INPUT);
+  // Plug detect (pin 7) and vehicle permission (pin 4) read HIGH when
+  // asserted. A plain INPUT floats with nothing plugged in, and a floating
+  // ESP32 input beside CAN transceivers reads HIGH - the state machine then
+  // walks off IDLE with no vehicle present (#1863). Pull them down where the
+  // silicon can; on input-only pads (the 3LB's GPIO 34/35) there are no
+  // internal pulls, the call degrades to plain INPUT, and the board needs its
+  // own external pull-downs.
+  pinMode(pin4, INPUT_PULLDOWN);
+  pinMode(pin7, INPUT_PULLDOWN);
 
   // initialise the CT measurement helper
   if (user_selected_shunt_type == ShuntType::CustomClamp) {

--- a/test/emul/esp-hal-gpio.h
+++ b/test/emul/esp-hal-gpio.h
@@ -5,6 +5,9 @@
 #define HIGH 0x1
 
 #define INPUT 0x01
+// arduino-esp32 values; the emulated pinMode treats every input mode alike.
+#define INPUT_PULLUP 0x05
+#define INPUT_PULLDOWN 0x09
 // Changed OUTPUT from 0x02 to behave the same as Arduino pinMode(pin,OUTPUT)
 // where you can read the state of pin even when it is set as OUTPUT
 #define OUTPUT 0x03


### PR DESCRIPTION
The CHAdeMO plug-detect (pin 7) and vehicle-permission (pin 4) inputs are configured as plain `INPUT`. With nothing plugged in they float, and a floating ESP32 input next to CAN transceivers reads HIGH often enough to walk the state machine off IDLE with no vehicle present — part of the #1863 picture. This enables the internal pull-down on both where the silicon has one (T-2CAN, GPIO 47/4). On the 3LB and LilyGo the pins are GPIO 34/35, input-only with no internal pulls: there the call degrades to a plain `INPUT` and those boards need external pull-downs, which the comment now says.

Polarity is unchanged (HIGH = asserted), so existing installs keep working. #2124 takes the other route — `INPUT_PULLUP` with inverted reads, i.e. an active-low convention — which is a valid design if the interface hardware is wired for it. I don't have a rig to settle which convention the deployed boards actually use; if the hardware owners prefer the active-low design this PR should be dropped in favour of that, and the 3LB/LilyGo external-pull note is the part worth keeping either way.

Refs #1863.

Note: drafted with AI assistance, reviewed by me.
