### PR TITLE
BYD Atto 3: retry contactor close when the BMS wakes after the inverter's permission

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -762,9 +762,21 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
     previousContactorsAllowedClosed = contactorsAllowedClosed;
     if (!contactorsAllowedClosed) {
       requestContactorOpen = true;
+      closeRetryArmed = false;  // Permission withdrawn - the abandoned close must not resurrect
     } else {
       requestContactorClose = true;
     }
+  }
+
+  // The close request is edge-triggered on permission, so a close that timed out against a
+  // still-silent BMS (emulator powered before the battery) used to consume the only edge:
+  // the FSM fell back to standby and nothing ever asked again until a reboot. Retry when the
+  // BMS has SPOKEN since the give-up - only feedback newer than the fallback counts, so a
+  // dead bus cannot loop this, and each failed retry re-arms against strictly newer feedback.
+  if (closeRetryArmed && contactorState == CONTACTORS_STANDBY && contactorsAllowedClosed &&
+      (int32_t)(lastContactorFeedbackMillis - closeRetryArmedMillis) >= 0 && lastContactorFeedbackMillis != 0) {
+    closeRetryArmed = false;
+    requestContactorClose = true;
   }
 
   if (requestContactorOpen) {
@@ -906,6 +918,10 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
       set_12D_payload(0x50, 0x14, 0x02, 0x10, 0x04, 0x31);  // Standby pattern
       contactorState = CONTACTORS_STANDBY;
       closeConfirmPending = false;
+      // A BMS that was simply not powered yet gets another close when it appears (see the
+      // retry above); permission is still granted or we would be on the open path instead.
+      closeRetryArmed = true;
+      closeRetryArmedMillis = currentMillis;
     }
   }
 }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -266,6 +266,8 @@ class BydAttoBattery : public CanBattery {
   unsigned long lastCurrentSampleMillis = 0;
   unsigned long lastContactorFeedbackMillis = 0;  // 0 = no 0x344 received yet
   bool closeConfirmPending = false;               // Only for user closes, not the boot default
+  bool closeRetryArmed = false;                   // Close gave up on a silent BMS; retry when it speaks
+  unsigned long closeRetryArmedMillis = 0;        // Only feedback NEWER than the give-up may retry
   bool openTimeoutEventSent = false;              // Open-delay warning fired once per attempt
   bool requestContactorOpen = false;
   bool requestContactorClose = false;

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -215,3 +215,50 @@ TEST(BydAtto3Tests, ShouldStopTrusting0x438OnceItDivergesFrom0x444) {
   EXPECT_EQ(datalayer.battery.status.voltage_dV, 4200);
   EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4200);
 }
+
+// The close request is edge-triggered on permission. Before the fix, a close that timed out
+// against a still-silent BMS (Battery-Emulator powered before the battery - the wiki's
+// documented startup-order restriction) consumed the only edge: the FSM fell back to standby
+// and no code path ever requested close again until the emulator was rebooted. The retry
+// fires only on 0x344 feedback NEWER than the give-up, so a dead bus cannot loop it.
+TEST(BydAtto3Tests, LateBmsGetsAnotherCloseAfterTheConfirmTimeoutGaveUp) {
+  reset_byd_state();
+  set_millis64(1000);
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // Boot with the inverter not yet granting permission: held open.
+  datalayer.system.info.equipment_stop_active = false;
+  datalayer.system.status.inverter_allows_contactor_closing = false;
+  datalayer.system.status.system_status = ACTIVE;
+  battery->transmit_can(millis());
+  battery->update_values();
+  ASSERT_EQ(datalayer_extended.bydAtto3.contactor_control_state, 7 /*CONTACTORS_BOOT_ESTOP*/);
+
+  // Permission arrives (the one edge); the battery is still powered off - no 0x344 ever.
+  datalayer.system.status.inverter_allows_contactor_closing = true;
+  set_millis64(2000);
+  battery->transmit_can(millis());
+  battery->update_values();
+  ASSERT_EQ(datalayer_extended.bydAtto3.contactor_control_state, 0 /*CONTACTORS_CLOSING*/);
+
+  // The confirm window expires against the silent BMS: fall back to standby.
+  set_millis64(2000 + 15001);
+  battery->transmit_can(millis());
+  battery->update_values();
+  ASSERT_EQ(datalayer_extended.bydAtto3.contactor_control_state, 4 /*CONTACTORS_STANDBY*/);
+
+  // The battery finally powers on and speaks: 0x344, contactors open (bit7 clear).
+  set_millis64(2000 + 20000);
+  battery->handle_incoming_can_frame(byd_frame(0x344, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+  battery->transmit_can(millis());
+  // The retry consumes the request on the NEXT tick (requests are processed at entry).
+  set_millis64(2000 + 20050);
+  battery->transmit_can(millis());
+  battery->update_values();
+  EXPECT_EQ(datalayer_extended.bydAtto3.contactor_control_state, 0 /*CONTACTORS_CLOSING*/)
+      << "a late BMS must get another close attempt without an emulator reboot";
+
+  set_millis64(0);
+  datalayer.system.status.inverter_allows_contactor_closing = false;
+}


### PR DESCRIPTION
The wiki documents a startup-order restriction for the Atto 3: if the BMS comes up after the inverter has already granted permission to close, the emulator sits in standby until a reboot. The cause is in the state machine: the close is requested only on the permission edge; when the close-confirm window times out (BMS not awake yet), the state machine falls back to standby with the edge already consumed — nothing re-requests, so it stays there until a reboot re-creates the edge.

This adds a feedback-gated retry: after a failed confirm, the close is re-requested only when battery feedback (0x344) is newer than the give-up — a dead bus cannot loop, and a permission withdrawal disarms the retry. With a live but refusing BMS the worst case is one visible MISMATCH per 15-second window, which matches the keep-trying-while-permitted semantics elsewhere in the machine.

Host-verified: a regression test drives the state machine through transmit_can and fails without the fix; a second test pins that stale feedback must not retry. Full suite + shuffle seeds green; lilygo_330 builds with -Werror. I don't have an Atto 3 pack, so this is host/bench evidence only — a confirm from an Atto 3 owner would close the wiki restriction for good.

Note: drafted with AI assistance, reviewed by me.
