### PR TITLE
fix(renault-zoe-gen1): fix cell balancing bit order and set balancing…

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -80,14 +80,21 @@ uint16_t RenaultZoeGen1Battery::handle_pid(uint16_t pid, uint32_t value, const u
         kWh_from_beginning_of_battery_life = (data[15] << 8) | data[16];
       }
       break;
-    case GROUP6_BALANCING:  // 0x07, one bit per cell, MSB first within each byte
+    case GROUP6_BALANCING: {  // 0x07, 18 bytes payload, 1 bit per cell (LSB-first bit order)
+      bool any_balancing = false;
       for (uint8_t cell = 0; cell < 96; cell++) {
         if ((cell >> 3) >= length) {
           break;
         }
-        datalayer_battery->status.cell_balancing_status[cell] = (data[cell >> 3] >> (7 - (cell & 7))) & 0x01;
+        bool is_balancing = (data[cell >> 3] >> (cell & 7)) & 0x01;
+        datalayer_battery->status.cell_balancing_status[cell] = is_balancing;
+        if (is_balancing) {
+          any_balancing = true;
+        }
       }
+      datalayer_battery->status.balancing_status = any_balancing ? BALANCING_STATUS_ACTIVE : BALANCING_STATUS_READY;
       break;
+    }
     default:  //Unknown PID, ignore
       break;
   }

--- a/test/can_log_based/canlog_safety_tests.cpp
+++ b/test/can_log_based/canlog_safety_tests.cpp
@@ -252,13 +252,13 @@ class PidDemuxTest : public CanLogTestFixture {
     }
     EXPECT_EQ(datalayer.battery.status.voltage_dV, 3552);
 
-    // 0x07 balancing group: one bit per cell, MSB first within each byte.
+    // 0x07 balancing group: one bit per cell, LSB first within each byte.
     // The log uses a pattern that spans every ISO-TP frame of the reply and
     // both edges of the first/last byte, so re-decode it here to check the
     // demuxed bits land on the right cells.
     const uint8_t balancing_bytes[] = {0xA5, 0x3C, 0x00, 0xFF, 0x81, 0x10, 0x42, 0x80, 0x01, 0x55, 0xAA, 0x0F};
     for (int i = 0; i < 96; i++) {
-      bool expected = (balancing_bytes[i / 8] >> (7 - (i % 8))) & 1;
+      bool expected = (balancing_bytes[i / 8] >> (i % 8)) & 1;
       EXPECT_EQ(datalayer.battery.status.cell_balancing_status[i], expected) << "cell " << i;
     }
 


### PR DESCRIPTION
### What
This PR fixes cell shunt bit ordering and updates overall balancing status for Renault Zoe Gen1 batteries in `RENAULT-ZOE-GEN1-BATTERY.cpp`.
### Why
1. **Bit Order Correction:** PID `0x07` (`GROUP6_BALANCING`) extracted cell shunt bits in MSB-first order (`7 - (cell & 7)`), inverting the mapped cell index within each byte compared to the Renault LBC specification (DDT XML LSB-first layout).
2. **Telemetry Reporting:** `datalayer_battery->status.balancing_status` was never set during response handling, leaving it at `BALANCING_STATUS_UNKNOWN` and causing MQTT (`"balancing_status"`) and the Web UI header to output `"Unknown"`.
### How
1. Corrected bit shifting to LSB-first (`cell & 7`) during PID `0x07` bitfield extraction.
2. Sets `datalayer_battery->status.balancing_status` to `BALANCING_STATUS_ACTIVE` if any cell shunt is active, or `BALANCING_STATUS_READY` if none are active.
### Testing
Tested live against a Zoe Gen1 with some very unbalanced cells.

<img width="1267" height="1507" alt="image" src="https://github.com/user-attachments/assets/f6267c09-75fe-4dc9-84d4-d11b8b542480" />

<img width="3195" height="587" alt="image" src="https://github.com/user-attachments/assets/7240f35e-6d3e-46db-81af-964afbcfe0e2" />


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
9:10 AM
