### PR TITLE
Fix: second CAN FD interface (BECom) fails to start when used without the first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(fd2-standalone)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,0 @@
-cmake_minimum_required(VERSION 3.16.0)
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(fd2-standalone)

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -257,11 +257,9 @@ bool init_CAN() {
       SPI2517_2->begin(sck_pin, sdo_pin, sdi_pin);
     }
 
-    // On boards that clock the 2nd chip from the 1st chip's CLKO output (a
-    // non-default MCP2517_CLKODIV), the divider is normally programmed when
-    // the 1st interface starts. Running the 2nd interface alone leaves the
-    // 1st chip at its divide-by-10 power-up default, clocking this chip 10x
-    // slower than MCP2517_FREQ2() declares, so program it here.
+    // Boards that clock the 2nd chip from the 1st chip's CLKO output normally get
+    // the divider programmed when the 1st interface starts. Running the 2nd alone
+    // leaves the 1st chip at its divide-by-10 default, so program it here.
     bool fd1_in_use = fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end();
     if (mcp2517fd_clko_kick_needed(fd1_in_use, esp32hal->MCP2517_CLKODIV())) {
       auto cs1_pin = esp32hal->MCP2517_CS();

--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -4,6 +4,7 @@
 #include "../../lib/pierremolinaro-acan-esp32/ACAN_ESP32.h"
 #include "CanReceiver.h"
 #include "comm_can.h"
+#include "mcp2517fd_clko.h"
 #include "src/datalayer/datalayer.h"
 #include "src/devboard/hal/hal.h"
 #include "src/devboard/safety/safety.h"
@@ -254,6 +255,20 @@ bool init_CAN() {
       }
 
       SPI2517_2->begin(sck_pin, sdo_pin, sdi_pin);
+    }
+
+    // On boards that clock the 2nd chip from the 1st chip's CLKO output (a
+    // non-default MCP2517_CLKODIV), the divider is normally programmed when
+    // the 1st interface starts. Running the 2nd interface alone leaves the
+    // 1st chip at its divide-by-10 power-up default, clocking this chip 10x
+    // slower than MCP2517_FREQ2() declares, so program it here.
+    bool fd1_in_use = fdNativeIt != can_receivers.end() || fdAddonIt != can_receivers.end();
+    if (mcp2517fd_clko_kick_needed(fd1_in_use, esp32hal->MCP2517_CLKODIV())) {
+      auto cs1_pin = esp32hal->MCP2517_CS();
+      if (!esp32hal->alloc_pins("CANFD", cs1_pin)) {
+        return false;
+      }
+      mcp2517fd_program_clko(*SPI2517, cs1_pin, esp32hal->MCP2517_CLKODIV());
     }
 
     canfd_2 = new ACAN2517FD(cs_pin, *SPI2517_2, int_pin);

--- a/Software/src/communication/can/mcp2517fd_clko.cpp
+++ b/Software/src/communication/can/mcp2517fd_clko.cpp
@@ -1,0 +1,35 @@
+#include "mcp2517fd_clko.h"
+
+#include <Arduino.h>
+#include <SPI.h>
+
+// SPI command format (DS20005688B table 4-1): 4-bit opcode + 12-bit address.
+static const uint16_t RESET_COMMAND = 0x0000;
+static const uint16_t WRITE_OPCODE = 0x2;
+static const uint16_t OSC_REGISTER = 0xE00;
+
+bool mcp2517fd_clko_kick_needed(bool fd1_in_use, int clkodiv) {
+  return !fd1_in_use && clkodiv != MCP2517_CLKODIV_DEFAULT;
+}
+
+void mcp2517fd_program_clko(SPIClass& spi, uint8_t cs_pin, int clkodiv) {
+  pinMode(cs_pin, OUTPUT);
+  digitalWrite(cs_pin, HIGH);
+
+  // 800 kHz keeps the transaction legal while the chip still runs on the
+  // divided-by-10 power-up clock (the SPI limit is just under SYSCLK/2).
+  spi.beginTransaction(SPISettings(800000, MSBFIRST, SPI_MODE0));
+
+  digitalWrite(cs_pin, LOW);
+  spi.transfer16(RESET_COMMAND);
+  digitalWrite(cs_pin, HIGH);
+
+  digitalWrite(cs_pin, LOW);
+  spi.transfer16((WRITE_OPCODE << 12) | OSC_REGISTER);
+  // CLKODIV lives in bits 6:5; PLLEN, OSCDIS and SCLKDIV stay 0 (oscillator
+  // on, SCLK divide-by-1) - the same byte ACAN2517FD::begin composes.
+  spi.transfer((uint8_t)((clkodiv & 0b11) << 5));
+  digitalWrite(cs_pin, HIGH);
+
+  spi.endTransaction();
+}

--- a/Software/src/communication/can/mcp2517fd_clko.cpp
+++ b/Software/src/communication/can/mcp2517fd_clko.cpp
@@ -16,8 +16,11 @@ void mcp2517fd_program_clko(SPIClass& spi, uint8_t cs_pin, int clkodiv) {
   pinMode(cs_pin, OUTPUT);
   digitalWrite(cs_pin, HIGH);
 
-  // 800 kHz keeps the transaction legal while the chip still runs on the
-  // divided-by-10 power-up clock (the SPI limit is just under SYSCLK/2).
+  // Deliberately slow: a one-off two-command transaction has no throughput
+  // needs, and 800 kHz is legal in every state this bus can be in. (Note:
+  // CLKODIV divides only the CLKO OUTPUT - chip 1 itself runs from its own
+  // crystal, so the divided-clock SPI limit belongs to chip 2, which this
+  // transaction never addresses.)
   spi.beginTransaction(SPISettings(800000, MSBFIRST, SPI_MODE0));
 
   digitalWrite(cs_pin, LOW);

--- a/Software/src/communication/can/mcp2517fd_clko.cpp
+++ b/Software/src/communication/can/mcp2517fd_clko.cpp
@@ -16,21 +16,17 @@ void mcp2517fd_program_clko(SPIClass& spi, uint8_t cs_pin, int clkodiv) {
   pinMode(cs_pin, OUTPUT);
   digitalWrite(cs_pin, HIGH);
 
-  // Deliberately slow: a one-off two-command transaction has no throughput
-  // needs, and 800 kHz is legal in every state this bus can be in. (Note:
-  // CLKODIV divides only the CLKO OUTPUT - chip 1 itself runs from its own
-  // crystal, so the divided-clock SPI limit belongs to chip 2, which this
-  // transaction never addresses.)
+  // 800 kHz: no throughput needs, and legal in every state this bus can be in.
   spi.beginTransaction(SPISettings(800000, MSBFIRST, SPI_MODE0));
 
+  // Reset first: it guarantees Configuration mode, where OSC is writable.
   digitalWrite(cs_pin, LOW);
   spi.transfer16(RESET_COMMAND);
   digitalWrite(cs_pin, HIGH);
 
+  // CLKODIV lives in bits 6:5; PLLEN, OSCDIS and SCLKDIV stay 0.
   digitalWrite(cs_pin, LOW);
   spi.transfer16((WRITE_OPCODE << 12) | OSC_REGISTER);
-  // CLKODIV lives in bits 6:5; PLLEN, OSCDIS and SCLKDIV stay 0 (oscillator
-  // on, SCLK divide-by-1) - the same byte ACAN2517FD::begin composes.
   spi.transfer((uint8_t)((clkodiv & 0b11) << 5));
   digitalWrite(cs_pin, HIGH);
 

--- a/Software/src/communication/can/mcp2517fd_clko.h
+++ b/Software/src/communication/can/mcp2517fd_clko.h
@@ -5,22 +5,15 @@
 
 class SPIClass;
 
-// Power-up value of the MCP2517FD CLKODIV field: clock output divided by 10
-// (DS20005688B, OSC register). Boards with no consumer on the CLKO pin leave
-// it alone, so a non-default MCP2517_CLKODIV() marks a board where something
-// (the 2nd CAN FD chip) is clocked from the 1st chip's CLKO output.
+// Power-up value of the MCP2517FD CLKODIV field: clock output divided by 10.
 static const int MCP2517_CLKODIV_DEFAULT = 0b11;
 
 // True when starting the 2nd CAN FD interface must program the 1st chip's
 // clock output by hand: the board declares a non-default divider, but no 1st
-// FD interface is configured, so the driver that normally programs it never
-// runs and the 2nd chip would be clocked 10x slow.
+// FD interface is configured, so the driver that normally programs it never runs.
 bool mcp2517fd_clko_kick_needed(bool fd1_in_use, int clkodiv);
 
-// Program the 1st MCP2517FD's OSC register so its CLKO pin outputs the clock
-// the board declares. Resets the chip first: it is unused in the only
-// configuration that gets here, and reset guarantees Configuration mode,
-// where the oscillator bits are writable.
+// Program the 1st MCP2517FD's OSC register so CLKO outputs the declared clock.
 void mcp2517fd_program_clko(SPIClass& spi, uint8_t cs_pin, int clkodiv);
 
-#endif
+#endif  // MCP2517FD_CLKO_H

--- a/Software/src/communication/can/mcp2517fd_clko.h
+++ b/Software/src/communication/can/mcp2517fd_clko.h
@@ -1,0 +1,26 @@
+#ifndef MCP2517FD_CLKO_H
+#define MCP2517FD_CLKO_H
+
+#include <stdint.h>
+
+class SPIClass;
+
+// Power-up value of the MCP2517FD CLKODIV field: clock output divided by 10
+// (DS20005688B, OSC register). Boards with no consumer on the CLKO pin leave
+// it alone, so a non-default MCP2517_CLKODIV() marks a board where something
+// (the 2nd CAN FD chip) is clocked from the 1st chip's CLKO output.
+static const int MCP2517_CLKODIV_DEFAULT = 0b11;
+
+// True when starting the 2nd CAN FD interface must program the 1st chip's
+// clock output by hand: the board declares a non-default divider, but no 1st
+// FD interface is configured, so the driver that normally programs it never
+// runs and the 2nd chip would be clocked 10x slow.
+bool mcp2517fd_clko_kick_needed(bool fd1_in_use, int clkodiv);
+
+// Program the 1st MCP2517FD's OSC register so its CLKO pin outputs the clock
+// the board declares. Resets the chip first: it is unused in the only
+// configuration that gets here, and reset guarantees Configuration mode,
+// where the oscillator bits are writable.
+void mcp2517fd_program_clko(SPIClass& spi, uint8_t cs_pin, int clkodiv);
+
+#endif

--- a/Software/src/devboard/hal/hw_becom.h
+++ b/Software/src/devboard/hal/hw_becom.h
@@ -29,7 +29,8 @@ class BEComHal : public Esp32Hal {
   virtual gpio_num_t MCP2517_INT2() { return GPIO_NUM_9; }
   virtual uint32_t MCP2517_FREQ2() { return 40000000; }
 
-  // Value for first MCP2517 CLKODIV register (divide by 1)
+  // Value for first MCP2517 CLKODIV register (divide by 1): the 2nd chip is
+  // clocked from the 1st chip's CLKO output, so it must carry the full 40 MHz
   virtual int MCP2517_CLKODIV() { return 0b00; }
 
   // Contactor handling

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX "/build/")
 add_executable(tests
     ${TEST_SOURCES}
     ../Software/src/devboard/safety/parallel_safety.cpp
+    ../Software/src/communication/can/mcp2517fd_clko.cpp
     ../Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
     ../Software/src/communication/rs485/comm_rs485.cpp
     ../Software/src/devboard/safety/safety.cpp

--- a/test/canfd2_clko_tests.cpp
+++ b/test/canfd2_clko_tests.cpp
@@ -4,30 +4,19 @@
 
 #include "../Software/src/communication/can/mcp2517fd_clko.h"
 
-// BECom's second MCP2518 has no crystal of its own: it is clocked from the
-// first chip's CLKO pin (hw_becom.h declares CLKODIV divide-by-1). The first
-// chip powers up with CLKO at divide-by-10, and only the first FD interface's
-// driver programs it - so running the second interface standalone used to
-// leave the second chip at 4 MHz while the driver configured it for 40 MHz,
-// and it never came up. These tests pin the fix: the kick fires exactly when
-// the first FD interface is absent AND the board declares a non-default
-// divider, and it shifts out the reset + OSC write the datasheet specifies.
+// BECom's 2nd MCP2518 is clocked from the 1st chip's CLKO pin, which powers up at
+// divide-by-10 and is otherwise only programmed by the 1st interface's begin().
 
 TEST(CanFd2Clko, KickOnlyWhenFd1AbsentAndDividerNonDefault) {
-  // BECom with only the 2nd interface configured: nothing else programs CLKO.
   EXPECT_TRUE(mcp2517fd_clko_kick_needed(false, 0b00));
-  // The 1st interface's own begin() programs the divider - no kick.
   EXPECT_FALSE(mcp2517fd_clko_kick_needed(true, 0b00));
-  // Default divider means nothing consumes CLKO (stark, lilygo2can) - the
-  // 2nd chip has its own clock and the 1st chip may not even be fitted.
   EXPECT_FALSE(mcp2517fd_clko_kick_needed(false, MCP2517_CLKODIV_DEFAULT));
 }
 
 TEST(CanFd2Clko, ProgramsOscViaResetThenWrite) {
   SPIClass spi;
   mcp2517fd_program_clko(spi, 14, 0b00);
-  // RESET (0x0000), then WRITE (0b0010 << 12 | 0xE00) of one byte: PLLEN,
-  // OSCDIS and SCLKDIV zero, CLKODIV divide-by-1 in bits 6:5.
+  // RESET (0x0000), then WRITE (0b0010 << 12 | 0xE00) of one byte.
   const std::vector<uint8_t> expected = {0x00, 0x00, 0x2E, 0x00, 0x00};
   EXPECT_EQ(spi.transferred, expected);
   EXPECT_FALSE(spi.in_transaction) << "transaction must be closed";
@@ -38,15 +27,4 @@ TEST(CanFd2Clko, DividerLandsInBits5and6) {
   mcp2517fd_program_clko(spi, 14, 0b10);
   ASSERT_EQ(spi.transferred.size(), 5u);
   EXPECT_EQ(spi.transferred[4], 0b10 << 5);
-}
-
-TEST(CanFd2Clko, KeepsTheDeliberatelyConservativeSpiSpeed) {
-  // The transaction runs at a deliberately conservative 800 kHz - it has no
-  // throughput needs and that speed is legal in every state the bus can be
-  // in. (CLKODIV divides only the CLKO OUTPUT: chip 1 runs from its own
-  // crystal, so no divided-clock SPI limit applies to this transaction -
-  // the speed is a choice, and this pins the choice.)
-  SPIClass spi;
-  mcp2517fd_program_clko(spi, 14, 0b00);
-  EXPECT_LE(spi.transaction_clock, 800000u);
 }

--- a/test/canfd2_clko_tests.cpp
+++ b/test/canfd2_clko_tests.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <SPI.h>
+
+#include "../Software/src/communication/can/mcp2517fd_clko.h"
+
+// BECom's second MCP2518 has no crystal of its own: it is clocked from the
+// first chip's CLKO pin (hw_becom.h declares CLKODIV divide-by-1). The first
+// chip powers up with CLKO at divide-by-10, and only the first FD interface's
+// driver programs it - so running the second interface standalone used to
+// leave the second chip at 4 MHz while the driver configured it for 40 MHz,
+// and it never came up. These tests pin the fix: the kick fires exactly when
+// the first FD interface is absent AND the board declares a non-default
+// divider, and it shifts out the reset + OSC write the datasheet specifies.
+
+TEST(CanFd2Clko, KickOnlyWhenFd1AbsentAndDividerNonDefault) {
+  // BECom with only the 2nd interface configured: nothing else programs CLKO.
+  EXPECT_TRUE(mcp2517fd_clko_kick_needed(false, 0b00));
+  // The 1st interface's own begin() programs the divider - no kick.
+  EXPECT_FALSE(mcp2517fd_clko_kick_needed(true, 0b00));
+  // Default divider means nothing consumes CLKO (stark, lilygo2can) - the
+  // 2nd chip has its own clock and the 1st chip may not even be fitted.
+  EXPECT_FALSE(mcp2517fd_clko_kick_needed(false, MCP2517_CLKODIV_DEFAULT));
+}
+
+TEST(CanFd2Clko, ProgramsOscViaResetThenWrite) {
+  SPIClass spi;
+  mcp2517fd_program_clko(spi, 14, 0b00);
+  // RESET (0x0000), then WRITE (0b0010 << 12 | 0xE00) of one byte: PLLEN,
+  // OSCDIS and SCLKDIV zero, CLKODIV divide-by-1 in bits 6:5.
+  const std::vector<uint8_t> expected = {0x00, 0x00, 0x2E, 0x00, 0x00};
+  EXPECT_EQ(spi.transferred, expected);
+  EXPECT_FALSE(spi.in_transaction) << "transaction must be closed";
+}
+
+TEST(CanFd2Clko, DividerLandsInBits5and6) {
+  SPIClass spi;
+  mcp2517fd_program_clko(spi, 14, 0b10);
+  ASSERT_EQ(spi.transferred.size(), 5u);
+  EXPECT_EQ(spi.transferred[4], 0b10 << 5);
+}
+
+TEST(CanFd2Clko, StaysUnderThePowerUpSpiLimit) {
+  // Until the divider is programmed the chip runs on a 4 MHz SYSCLK, capping
+  // SPI at just under SYSCLK/2 - the whole transaction must respect that.
+  SPIClass spi;
+  mcp2517fd_program_clko(spi, 14, 0b00);
+  EXPECT_LE(spi.transaction_clock, 2000000u - 1);
+}

--- a/test/canfd2_clko_tests.cpp
+++ b/test/canfd2_clko_tests.cpp
@@ -40,10 +40,13 @@ TEST(CanFd2Clko, DividerLandsInBits5and6) {
   EXPECT_EQ(spi.transferred[4], 0b10 << 5);
 }
 
-TEST(CanFd2Clko, StaysUnderThePowerUpSpiLimit) {
-  // Until the divider is programmed the chip runs on a 4 MHz SYSCLK, capping
-  // SPI at just under SYSCLK/2 - the whole transaction must respect that.
+TEST(CanFd2Clko, KeepsTheDeliberatelyConservativeSpiSpeed) {
+  // The transaction runs at a deliberately conservative 800 kHz - it has no
+  // throughput needs and that speed is legal in every state the bus can be
+  // in. (CLKODIV divides only the CLKO OUTPUT: chip 1 runs from its own
+  // crystal, so no divided-clock SPI limit applies to this transaction -
+  // the speed is a choice, and this pins the choice.)
   SPIClass spi;
   mcp2517fd_program_clko(spi, 14, 0b00);
-  EXPECT_LE(spi.transaction_clock, 2000000u - 1);
+  EXPECT_LE(spi.transaction_clock, 800000u);
 }

--- a/test/emul/SPI.h
+++ b/test/emul/SPI.h
@@ -1,6 +1,48 @@
 #pragma once
 
+#include <stdint.h>
+
+#include <vector>
+
 // Arbitrary bus indices
 #define HSPI 1
 #define VSPI 2
 #define FSPI 3
+
+#define MSBFIRST 1
+#define SPI_MODE0 0
+
+class SPISettings {
+ public:
+  SPISettings() {}
+  SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) : clock(clock) {
+    (void)bitOrder;
+    (void)dataMode;
+  }
+  uint32_t clock = 0;
+};
+
+// Records every byte shifted out so tests can assert the exact command
+// sequence a driver puts on the wire (chip-select edges are not modelled).
+class SPIClass {
+ public:
+  std::vector<uint8_t> transferred;
+  uint32_t transaction_clock = 0;
+  bool in_transaction = false;
+
+  void begin(int8_t sck = -1, int8_t miso = -1, int8_t mosi = -1, int8_t ss = -1) {}
+  void beginTransaction(SPISettings settings) {
+    in_transaction = true;
+    transaction_clock = settings.clock;
+  }
+  void endTransaction() { in_transaction = false; }
+  uint8_t transfer(uint8_t data) {
+    transferred.push_back(data);
+    return 0;
+  }
+  uint16_t transfer16(uint16_t data) {
+    transferred.push_back(static_cast<uint8_t>(data >> 8));
+    transferred.push_back(static_cast<uint8_t>(data & 0xFF));
+    return 0;
+  }
+};

--- a/test/emul/SPI.h
+++ b/test/emul/SPI.h
@@ -14,27 +14,17 @@
 
 class SPISettings {
  public:
-  SPISettings() {}
-  SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) : clock(clock) {
-    (void)bitOrder;
-    (void)dataMode;
-  }
-  uint32_t clock = 0;
+  SPISettings(uint32_t, uint8_t, uint8_t) {}
 };
 
-// Records every byte shifted out so tests can assert the exact command
-// sequence a driver puts on the wire (chip-select edges are not modelled).
+// Records the bytes shifted out so tests can assert the exact command sequence
+// a driver puts on the wire (chip-select edges are not modelled).
 class SPIClass {
  public:
   std::vector<uint8_t> transferred;
-  uint32_t transaction_clock = 0;
   bool in_transaction = false;
 
-  void begin(int8_t sck = -1, int8_t miso = -1, int8_t mosi = -1, int8_t ss = -1) {}
-  void beginTransaction(SPISettings settings) {
-    in_transaction = true;
-    transaction_clock = settings.clock;
-  }
+  void beginTransaction(SPISettings) { in_transaction = true; }
   void endTransaction() { in_transaction = false; }
   uint8_t transfer(uint8_t data) {
     transferred.push_back(data);


### PR DESCRIPTION
On the BECom, the second MCP2518 is clocked from the first chip's CLKO output — `hw_becom.h` sets `MCP2517_CLKODIV()` to divide-by-1 for exactly this (aebce6da). That divider is programmed by the first FD interface's `begin()`, and the chip powers up at divide-by-10. So configuring only "CAN FD Battery 2" leaves the second chip on a 4 MHz clock while the driver assumes 40 MHz, and init fails with a CAN-FD-2 configuration error. Both interfaces together work, which is why this only bites standalone use.

Fix: when the second FD interface starts without the first, program the first chip's OSC register directly (reset + one register write over the already-initialized shared SPI bus) so CLKO carries the declared frequency. Boards with the default divider (their second chips have their own clocks) are unaffected — the gate excludes them.

Verified: host tests for the gate and the exact SPI command sequence (192/192 pass); BECom_330 / stark_330 / lilygo_2CAN_330 compile. I don't own a BECom, so a hardware confirm from someone who does would be very welcome — the CLKO wiring is inferred from the CLKODIV override and its commit message, not a schematic.

Note: drafted with AI assistance, reviewed by me.
