### PR TITLE
Silent assertions: drop the assert message strings, keep every check (-55 KB flash per board)

### DIFF
--- a/sdkconfig.be_size.defaults
+++ b/sdkconfig.be_size.defaults
@@ -85,11 +85,16 @@ CONFIG_FMB_MASTER_MAX_API_BLOCKING_TIME_MS=6000
 # >>> Caveat: same as above - if you ever run an on-device TLS server, revert.
 CONFIG_MBEDTLS_TLS_CLIENT_ONLY=y
 
-# Remove assertion checks outright (not just the message strings). Larger flash
-# win than SILENT. Trade-off: a bug that would have cleanly asserted becomes
-# undefined behaviour instead. Switch back to _SILENT if you want the aborts.
-# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
-# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT is not set
+# Silent assertions: every check is KEPT and still aborts on failure - only the
+# per-assert message strings are dropped, which is where the flash mass is
+# (~85.6 % of the full-disable saving: lilygo_330 -55,664 B, esp32devkit_330
+# -55,432 B, vs -65,040/-64,704 for _DISABLE). A failed assert reports the
+# abort address instead of the string; it decodes against the build's ELF:
+#   xtensa-esp32-elf-addr2line -pfiaC -e firmware.elf <PC>
+# _DISABLE (checks compiled OUT, silent UB on broken invariants) stays
+# deliberately unset until the base is declared stable.
+CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT=y
+# CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE is not set
 
 # -----------------------------------------------------------------------------
 # TIER 3 - measure carefully, board-by-board. May interact with AsyncTCP / mDNS.


### PR DESCRIPTION
This enables `CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT` in the shared `sdkconfig.be_size.defaults`, so it applies to every board env identically.

**What it does:** every `assert()`/IDF invariant check is compiled in and still aborts on failure, exactly as today. Only the per-assert message strings (file/expression text) are dropped — and the strings are where the flash mass is.

**Measured** (wiped build dirs, config verified in each env's regenerated sdkconfig, baseline/subject pairs built back-to-back; the SILENT lilygo number reproduced twice byte-exact):

| env | baseline | SILENT | delta | full-DISABLE (reference) |
|---|---|---|---|---|
| lilygo_330 | 1,866,720 B | 1,811,056 B | **−55,664 B (−2.99 %)** | −65,040 B |
| esp32devkit_330 | 1,821,232 B | 1,765,800 B | **−55,432 B (−3.05 %)** | −64,704 B |

That is ~85.6 % of the full `ASSERTIONS_DISABLE` saving with none of its safety cost — and a word of caution on the other half: **`_DISABLE` is the wrong move on a safety-related system.** It compiles the checks OUT, so a broken invariant no longer aborts — the firmware keeps running on falsified assumptions, on hardware that drives contactors. Test coverage does not change that arithmetic: tests cover the cases we thought of; asserts exist for the ones we didn't. The remaining ~9.4 KB is, in effect, the price of every runtime invariant in the image — this PR's position is that it is the right 9.4 KB to keep, permanently. SILENT needs no stability gate at all, which is why it can merge today.

**Why this matters now:** the 4 MB boards are against the wall. Recent size-bot reports show Lilygo T-CAN485 at **94.8 %** and DevKit at **92.5 %**, and every merged feature nudges those up. This change takes the tightest tier from ~94.7 % to ~91.9 % — roughly **three points of headroom back for a one-line config change**, which is the largest single non-breaking flash win currently available to the project. Flash pressure is also what pushes riskier ideas (dropping features, disabling checks outright) onto the table; landing the safe 86 % first is how the remaining 9.4 KB never needs to be argued about.

**The honest cost:** an assert failure now aborts with the program counter instead of the message string. The backtrace still prints and decodes against the ELF of that build:

    xtensa-esp32-elf-addr2line -pfiaC -e .pio/build/<env>/firmware.elf <PC>

So field reports go from "assert failed: \<string\>" to one addr2line invocation against the matching release ELF.

**On the three adoption questions** (cost / pace / breakage): abstraction cost — none, one config line, no code changes; pace — nothing changes for anyone's workflow; breakage plan — revert is the same one line, and any assert that fires still aborts loudly, so a problem would present exactly as it does today, minus one string.

All board envs build green with the flag verified present in each env's generated sdkconfig (the generated-config check matters: PlatformIO can silently skip a config change under some cache states, so each env was built alone and its regenerated sdkconfig inspected).

**On sequencing:** agreed that this waits for #2652 — a known crash class should keep its message strings while it is being hunted. This PR is ready to merge the day #2652 lands, and the field-crash workflow from that point on is the addr2line invocation above against the release ELF.

Note: drafted with AI assistance, reviewed by me.

