### PR TITLE
Fix battery 2 charge/discharge power defaulting to 0W in double-battery setups

### DIFF
--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -244,6 +244,12 @@ void init_stored_settings() {
   //Some early integrations need manually set allowed charge/discharge power
   datalayer.battery.status.override_charge_power_W = settings.getUInt("CHGPOWER", 1000);
   datalayer.battery.status.override_discharge_power_W = settings.getUInt("DCHGPOWER", 1000);
+  // Battery 2 reuses battery 1's manual power settings: update_calculated_values() caps the
+  // combined system's max charge/discharge power to whichever battery reports less, so leaving
+  // these at their unset default of 0 would silently zero out the whole system for double-battery
+  // setups using the same "estimated power" integrations as above.
+  datalayer.battery2.status.override_charge_power_W = settings.getUInt("CHGPOWER", 1000);
+  datalayer.battery2.status.override_discharge_power_W = settings.getUInt("DCHGPOWER", 1000);
 
   // WIFI AP is enabled by default unless disabled in the settings
   wifiap_enabled = settings.getBool("WIFIAPENABLED", true);


### PR DESCRIPTION
### What
Battery 2 now reuses battery 1's manual charge/discharge power settings (CHGPOWER/DCHGPOWER) on init, instead of defaulting to 0.

### Why
datalayer.battery2's override_charge_power_W/override_discharge_power_W were never initialized from NVM anywhere, so they stayed at their struct default of 0. Drivers that don't get real max power from CAN (Tesla, Bolt/Ampera, Geely SEA, etc.) use this override as their authoritative max charge/discharge power, so battery 2 always reported 0W.

update_calculated_values() caps the combined system's max charge/discharge power to whichever battery reports less — so this silently zeroed out charging and discharging for the entire double-battery system, regardless of what the user configured in Settings. This affects any double-battery setup using an "estimated power" driver as battery 2 (confirmed with double Tesla Model 3/Y).

### How
Two lines in comm_nvm.cpp: battery 2's override_charge_power_W/override_discharge_power_W are now loaded from the same CHGPOWER/DCHGPOWER settings as battery 1, rather than left uninitialized.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)