### PR TITLE
Make the Lilygo T-2CAN use INT rather than INT0/INT1

### DIFF
--- a/Software/src/communication/can/comm_can.cpp
+++ b/Software/src/communication/can/comm_can.cpp
@@ -190,24 +190,12 @@ bool init_CAN() {
 
     auto cs_pin = esp32hal->MCP2517_CS();
     auto int_pin = esp32hal->MCP2517_INT();
-    auto int0_pin = esp32hal->MCP2517_INT0();
-    auto int1_pin = esp32hal->MCP2517_INT1();
 
-    if (!esp32hal->alloc_pins("CANFD", cs_pin)) {
+    if (!esp32hal->alloc_pins("CANFD", cs_pin, int_pin)) {
       return false;
     }
-    if (int_pin != GPIO_NUM_NC) {
-      if (!esp32hal->alloc_pins("CANFD", int_pin)) {
-        return false;
-      }
-    } else {
-      if (!esp32hal->alloc_pins("CANFD", int0_pin, int1_pin)) {
-        return false;
-      }
-    }
 
-    canfd = new ACAN2517FD(cs_pin, *SPI2517, int_pin != GPIO_NUM_NC ? int_pin : 255,
-                           int0_pin != GPIO_NUM_NC ? int0_pin : 255, int1_pin != GPIO_NUM_NC ? int1_pin : 255);
+    canfd = new ACAN2517FD(cs_pin, *SPI2517, int_pin);
 
     logging.println("CAN FD add-on (ESP32+MCP2517) selected");
 

--- a/Software/src/devboard/hal/hal.h
+++ b/Software/src/devboard/hal/hal.h
@@ -143,8 +143,6 @@ class Esp32Hal {
   virtual gpio_num_t MCP2517_SDO() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_CS() { return GPIO_NUM_NC; }
   virtual gpio_num_t MCP2517_INT() { return GPIO_NUM_NC; }
-  virtual gpio_num_t MCP2517_INT0() { return GPIO_NUM_NC; }
-  virtual gpio_num_t MCP2517_INT1() { return GPIO_NUM_NC; }
   virtual uint32_t MCP2517_FREQ() { return 0; }  // 0 means unknown
 
   // 2nd CANFD Interface: MCP2517/8

--- a/Software/src/devboard/hal/hw_lilygo2can.h
+++ b/Software/src/devboard/hal/hw_lilygo2can.h
@@ -60,9 +60,7 @@ class LilyGo2CANHal : public Esp32Hal {
   virtual gpio_num_t MCP2517_SDI() { return is_fd() ? GPIO_NUM_11 : GPIO_NUM_42; }
   virtual gpio_num_t MCP2517_SDO() { return is_fd() ? GPIO_NUM_13 : GPIO_NUM_37; }
   virtual gpio_num_t MCP2517_CS() { return is_fd() ? GPIO_NUM_10 : GPIO_NUM_41; }
-  virtual gpio_num_t MCP2517_INT() { return is_fd() ? GPIO_NUM_NC : GPIO_NUM_39; }
-  virtual gpio_num_t MCP2517_INT0() { return is_fd() ? GPIO_NUM_9 : GPIO_NUM_NC; }
-  virtual gpio_num_t MCP2517_INT1() { return is_fd() ? GPIO_NUM_3 : GPIO_NUM_NC; }
+  virtual gpio_num_t MCP2517_INT() { return is_fd() ? GPIO_NUM_8 : GPIO_NUM_39; }
   virtual uint32_t MCP2517_FREQ() { return is_fd() ? 40000000 : 0; }
 
   // Use the 2515 SPI bus for the add-on on the FD (as it isn't being used for a 2515)
@@ -81,11 +79,10 @@ class LilyGo2CANHal : public Esp32Hal {
     if (user_selected_gpioopt1 == GPIOOPT1::ESTOP_BMS_POWER) {
       return GPIO_NUM_2;
     }
-    // GPIO3 is used as INT1 on a T-2CAN FD (MCP2518), so use GPIO45 instead.
-    return is_fd() ? GPIO_NUM_45 : GPIO_NUM_3;
+    return GPIO_NUM_3;
   }
   // Pins to be latched across a reset/OTA reboot (RTC-capable pins only): BMS_POWER is either GPIO2, GPIO3, or GPIO45
-  virtual std::vector<gpio_num_t> reset_hold_pins() { return {GPIO_NUM_2, is_fd() ? GPIO_NUM_45 : GPIO_NUM_3}; }
+  virtual std::vector<gpio_num_t> reset_hold_pins() { return {GPIO_NUM_2, GPIO_NUM_3}; }
   virtual gpio_num_t SECOND_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_5; }
   virtual gpio_num_t TRIPLE_BATTERY_CONTACTORS_PIN() { return GPIO_NUM_4; }
 

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
@@ -210,15 +210,11 @@ static inline void turnOnInterrupts() {
 
 ACAN2517FD::ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                         SPIClass & inSPI, // Hardware SPI object
-                        const uint8_t inINT, // INT output of MCP2517FD
-                        const uint8_t inINT0,
-                        const uint8_t inINT1) :
+                        const uint8_t inINT) : // INT output of MCP2517FD
 mSPISettings (),
 mSPI (inSPI),
 mCS (inCS),
 mINT (inINT),
-mINT0 (inINT0),
-mINT1 (inINT1),
 mUsesTXQ (false),
 mHardwareTxFIFOFull (false),
 mRxInterruptEnabled (true),
@@ -258,18 +254,12 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
   if ((mINT != 255) && (itPin == NOT_AN_INTERRUPT)) {
     errorCode = kINTPinIsNotAnInterrupt ;
   }
-  const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
-  const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
-  if((mINT0 != 255 && itPin0 == NOT_AN_INTERRUPT) || (mINT1 != 255 && itPin1 == NOT_AN_INTERRUPT)) {
-    errorCode = kINTPinIsNotAnInterrupt ;
-  }
-
 //----------------------------------- Check interrupt service routine is not null
-  if ((mINT != 255 || mINT0 != 255 || mINT1 != 255) && (inInterruptServiceRoutine == NULL)) {
+  if ((mINT != 255) && (inInterruptServiceRoutine == NULL)) {
     errorCode |= kISRIsNull ;
   }
 //----------------------------------- Check consistency between ISR and INT pin
-  if ((mINT == 255) && (mINT0 == 255) && (mINT1 == 255) && (inInterruptServiceRoutine != NULL)) {
+  if ((mINT == 255) && (inInterruptServiceRoutine != NULL)) {
     errorCode |= kISRNotNullAndNoIntPin ;
   }
 //----------------------------------- Check TXQ size is <= 32
@@ -311,12 +301,6 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
   if (errorCode == 0) {
     if (mINT != 255) { // 255 means interrupt is not used (thanks to Tyler Lewis)
       pinMode (mINT, INPUT_PULLUP) ;
-    }
-    if (mINT0 != 255) {
-      pinMode (mINT0, INPUT_PULLUP) ;
-    }
-    if (mINT1 != 255) {
-      pinMode (mINT1, INPUT_PULLUP) ;
     }
     initCS () ;
   //----------------------------------- Set SPI clock to 800 kHz
@@ -440,12 +424,6 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
     }
     if (inSettings.mINTIsOpenDrain) {
       data8 |= 1 << 6 ; // INTOD
-    }
-    if (mINT0 != 255) {
-      data8 &= ~(1 << 0) ; // PM0
-    }
-    if (mINT1 != 255) {
-      data8 &= ~(1 << 1) ; // PM1
     }
     writeRegister8 (IOCON_REGISTER_24_31, data8) ; // DS20005688B, page 24
   //----------------------------------- Configure ISO CRC Enable bit
@@ -581,15 +559,6 @@ uint32_t ACAN2517FD::begin (const ACAN2517FDSettings & inSettings,
         attachInterrupt (itPin, inInterruptServiceRoutine, LOW) ; // Thank to Flole998
         mSPI.usingInterrupt (itPin) ; // usingInterrupt is not implemented in Arduino ESP32
       #endif
-    } else if( mINT0 != 255 && mINT1 != 255 ) {
-      const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
-      const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
-      #ifdef ARDUINO_ARCH_ESP32
-        attachInterrupt (itPin0, inInterruptServiceRoutine, FALLING) ;
-        attachInterrupt (itPin1, inInterruptServiceRoutine, FALLING) ;
-      #else
-        #error Unsupported
-      #endif
     }
   // If you begin() multiple times without constructor,
   // mHardwareTxFIFOFull = true will block the transmitter.
@@ -611,11 +580,6 @@ bool ACAN2517FD::end (void) {
     if (mINT != 255) { // 255 means interrupt is not used
       const int8_t itPin = digitalPinToInterrupt (mINT) ;
       detachInterrupt (itPin) ; // Available for ESP32 and Arduino
-    } else if( mINT0 != 255 && mINT1 != 255 ) {
-      const int8_t itPin0 = digitalPinToInterrupt (mINT0) ;
-      const int8_t itPin1 = digitalPinToInterrupt (mINT1) ;
-      detachInterrupt (itPin0) ;
-      detachInterrupt (itPin1) ;
     }
   //--- Request configuration mode
     bool wait = true ;
@@ -857,7 +821,7 @@ bool ACAN2517FD::receive (CANFDMessage & outMessage) {
       turnOffInterrupts () ;
       const bool hasReceivedMessage = mDriverReceiveBuffer.remove (outMessage) ;
     //--- If receive interrupt is disabled, enable it (added in release 2.17)
-      if (mINT == 255 && mINT0 == 255 && mINT1 == 255) { // No interrupt is used
+      if (mINT == 255) { // No interrupt pin
         mRxInterruptEnabled = true ;
         isr_poll_core () ; // Perform polling
       }else if (!mRxInterruptEnabled) {
@@ -1059,7 +1023,7 @@ void ACAN2517FD::receiveInterrupt (void) {
 //--- If mDriverReceiveBuffer is full, disable receive interrupt (added in release 2.17)
   if (mDriverReceiveBuffer.isFull ()) {
     mRxInterruptEnabled = false ;
-    if (mINT != 255 || mINT0 != 255 || mINT1 != 255) {
+    if (mINT != 255) {
       uint8_t data8 = readRegister8Assume_SPI_transaction (INT_REGISTER + 2) ;
       data8 &= ~ (1 << 1) ; // Receive FIFO Interrupt disable
       writeRegister8Assume_SPI_transaction (INT_REGISTER + 2, data8) ;

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.h
@@ -37,9 +37,7 @@ class ACAN2517FD {
 
   public: ACAN2517FD (const uint8_t inCS, // CS input of MCP2517FD
                       SPIClass & inSPI, // Hardware SPI object
-                      const uint8_t inINT,
-                      const uint8_t inINT0 = 255,
-                      const uint8_t inINT1 = 255);
+                      const uint8_t inINT) ; // INT output of MCP2517FD
 
 //······················································································································
 //   begin method (returns 0 if no error)
@@ -146,8 +144,6 @@ class ACAN2517FD {
   private: SPIClass & mSPI ;
   private: const uint8_t mCS ;
   private: const uint8_t mINT ;
-  private: const uint8_t mINT0 ;
-  private: const uint8_t mINT1 ;
   private: bool mUsesTXQ ;
   private: bool mHardwareTxFIFOFull ;
   private: bool mRxInterruptEnabled ; // Added in 2.1.7


### PR DESCRIPTION
### What
Due to me misreading the schematic, the previous LilyGo T-2CAN FD integration had a modified HAL and driver to use the `INT0`/`INT1` pins instead of `INT` (since `INT` wasn't very obvious).

This rolls back those changes, which also fully restores the use of `IO3` for `BMS_POWER`

Well done @ekholm for spotting it!

### Why
Simpler code, and means people won't have to mess with DIP switches.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
