### PR TITLE
Precharge: reset the last-voltage-reading when starting

### DIFF
--- a/Software/src/communication/precharge_control/precharge_control.cpp
+++ b/Software/src/communication/precharge_control/precharge_control.cpp
@@ -21,7 +21,8 @@ uint16_t Precharge_max_PWM_Freq = 34000;
 static unsigned long prechargeStartTime = 0;
 static uint32_t freq = Precharge_default_PWM_Freq;
 static uint16_t delta_freq = 1;
-static int32_t prev_external_voltage = 20000;
+static const int32_t UNREAD_EXTERNAL_VOLTAGE = 20000;  // 2000V, bogus value
+static int32_t prev_external_voltage = UNREAD_EXTERNAL_VOLTAGE;
 
 // Initialization functions
 
@@ -87,6 +88,8 @@ void handle_precharge_control(unsigned long currentMillis) {
       }
       break;
     case AUTO_PRECHARGE_START:
+      // Reset the last reading and initial frequency
+      prev_external_voltage = UNREAD_EXTERNAL_VOLTAGE;
       freq = Precharge_default_PWM_Freq;
       ledcAttachChannel(hia4v1_pin, freq, Precharge_PWM_Res, PWM_Precharge_Channel);
       ledcWriteTone(hia4v1_pin, freq);  // Set frequency and set dutycycle to 50%


### PR DESCRIPTION
### What
This was initially a test fix because the test-shuffle was causing the precharge test to fail.

It turns out that the precharge (used by MEB) doesn't reset the `prev_external_voltage` last voltage reading to the initial bogus 2000V value when it starts, meaning that a repeat precharge doesn't start in exactly the same way. This now resets it, which will change the behaviour and fix the test.

**CAVEAT:** - I'm not familiar enough with the MEB precharge to know if this is now the correct behaviour, or the test was wrong. It looks like this will have hardly any effect, as the chance of the new reading exactly matching the previous value is very small, but would be good to be sure.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
