### PR TITLE
BMW i3: Raise 94Ah limits

### DIFF
--- a/Software/src/battery/BMW-I3-BATTERY.h
+++ b/Software/src/battery/BMW-I3-BATTERY.h
@@ -113,14 +113,14 @@ class BmwI3Battery : public CanBattery {
 
   const int MAX_CELL_VOLTAGE_60AH = 4110;   // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_60AH = 2700;   // Battery is put into emergency stop if one cell goes below this value
-  const int MAX_CELL_VOLTAGE_94AH = 4140;   // Battery is put into emergency stop if one cell goes over this value
+  const int MAX_CELL_VOLTAGE_94AH = 4150;   // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_94AH = 2700;   // Battery is put into emergency stop if one cell goes below this value
   const int MAX_CELL_VOLTAGE_120AH = 4210;  // Battery is put into emergency stop if one cell goes over this value
   const int MIN_CELL_VOLTAGE_120AH = 2790;  // Battery is put into emergency stop if one cell goes below this value
   const int MAX_CELL_DEVIATION_MV = 250;    // LED turns yellow on the board if mv delta exceeds this value
   const int MAX_PACK_VOLTAGE_60AH = 3950;   // Charge stops if pack voltage exceeds this value
   const int MIN_PACK_VOLTAGE_60AH = 2590;   // Discharge stops if pack voltage exceeds this value
-  const int MAX_PACK_VOLTAGE_94AH = 3980;   // Charge stops if pack voltage exceeds this value
+  const int MAX_PACK_VOLTAGE_94AH = 3985;   // Charge stops if pack voltage exceeds this value
   const int MIN_PACK_VOLTAGE_94AH = 2590;   // Discharge stops if pack voltage exceeds this value
   const int MAX_PACK_VOLTAGE_120AH = 4032;  // Charge stops if pack voltage exceeds this value
   const int MIN_PACK_VOLTAGE_120AH = 2680;  // Discharge stops if pack voltage exceeds this value


### PR DESCRIPTION
### What
This PR raises the BMW i3 9Ah safety limit

### Why
Avoids this on full charge

<img width="803" height="227" alt="image" src="https://github.com/user-attachments/assets/167e5cc1-aa02-4895-b1c9-8e7348611128" />

### How
Slight raise max pack voltage and cellvoltage for 94Ah

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
