### PR TITLE
Fix: Re-disable the BYD insulation monitor when it re-arms after a contactor open

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -346,6 +346,12 @@ void BydAttoBattery::
       }
     }
     bms_was_alive = bms_alive;
+    // Also re-arms ~30s after a contactor open, which is no BMS start: catch it on the 0x35E edge.
+    if (battery_iso_measurement_active && !iso_measurement_was_active && datalayer_bydatto->keep_iso_disabled) {
+      iso_reassert_needed = true;
+      iso_reassert_attempt_ms = 0;
+    }
+    iso_measurement_was_active = battery_iso_measurement_active;
     if (!datalayer_bydatto->keep_iso_disabled) {
       iso_reassert_needed = false;
     }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -199,6 +199,7 @@ class BydAttoBattery : public CanBattery {
   // keep_iso_disabled enforcement: re-send disable after each BMS start (monitor re-enables on power-up)
   bool bms_was_alive = false;
   bool iso_reassert_needed = false;
+  bool iso_measurement_was_active = false;
   unsigned long bms_alive_since_ms = 0;
   unsigned long iso_reassert_attempt_ms = 0;
 

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -51,6 +51,9 @@ void reset_byd_state() {
   datalayer_extended.bydAtto3.BMS_min_temp_module_number = 0;
   datalayer_extended.bydAtto3.BMS_max_temp_module_number = 0;
   datalayer_extended.bydAtto3.pack_voltage_dV = 0;
+  datalayer_extended.bydAtto3.keep_iso_disabled = false;
+  datalayer_extended.bydAtto3.iso_command_status = 0;
+  datalayer_extended.bydAtto3.iso_measurement_active = false;
 }
 
 // Coldest sensor 9 at 8C, hottest sensor 1 at 24C, SOC 99.2%, average 16C.
@@ -61,6 +64,16 @@ CAN_frame temperature_frame() {
 // Discharge 285.5kW (b0:b1 = 0x0B27), charge 131.1kW (b2:b3 = 0x051F).
 CAN_frame power_limit_frame() {
   return byd_checksummed_frame(0x345, {0x27, 0x0B, 0x1F, 0x05, 0x00, 0x00, 0x00});
+}
+
+// 0x35E b0 bit7 = isolation measurement running: 0x01 disabled, 0x81 re-armed.
+CAN_frame iso_measurement_frame(bool active) {
+  return byd_checksummed_frame(0x35E, {(uint8_t)(active ? 0x81 : 0x01), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+}
+
+// 0x344 carries contactor feedback; receiving it is what marks the BMS alive.
+CAN_frame contactor_feedback_frame(uint8_t mode) {
+  return byd_frame(0x344, {mode, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
 }
 
 }  // namespace
@@ -214,4 +227,27 @@ TEST(BydAtto3Tests, ShouldStopTrusting0x438OnceItDivergesFrom0x444) {
 
   EXPECT_EQ(datalayer.battery.status.voltage_dV, 4200);
   EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4200);
+}
+
+// The monitor re-arms ~30s after a contactor open, with the BMS never restarting.
+TEST(BydAtto3Tests, ShouldReDisableIsolationMonitorWhenItRearmsWithoutABmsRestart) {
+  reset_byd_state();
+  set_millis64(10000);
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  // Come alive with the setting off, so the BMS-start edge arms nothing and cannot fire again.
+  battery->handle_incoming_can_frame(contactor_feedback_frame(0x84));
+  battery->handle_incoming_can_frame(iso_measurement_frame(false));
+  battery->update_values();
+  EXPECT_EQ(datalayer_extended.bydAtto3.iso_command_status, 0);
+
+  datalayer_extended.bydAtto3.keep_iso_disabled = true;
+
+  // A contactor cycle keeps the BMS alive, so the 0x35E edge is the only report of the re-arm.
+  set_millis64(60000);
+  battery->handle_incoming_can_frame(contactor_feedback_frame(0x84));
+  battery->handle_incoming_can_frame(iso_measurement_frame(true));
+  battery->update_values();
+  EXPECT_EQ(datalayer_extended.bydAtto3.iso_command_status, 1);
 }


### PR DESCRIPTION
### What
Re-send the insulation monitor disable when the BMS re-arms it on its own after contactor opening.

### Why
Opening the contactors makes the BMS re-arm its monitor about 30s later, which isn't a BMS start so the disable never got re-sent — the pack then stores an insulation fault and derates discharge to ~7% until it's physically power cycled.  This fix is important for the balancing update, which requires contactors to be opened and re-close if the full discharge limit is to be kept.

### How
Arm the re-assert on the 0x35E measurement-active edge as well as the existing BMS-alive edge.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
