### PR TITLE
OTA: confirm a new image only after the system has actually run

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -24,6 +24,8 @@
 #include "src/devboard/utils/events.h"
 #include "src/devboard/utils/led_handler.h"
 #include "src/devboard/utils/logging.h"
+#include "src/devboard/utils/ota_confirm_gate.h"
+#include "src/devboard/utils/ota_rollback.h"
 #include "src/devboard/utils/time_meas.h"
 #include "src/devboard/utils/timer.h"
 #include "src/devboard/utils/types.h"
@@ -618,6 +620,14 @@ void core_loop(void*) {
 
     // Process
     currentMillis = millis();
+
+    /* The OTA confirmation CHECK, and deliberately unconditional: reaching this
+       line is what it is measuring. A tick that has come round for 42 s has
+       received CAN, reached both the 10 ms and the 1 s sub-task, and fed the
+       task watchdog every pass - the strongest liveness witness the firmware
+       has. It sets a flag; loop() does the writing (ota_confirm_gate.h). */
+    ota_confirm_check(currentMillis);
+
     loopPhase = 1 - loopPhase;  // Spread out slower tasks across multiple iterations
     if (currentMillis - previousMillis10ms >= INTERVAL_10_MS && loopPhase == 0) {
       if ((currentMillis - previousMillis10ms >= INTERVAL_10_MS_DELAYED) &&
@@ -735,6 +745,11 @@ void setup() {
 
   init_events();
 
+  /* Before anything that can itself fail: if the previous update never got
+     through setup(), this boot is the bootloader's doing and the user should be
+     told so even if this boot also goes badly. */
+  report_ota_rollback();
+
   init_stored_settings();
 
   // AP-button recovery must always run
@@ -830,8 +845,22 @@ void setup() {
   xTaskCreatePinnedToCore((TaskFunction_t)&core_loop, "core_loop", 4096, NULL, TASK_CORE_PRIO, &main_loop_task,
                           esp32hal->CORE_FUNCTION_CORE());
 
+  /* No OTA confirmation here on purpose. Reaching the end of setup() only says
+     the drivers were constructed, and the crashes worth rolling back for happen
+     after that - the first frames parsed, the first MQTT or HTTP exchange, a
+     watchdog trip under real load. The image is confirmed once the running
+     system has held together for 42 s instead; see ota_confirm_gate.h. Placing
+     it here would also have raced the core_loop task that the line above just
+     started, which is a boundary decided by microseconds and worse than either
+     clean answer. */
+
   DEBUG_PRINTF("Setup complete!\n");
 }
 
-// Loop empty, all functionality runs in tasks
-void loop() {}
+// Ordinary main-task context. Everything else runs in tasks, so this stays the
+// place for work that must not be initiated from the 1 ms core tick - today the
+// otadata write that confirms a fresh image, once the tick says it has earned
+// it.
+void loop() {
+  ota_confirm_service();
+}

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -5,6 +5,7 @@
 #include "../../devboard/utils/logging.h"
 #include "../../inverter/INVERTERS.h"
 #include "../utils/events.h"
+#include "../utils/ota_confirm_gate.h"
 
 static uint16_t cell_deviation_mV = 0;
 static uint8_t charge_limit_failures = 0;
@@ -655,6 +656,15 @@ void graceful_restart() {
   // Pause charge/discharge, and then restart the ESP32 within 5s (as soon as the power stops).
 
   set_event(EVENT_RESTARTING, 0);
+
+  /* An intentional restart must not throw away a fresh update. The board was
+     well enough to be asked for one, which is the health this needs; without
+     this, restarting inside the 42 s window - the very thing a user does after
+     an update - would silently revert it. Armed at the REQUEST rather than at
+     the reboot, because the pause below buys 5-10 s, which is what lets the
+     write happen where every other runtime flash write happens instead of from
+     the 1 ms tick. */
+  ota_confirm_request();
 
   // Stop charge/discharge so we don't damage the contactors
   setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -253,6 +253,7 @@ void init_events(void) {
   events.entries[EVENT_UNKNOWN_EVENT_SET].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_OTA_UPDATE].level = EVENT_LEVEL_UPDATE;
   events.entries[EVENT_OTA_UPDATE_TIMEOUT].level = EVENT_LEVEL_INFO;
+  events.entries[EVENT_OTA_ROLLBACK].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_RESTARTING].level = EVENT_LEVEL_UPDATE;  // Stops Fronius erroring out during restarts
   events.entries[EVENT_DUMMY_INFO].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DUMMY_DEBUG].level = EVENT_LEVEL_DEBUG;
@@ -641,6 +642,9 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
       return "OTA update started!";
     case EVENT_OTA_UPDATE_TIMEOUT:
       return "OTA update timed out!";
+    case EVENT_OTA_ROLLBACK:
+      return "A firmware update did not start up and was rolled back. This board is running the previous firmware; "
+             "the log line names which version failed.";
     case EVENT_RECOVERY_START:
       return "CAUTION! Emergency low charge recovery started! Make sure battery cells do not overheat!";
     case EVENT_RECOVERY_END:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -140,6 +140,7 @@
   XX(EVENT_UNKNOWN_EVENT_SET)            \
   XX(EVENT_OTA_UPDATE)                   \
   XX(EVENT_OTA_UPDATE_TIMEOUT)           \
+  XX(EVENT_OTA_ROLLBACK)                 \
   XX(EVENT_RESTARTING)                   \
   XX(EVENT_DUMMY_INFO)                   \
   XX(EVENT_DUMMY_DEBUG)                  \

--- a/Software/src/devboard/utils/ota_confirm_gate.cpp
+++ b/Software/src/devboard/utils/ota_confirm_gate.cpp
@@ -1,0 +1,44 @@
+#include "ota_confirm_gate.h"
+
+namespace {
+
+/* Two flags, written from different tasks, and no lock - which is safe here
+ * because of what they are, not because it is usually fine.
+ *
+ * Each transition has exactly one writer (the CHECK side only ever sets `owed`,
+ * the WRITE side only ever clears it and sets `taken`), each is a single
+ * aligned word, and neither ever moves back. The worst a torn read could do is
+ * miss the flag for one pass, and the next pass is a millisecond away.
+ */
+volatile bool confirmation_owed = false;
+volatile bool confirmation_taken = false;
+
+}  // namespace
+
+void ota_confirm_check(uint32_t uptime_ms) {
+  if (!confirmation_taken && uptime_ms >= OTA_CONFIRM_UPTIME_MS) {
+    confirmation_owed = true;
+  }
+}
+
+void ota_confirm_request(void) {
+  if (!confirmation_taken) {
+    confirmation_owed = true;
+  }
+}
+
+bool ota_confirm_take_pending(void) {
+  if (!confirmation_owed) {
+    return false;
+  }
+  confirmation_owed = false;
+  confirmation_taken = true;
+  return true;
+}
+
+#ifdef UNIT_TEST
+void ota_confirm_gate_reset(void) {
+  confirmation_owed = false;
+  confirmation_taken = false;
+}
+#endif

--- a/Software/src/devboard/utils/ota_confirm_gate.h
+++ b/Software/src/devboard/utils/ota_confirm_gate.h
@@ -1,0 +1,75 @@
+#ifndef OTA_CONFIRM_GATE_H
+#define OTA_CONFIRM_GATE_H
+
+#include <stdint.h>
+
+/* WHEN a freshly updated image has earned confirmation, and WHO performs it.
+ *
+ * The decision and the flash write are deliberately split across two contexts,
+ * and the split is about routing, not cost:
+ *
+ *   CHECK  - the 1 ms core tick, unconditionally. That tick alternating for 42 s
+ *            is the strongest liveness witness this firmware has: CAN is being
+ *            received, the 10 ms and 1 s sub-tasks are both being reached, and
+ *            the task watchdog has been fed the whole time. All this side does
+ *            is set a flag.
+ *   WRITE  - ordinary main-task context. Confirming an image writes otadata,
+ *            which is a runtime flash write like any other and belongs on the
+ *            same path as every other one (the planned flash-write broker in
+ *            the end state: pre-drain, op, drainage gap, so the cache-off
+ *            window lands on empty CAN FIFOs). Initiating it from the 1 ms
+ *            tick would bypass
+ *            that discipline. It would NOT save the tick a stall - during a
+ *            flash op the scheduler is suspended whoever started it - so
+ *            routing is the whole of the argument.
+ *
+ * Nothing here touches esp_ota_*: this is the policy, and it holds no opinion
+ * about how the confirmation is written. That is what lets the 42 s boundary be
+ * tested on the host, where ota_rollback.cpp cannot be built.
+ */
+
+// The uptime a fresh image must survive before it is confirmed.
+//
+// 42 s clears STA association, the TLS MQTT handshake and autodiscovery, so the
+// crashes that only happen on first contact - the first frames parsed, the
+// first MQTT or HTTP exchange, a watchdog trip under real load - still fall
+// inside the window and still roll back. Criteria that sound stronger were
+// rejected on purpose: "all RTOS tasks started" measures starting, not
+// surviving, and anything externally dependent (CAN frames seen, WiFi up) would
+// never confirm on a bench board with no bus or an offline install, so every
+// reboot would revert a perfectly good image forever.
+constexpr uint32_t OTA_CONFIRM_UPTIME_MS = 42 * 1000;
+
+// CHECK side. Call unconditionally from a steady-state tick, passing the uptime
+// in ms (millis(), not a delta). One guarded compare; sets a flag and no more.
+//
+// The comparison is against absolute uptime rather than an interval, so the
+// millis() wrap at ~49.7 days is not a hazard: the flag latches 42 s into the
+// first boot, tens of thousands of wraps before the counter comes back round.
+void ota_confirm_check(uint32_t uptime_ms);
+
+// A deliberate restart is its own liveness witness - the board was well enough
+// to serve the request - so an intentional reboot inside the window keeps the
+// update instead of reverting it. Called when the restart is REQUESTED, not
+// when it is enacted: the 5-10 s the graceful restart spends pausing
+// charge/discharge is what lets the write take the ordinary-context route
+// above. A board whose main task cannot complete one pass in those seconds is
+// not healthy, and rolling it back is the right answer, not a gap.
+void ota_confirm_request(void);
+
+// WRITE side. True exactly once, on the first call after a confirmation becomes
+// owed; false forever after. The caller performs the write.
+//
+// Once taken, no further confirmation is ever owed - including when the write
+// itself fails. There is nothing useful to retry (a failure here means otadata
+// is unwritable), and re-arming would repeat it on every pass of a loop that
+// runs flat out. The failing write says so in the log instead.
+bool ota_confirm_take_pending(void);
+
+#ifdef UNIT_TEST
+// Test seam only: the gate is a boot-lifetime latch, and the host tests need to
+// run more than one boot.
+void ota_confirm_gate_reset(void);
+#endif
+
+#endif  // OTA_CONFIRM_GATE_H

--- a/Software/src/devboard/utils/ota_rollback.cpp
+++ b/Software/src/devboard/utils/ota_rollback.cpp
@@ -1,0 +1,105 @@
+#include "ota_rollback.h"
+
+#include <esp_app_format.h>
+#include <esp_ota_ops.h>
+
+#include "events.h"
+#include "logging.h"
+#include "ota_confirm_gate.h"
+
+/* Take the confirmation away from initArduino() and do it ourselves.
+ *
+ * Rollback is already enabled in this build (CONFIG_APP_ROLLBACK_ENABLE comes
+ * from the framework's own config, not from anything here), and the bootloader
+ * already runs a freshly updated image as PENDING_VERIFY. What closes the
+ * window is arduino-esp32: initArduino() calls
+ * esp_ota_mark_app_valid_cancel_rollback() BEFORE setup() begins, so an update
+ * is confirmed before a single line of this firmware has run. Every crash the
+ * field reports - stored settings meeting new code, a driver that dies on
+ * init - happens after that point, with the safety net already folded away.
+ *
+ * This weak hook is the framework's own way out: returning true defers the
+ * decision to the application. It means the responsibility is now entirely
+ * ours - if mark_ota_image_valid() is not reached, the next reset undoes the
+ * update - which is why every steady state this firmware can be in reaches the
+ * gate in ota_confirm_gate.h, and why failing to confirm is logged rather than
+ * passed over.
+ */
+extern "C" bool verifyRollbackLater(void) {
+  return true;
+}
+
+void report_ota_rollback(void) {
+#ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+  /* The image the bootloader gave up on is the OTHER slot, and its otadata
+   * state is the record of what happened: ABORTED when it reset before
+   * confirming itself, INVALID when it (or a previous boot of it) was rejected
+   * outright. Both mean the same thing to a user - the update did not run, and
+   * this older firmware is what is running instead.
+   *
+   * Reported on EVERY boot, not once. The device really is running behind, and
+   * the state stays until a later update succeeds, so a line that appeared once
+   * and then vanished would be the less honest of the two. */
+  const esp_partition_t* other = esp_ota_get_next_update_partition(NULL);
+  if (other == NULL) {
+    return;
+  }
+  esp_ota_img_states_t state;
+  if (esp_ota_get_state_partition(other, &state) != ESP_OK) {
+    return;
+  }
+  if (state != ESP_OTA_IMG_ABORTED && state != ESP_OTA_IMG_INVALID) {
+    return;
+  }
+
+  /* Naming the version it rolled back FROM is the difference between "something
+   * went wrong once" and a user knowing which release not to install again. It
+   * is read from the failed image's own header, so it is right even when the
+   * failure happened several boots ago. */
+  esp_app_desc_t failed;
+  if (esp_ota_get_partition_description(other, &failed) == ESP_OK) {
+    LOG_SET_NEXT_SEVERITY(4);  // warning
+    logging.printf("Firmware %s failed to start and was rolled back; running %s instead\n", failed.version,
+                   esp_app_get_description()->version);
+  } else {
+    LOG_SET_NEXT_SEVERITY(4);  // warning
+    logging.println("A firmware update failed to start and was rolled back to this version");
+  }
+  set_event(EVENT_OTA_ROLLBACK, 0);
+#endif  // CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+}
+
+void ota_confirm_service(void) {
+  /* Everything expensive is behind the flag, so this costs one read on the
+     millions of passes where nothing is owed. */
+  if (ota_confirm_take_pending()) {
+    mark_ota_image_valid();
+  }
+}
+
+void mark_ota_image_valid(void) {
+#ifdef CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+  /* Only one boot is ever pending, so this is a no-op on every ordinary start;
+   * checking the state first keeps the log line meaningful instead of claiming
+   * an update was confirmed on a board that has not been updated. */
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  esp_ota_img_states_t state;
+  if (running == NULL || esp_ota_get_state_partition(running, &state) != ESP_OK) {
+    return;
+  }
+  if (state != ESP_OTA_IMG_PENDING_VERIFY) {
+    return;
+  }
+  if (esp_ota_mark_app_valid_cancel_rollback() == ESP_OK) {
+    LOG_SET_NEXT_SEVERITY(5);  // notice
+    logging.printf("Firmware %s started cleanly and is now confirmed; rollback window closed\n",
+                   esp_app_get_description()->version);
+  } else {
+    /* Nothing to do about it here, but say so: the image stays pending, so the
+     * next reset - however ordinary - will roll it back, and that is otherwise
+     * a very confusing thing to have happen. */
+    LOG_SET_NEXT_SEVERITY(4);  // warning
+    logging.println("Could not confirm this firmware; the next restart will roll it back");
+  }
+#endif  // CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE
+}

--- a/Software/src/devboard/utils/ota_rollback.h
+++ b/Software/src/devboard/utils/ota_rollback.h
@@ -1,0 +1,43 @@
+#ifndef OTA_ROLLBACK_H
+#define OTA_ROLLBACK_H
+
+/* App rollback: keeping a firmware that cannot boot from becoming permanent.
+ *
+ * The bootloader already runs a freshly updated image once with its otadata
+ * state set to PENDING_VERIFY, and already restores the previous image if that
+ * boot resets before the app confirms itself. None of that needed enabling -
+ * CONFIG_APP_ROLLBACK_ENABLE is on in the framework's own config.
+ *
+ * What was missing is that arduino-esp32 confirms the image inside
+ * initArduino(), before setup() runs, so the window closed before this
+ * firmware had done anything at all. The .cpp overrides the framework's
+ * verifyRollbackLater() hook to defer that, and these two calls are then the
+ * app's side of the contract.
+ *
+ * All of these are no-ops when rollback is not enabled, so they can be called
+ * unconditionally.
+ *
+ * WHEN the confirmation happens is not decided here - see ota_confirm_gate.h.
+ * The short version: not at the end of setup(), but 42 s into a running system,
+ * so the crashes that only appear once the board is talking to something are
+ * still inside the window.
+ */
+
+// Report at boot whether the previous update failed to run. Call it early -
+// after init_events(), before anything that might itself fail - so the reason
+// is visible even if this boot goes badly too.
+void report_ota_rollback(void);
+
+// The WRITE side of the gate, for ordinary main-task context: performs the
+// confirmation on the one pass where the gate says it is owed, and costs a
+// single flag read on every other. Call it from loop().
+void ota_confirm_service(void);
+
+// "This image works." Writes otadata, so it belongs on the runtime flash-write
+// path like every other one; ota_confirm_service() is what decides when. Public
+// because the gate's decision and the write are deliberately separable, not
+// because setup() should call it - a boot that confirms itself before it has
+// run is the whole defect this exists to fix.
+void mark_ota_image_valid(void);
+
+#endif  // OTA_ROLLBACK_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ add_executable(tests
     ../Software/src/devboard/utils/events.cpp
     ../Software/src/devboard/utils/time_format.cpp
     ../Software/src/devboard/utils/common_functions.cpp
+    ../Software/src/devboard/utils/ota_confirm_gate.cpp
     ../Software/src/devboard/utils/led_handler.cpp
     ../Software/src/lib/adafruit-Adafruit_NeoPixel/Adafruit_NeoPixel.cpp
     ../Software/src/datalayer/datalayer.cpp

--- a/test/ota_confirm_tests.cpp
+++ b/test/ota_confirm_tests.cpp
@@ -1,0 +1,363 @@
+#include <gtest/gtest.h>
+
+#include <cctype>
+#include <fstream>
+#include <string>
+
+#include "../Software/src/devboard/safety/safety.h"
+#include "../Software/src/devboard/utils/events.h"
+#include "../Software/src/devboard/utils/ota_confirm_gate.h"
+
+/* A fresh image is confirmed by a RUNNING system, and every steady state
+ * this firmware can be in has to reach that confirmation.
+ *
+ * Once verifyRollbackLater() defers the mark to us, not confirming is
+ * not "nothing happens" - the bootloader undoes the update on the next reset.
+ * So the dangerous shape is a normal operating state that never gets to the
+ * mark, and one already exists: on the wizard branches setup() returns early,
+ * above the line that starts the core tick. A board in wizard mode is a fresh
+ * or factory-reset board, which is exactly the one being rebooted.
+ *
+ * Two halves below. The first exercises the gate. The second reads
+ * Software.cpp, because Software.cpp is not in this binary - which is also why
+ * a mark placed there could sit wrong without any test noticing.
+ */
+
+namespace {
+
+/* Strip comments out, before anything is asserted about the code.
+ *
+ * Every test below decides whether the firmware does something by looking for
+ * the text of a call, and this file is surrounded by comments that NAME those
+ * calls - the placement comment in core_loop says `ota_confirm_check`, the one
+ * in setup() explains why the mark is gone. Commenting a call out then leaves
+ * its name in place and the assertion passes on dead code, which is exactly
+ * how an earlier mutation harness certified a mutation it never ran. Newlines
+ * are kept so brace depth and ordering still mean what they meant.
+ */
+std::string strip_comments(const std::string& src) {
+  std::string out;
+  out.reserve(src.size());
+  for (size_t i = 0; i < src.size();) {
+    if (src.compare(i, 2, "//") == 0) {
+      while (i < src.size() && src[i] != '\n') {
+        ++i;
+      }
+    } else if (src.compare(i, 2, "/*") == 0) {
+      const size_t end = src.find("*/", i + 2);
+      const size_t stop = end == std::string::npos ? src.size() : end + 2;
+      for (; i < stop; ++i) {
+        if (src[i] == '\n') {
+          out += '\n';
+        }
+      }
+    } else {
+      out += src[i++];
+    }
+  }
+  return out;
+}
+
+std::string read_source(const std::string& relative_to_test_dir) {
+  // Located relative to this file rather than through a CMake define, so the
+  // test needs no build-system plumbing to run.
+  const std::string self = __FILE__;
+  const std::string dir = self.substr(0, self.find_last_of('/'));
+  const std::string path = dir + "/" + relative_to_test_dir;
+  std::ifstream src(path);
+  EXPECT_TRUE(src.is_open()) << "this test reads " << path;
+  return strip_comments(std::string((std::istreambuf_iterator<char>(src)), std::istreambuf_iterator<char>()));
+}
+
+// The body of a function, by brace depth from its signature line.
+std::string function_body(const std::string& src, const std::string& signature) {
+  const size_t at = src.find(signature);
+  EXPECT_NE(at, std::string::npos) << "no `" << signature << "` in the source this test reads";
+  if (at == std::string::npos) {
+    return "";
+  }
+  const size_t open = src.find('{', at);
+  int depth = 0;
+  for (size_t i = open; i < src.size(); ++i) {
+    if (src[i] == '{') {
+      ++depth;
+    } else if (src[i] == '}') {
+      if (--depth == 0) {
+        return src.substr(open, i - open + 1);
+      }
+    }
+  }
+  return "";
+}
+
+// The `{ ... }` block that follows `at`, by brace depth. Used to ask whether a
+// call sits INSIDE a particular guard rather than merely somewhere near it.
+std::string brace_block_at(const std::string& src, size_t at) {
+  const size_t open = src.find('{', at);
+  if (open == std::string::npos) {
+    return "";
+  }
+  int depth = 0;
+  for (size_t i = open; i < src.size(); ++i) {
+    if (src[i] == '{') {
+      ++depth;
+    } else if (src[i] == '}') {
+      if (--depth == 0) {
+        return src.substr(open, i - open + 1);
+      }
+    }
+  }
+  return "";
+}
+
+// The text between the parentheses of the first `call` in `src`, trimmed.
+std::string call_argument(const std::string& src, const std::string& call) {
+  const size_t at = src.find(call);
+  if (at == std::string::npos) {
+    return "";
+  }
+  const size_t open = at + call.size();
+  const size_t close = src.find(')', open);
+  if (close == std::string::npos) {
+    return "";
+  }
+  std::string arg = src.substr(open, close - open);
+  const size_t first = arg.find_first_not_of(" \t\n");
+  const size_t last = arg.find_last_not_of(" \t\n");
+  return first == std::string::npos ? "" : arg.substr(first, last - first + 1);
+}
+
+// A bare C identifier - no literal, no arithmetic, no call.
+bool is_identifier(const std::string& s) {
+  if (s.empty() || (!isalpha(static_cast<unsigned char>(s[0])) && s[0] != '_')) {
+    return false;
+  }
+  for (const char c : s) {
+    if (!isalnum(static_cast<unsigned char>(c)) && c != '_') {
+      return false;
+    }
+  }
+  return true;
+}
+
+class OtaConfirmGate : public ::testing::Test {
+ protected:
+  void SetUp() override { ota_confirm_gate_reset(); }
+  void TearDown() override { ota_confirm_gate_reset(); }
+};
+
+}  // namespace
+
+/* The boundary, stated as the ruling states it: nothing is owed at
+ * 42 * 1000 - 1 ms, and the confirmation is owed at 42 * 1000 exactly. The
+ * constant is the interesting part of the change, so it is pinned rather than
+ * left to be read off a comment.
+ */
+TEST_F(OtaConfirmGate, NothingIsOwedOneMillisecondShortOfTheWindow) {
+  EXPECT_EQ(OTA_CONFIRM_UPTIME_MS, 42u * 1000u);
+
+  ota_confirm_check(0);
+  ota_confirm_check(OTA_CONFIRM_UPTIME_MS - 1);
+  EXPECT_FALSE(ota_confirm_take_pending()) << "an image was confirmed before it had survived the window";
+}
+
+TEST_F(OtaConfirmGate, TheConfirmationIsOwedAtTheWindowExactly) {
+  ota_confirm_check(OTA_CONFIRM_UPTIME_MS);
+  EXPECT_TRUE(ota_confirm_take_pending());
+}
+
+/* The write happens once per boot. The check runs on every 1 ms tick and the
+ * take runs on every pass of loop(), so "once" is the property that keeps this
+ * from becoming a flash write per millisecond for the rest of the board's
+ * uptime.
+ */
+TEST_F(OtaConfirmGate, TheConfirmationIsTakenExactlyOnce) {
+  for (uint32_t t = OTA_CONFIRM_UPTIME_MS; t < OTA_CONFIRM_UPTIME_MS + 10; ++t) {
+    ota_confirm_check(t);
+  }
+  EXPECT_TRUE(ota_confirm_take_pending());
+
+  for (uint32_t t = OTA_CONFIRM_UPTIME_MS + 10; t < OTA_CONFIRM_UPTIME_MS + 20; ++t) {
+    ota_confirm_check(t);
+    EXPECT_FALSE(ota_confirm_take_pending()) << "a second confirmation was owed at uptime " << t;
+  }
+}
+
+/* A deliberate restart inside the window keeps the update. Without this, the
+ * most ordinary thing a user does after updating - press restart - is what
+ * reverts it.
+ */
+TEST_F(OtaConfirmGate, AnIntentionalRestartConfirmsBeforeTheWindowElapses) {
+  ota_confirm_check(1000);
+  ASSERT_FALSE(ota_confirm_take_pending());
+
+  ota_confirm_request();
+  EXPECT_TRUE(ota_confirm_take_pending());
+}
+
+/* ...and once confirmed, a restart does not arm a second write. */
+TEST_F(OtaConfirmGate, AnIntentionalRestartAfterConfirmationOwesNothing) {
+  ota_confirm_check(OTA_CONFIRM_UPTIME_MS);
+  ASSERT_TRUE(ota_confirm_take_pending());
+
+  ota_confirm_request();
+  EXPECT_FALSE(ota_confirm_take_pending());
+}
+
+/* graceful_restart() is the one restart path in the tree (#2551), so it is the
+ * one place this has to be wired. Testing it through safety.cpp rather than by
+ * reading the source, because safety.cpp IS in this binary.
+ */
+TEST_F(OtaConfirmGate, GracefulRestartArmsTheConfirmation) {
+  reset_all_events();
+  ota_confirm_check(1000);
+  ASSERT_FALSE(ota_confirm_take_pending());
+
+  graceful_restart();
+  EXPECT_TRUE(ota_confirm_take_pending()) << "a requested restart inside the window would revert the update";
+}
+
+/* ---- the source-readable half ---- */
+
+/* The mark is in runtime cadence, not in setup(). Two things would be wrong if
+ * it went back: an image confirmed at the end of setup() has survived driver
+ * construction and nothing else, and the previous placement sat immediately
+ * after the core_loop task was created, so whether the first loop pass was
+ * covered was decided by a race of microseconds.
+ */
+TEST(OtaConfirmPlacement, SetupDoesNotConfirmTheImage) {
+  const std::string setup = function_body(read_source("../Software/Software.cpp"), "void setup() {");
+  ASSERT_FALSE(setup.empty());
+
+  EXPECT_EQ(setup.find("mark_ota_image_valid"), std::string::npos)
+      << "setup() confirms the image again - reaching the end of setup() is not evidence the image works";
+  EXPECT_EQ(setup.find("ota_confirm_service"), std::string::npos)
+      << "setup() performs the confirmation write - it belongs in runtime cadence";
+}
+
+/* The check has to be unconditional inside the core tick. Inside the 10 ms or
+ * 1 s sub-task it would still fire, but it would then be witnessing that ONE
+ * sub-task ran, which is a weaker statement than the tick itself coming round.
+ */
+TEST(OtaConfirmPlacement, TheCoreTickChecksUnconditionally) {
+  const std::string core_loop = function_body(read_source("../Software/Software.cpp"), "void core_loop(void*) {");
+  ASSERT_FALSE(core_loop.empty());
+  ASSERT_NE(core_loop.find("ota_confirm_check("), std::string::npos)
+      << "the core tick no longer checks - in normal mode nothing would ever confirm the image";
+
+  // Depth 1 is the while-loop body; anything deeper is inside one of the
+  // conditional sub-tasks.
+  int depth = 0;
+  int depth_at_check = -1;
+  for (size_t i = 0; i < core_loop.size(); ++i) {
+    if (core_loop[i] == '{') {
+      ++depth;
+    } else if (core_loop[i] == '}') {
+      --depth;
+    } else if (core_loop.compare(i, 18, "ota_confirm_check(") == 0) {
+      depth_at_check = depth;
+    }
+  }
+  EXPECT_EQ(depth_at_check, 2) << "the confirmation check sits inside a conditional in core_loop - it must run on "
+                                  "every tick, because the tick coming round is the thing it is measuring";
+}
+
+/* The write side is reached from ordinary main-task context. */
+TEST(OtaConfirmPlacement, LoopPerformsTheConfirmationWrite) {
+  const std::string loop = function_body(read_source("../Software/Software.cpp"), "void loop() {");
+  EXPECT_NE(loop.find("ota_confirm_service("), std::string::npos)
+      << "loop() no longer services the gate - the check would set a flag nobody acts on";
+}
+
+/* THE COMPOSITION GUARD, and the reason this item exists.
+ *
+ * `setup()` returning early means the core tick is never started, so the whole
+ * of the normal-mode confirmation path is skipped. On the wizard branches that
+ * is exactly what happens, and wizard mode is a normal operating state - its
+ * own comment calls it "a strict PREFIX of a normal boot".
+ *
+ * So: any early exit from setup() has to be matched by a steady state that
+ * checks for itself. connectivity_loop() is the loop that keeps running when
+ * setup() stops early - it is the task that serves the wizard UI - so that is
+ * where the second check belongs.
+ *
+ * On a tree whose setup() runs straight through, this asserts nothing. It goes
+ * red the moment an early return is added without the matching check, which is
+ * the merge these two lanes must not make unnoticed.
+ */
+TEST(OtaConfirmPlacement, AnEarlyReturnFromSetupBringsItsOwnCheck) {
+  const std::string src = read_source("../Software/Software.cpp");
+  const std::string setup = function_body(src, "void setup() {");
+  ASSERT_FALSE(setup.empty());
+
+  if (setup.find("return;") == std::string::npos) {
+    GTEST_SKIP() << "setup() has no early exit on this branch - nothing to compose with yet";
+  }
+
+  const std::string service = function_body(src, "void connectivity_loop(void*) {");
+  ASSERT_FALSE(service.empty());
+  ASSERT_NE(service.find("ota_confirm_check("), std::string::npos)
+      << "setup() can now return before the core tick is started, and the loop that keeps running when it does "
+         "never confirms the image. A board that boots into that state has a good update reverted on its next "
+         "reset, repeatedly.";
+
+  /* And it has to be GATED on wizard mode. Presence alone was what this
+     asserted, and an ungated check passes that while quietly weakening the
+     normal boot: connectivity_loop runs there too, so whichever of the two
+     loops reaches 42 s first would confirm, and the witness degrades from "the
+     core tick has been coming round" to "networking survived". Both are true
+     of a healthy board; only the first is true of a board whose core tick has
+     stopped. */
+  const size_t gate = service.find("if (wizard_mode_active()) {");
+  ASSERT_NE(gate, std::string::npos) << "the wizard-mode check in connectivity_loop is not gated on "
+                                        "wizard_mode_active() - in a normal boot it would confirm on the "
+                                        "networking task's liveness instead of the core tick's";
+  EXPECT_NE(brace_block_at(service, gate).find("ota_confirm_check("), std::string::npos)
+      << "connectivity_loop checks outside the wizard_mode_active() gate - see above";
+}
+
+/* WHAT the core tick passes to the check, not just that it calls it.
+ *
+ * The placement tests above pin that a call exists and that it is
+ * unconditional, and both survive `ota_confirm_check(0)` and
+ * `ota_confirm_check(currentMillis - previousMillis10ms)` - a plausible
+ * copy-paste from the two lines under it. Either one compiles, keeps every
+ * other test green, and means the gate never fires in normal mode: nothing
+ * confirms, and the bootloader reverts a good update on every reset. That is
+ * the whole failure this item exists to prevent, so the argument is pinned to
+ * absolute uptime the same way the constant is.
+ */
+TEST(OtaConfirmPlacement, TheCoreTickChecksAgainstAbsoluteUptime) {
+  const std::string core_loop = function_body(read_source("../Software/Software.cpp"), "void core_loop(void*) {");
+  ASSERT_FALSE(core_loop.empty());
+
+  const std::string argument = call_argument(core_loop, "ota_confirm_check(");
+  ASSERT_FALSE(argument.empty()) << "no ota_confirm_check(...) call in core_loop";
+
+  EXPECT_TRUE(is_identifier(argument)) << "the core tick passes `" << argument
+                                       << "` to ota_confirm_check. It takes absolute uptime, not a literal and not "
+                                          "an interval - an elapsed-time expression never reaches 42 s and nothing "
+                                          "would ever confirm";
+  EXPECT_NE(core_loop.find(argument + " = millis();"), std::string::npos)
+      << "`" << argument << "` is passed as the uptime but is not assigned from millis() in core_loop";
+}
+
+/* The write side actually writes.
+ *
+ * LoopPerformsTheConfirmationWrite pins that loop() CALLS ota_confirm_service();
+ * nothing pins what that function does, and it lives in ota_rollback.cpp, which
+ * has no host build - the file the change's own note calls out as the one where
+ * a mistake "could sit unnoticed". Gutting the body leaves all 216 tests green.
+ * Read it, then, the same way Software.cpp is read.
+ */
+TEST(OtaConfirmPlacement, TheServiceWritesExactlyWhenTheGateSaysSo) {
+  const std::string service =
+      function_body(read_source("../Software/src/devboard/utils/ota_rollback.cpp"), "void ota_confirm_service(void) {");
+  ASSERT_FALSE(service.empty());
+
+  const size_t gate = service.find("if (ota_confirm_take_pending()) {");
+  ASSERT_NE(gate, std::string::npos) << "ota_confirm_service() no longer performs the write on exactly the pass the "
+                                        "gate hands it - the check would set a flag nobody acts on";
+  EXPECT_NE(brace_block_at(service, gate).find("mark_ota_image_valid()"), std::string::npos)
+      << "the gate is taken but the image is never marked valid - every update would be reverted on the next reset";
+}


### PR DESCRIPTION
A firmware update that cannot run is permanent today. The board boot-loops, and the only way out is USB - which is why the standing advice for "bricked by update" has become "erase the flash and reconfigure", losing every setting.

That is not for want of a rollback mechanism. `CONFIG_APP_ROLLBACK_ENABLE` is already on, and the bootloader already runs a new image as `PENDING_VERIFY` and restores the previous one if that boot resets before the app confirms itself. What closes the window is arduino-esp32: `initArduino()` calls `esp_ota_mark_app_valid_cancel_rollback()` **before** `setup()` runs, so an update is confirmed before a single line of this firmware has executed. Every crash worth rolling back for happens after that point.

This takes the framework's own opt-out - the weak `verifyRollbackLater()` hook - and moves the confirmation to where it can mean something: **the image is confirmed once the running system has held together for 42 seconds.**

**Why a running system and not the end of `setup()`.** Reaching the end of `setup()` only says the drivers were constructed. The failures that justify a rollback happen after that - the first frames parsed, the first MQTT or HTTP exchange, a watchdog trip under real load. 42 s also clears STA association, TLS-MQTT and autodiscovery bring-up, so first-contact crashes still revert.

The check is one guarded compare at an unconditional point in the 1 ms core task - "both sub-tasks have been alternating for 42 s" is the strongest liveness witness the firmware has, since it means CAN is being serviced and the task watchdog fed every pass. The check only sets a flag; the write happens in ordinary main-task context from `loop()`, because confirming is itself a flash write and belongs on the same path as every other runtime flash write rather than being initiated from the core tick.

**Criteria deliberately rejected**, since they look reasonable: *"all RTOS tasks started"* - starting is cheap, surviving under load is the signal. *Anything externally dependent* (CAN frames seen, WiFi up) - a bench board with no bus, or an offline install, must still be able to confirm, or every reboot reverts a perfectly good image forever.

**A deliberate restart inside the window keeps the update.** The web-UI restart path confirms first if the system is healthy, then reboots. Panics, watchdog resets and brownouts still revert.

**The honest cost to a user, stated plainly:** an image that dies at t = 30 s, or a power cut inside the window, now rolls back where previously it would have been kept. That is the intent - an image that cannot survive its first 42 seconds is not one to keep - but it is a real behaviour change and not only an improvement.

**Evidence.** On a T-CAN485, with a deliberately faulted image OTA'd over a good one: before, OTA -> panic -> reboot -> still dead 200 s later, USB recovery required. After, the board is back on the previous firmware on its own, `otadata` reads `ABORTED` for the failed slot and `VALID` for the running one, and the event log names which version failed. Three further cases pass on hardware: a good update survives 42 s and a reboot; a good update survives a restart issued from the web UI *inside* the window; and a board sitting in first-boot configuration mode confirms there too, so no healthy state exists in which an update is never confirmed.

On the host, 217 tests pass and the policy is now testable in a way it was not before - the 42 s boundary, the once-only latch and the restart arming all run on the host; only the `otadata` mechanics remain bench-only.

Cost is **+1,072 B** of flash (`esp32devkit_330`, baseline and subject built back-to-back from wiped build directories in one lock hold). No sdkconfig change - the flag was never off.

Note: drafted with AI assistance, reviewed by me.
