### PR TITLE
Enhance PR template with sections motivating to conrtibute to the wiki

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,5 +7,24 @@ Why does it do it?
 ### How
 How does it do it?
 
+### Types of changes
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
+- [ ] Code quality improvements to existing code or addition of tests
+
+### Related issue or feature (if applicable):
+
+- fixes <link to issue>
+
+### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):**
+
+- wiki PR <link to PR>
+
+## Checklist:
+
+  - [ ] The code change is tested and works locally.
+
 > [!TIP]
 > [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,6 @@ How does it do it?
   - [ ] The code change is tested and works locally.
 
 > [!TIP]
-> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please contribute tho the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
+> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
 > 
 > [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,9 @@ How does it do it?
 
 - wiki PR <link to PR>
 
-## Checklist:
+### Checklist:
 
   - [ ] The code change is tested and works locally.
 
 > [!TIP]
-> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
+> [You can help test this PR with this guide](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,6 @@ How does it do it?
   - [ ] The code change is tested and works locally.
 
 > [!TIP]
-> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please contribute tho the docs as the next step. Then, come back here and edit this description with the link of the PR you just created.
+> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please contribute tho the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
 > 
 > [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,4 +27,6 @@ How does it do it?
   - [ ] The code change is tested and works locally.
 
 > [!TIP]
-> [You can help test this PR with this guide](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
+> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please contribute tho the docs as the next step. Then, come back here and edit this description with the link of the PR you just created.
+> 
+> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ How does it do it?
 
 - fixes <link to issue>
 
-### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):**
+### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):
 
 - wiki PR <link to PR>
 


### PR DESCRIPTION
### What
Crosslinks between the software repo and the documentation repo for each PR. By requiring to post here the link to the wiki PR.

### Why
- motivate software contributors not to forget updating the documentation about their changes
- motivate code reviewers to also check if wiki is appropriately updated with the changes
- easier to track which software change PR corresponds to which Wiki updated PR

### How
Updated the pull request template to include sections for related issues and types of changes.
Corresponding template has beed added to the wiki site too: https://github.com/dalathegreat/Battery-Emulator-Wiki/pull/42

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes https://github.com/dalathegreat/Battery-Emulator/issues/2419 (example issue link)

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR https://github.com/dalathegreat/Battery-Emulator-Wiki/pull/42

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please contribute to the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
