### PR TITLE
Feature: BYD balancing contactor cycle and voltage rail control

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -226,9 +226,17 @@ void BydAttoBattery::
   // Lift the cell rails only once the BMS has actually granted the charge (and through the
   // terminated rest), so it can reach its own 3742-3753mV termination band. Everywhere else,
   // including a session still waiting for a grant, the stock limits are in force.
-  const bool session_owns_top = chargeSessionState == CHG_SESSION_CHARGING ||
-                                chargeSessionState == CHG_SESSION_FINISHING ||
-                                (chargeSessionState == CHG_SESSION_HOLD && chargeSessionTerminated);
+  // Rails follow the pack, not the session: an open leaves the cells where the BMS left them.
+  const uint16_t rails_cell_max_mV = datalayer_battery->status.cell_max_voltage_mV;
+  const uint16_t rails_cell_min_mV = datalayer_battery->status.cell_min_voltage_mV;
+  if (chargeTerminatedRails && rails_cell_min_mV > 0 && rails_cell_max_mV <= MAX_CELL_VOLTAGE_MV &&
+      (rails_cell_max_mV - rails_cell_min_mV) <= MAX_CELL_DEVIATION_MV) {
+    chargeTerminatedRails = false;
+  }
+  const bool rails_owned = chargeSessionState == CHG_SESSION_CHARGING || chargeSessionState == CHG_SESSION_FINISHING ||
+                           (chargeSessionState == CHG_SESSION_HOLD && chargeSessionTerminated) || chargeTerminatedRails;
+  // Turning native termination off restores the stock limits immediately.
+  const bool session_owns_top = rails_owned && datalayer_bydatto && datalayer_bydatto->native_termination_enabled;
   datalayer_battery->info.max_cell_voltage_mV = session_owns_top ? SESSION_CELL_CLAMP_MV : MAX_CELL_VOLTAGE_MV;
   datalayer_battery->info.max_cell_voltage_deviation_mV =
       session_owns_top ? SESSION_DELTA_LIMIT_MV : MAX_CELL_DEVIATION_MV;
@@ -930,6 +938,11 @@ void BydAttoBattery::confirm_charge_termination() {
     datalayer_bydatto->termination_cell_delta_mV = spread_mV;
     datalayer_bydatto->termination_cell_max_number = BMS_max_cell_voltage_number;
     datalayer_bydatto->termination_cell_min_number = BMS_min_cell_voltage_number;
+    chargeTerminatedRails = true;
+    if (datalayer_bydatto->balancing_enabled && datalayer_battery == &datalayer.battery && !balancingCycleDone) {
+      balancingState = BALANCING_ARMED;
+      balancingStateMillis = millis();
+    }
   }
   set_event(EVENT_BYD_CHARGE_TERMINATED, (uint8_t)(spread_mV / 10));
   DEBUG_PRINTF("[BYD] Battery ended the charge at %umV, cell spread %umV\n", cell_max_mV, spread_mV);
@@ -1114,6 +1127,117 @@ void BydAttoBattery::handle_charge_session(unsigned long currentMillis) {
   }
 }
 
+// Cycle the contactors after a termination, holding the pack open for the configured time.
+void BydAttoBattery::handle_balancing(unsigned long currentMillis) {
+  if (!datalayer_bydatto) {
+    return;
+  }
+  const bool enabled = datalayer_bydatto->balancing_enabled && datalayer_battery == &datalayer.battery;
+  const bool pack_closed = (contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) != 0;
+  // Still closed only because the open has not finished yet, which is not the same as closed.
+  const bool open_in_flight = contactorState == CONTACTORS_AWAIT_ZERO_CURRENT || contactorState == CONTACTORS_OPENING ||
+                              contactorState == CONTACTORS_OPEN_REQUESTED || contactorState == CONTACTORS_OPEN_SETTLE;
+  const uint32_t hold_ms = (uint32_t)datalayer_bydatto->balancing_hold_minutes * 60000UL;
+
+  // One cycle per real discharge, so a day of solar top-ups cannot cycle the contactors repeatedly.
+  if (datalayer_battery->status.current_dA <= SESSION_REARM_DISCHARGE_dA) {
+    if (balancingDischargeSinceMillis == 0) {
+      balancingDischargeSinceMillis = currentMillis;
+    } else if (currentMillis - balancingDischargeSinceMillis >= SESSION_REARM_DWELL_MS) {
+      balancingCycleDone = false;
+    }
+  } else {
+    balancingDischargeSinceMillis = 0;
+  }
+
+  if (datalayer.system.info.equipment_stop_active) {
+    balancingState = BALANCING_IDLE;  // the stop owns the contactors
+  } else if (!enabled && balancingState != BALANCING_IDLE && balancingState != BALANCING_CLOSING) {
+    // Turned off mid-cycle: close the pack back up rather than leaving it open indefinitely. Once
+    // this has handed over to CLOSING, the bounded retry below owns it - re-running would reset it.
+    const bool give_up = balancingState == BALANCING_ARMED || balancingState == BALANCING_CLOSE_FAILED;
+    if (balancingState == BALANCING_OPENING) {
+      request_close_contactors();  // cancels the wind-down outright if it has not shut down yet
+    }
+    balancingState = give_up ? BALANCING_IDLE : BALANCING_CLOSING;
+    balancingStateMillis = currentMillis;
+    balancingCloseAttempts = 0;
+  }
+
+  switch (balancingState) {
+    case BALANCING_ARMED:
+      // The charge-flag fallback can take 30s, so wait for the session to be genuinely at rest.
+      if (currentMillis - balancingStateMillis >= BALANCING_MOVE_TIMEOUT_MS) {
+        balancingState = BALANCING_IDLE;  // never got there, leave the pack alone
+      } else if (chargeSessionState == CHG_SESSION_HOLD && chargeSessionTerminated &&
+                 currentMillis - balancingStateMillis >= BALANCING_SETTLE_MS && !cell_balance_time_active) {
+        request_open_contactors_optional();
+        balancingCycleDone = true;
+        balancingState = BALANCING_OPENING;
+        balancingStateMillis = currentMillis;
+      }
+      break;
+    case BALANCING_OPENING:
+      if (!pack_closed) {
+        balancingState = BALANCING_WAITING;
+        balancingStateMillis = currentMillis;
+      } else if (contactorState == CONTACTORS_ACTIVE && currentMillis - balancingStateMillis >= 1000) {
+        balancingState = BALANCING_IDLE;  // abandoned under load, the pack stayed closed
+      } else if (currentMillis - balancingStateMillis >= BALANCING_MOVE_TIMEOUT_MS) {
+        // Reverse it rather than walking away with the contactor machine still mid-open.
+        request_close_contactors();
+        balancingCloseAttempts = 1;
+        balancingState = BALANCING_CLOSING;
+        balancingStateMillis = currentMillis;
+      }
+      break;
+    case BALANCING_WAITING:
+      if (pack_closed) {
+        balancingState = BALANCING_IDLE;  // closed by something else, do not fight it
+      } else if (currentMillis - balancingStateMillis >= hold_ms) {
+        balancingState = BALANCING_CLOSING;
+        balancingStateMillis = currentMillis;
+        balancingCloseAttempts = 0;
+      }
+      break;
+    case BALANCING_CLOSING:
+      // A close is ignored during the ~1.5s shutdown hold, so retry from standby, but only a few
+      // times and with a backoff (measured from the request, so ~30s idle after a failed confirm) -
+      // a pack that will not come back needs a person, not more attempts.
+      if (pack_closed && !open_in_flight) {
+        balancingState = BALANCING_IDLE;
+      } else if (contactorState == CONTACTORS_STANDBY &&
+                 (balancingCloseAttempts == 0 || currentMillis - balancingStateMillis >= BALANCING_CLOSE_BACKOFF_MS)) {
+        if (balancingCloseAttempts > BALANCING_CLOSE_RETRIES) {
+          set_event(EVENT_BYD_CONTACTOR_MISMATCH, 4);
+          balancingState = BALANCING_CLOSE_FAILED;
+        } else {
+          request_close_contactors();
+          balancingCloseAttempts++;
+          balancingStateMillis = currentMillis;
+        }
+      }
+      break;
+    case BALANCING_CLOSE_FAILED:
+      if (pack_closed) {
+        balancingState = BALANCING_IDLE;  // closed by hand, carry on
+      }
+      break;
+    default:
+      break;
+  }
+
+  datalayer_bydatto->balancing_state = balancingState;
+  uint16_t remaining = 0;
+  if (balancingState == BALANCING_WAITING) {
+    const uint32_t elapsed = currentMillis - balancingStateMillis;
+    if (elapsed < hold_ms) {
+      remaining = (uint16_t)((hold_ms - elapsed + 59999UL) / 60000UL);
+    }
+  }
+  datalayer_bydatto->balancing_remaining_min = remaining;
+}
+
 void BydAttoBattery::transmit_charge_session(unsigned long currentMillis) {
   if (chargeSessionState == CHG_SESSION_IDLE) {
     return;
@@ -1205,6 +1329,7 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
   if (contactorsAllowedClosed != previousContactorsAllowedClosed) {
     previousContactorsAllowedClosed = contactorsAllowedClosed;
     if (!contactorsAllowedClosed) {
+      contactorOpenOptional = false;  // a fault, stop or withdrawn permission always opens
       requestContactorOpen = true;
     } else {
       requestContactorClose = true;
@@ -1230,8 +1355,8 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
 
   if (requestContactorClose) {
     requestContactorClose = false;
-    if (datalayer.system.info.equipment_stop_active) {
-      // Don't close while the stop is active - releasing the stop is what asks to close
+    if (!contactorsAllowedClosed) {
+      // A fault, the equipment stop or the inverter withdrawing permission all hold the pack open
     } else if (contactorState == CONTACTORS_AWAIT_ZERO_CURRENT) {
       // Cancel the pending open (shutdown not sent yet). If the pack already closed, resume the
       // drive-ready hold; if it was still precharging, resume the close so it finishes properly
@@ -1277,8 +1402,14 @@ void BydAttoBattery::handle_contactor_control(unsigned long currentMillis) {
       if ((int32_t)(lastCurrentSampleMillis - contactorStateEntryMillis) >= (int32_t)ZERO_CURRENT_MIN_WAIT_MS &&
           battery_current_dA > -OPEN_MAX_CURRENT_dA && battery_current_dA < OPEN_MAX_CURRENT_dA) {
         set_12D_payload(0xA0, 0x28, 0x02, 0x60, 0x04, 0x31);  // Shutdown pattern
+        contactorOpenOptional = false;
         contactorState = CONTACTORS_OPENING;
         contactorStateEntryMillis = currentMillis;
+      } else if (currentMillis - contactorStateEntryMillis >= ZERO_CURRENT_TIMEOUT_MS && contactorOpenOptional) {
+        // Optional open: current never settled, so stay closed rather than breaking contact under load
+        set_12D_payload(0xA0, 0x28, 0x00, 0x22, 0x0C, 0x31);  // Drive-ready pattern
+        contactorState = CONTACTORS_ACTIVE;
+        contactorOpenOptional = false;
       } else if (currentMillis - contactorStateEntryMillis >= ZERO_CURRENT_TIMEOUT_MS) {
         // Timed out - open anyway. Flag whether a fresh reading stayed high (0) or none arrived (1)
         bool had_fresh_sample =
@@ -1526,6 +1657,7 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
 
     handle_contactor_control(currentMillis);
     handle_charge_session(currentMillis);
+    handle_balancing(currentMillis);
 
     // Byte 6 = rolling counter (high nibble counts up, low nibble 0xF), byte 7 = checksum
     frame6_counter = (frame6_counter + 1) & 0x0F;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -69,7 +69,15 @@ class BydAttoBattery : public CanBattery {
   bool supports_calibrate_SOC() { return true; }
   void reset_SOC() { datalayer_bydatto->UserRequestCalibrateSOC = true; }
   bool supports_contactor_close() { return true; }
-  void request_open_contactors() { requestContactorOpen = true; }
+  void request_open_contactors() {
+    contactorOpenOptional = false;
+    requestContactorOpen = true;
+  }
+  // An open that is worth abandoning rather than breaking contact under load for.
+  void request_open_contactors_optional() {
+    contactorOpenOptional = true;
+    requestContactorOpen = true;
+  }
   void request_close_contactors() { requestContactorClose = true; }
   bool supports_read_DTC() { return true; }
   void read_DTC() { datalayer_bydatto->UserRequestDTCreadout = true; }
@@ -218,6 +226,18 @@ class BydAttoBattery : public CanBattery {
   static const uint8_t CHG_SESSION_CHARGING = 3;   // 0x24A=88, 0x47E b2=0C, BMS granted
   static const uint8_t CHG_SESSION_FINISHING = 4;  // grant withdrawn, acknowledging the end
   static const uint8_t CHG_SESSION_HOLD = 5;       // resting at 0x84, keepalive only
+
+  // Balancing enabled: cycle the contactors after a termination. Opt-in, off by default.
+  static const uint8_t BALANCING_IDLE = 0;
+  static const uint8_t BALANCING_ARMED = 1;         // terminated, letting the session settle first
+  static const uint8_t BALANCING_OPENING = 2;       // open asked for, waiting for the pack to go
+  static const uint8_t BALANCING_WAITING = 3;       // open, running the configured hold
+  static const uint8_t BALANCING_CLOSING = 4;       // close asked for, waiting for the pack to come back
+  static const uint8_t BALANCING_CLOSE_FAILED = 5;  // pack would not close, left open for a person
+  static const uint8_t BALANCING_CLOSE_RETRIES = 2;
+  static const uint32_t BALANCING_CLOSE_BACKOFF_MS = 45000;
+  static const uint32_t BALANCING_SETTLE_MS = 10000;         // session reaches rest ~5s after termination
+  static const uint32_t BALANCING_MOVE_TIMEOUT_MS = 120000;  // give up if the pack will not move
 
   uint16_t rampdown_power = 0;
   uint16_t poll_state = POLL_FOR_ORIGINAL_CALIBRATION;
@@ -375,7 +395,14 @@ class BydAttoBattery : public CanBattery {
   void handle_contactor_control(unsigned long currentMillis);
 
   uint8_t chargeSessionState = CHG_SESSION_IDLE;
+  uint8_t balancingState = BALANCING_IDLE;
+  unsigned long balancingStateMillis = 0;
+  uint8_t balancingCloseAttempts = 0;
+  bool contactorOpenOptional = false;
+  bool balancingCycleDone = false;  // one cycle per real discharge, like the session re-arm
+  unsigned long balancingDischargeSinceMillis = 0;
   bool chargeSessionTerminated = false;  // last session ended on a grant edge, not an interruption
+  bool chargeTerminatedRails = false;    // rails stay lifted after the session ends, until cells relax
   bool chargeSessionHeartbeat = false;
   bool chargeRampDone = false;
   bool chargeDonePending = false;  // grant edge confirmed, stop offering current
@@ -395,6 +422,7 @@ class BydAttoBattery : public CanBattery {
   unsigned long chargeBackoffStartMillis = 0;
 
   void handle_charge_session(unsigned long currentMillis);
+  void handle_balancing(unsigned long currentMillis);
   void handle_charge_grant(uint8_t grant);
   void confirm_charge_termination();
   void start_charge_session(unsigned long currentMillis);

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -209,7 +209,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     if (s.length() > 0) {
       content += "<hr>";
       content += "<div style='max-width:560px;margin:16px auto;text-align:center;color:white'>";
-      content += "<h4 style='margin:0 0 8px 0;color:white'>Native SOC calibration &amp; charge termination</h4>";
+      content +=
+          "<h4 style='margin:0 0 8px 0;color:white'>Native SOC calibration, charge termination &amp; balancing</h4>";
       content +=
           "<div style='margin:0 0 10px;font-size:0.9em;color:#8b949e'>Not available on the second battery: "
           "the inverter charge limit follows battery 1, so a termination here could not stop the "
@@ -248,11 +249,13 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
 
       content += "<hr>";
       content += "<div style='max-width:560px;margin:16px auto;text-align:center;color:white'>";
-      content += "<h4 style='margin:0 0 8px 0;color:white'>Native SOC calibration &amp; charge termination</h4>";
       content +=
-          "<div style='margin:0 0 10px;font-size:0.9em;color:#8b949e'>The battery ends the charge itself and "
-          "recalibrates its own SOC to 100&percnt; and SOH, as it would in the car, then rests full with discharge "
-          "still available.</div>";
+          "<h4 style='margin:0 0 8px 0;color:white'>Native SOC calibration, charge termination &amp; balancing</h4>";
+      content +=
+          "<div style='margin:0 0 10px;font-size:0.9em;color:#8b949e'>Native termination lets the battery "
+          "finish charging and recalibrate its own SOC and SOH, as it does in the car. Without balancing, the "
+          "pack remains closed and available for discharge. With balancing enabled, the contactors open for the "
+          "selected hold time before closing again &mdash; a cycle that appears to trigger balancing.</div>";
       content += panel_table;
 
       content += "<tr>";
@@ -264,6 +267,63 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
       content += " onchange='toggleNativeTermination" + s + "()'>";
       content += "<span style='font-weight:normal;color:#8b949e'> default on</span>";
       content += "</td></tr>";
+
+      content += "<tr>";
+      content += label_td;
+      content += "Balancing enabled:</td>";
+      content += value_td;
+      content += "<input type='checkbox' id='balancingEnabled' ";
+      content += (byd_datalayer->balancing_enabled ? "checked" : "");
+      content += " onchange='toggleBalancingEnabled()'>";
+      content += "<span style='font-weight:normal;color:#8b949e'> open/reclose after charge</span>";
+      content += "</td></tr>";
+
+      content += "<tr>";
+      content += label_td;
+      content += "Hold for:</td>";
+      content += value_td;
+      content +=
+          "<input type='number' style='width:4.5em;margin:0;padding:1px 4px;vertical-align:middle' "
+          "id='balancingMinutes' value='";
+      content += String(byd_datalayer->balancing_hold_minutes);
+      content +=
+          "' min='1' max='1440'> min <button style='margin:0 0 0 8px;padding:2px 12px;vertical-align:middle' "
+          "onclick='setBalancingMinutes()'>Save</button>";
+      content += "</td></tr>";
+
+      if (byd_datalayer->balancing_state != 0) {
+        const char* hold_text = "Idle";
+        switch (byd_datalayer->balancing_state) {
+          case 1:
+            hold_text = "Armed";
+            break;
+          case 2:
+            hold_text = "Opening";
+            break;
+          case 3:
+            hold_text = "Holding open";
+            break;
+          case 4:
+            hold_text = "Closing";
+            break;
+          case 5:
+            hold_text = "Close failed - pack left open";
+            break;
+          default:
+            break;
+        }
+        content += "<tr>";
+        content += label_td;
+        content += "Hold state:</td>";
+        content += value_td;
+        content +=
+            (byd_datalayer->balancing_state == 5) ? "<span style='color:#d29922'>" : "<span style='color:white'>";
+        content += hold_text;
+        if (byd_datalayer->balancing_state == 3) {
+          content += " (" + String(byd_datalayer->balancing_remaining_min) + " min left)";
+        }
+        content += "</span></td></tr>";
+      }
 
       content += "<tr>";
       content += label_td;
@@ -612,6 +672,22 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
       content += "  xhr.onload=editComplete;";
       content += "  xhr.onerror=editError;";
       content += "  xhr.open('GET','/editBydAtto3NativeTermination?value='+enabled,true);";
+      content += "  xhr.send();";
+      content += "}";
+      content += "function toggleBalancingEnabled(){";
+      content += "  var enabled = document.getElementById('balancingEnabled').checked ? 1 : 0;";
+      content += "  var xhr=new XMLHttpRequest();";
+      content += "  xhr.onload=editComplete;";
+      content += "  xhr.onerror=editError;";
+      content += "  xhr.open('GET','/editBydAtto3BalancingEnabled?value='+enabled,true);";
+      content += "  xhr.send();";
+      content += "}";
+      content += "function setBalancingMinutes(){";
+      content += "  var v = document.getElementById('balancingMinutes').value;";
+      content += "  var xhr=new XMLHttpRequest();";
+      content += "  xhr.onload=editComplete;";
+      content += "  xhr.onerror=editError;";
+      content += "  xhr.open('GET','/editBydAtto3BalancingMinutes?value='+v,true);";
       content += "  xhr.send();";
       content += "}";
     }

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -313,6 +313,8 @@ void init_stored_settings() {
   // Native termination is primary-battery only: inverter charge limits come from battery 1 alone,
   // so a secondary termination could not stop a parallel bank.
   datalayer_extended.bydAtto3.native_termination_enabled = settings.getBool("BYDNATTERM", true);
+  datalayer_extended.bydAtto3.balancing_enabled = settings.getBool("BYDBALEN", false);
+  datalayer_extended.bydAtto3.balancing_hold_minutes = constrain(settings.getUInt("BYDBALMIN", 30), 1u, 1440u);
 }
 
 void clear_wifi_sta_settings() {
@@ -381,4 +383,6 @@ void store_settings() {
   settings.saveUInt("BYDAUTOCALDRFT2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_drift_percent);
   settings.saveBool("BYDAUTOCALEN2", datalayer_extended.bydAtto3_2.auto_calibrate_soc_enabled);
   settings.saveBool("BYDNATTERM", datalayer_extended.bydAtto3.native_termination_enabled);
+  settings.saveBool("BYDBALEN", datalayer_extended.bydAtto3.balancing_enabled);
+  settings.saveUInt("BYDBALMIN", datalayer_extended.bydAtto3.balancing_hold_minutes);
 }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -216,6 +216,14 @@ struct DATALAYER_INFO_BYDATTO3 {
   uint16_t termination_cell_delta_mV;
   uint8_t termination_cell_max_number;
   uint8_t termination_cell_min_number;
+  /** Cycle the contactors open after a native termination, then close again */
+  bool balancing_enabled;
+  /** How long to hold the pack open for */
+  uint16_t balancing_hold_minutes;
+  /** Hold state: 0 idle, 1 armed, 2 opening, 3 holding open, 4 closing, 5 close failed */
+  uint8_t balancing_state;
+  /** Minutes left of the hold */
+  uint16_t balancing_remaining_min;
 
   // DTC readout (UDS 0x19 0x02). Codes packed as raw 3 bytes in a uint32, rendered to string in HTML.
   bool dtc_read_in_progress;
@@ -1082,6 +1090,8 @@ class DataLayerExtended {
       data.auto_calibrate_soc_enabled = true;
       data.auto_calibrate_soc_drift_percent = 5;
       data.native_termination_enabled = true;
+      data.balancing_enabled = false;
+      data.balancing_hold_minutes = 30;
     };
     initBydAtto3(bydAtto3);
     initBydAtto3(bydAtto3_2);

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -555,7 +555,7 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
       return "Battery ended the charge itself and recalibrated SOC. Data column shows cell spread in tens of mV.";
     case EVENT_BYD_CONTACTOR_MISMATCH:
       return "Battery did not confirm the contactor command in time. Data: 2 = open not confirmed, 3 = close not "
-             "confirmed.";
+             "confirmed, 4 = close retries exhausted, pack left open.";
     case EVENT_BYD_CONTACTOR_FORCE_OPEN:
       return "Contactors force-opened: pack current was not confirmed safe before the timeout. Data: 0 = current "
              "stayed high, 1 = no fresh current reading. Check the inverter ramped down.";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -781,6 +781,34 @@ void init_webserver() {
     request->send(200, "text/plain", "OK");
   });
 
+  // Save balancing enabled flag to RAM + NVM
+  def_route_with_auth("/editBydAtto3BalancingEnabled", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      bool enabled = request->getParam("value")->value().toInt() != 0;
+      datalayer_extended.bydAtto3.balancing_enabled = enabled;
+      Preferences prefs;
+      prefs.begin("batterySettings", false);
+      prefs.putBool("BYDBALEN", enabled);
+      prefs.end();
+    }
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Save balancing hold duration to RAM + NVM
+  def_route_with_auth("/editBydAtto3BalancingMinutes", server, HTTP_GET, [](AsyncWebServerRequest* request) {
+    if (request->hasParam("value")) {
+      int value = request->getParam("value")->value().toInt();
+      if (value >= 1 && value <= 1440) {
+        datalayer_extended.bydAtto3.balancing_hold_minutes = (uint16_t)value;
+        Preferences prefs;
+        prefs.begin("batterySettings", false);
+        prefs.putUInt("BYDBALMIN", (uint16_t)value);
+        prefs.end();
+      }
+    }
+    request->send(200, "text/plain", "OK");
+  });
+
   // Route for editing AH Calibration BYD
   update_string_setting("/editCalTargetAH", [](String value) {
     datalayer_extended.bydAtto3.calibrationTargetAH = static_cast<uint16_t>(value.toFloat());


### PR DESCRIPTION
### What
Adds an automatic contactor open/close cycle after a native charge termination, which is what makes the BYD BMS run its own cell balancing, and holds the cell voltage rails through the cycle.

### Why
The BMS arms balancing only after a native termination followed by a contactor open — termination alone never triggers it, so without this the pack never balances. Holding the rails is needed because the open tears down the charge session, which snaps the cell and deviation limits back to stock while cells are still at knee voltage, raising over-voltage and deviation alarms and dropping published power to zero.

### How
A state machine (Idle → Armed → Opening → Holding open → Closing) runs one cycle per real discharge, with two close retries at 45 s backoff and a 120 s timeout; if the pack will not re-close it stops and leaves it open rather than retrying indefinitely.

Details:

* Two settings on the More Battery Info page: Balancing enabled - off by default (BYDBALEN) and Hold for minutes (BYDBALMIN, default 30, range 1–1440), plus a live Hold state readout.
* The BMS selects the highest cells by voltage at the termination instant and bleeds each for ~17 hours, then stops. The next termination selects the next tier down, so the pack converges over repeated charge cycles.
* A 2-minute hold does not arm it; 10 minutes does. The 30-minute default is deliberately conservative.
* The bleed itself runs with contactors closed, including under load, so the pack stays available throughout.
* Depth of discharge makes no difference — shallow and deep cycles behave identically.

Behaviour confirmed across multiple packs and multiple users, with per-cell balance timers read over UDS.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
