### PR TITLE
Nissan LEAF 🔋: apply Hx raw-to-percent scale on ZE0/AZE0 too

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -585,18 +585,21 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
 
         if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame
-          // Hx sits at a different payload offset and uses a different scale depending on which
-          // layout the LBC answered with, so the reply length decides how to read it:
-          //   0x29 (ZE0 24kWh) / 0x2B (AZE0 30kWh) -> payload[26..27], already in hundredths of a %
-          //   0x35 (ZE1 40/62kWh)                  -> payload[28..29], raw / 102.4 = percent
+          // Hx sits at a different payload offset depending on which layout the LBC answered with,
+          // so the reply length decides where to read it. The unit is the same for all of them:
+          //   0x29 (ZE0 24kWh) / 0x2B (AZE0 30kWh) -> payload[26..27]
+          //   0x35 (ZE1 40/62kWh)                  -> payload[28..29]
           // This frame carries payload[25..31] in u8[1..7]. Any other length is a layout we do not
           // know (a ZE1 answers 0x2C shortly after wakeup), so leave the last good value in place.
+          uint16_t battery_HX_raw = 0;
           if (group_7bb_length == 0x35) {  //ZE1
-            uint16_t battery_HX_raw = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+            battery_HX_raw = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
+          } else if (group_7bb_length == 0x29 || group_7bb_length == 0x2B) {  //ZE0 / AZE0
+            battery_HX_raw = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+          }
+          if (battery_HX_raw > 0) {
             //raw / 102.4 * 100 == raw * 125 / 128, rounded to nearest
             battery_HX_pptt = (uint16_t)(((uint32_t)battery_HX_raw * 125u + 64u) / 128u);
-          } else if (group_7bb_length == 0x29 || group_7bb_length == 0x2B) {  //ZE0 / AZE0
-            battery_HX_pptt = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
           }
         }
       }


### PR DESCRIPTION
### What
Applies the raw -> percent conversion to Hx for ZE0/AZE0 packs, not only ZE1.

### Why
"More battery info" reported Hx 100.00 % on my AZE0 pack that LeafSpy reads as 97.66 %. All generations likely report Hx in the same 1/102.4-per-percent unit; only the payload offset differs, so the ZE0/AZE0 branch would also be in parity with LeafSpy. 

<img width="415" height="116" alt="kép" src="https://github.com/user-attachments/assets/f0d87f5b-dc59-4dd3-94fb-26a2ad8fb658" />
<img width="161" height="51" alt="kép" src="https://github.com/user-attachments/assets/69ba306f-4403-4c44-a00b-2e24b4f96021" />



### How
Reads the raw value per generation, then converts once. Verified on my 30 kWh AZE0: group 1 frame `24 5c 27 10 ...` gives 0x2710 = 10000 -> 97.66 %, matching LeafSpy. SOC at the adjacent offset decodes to 95.95 %, matching `0x55B` in the same capture.


> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
