### PR TITLE
Nissan LEAF: probe for a second firmware string and show it on the info page

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -279,6 +279,8 @@ void NissanLeafBattery::
   if (datalayer_nissan) {
     memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
     memcpy(datalayer_nissan->BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
+    memcpy(datalayer_nissan->BatteryFirmwareSecondary, BatteryFirmwareSecondary,
+           sizeof(BatteryFirmwareSecondary));
     datalayer_nissan->LEAF_gen = LEAF_battery_Type;
     if (allows_contactor_closing) {  //Only the main battery names the protocol shown on the status page
       //setup() already wrote Name, so only the "battery" part gets replaced by the detected generation
@@ -566,6 +568,42 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       }
 
       transmit_can_frame(&LEAF_NEXT_LINE_REQUEST);  //Request the next frame for the group
+
+      /* Identity probe replies. Service 0x21 answers 61 85 / 61 86, the UDS DIDs answer
+         62 F1 94 / 62 F1 95, either as a single frame or as a first frame. A negative reply
+         (7F 21 ..) matches neither, so an identifier the LBC does not implement is ignored.
+         Only the first probe that returns text is kept, so a later reply cannot overwrite it. */
+      uint8_t probe_payload_start = 0;
+      bool probe_header_frame = false;
+      if (rx_frame.data.u8[0] == 0x10) {  //First frame of a multi frame reply
+        probe_header_frame = true;
+        if (rx_frame.data.u8[2] == 0x61 && (rx_frame.data.u8[3] == 0x85 || rx_frame.data.u8[3] == 0x86)) {
+          probe_payload_start = 4;
+        } else if (rx_frame.data.u8[2] == 0x62 && rx_frame.data.u8[3] == 0xF1 &&
+                   (rx_frame.data.u8[4] == 0x94 || rx_frame.data.u8[4] == 0x95)) {
+          probe_payload_start = 5;
+        }
+      } else if (rx_frame.data.u8[0] >= 0x01 && rx_frame.data.u8[0] <= 0x07) {  //Single frame reply
+        probe_header_frame = true;
+        if (rx_frame.data.u8[1] == 0x61 && (rx_frame.data.u8[2] == 0x85 || rx_frame.data.u8[2] == 0x86)) {
+          probe_payload_start = 3;
+        } else if (rx_frame.data.u8[1] == 0x62 && rx_frame.data.u8[2] == 0xF1 &&
+                   (rx_frame.data.u8[3] == 0x94 || rx_frame.data.u8[3] == 0x95)) {
+          probe_payload_start = 4;
+        }
+      }
+      if (probe_header_frame) {
+        probe_reply_streaming = (probe_payload_start != 0 && BatteryFirmwareSecondary[0] == 0);
+        probe_chars_collected = 0;
+      }
+      if (probe_reply_streaming) {
+        uint8_t first_byte = probe_header_frame ? probe_payload_start : 1;
+        if (probe_header_frame || (rx_frame.data.u8[0] >= 0x21 && rx_frame.data.u8[0] <= 0x2F)) {
+          for (uint8_t i = first_byte; i < 8; i++) {
+            collect_probe_char(rx_frame.data.u8[i]);
+          }
+        }
+      }
 
       if (group_7bb == 0x01)  //High precision SOC, Current, voltages etc.
       {
@@ -908,6 +946,39 @@ void NissanLeafBattery::handle_DTC_requests(unsigned long currentMillis) {
   }
 }
 
+/* Appends one byte of an identity probe reply. Stops at the first byte that is not printable
+   ASCII, since anything else is not a version string, and when the buffer is full. */
+void NissanLeafBattery::collect_probe_char(uint8_t value) {
+  if (!probe_reply_streaming) {
+    return;
+  }
+  if (probe_chars_collected >= sizeof(BatteryFirmwareSecondary) || value < 0x20 || value > 0x7E) {
+    probe_reply_streaming = false;
+    return;
+  }
+  BatteryFirmwareSecondary[probe_chars_collected++] = value;
+}
+
+/* Sends the next unasked identity probe, one per call, and reports whether it sent anything.
+   Returns false once the list is exhausted, which hands the 10s slot back to the group rotation. */
+bool NissanLeafBattery::send_identity_probe(unsigned long currentMillis) {
+  if (identity_probe_index >= (sizeof(identity_probes) / sizeof(identity_probes[0]))) {
+    return false;
+  }
+  IdentityProbe probe = identity_probes[identity_probe_index++];
+  uds_busy = true;
+  uds_request_millis = currentMillis;
+  if (probe.service == 0x22) {
+    LEAF_DID_REQUEST.data.u8[2] = (uint8_t)(probe.identifier >> 8);
+    LEAF_DID_REQUEST.data.u8[3] = (uint8_t)(probe.identifier & 0xFF);
+    transmit_can_frame(&LEAF_DID_REQUEST);
+  } else {
+    LEAF_GROUP_REQUEST.data.u8[2] = (uint8_t)(probe.identifier & 0xFF);
+    transmit_can_frame(&LEAF_GROUP_REQUEST);
+  }
+  return true;
+}
+
 void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
 
   handle_DTC_requests(currentMillis);
@@ -923,6 +994,9 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
        both are cleared from the polling code once the pass has actually been sent. */
     repoll_static_groups = true;
     poll_burst_remaining = sizeof(PIDgroups) / sizeof(PIDgroups[0]);
+    //The identity probes belong to the old session too, so ask them again on the new one.
+    identity_probe_index = 0;
+    memset(BatteryFirmwareSecondary, 0, sizeof(BatteryFirmwareSecondary));
     return;
   }
 
@@ -1154,7 +1228,8 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       //the 0x79B/0x7BB channel, and whichever request lands second gets dropped by the LBC.
       bool dtc_operation_pending =
           UserRequestDTCreadout || UserRequestDTCreset || dtc_read_in_progress || dtc_clear_in_progress;
-      if (!stop_battery_query && !dtc_operation_pending) {
+      //The identity probes get the first 10s slots of a session, before the group rotation starts.
+      if (!stop_battery_query && !dtc_operation_pending && !send_identity_probe(currentMillis)) {
 
         // Move to the next group, skipping the static ones that already answered. The charge
         // counters and the two identity strings cannot change while the pack is powered, so each

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -279,8 +279,7 @@ void NissanLeafBattery::
   if (datalayer_nissan) {
     memcpy(datalayer_nissan->BatterySerialNumber, BatterySerialNumber, sizeof(BatterySerialNumber));
     memcpy(datalayer_nissan->BatteryPartNumber, BatteryPartNumber, sizeof(BatteryPartNumber));
-    memcpy(datalayer_nissan->BatteryFirmwareSecondary, BatteryFirmwareSecondary,
-           sizeof(BatteryFirmwareSecondary));
+    memcpy(datalayer_nissan->BatteryFirmwareSecondary, BatteryFirmwareSecondary, sizeof(BatteryFirmwareSecondary));
     datalayer_nissan->LEAF_gen = LEAF_battery_Type;
     if (allows_contactor_closing) {  //Only the main battery names the protocol shown on the status page
       //setup() already wrote Name, so only the "battery" part gets replaced by the detected generation

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -68,6 +68,8 @@ class NissanLeafBattery : public CanBattery {
 
   // Sends pending DTC requests once the diagnostic channel is idle, and times out unanswered ones.
   void handle_DTC_requests(unsigned long currentMillis);
+  bool send_identity_probe(unsigned long currentMillis);
+  void collect_probe_char(uint8_t value);
   static const int MAX_PACK_VOLTAGE_DV = 4055;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2400;
   static const int MAX_CELL_DEVIATION_MV = 150;
@@ -162,6 +164,21 @@ class NissanLeafBattery : public CanBattery {
                                   .DLC = 8,
                                   .ID = 0x79B,
                                   .data = {2, 0x21, 1, 0, 0, 0, 0, 0}};
+  //Read only probes looking for a second firmware/identity string next to the one group 0x83
+  //already returns. 0x85 and 0x86 are Nissan local identifiers read with service 0x21, 0xF194 and
+  //0xF195 are the UDS supplier software number/version DIDs read with service 0x22. Each is asked
+  //once per session; an identifier the LBC does not implement answers 7F and is simply ignored.
+  struct IdentityProbe {
+    uint8_t service;      //0x21 for a one byte local identifier, 0x22 for a two byte DID
+    uint16_t identifier;  //Low byte only for service 0x21
+  };
+  IdentityProbe identity_probes[4] = {{0x21, 0x0085}, {0x21, 0x0086}, {0x22, 0xF194}, {0x22, 0xF195}};
+  uint8_t identity_probe_index = 0;
+  CAN_frame LEAF_DID_REQUEST = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x79B,
+                                .data = {3, 0x22, 0xF1, 0x95, 0, 0, 0, 0}};
   CAN_frame LEAF_NEXT_LINE_REQUEST = {.FD = false,
                                       .ext_ID = false,
                                       .DLC = 8,
@@ -319,6 +336,10 @@ class NissanLeafBattery : public CanBattery {
   int16_t battery_temp_polled_min = 0;
   uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
   uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
+  //Filled by the first identity probe that answers with text. Stays empty when none of them does.
+  uint8_t BatteryFirmwareSecondary[7] = {0};  // Stores raw HEX values for ASCII chars
+  uint8_t probe_chars_collected = 0;
+  bool probe_reply_streaming = false;
   uint8_t stateMachineClearSOH = 0xFF;
 
 #ifndef SMALL_FLASH_DEVICE

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -43,10 +43,9 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
        probes answered with one. */
     char readableFirmware[6];  // One extra space for null terminator
     memcpy(readableFirmware, nissan_dl->BatteryPartNumber, 5);
-    readableFirmware[5] = '\0';  // Null terminate the string
+    readableFirmware[5] = '\0';         // Null terminate the string
     char readableFirmwareSecondary[8];  // One extra space for null terminator
-    memcpy(readableFirmwareSecondary, nissan_dl->BatteryFirmwareSecondary,
-           sizeof(nissan_dl->BatteryFirmwareSecondary));
+    memcpy(readableFirmwareSecondary, nissan_dl->BatteryFirmwareSecondary, sizeof(nissan_dl->BatteryFirmwareSecondary));
     readableFirmwareSecondary[7] = '\0';  // Null terminate the string
     for (int i = 6; i >= 0 && readableFirmwareSecondary[i] == ' '; i--) {
       readableFirmwareSecondary[i] = '\0';  // Trim the padding some identifiers come with

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -37,10 +37,25 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     memcpy(readableSerialNumber, nissan_dl->BatterySerialNumber, sizeof(nissan_dl->BatterySerialNumber));
     readableSerialNumber[15] = '\0';  // Null terminate the string
     content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
-    char readablePartNumber[8];  // One extra space for null terminator
-    memcpy(readablePartNumber, nissan_dl->BatteryPartNumber, sizeof(nissan_dl->BatteryPartNumber));
-    readablePartNumber[7] = '\0';  // Null terminate the string
-    content += "<h4>Part number: " + String(readablePartNumber) + "</h4>";
+    /* The LBC reports its software level as the five character suffix of a Nissan part number.
+       The two bytes that follow it in group 0x83 are a separate field, so they are not part of
+       the version and are left out here. A second string appears only when one of the identity
+       probes answered with one. */
+    char readableFirmware[6];  // One extra space for null terminator
+    memcpy(readableFirmware, nissan_dl->BatteryPartNumber, 5);
+    readableFirmware[5] = '\0';  // Null terminate the string
+    char readableFirmwareSecondary[8];  // One extra space for null terminator
+    memcpy(readableFirmwareSecondary, nissan_dl->BatteryFirmwareSecondary,
+           sizeof(nissan_dl->BatteryFirmwareSecondary));
+    readableFirmwareSecondary[7] = '\0';  // Null terminate the string
+    for (int i = 6; i >= 0 && readableFirmwareSecondary[i] == ' '; i--) {
+      readableFirmwareSecondary[i] = '\0';  // Trim the padding some identifiers come with
+    }
+    content += "<h4>Firmware: " + String(readableFirmware);
+    if (readableFirmwareSecondary[0] != '\0') {
+      content += " / " + String(readableFirmwareSecondary);
+    }
+    content += "</h4>";
     content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
     content +=
         "<h4>Hx: " +

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -844,6 +844,8 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** Battery info, stores raw HEX values for ASCII chars */
   uint8_t BatterySerialNumber[15];
   uint8_t BatteryPartNumber[7];
+  /** Second identity string, if one of the identity probes answered. Empty otherwise. */
+  uint8_t BatteryFirmwareSecondary[7];
 };
 
 struct DATALAYER_INFO_MEB {


### PR DESCRIPTION
### What
Renames the LEAF "Part number:" field to "Firmware:", shows it as the five-character software level, and adds four read-only probes that look for a second version string next to it.

### Why
The value in group 0x83 is the LBC's software level, not the assembly number printed on the pack, so the old label sent owners looking for a number that will never match. Packs are known to carry a second version (4NR6B / 4NR6A on the pack this was found on) that the emulator cannot surface at all today.

### How
Asks `21 85`, `21 86`, `22 F1 94` and `22 F1 95` once per session in the 10 s slots ahead of the normal group rotation, re-armed after a BMS reset, and keeps the first reply that returns text. Identifiers the LBC does not implement answer `7F` and are ignored, so the page simply falls back to the single version.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
