### PR TITLE
Fix: BYD More Battery Info page reservation

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -14,7 +14,7 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
 
   String get_status_html() {
     String content;
-    content.reserve(9000);
+    content.reserve(16000);
 
     const auto& dl_bat = s.length() ? datalayer.battery2 : datalayer.battery;
     content += "<h4>Detected cells: " + String(dl_bat.info.number_of_cells) + "</h4>";


### PR DESCRIPTION
### What
Raises the string reservation for the BYD More Battery Info page from 9,000 to 16,000 bytes.

### Why
The page has quietly outgrown its reservation. It now builds around 12.9 kB, but only 9 kB is reserved, so the String has to grow past it every single time the page is rendered — and on the ESP32 core that growth happens in 16-byte steps.

That would just be slow, except a failed realloc doesn't throw. String::concat returns false and carries on, so what you get is a blank or half-finished page rather than an error. Whether it survives depends on how fragmented the heap happens to be at that moment, which is why #2890 describes it as working sometimes and blank most of the time. Boards with PSRAM have enough room to get away with it; a LilyGo T-CAN doesn't.

### How
One-line change. 16,000 covers the measured worst case with ~3.1 kB headroom; the file has grown 7,651 → 11,191 → 12,656 B across three recent merges, so a tighter value would recur.

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes #2890 

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

### Checklist:

  - [ ] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
