### PR TITLE
Fix: Modbus FC06 response should echo the register address

### DIFF
--- a/Software/src/inverter/ModbusInverterProtocol.cpp
+++ b/Software/src/inverter/ModbusInverterProtocol.cpp
@@ -83,8 +83,8 @@ ModbusMessage ModbusInverterProtocol::FC06(ModbusMessage request) {
   // Do the write
   mbPV[addr] = val;
 
-  // Set up response
-  response.add(request.getServerID(), request.getFunctionCode(), mbPV[addr]);
+  // Set up response, including addr
+  response.add(request.getServerID(), request.getFunctionCode(), addr, mbPV[addr]);
   return response;
 }
 

--- a/test/modbus_fc06_tests.cpp
+++ b/test/modbus_fc06_tests.cpp
@@ -45,12 +45,12 @@ struct CapturedWrite {
 // followed by the standby/active pair it sends at +7.2/+7.7 s to a battery
 // that has power-cycled. Values are identical across four captured cold starts.
 const CapturedWrite kBootWrites[] = {
-    {1102, 4100},  // discharge DC-bus rail, 0.1 V
-    {1103, 4200},  // charge DC-bus rail, 0.1 V
-    {1104, 350},   {1106, 350}, {1109, 7000},  // peak discharge nameplate, W
-    {1109, 5000},                              // continuous nameplate, W
-    {1101, 1},                                 // standby
-    {1101, 3},                                 // active
+    {1102, 4100},                             // discharge DC-bus rail, 0.1 V
+    {1103, 4200},                             // charge DC-bus rail, 0.1 V
+    {1104, 350},  {1106, 350}, {1109, 7000},  // peak discharge nameplate, W
+    {1109, 5000},                             // continuous nameplate, W
+    {1101, 1},                                // standby
+    {1101, 3},                                // active
 };
 
 }  // namespace
@@ -62,8 +62,7 @@ TEST(ModbusFc06, ResponseEchoesAddressAndValue) {
   ModbusMessage response = inverter.FC06(request);
 
   const std::vector<uint8_t> expected = {0x0F, 0x06, 0x04, 0x4E, 0x10, 0x04};
-  EXPECT_EQ(bytes_of(response), expected)
-      << "FC06 must echo the request: [id][06][addrHi][addrLo][valHi][valLo]";
+  EXPECT_EQ(bytes_of(response), expected) << "FC06 must echo the request: [id][06][addrHi][addrLo][valHi][valLo]";
   EXPECT_EQ(response.size(), 6u) << "a 4-byte response means the address was omitted";
 }
 

--- a/test/modbus_fc06_tests.cpp
+++ b/test/modbus_fc06_tests.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../Software/src/inverter/ModbusInverterProtocol.h"
+
+// Regression tests for ModbusInverterProtocol::FC06 (Write Single Register).
+//
+// A Modbus FC06 response is a byte-for-byte echo of the request:
+//     [slaveID][0x06][addrHi][addrLo][valHi][valLo]
+// FC06 previously omitted the address and answered with 4 bytes instead of 6.
+// Masters that validate the echo reject that; a Delta E6-TL-US will not finish
+// its boot handshake without it.
+//
+// The expectations below are not invented. They are the actual bytes an
+// LG RESU10H Prime put on the wire in reply to a Delta E6-TL-US, captured
+// 2026-08-26 during an inverter cold start (payload only -- the CRC is added by
+// the RTU layer, not by FC06).
+
+namespace {
+
+class Fc06TestInverter : public ModbusInverterProtocol {
+ public:
+  Fc06TestInverter() : ModbusInverterProtocol(kServerId) {}
+  const char* name() override { return "FC06 regression test"; }
+  void update_values() override {}
+
+  using ModbusInverterProtocol::FC06;
+  using ModbusInverterProtocol::mbPV;
+
+  static constexpr int kServerId = 15;  // 0x0F, the LG RESU's Modbus address
+};
+
+std::vector<uint8_t> bytes_of(ModbusMessage& m) {  // eModbus data()/size() are non-const
+  return std::vector<uint8_t>(m.data(), m.data() + m.size());
+}
+
+// One real write from the captured boot handshake.
+struct CapturedWrite {
+  uint16_t reg;
+  uint16_t value;
+};
+
+// The six configuration writes the Delta issues at +3.0..+5.1 s after boot,
+// followed by the standby/active pair it sends at +7.2/+7.7 s to a battery
+// that has power-cycled. Values are identical across four captured cold starts.
+const CapturedWrite kBootWrites[] = {
+    {1102, 4100},  // discharge DC-bus rail, 0.1 V
+    {1103, 4200},  // charge DC-bus rail, 0.1 V
+    {1104, 350},   {1106, 350}, {1109, 7000},  // peak discharge nameplate, W
+    {1109, 5000},                              // continuous nameplate, W
+    {1101, 1},                                 // standby
+    {1101, 3},                                 // active
+};
+
+}  // namespace
+
+TEST(ModbusFc06, ResponseEchoesAddressAndValue) {
+  Fc06TestInverter inverter;
+
+  ModbusMessage request(Fc06TestInverter::kServerId, 0x06, uint16_t{1102}, uint16_t{4100});
+  ModbusMessage response = inverter.FC06(request);
+
+  const std::vector<uint8_t> expected = {0x0F, 0x06, 0x04, 0x4E, 0x10, 0x04};
+  EXPECT_EQ(bytes_of(response), expected)
+      << "FC06 must echo the request: [id][06][addrHi][addrLo][valHi][valLo]";
+  EXPECT_EQ(response.size(), 6u) << "a 4-byte response means the address was omitted";
+}
+
+TEST(ModbusFc06, EchoesEveryWriteOfTheCapturedBootHandshake) {
+  Fc06TestInverter inverter;
+
+  for (const CapturedWrite& w : kBootWrites) {
+    ModbusMessage request(Fc06TestInverter::kServerId, 0x06, w.reg, w.value);
+    ModbusMessage response = inverter.FC06(request);
+
+    EXPECT_EQ(bytes_of(response), bytes_of(request))
+        << "reg " << w.reg << " <- " << w.value << ": response is not a byte-for-byte echo";
+  }
+}
+
+TEST(ModbusFc06, StoresTheWrittenValue) {
+  Fc06TestInverter inverter;
+
+  for (const CapturedWrite& w : kBootWrites) {
+    ModbusMessage request(Fc06TestInverter::kServerId, 0x06, w.reg, w.value);
+    inverter.FC06(request);
+  }
+
+  // 1109 is written twice (7000 then 5000); the later value must win.
+  EXPECT_EQ(inverter.mbPV[1109], 5000);
+  EXPECT_EQ(inverter.mbPV[1102], 4100);
+  EXPECT_EQ(inverter.mbPV[1103], 4200);
+  // 1101 likewise: standby then active.
+  EXPECT_EQ(inverter.mbPV[1101], 3);
+}
+
+TEST(ModbusFc06, RejectsOutOfRangeAddress) {
+  Fc06TestInverter inverter;
+
+  ModbusMessage request(Fc06TestInverter::kServerId, 0x06, uint16_t{40000}, uint16_t{1});
+  ModbusMessage response = inverter.FC06(request);
+
+  ASSERT_GE(response.size(), 3u);
+  EXPECT_EQ(response[1], 0x86) << "an exception response sets the high bit of the function code";
+  EXPECT_EQ(response[2], ILLEGAL_DATA_ADDRESS);
+}


### PR DESCRIPTION
### What
This PR implements correctly echoing the address of a register write command
A Modbus FC06 response is a byte-for-byte ECHO of the request:
     [slaveID][0x06][addrHi][addrLo][valHi][valLo]
The previous version omitted the address and returned only
     [slaveID][0x06][valHi][valLo]
which is 4 bytes instead of 6 and is not a valid FC06 response.

### Why
At least my Delta inverter & LG Resu Prime rs485 comms fail without it.  Not sure that anyone else had used this functionality yet.  Searching project shows that `BYD-MODBUS` is currently the only Modbus RTU inverter protocol, and BYD never writes registers — so `FC06` has likely not been run.

### How
 Add the addr to the response, looks like it was missing.  The existing response left out the addr.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):      n/a

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):     n/a

### Checklist:

  - [x] The code change is tested and works locally.    Needed for my inverter & battery startup, several successful power up sequences (only happens on startup) where inverter configures the battery with FC06 commands, and several days now of running nominally.  BE rs485 is communicating with inverter, and separate RPi rs485 talking to battery, mqtt between them to form MITM.

Verified against a real device: an LG RESU10H Prime answering a Delta E6-TL-US
echoes the full request on every fn6 write (21 writes captured 2026-08-26 across
four inverter power cycles, e.g. request 0f0604 4e10 04.. -> identical response).
Masters that validate the echo -- the Delta does -- reject the short form, which
breaks the boot handshake and leaves the battery unconfigured.

