### PR TITLE
fix: Report the BYD link voltage only after the BMS has started precharging

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -551,6 +551,11 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       contactor_feedback = rx_frame.data.u8[0];
       lastContactorFeedbackMillis = millis();
+      if ((rx_frame.data.u8[1] & 0x40) && !(contactor_feedback_state & 0x40)) {
+        prechargeRampStartMillis = millis();  // BMS started precharging
+        prechargeEdgeSeen = true;
+      }
+      contactor_feedback_state = rx_frame.data.u8[1];
       discharge_status = (rx_frame.data.u8[1] & 0x0F);
       break;
     case 0x345:
@@ -1677,16 +1682,46 @@ void BydAttoBattery::transmit_can(unsigned long currentMillis) {
     if (counter_100ms > 3) {
       // Bytes 4-5 = link voltage; matched to the pack it's the precharge-done signal that closes
       // the contactors. Report the low floating link while open, else we hold close while opening.
-      bool report_link_voltage_low = !BMS_voltage_available || contactorState == CONTACTORS_OPEN_SETTLE ||
-                                     contactorState == CONTACTORS_STANDBY || contactorState == CONTACTORS_BOOT_ESTOP;
+      const bool pack_open = contactorState == CONTACTORS_OPEN_SETTLE || contactorState == CONTACTORS_STANDBY ||
+                             contactorState == CONTACTORS_BOOT_ESTOP;
+      // byte 1 is 0x00 only while open: 0x40 on the close, 0x44 precharging, 0x41 running
+      if (!prechargeInitialised) {
+        prechargeInitialised = true;
+        prechargeWaitStartMillis = currentMillis;  // boot-default close: time out from here, not from uptime 0
+      }
+      if (pack_open) {
+        prechargeState = PRECHARGE_WAIT;  // next close ramps from the floating link again
+        prechargeEdgeSeen = false;
+        prechargeWaitStartMillis = currentMillis;
+      } else if (prechargeState == PRECHARGE_WAIT) {
+        if (contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) {
+          prechargeState = PRECHARGE_DONE;  // booted into a closed pack, never fake a ramp
+        } else if (prechargeEdgeSeen) {
+          prechargeState = PRECHARGE_RAMP;
+        } else if (currentMillis - prechargeWaitStartMillis >= PRECHARGE_WAIT_MAX_MS) {
+          prechargeState = PRECHARGE_DONE;  // BMS never moved, report the link rather than stall
+        }
+      } else if (prechargeState == PRECHARGE_RAMP && currentMillis - prechargeRampStartMillis >= PRECHARGE_RAMP_MS) {
+        prechargeState = PRECHARGE_DONE;
+      }
+      // Pack voltage before the BMS has precharged reads as a stuck contactor - P1A3400
+      bool report_link_voltage_low = !BMS_voltage_available || pack_open || prechargeState == PRECHARGE_WAIT;
+      uint16_t link_voltage = battery_voltage ? (uint16_t)(battery_voltage - 1) : 0;
+      if (prechargeState == PRECHARGE_RAMP && !report_link_voltage_low && battery_voltage > 12) {
+        const uint32_t since = currentMillis - prechargeRampStartMillis;
+        uint32_t pct = (since < 100)   ? (62 * since) / 100
+                       : (since < 400) ? 62 + (33 * (since - 100)) / 300
+                                       : 95 + (5 * (since - 400)) / 500;
+        link_voltage = (uint16_t)(12 + ((uint32_t)(link_voltage - 12) * pct) / 100);
+      }
       if (report_link_voltage_low) {
         ATTO_3_441.data.u8[4] = 0x0C;
         ATTO_3_441.data.u8[5] = 0x00;
         ATTO_3_441.data.u8[6] = 0xFF;
         ATTO_3_441.data.u8[7] = 0x87;
       } else {
-        ATTO_3_441.data.u8[4] = (uint8_t)(battery_voltage - 1);
-        ATTO_3_441.data.u8[5] = ((battery_voltage - 1) >> 8);
+        ATTO_3_441.data.u8[4] = (uint8_t)link_voltage;
+        ATTO_3_441.data.u8[5] = (link_voltage >> 8);
         ATTO_3_441.data.u8[6] = 0xFF;
         ATTO_3_441.data.u8[7] = computeBydChecksum(ATTO_3_441.data.u8);
       }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -370,6 +370,13 @@ class BydAttoBattery : public CanBattery {
   static const uint8_t BMS_FEEDBACK_DRIVE_FLAG = 0x02;
   static const uint8_t BMS_FEEDBACK_CHARGE_FLAG = 0x01;
 
+  // Car ramps the link to pack over ~900ms: ~62% at 100ms, ~95% at 400ms
+  static const uint32_t PRECHARGE_RAMP_MS = 900;
+  // BMS never moved - report the link anyway rather than hold the pack open waiting on ourselves
+  static const uint32_t PRECHARGE_WAIT_MAX_MS = 3000;
+  static const uint8_t PRECHARGE_WAIT = 0;                 // closed, BMS hasn't started precharging
+  static const uint8_t PRECHARGE_RAMP = 1;                 // BMS moved, walking the link up to pack
+  static const uint8_t PRECHARGE_DONE = 2;                 // link at pack voltage, latched until the pack opens
   static const int16_t OPEN_MAX_CURRENT_dA = 25;           // Open only below 2.5A
   static const uint32_t ZERO_CURRENT_MIN_WAIT_MS = 5000;   // Let the inverter settle before trusting current
   static const uint32_t ZERO_CURRENT_TIMEOUT_MS = 10000;   // Force the open if current never drops
@@ -380,6 +387,12 @@ class BydAttoBattery : public CanBattery {
 
   uint8_t contactorState = CONTACTORS_CLOSING;  // Boot default: close right away, as before
   uint8_t contactor_feedback = 0;               // Raw 0x344 byte 0
+  uint8_t contactor_feedback_state = 0;         // 0x344 byte 1; 0x00 while open, bit 0x40 once the BMS moves
+  uint8_t prechargeState = PRECHARGE_WAIT;
+  bool prechargeEdgeSeen = false;
+  bool prechargeInitialised = false;
+  unsigned long prechargeRampStartMillis = 0;
+  unsigned long prechargeWaitStartMillis = 0;
   unsigned long contactorStateEntryMillis = 0;
   unsigned long closeConfirmStartMillis = 0;
   unsigned long lastCurrentSampleMillis = 0;

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -423,3 +423,126 @@ TEST_F(BydAtto3BalanceTimeTest, TimesOutAfterOneRetry) {
   EXPECT_EQ(result.received_cells, 0);
   EXPECT_EQ(result.scan_id, 1u);
 }
+
+// TX frame capture injected by the emulated CAN layer (see emul/can.cpp).
+void clear_transmitted_frames();
+const std::vector<CAN_frame>& get_transmitted_frames();
+
+namespace {
+
+const uint16_t kPackVolts = 426;  // 0x441 reports pack - 1
+const uint16_t kLowLink = 12;     // bytes 4-5 = 0x0C 0x00, the floating link
+const uint16_t kNo441 = 0xFFFF;
+
+// 0x344 b0 = contactor feedback, b1 = BMS precharge state: 0x00 open, 0x40 moving, 0x41 running.
+CAN_frame contactor_state_frame(uint8_t b0, uint8_t b1) {
+  return byd_frame(0x344, {b0, b1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+}
+
+// 0x444 sets battery_voltage and BMS_voltage_available; without it 0x441 only ever reports the low link.
+CAN_frame pack_voltage_frame() {
+  return byd_checksummed_frame(
+      0x444, {(uint8_t)(kPackVolts & 0xFF), (uint8_t)((kPackVolts >> 8) & 0x0F), 0x88, 0x13, 0x64, 0x50, 0x00});
+}
+
+void byd_precharge_setup() {
+  reset_byd_state();
+  clear_transmitted_frames();
+  datalayer.system.status.system_status = ACTIVE;
+  datalayer.system.status.inverter_allows_contactor_closing = true;
+  datalayer.system.info.equipment_stop_active = false;
+}
+
+// The RX edge stamps millis(), the ramp reads currentMillis; the test clock has to drive both.
+void rx_at(BydAttoBattery* battery, const CAN_frame& frame, uint32_t ms) {
+  set_millis64(ms);
+  battery->handle_incoming_can_frame(frame);
+}
+
+uint16_t link_on_tick(BydAttoBattery* battery, uint32_t ms) {
+  clear_transmitted_frames();
+  set_millis64(ms);
+  battery->transmit_can(ms);
+  const std::vector<CAN_frame>& frames = get_transmitted_frames();
+  for (size_t i = frames.size(); i > 0; i--) {
+    if (frames[i - 1].ID == 0x441) {
+      return (uint16_t)((frames[i - 1].data.u8[5] << 8) | frames[i - 1].data.u8[4]);
+    }
+  }
+  return kNo441;
+}
+
+// 0x441 is only computed once counter_100ms > 3, so run six 100ms ticks before asserting anything.
+uint16_t warmup(BydAttoBattery* battery, uint8_t b0, uint8_t b1, uint32_t start_ms) {
+  uint16_t link = kNo441;
+  for (uint32_t i = 0; i < 6; i++) {
+    const uint32_t ms = start_ms + i * 100;
+    rx_at(battery, contactor_state_frame(b0, b1), ms);
+    rx_at(battery, pack_voltage_frame(), ms);
+    link = link_on_tick(battery, ms);
+  }
+  return link;
+}
+
+}  // namespace
+
+// Rebooting into a live pack must not fake a precharge. The first 0x344 also carries b1 = 0x41, which
+// looks like a precharge edge, so b0's main-closed bit has to outrank it.
+TEST(BydAtto3PrechargeTests, BootIntoAClosedPackReportsPackVoltageWithoutRamping) {
+  byd_precharge_setup();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  EXPECT_EQ(warmup(battery, 0x84, 0x41, 0), kPackVolts - 1);
+
+  delete battery;
+}
+
+// Boot with the pack open is also CONTACTORS_CLOSING, so the wait timer starts when this block first
+// runs. Timed from uptime 0 instead, a boot slower than 3s times out at once and reports full pack.
+TEST(BydAtto3PrechargeTests, BootWithThePackOpenHoldsTheLowLinkThroughASlowBoot) {
+  byd_precharge_setup();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  EXPECT_EQ(warmup(battery, 0x00, 0x00, 4000), kLowLink);
+  EXPECT_EQ(link_on_tick(battery, 6000), kLowLink);
+
+  delete battery;
+}
+
+// A real close: b1 goes 0x40 well before b0 reports closed, and the car walks the link up over ~900ms.
+// Asserting pack voltage before the BMS has precharged reads as a stuck contactor - P1A3400.
+TEST(BydAtto3PrechargeTests, RampsTheLinkOnlyAfterTheBmsStartsPrecharging) {
+  byd_precharge_setup();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  EXPECT_EQ(warmup(battery, 0x00, 0x00, 0), kLowLink);
+
+  rx_at(battery, contactor_state_frame(0x00, 0x40), 600);
+  EXPECT_EQ(link_on_tick(battery, 600), kLowLink);
+  EXPECT_EQ(link_on_tick(battery, 700), 268);
+  EXPECT_EQ(link_on_tick(battery, 1000), 404);
+  EXPECT_EQ(link_on_tick(battery, 1500), kPackVolts - 1);
+
+  delete battery;
+}
+
+// If the BMS never moves we report the link rather than stall the close, and that has to latch. A late
+// b1 edge dropping 0x441 back to 12V is its own plausibility fault.
+TEST(BydAtto3PrechargeTests, ALateBmsResponseCannotReverseTheReportedLink) {
+  byd_precharge_setup();
+  auto battery = new BydAttoBattery();
+  battery->setup();
+
+  EXPECT_EQ(warmup(battery, 0x00, 0x00, 0), kLowLink);
+  EXPECT_EQ(link_on_tick(battery, 3300), kLowLink);
+  EXPECT_EQ(link_on_tick(battery, 3500), kPackVolts - 1);
+
+  rx_at(battery, contactor_state_frame(0x00, 0x40), 3600);
+  EXPECT_EQ(link_on_tick(battery, 3700), kPackVolts - 1);
+  EXPECT_EQ(link_on_tick(battery, 4000), kPackVolts - 1);
+
+  delete battery;
+}


### PR DESCRIPTION
### What
Report the low link voltage on 0x441 until the BMS has actually started precharging, then ramp it up the way the car does.

### Why
We were asserting full pack voltage on 0x441 before the BMS had precharged, so it saw pack voltage across a contactor it hadn't closed yet and stored `P1A3400 Pre-charge Failure` — and the inrush that implies goes through the main contactor once per charge cycle.

### How
Hold the link low until 0x344 byte 1 shows the BMS moving, then walk it up to pack voltage over 900ms, with the already-closed and slow-boot cases skipping the ramp instead of faking one.

> [!TIP]
> [You can help test this PR with this guide](https://github.com/dalathegreat/Battery-Emulator/blob/main/CONTRIBUTING.md#downloading-a-pull-request-build-to-test-locally-)
