### PR TITLE
Fisker Ocean wake control and UDS diagnostics

### DIFF
--- a/Software/src/battery/FISKER-OCEAN-BATTERY.cpp
+++ b/Software/src/battery/FISKER-OCEAN-BATTERY.cpp
@@ -1,9 +1,7 @@
 #include "FISKER-OCEAN-BATTERY.h"
-#include <cstring>  //For unit test
-#include "../battery/BATTERIES.h"
+#include <cstring>
 #include "../datalayer/datalayer.h"
 #include "../devboard/utils/common_functions.h"  //For CRC table
-#include "../devboard/utils/events.h"
 
 uint8_t expected_CRC(CAN_frame* frame, uint8_t xor_out) {
   //CRC-8, Polynomial = 0x1D, Init = 0xFF, XorOut varies per message
@@ -49,6 +47,10 @@ void FiskerOceanBattery::update_values() {
 
   datalayer.battery.status.voltage_dV = pack_voltage / 10;
 
+  if (datalayer_extended.fiskerOcean.broadcast_soc_valid) {
+    datalayer.battery.status.real_soc = datalayer_extended.fiskerOcean.broadcast_soc_percent * 100;
+  }
+
   datalayer.battery.status.temperature_min_dC = cell_temperature_min_C * 10;
 
   datalayer.battery.status.temperature_max_dC = cell_temperature_max_C * 10;
@@ -57,6 +59,11 @@ void FiskerOceanBattery::update_values() {
 }
 
 void FiskerOceanBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
+  if (handle_incoming_uds_can_frame(rx_frame)) {
+    datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+    return;
+  }
+
   switch (rx_frame.ID) {
     case 0x100:  //BBus 10ms
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -138,6 +145,8 @@ void FiskerOceanBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x2F5:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      datalayer_extended.fiskerOcean.broadcast_soc_percent = rx_frame.data.u8[0];
+      datalayer_extended.fiskerOcean.broadcast_soc_valid = rx_frame.data.u8[0] <= 100;
       break;
     case 0x2F6:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -286,257 +295,6 @@ void FiskerOceanBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
     case 0x6F4:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       break;
-    case 0x7E9:  //BMS reply
-      datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-
-      if (rx_frame.data.u8[0] < 0x10) {  //One line response
-        incoming_poll = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
-      }
-
-      if (rx_frame.data.u8[0] == 0x10) {  //Multiframe response, send ACK
-        transmit_can_frame(&FISKER_PID_ACK);
-        incoming_poll = (rx_frame.data.u8[3] << 8) | rx_frame.data.u8[4];
-      }
-
-      switch (incoming_poll) {
-        case PID_BATTERY_SUM_VOLTAGE:
-          POLL_BATTERY_SUM_VOLTAGE = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
-          break;
-        case PID_BATTERY_CURRENT:
-          POLL_BATTERY_CURRENT = (rx_frame.data.u8[4] << 24) | (rx_frame.data.u8[5] << 16) |
-                                 (rx_frame.data.u8[6] << 8) | (rx_frame.data.u8[7]);
-          break;
-        case PID_BATTERY_CURRENT_VALID:
-          POLL_BATTERY_CURRENT_VALID = (bool)(rx_frame.data.u8[4] & 0x01);
-          break;
-        case PID_DISCHARGE_CURR_LIMIT:
-          //POLL_DISCHARGE_CURR_LIMIT;
-          break;
-        case PID_CHARGE_CURR_LIMIT:
-          //POLL_CHARGE_CURR_LIMIT:
-          break;
-        case PID_CHARGE_OVER_CURR_LIMIT:
-          //POLL_CHARGE_OVER_CURR_LIMIT:
-          break;
-        case PID_HALL_SAMPLE_CURRENT:
-          //POLL_HALL_SAMPLE_CURRENT:
-          break;
-        case PID_CSU_SAMPLE_CURRENT:
-          //POLL_CSU_SAMPLE_CURRENT:
-          break;
-        case PID_CSU_CURRENT_STATE:
-          //POLL_CSU_CURRENT_STATE:
-          break;
-        case PID_INLET_WATER_TEMP:
-          //POLL_INLET_WATER_TEMP:
-          break;
-        case PID_OUTLET_WATER_TEMP:
-          //POLL_OUTLET_WATER_TEMP:
-          break;
-        case PID_MAX_BALANCE_CIRCUIT_TEMP:
-          POLL_MAX_BALANCE_CIRCUIT_TEMP = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
-          break;
-        case PID_SA_LVMD_BAL_TEMP_VALID:    //Multiframe
-          if (rx_frame.data.u8[0] == 10) {  //First frame
-            //POLL_SA_LVMD_BAL_TEMP_VALID =
-            //   (rx_frame.data.u8[5] << 40) | (rx_frame.data.u8[6] << 32) | (rx_frame.data.u8[7] << 24);
-          } else if (rx_frame.data.u8[0] == 21) {  //Second frame
-                                                   // POLL_SA_LVMD_BAL_TEMP_VALID =
-            //    POLL_SA_LVMD_BAL_TEMP_VALID &
-            //    ((rx_frame.data.u8[1] << 16) | (rx_frame.data.u8[2] << 8) | (rx_frame.data.u8[3]));
-          }
-          break;
-        case PID_MAX_CHIP_TEMP:
-          POLL_MAX_CHIP_TEMP = (((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 2) - 40;
-          break;
-        case PID_SA_LVMD_CHIP_INSIDE_TEMP_VALID:
-          if (rx_frame.data.u8[0] == 10) {  //First frame
-            //POLL_SA_LVMD_CHIP_INSIDE_TEMP_VALID =
-            //   (rx_frame.data.u8[5] << 40) | (rx_frame.data.u8[6] << 32) | (rx_frame.data.u8[7] << 24);
-          } else if (rx_frame.data.u8[0] == 21) {  //Second frame
-                                                   // POLL_SA_LVMD_CHIP_INSIDE_TEMP_VALID =
-            //    POLL_SA_LVMD_CHIP_INSIDE_TEMP_VALID &
-            //    ((rx_frame.data.u8[1] << 16) | (rx_frame.data.u8[2] << 8) | (rx_frame.data.u8[3]));
-          }
-          break;
-        case PID_AVG_MODULE_TEMP:
-          POLL_AVG_MODULE_TEMP = (((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 2) - 40;
-          break;
-        case PID_MAX_MODULE_TEMP:
-          POLL_MAX_MODULE_TEMP = (((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 2) - 40;
-          break;
-        case PID_MIN_MODULE_TEMP:
-          POLL_MIN_MODULE_TEMP = (((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]) / 2) - 40;
-          break;
-        case PID_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN:
-          if (rx_frame.data.u8[0] == 10) {  //First frame
-                                            // POLL_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN =
-            //  (rx_frame.data.u8[5] << 40) | (rx_frame.data.u8[6] << 32) | (rx_frame.data.u8[7] << 24);
-          } else if (rx_frame.data.u8[0] == 21) {  //Second frame
-                                                   // POLL_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN =
-            //    POLL_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN &
-            //   ((rx_frame.data.u8[1] << 16) | (rx_frame.data.u8[2] << 8) | (rx_frame.data.u8[3]));
-          }
-          break;
-        case PID_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN:
-          if (rx_frame.data.u8[0] == 10) {  //First frame
-            //POLL_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN =
-            //   (rx_frame.data.u8[5] << 40) | (rx_frame.data.u8[6] << 32) | (rx_frame.data.u8[7] << 24);
-          } else if (rx_frame.data.u8[0] == 21) {  //Second frame
-                                                   // POLL_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN =
-                                                   //   POLL_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN &
-            //  ((rx_frame.data.u8[1] << 16) | (rx_frame.data.u8[2] << 8) | (rx_frame.data.u8[3]));
-          }
-          break;
-        case PID_MODULE_TEMP_VALID:
-          //Very large bitfield, not needed for us to store this much information
-          //(2963.552) RX6 7E9 [8] 10 23 62 20 43 01 00 01
-          //(2963.554) RX6 7E9 [8] 21 00 03 00 00 00 00 00
-          //(2963.554) RX6 7E9 [8] 22 00 00 00 00 00 00 00
-          //(2963.554) RX6 7E9 [8] 23 00 00 00 00 00 00 00
-          //(2963.554) RX6 7E9 [8] 24 00 00 00 00 00 00 00
-          //(2963.554) RX6 7E9 [8] 25 00 AA AA AA AA AA AA
-          break;
-        case PID_MAX_VOLT_CELL_SOC_PERCENT:
-          if (rx_frame.data.u8[0] == 10) {  //First frame only, rest empty
-            POLL_MAX_VOLT_CELL_SOC_PERCENT = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-          }
-          break;
-        case PID_MIN_VOLT_CELL_SOC_PERCENT:
-          if (rx_frame.data.u8[0] == 10) {  //First frame only, rest empty
-            POLL_MIN_VOLT_CELL_SOC_PERCENT = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-          }
-          break;
-        case PID_AVG_VOLT_CELL_SOC_PERCENT:
-          if (rx_frame.data.u8[0] == 10) {  //First frame only, rest empty
-            POLL_AVG_VOLT_CELL_SOC_PERCENT = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-          }
-          break;
-        case PID_PACK_DISPLAY_SOC_PERCENT:
-          if (rx_frame.data.u8[0] == 10) {  //First frame only, rest empty
-            POLL_PACK_DISPLAY_SOC_PERCENT = ((rx_frame.data.u8[5] << 8) | rx_frame.data.u8[6]);
-          }
-          break;
-        case PID_UNEXPECTED_POWER_DOWN_FAULT:
-          POLL_UNEXPECTED_POWER_DOWN_FAULT = rx_frame.data.u8[4];
-          break;
-        case PID_MODULE_TEMP_DAISYCHAIN_UPDATED:
-          //Reply 06 62 20 54 00 26 00 AA
-          //POLL_MODULE_TEMP_DAISYCHAIN_UPDATED;
-          break;
-        case PID_CELL_VOLT_DAISYCHAIN_UPDATED:
-          //Reply 06 62 20 55 00 26 00 AA
-          ///POLL_CELL_VOLT_DAISYCHAIN_UPDATED:
-          break;
-        case PID_CMC_RESET_ERR_FLAG:
-          //POLL_CMC_RESET_ERR_FLAG:
-          break;
-        case PID_VCU_CRASH_MESSAGE_STATUS:
-          //POLL_VCU_CRASH_MESSAGE_STATUS:
-          break;
-        case PID_HARDWARE_SIG_PWM_PERIOD:
-          //POLL_HARDWARE_SIG_PWM_PERIOD:
-          break;
-        case PID_HARDWARE_PWM_DUTY_CYCLE:
-          //POLL_HARDWARE_PWM_DUTY_CYCLE:
-          break;
-        case PID_FORCE_FORBIDDEN_ISO_DETECT_CMD:
-          POLL_FORCE_FORBIDDEN_ISO_DETECT_CMD = rx_frame.data.u8[4];
-          break;
-        case PID_ISOLATION_MEAS_STATUS:
-          POLL_ISOLATION_MEAS_STATUS = rx_frame.data.u8[4];
-          break;
-        case PID_ISOLATION_MEAS_STATE:
-          POLL_ISOLATION_MEAS_STATE = rx_frame.data.u8[4];
-          break;
-        case PID_POS_ISO_MEAS_VOLT_RAW:
-          POLL_POS_ISO_MEAS_VOLT_RAW = ((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);
-          break;
-        case PID_NEG_ISO_MEAS_VOLT_RAW:
-          //POLL_NEG_ISO_MEAS_VOLT_RAW:
-          break;
-        case PID_ISO_MEAS_POS_RES_KOHM:
-          //POLL_ISO_MEAS_POS_RES_KOHM:
-          break;
-        case PID_ISO_MEAS_NEG_RES_KOHM:
-          //POLL_ISO_MEAS_NEG_RES_KOHM:
-          break;
-        case PID_BAL_CIRCUIT_OPEN_ERR_CMC_PSTN:
-          //POLL_BAL_CIRCUIT_OPEN_ERR_CMC_PSTN:
-          break;
-        case PID_BAL_CIRCUIT_OPEN_ERR_CELL_PSTN:
-          //POLL_BAL_CIRCUIT_OPEN_ERR_CELL_PSTN:
-          break;
-        case PID_BAL_CIRCUIT_SHORT_ERR_CMC_PSTN:
-          //POLL_BAL_CIRCUIT_SHORT_ERR_CMC_PSTN:
-          break;
-        case PID_BAL_CIRCUIT_SHORT_ERR_CELL_PSTN:
-          //POLL_BAL_CIRCUIT_SHORT_ERR_CELL_PSTN:
-          break;
-        case PID_VOLT_OR_CURR_CH0_HIGH_VOLT_MV:
-          //POLL_VOLT_OR_CURR_CH0_HIGH_VOLT_MV:
-          break;
-        case PID_VOLT_OR_CURR_CH1_HIGH_VOLT_MV:
-          //POLL_VOLT_OR_CURR_CH1_HIGH_VOLT_MV:
-          break;
-        case PID_BATTERY_TO_G0_VOLT:
-          //POLL_BATTERY_TO_G0_VOLT:
-          break;
-        case PID_PV_POS_TO_G0_VOLT:
-          ////POLL_PV_POS_TO_G0_VOLT:
-          break;
-        case PID_MAIN_POS_TO_G0_VOLT:
-          //POLL_MAIN_POS_TO_G0_VOLT:
-          break;
-        case PID_MAIN_POS_TO_G1_VOLT:
-          //POLL_MAIN_POS_TO_G1_VOLT:
-          break;
-        case PID_KL30C_VOLTAGE:
-          //POLL_KL30C_VOLTAGE:
-          break;
-        case PID_MAX_CELL_VOLT_CMC_AND_POINT_PSTN:
-          //POLL_MAX_CELL_VOLT_CMC_AND_POINT_PSTN:
-          break;
-        case PID_MIN_CELL_VOLT_CMC_AND_POINT_PSTN:
-          //POLL_MIN_CELL_VOLT_CMC_AND_POINT_PSTN:
-          break;
-        case PID_AVG_CELL_VOLTAGE:
-          //POLL_AVG_CELL_VOLTAGE:
-          break;
-        case PID_MAX_CELL_VOLTAGE:
-          //POLL_MAX_CELL_VOLTAGE:
-          break;
-        case PID_MIN_CELL_VOLTAGE:
-          //POLL_MIN_CELL_VOLTAGE:
-          break;
-        case PID_CELL_VOLT_VALID:
-          //POLL_CELL_VOLT_VALID:
-          break;
-        case PID_PV_POS_CONTACTOR_AGING:
-          //POLL_PV_POS_CONTACTOR_AGING:
-          break;
-        case PID_PR_NEG_CONTACTOR_AGING:
-          //POLL_PR_NEG_CONTACTOR_AGING:
-          break;
-        case PID_TIME_STAMP:
-          //POLL_TIME_STAMP:
-          break;
-        case PID_VEHICLE_SPEED:
-          //POLL_VEHICLE_SPEED:
-          break;
-        case PID_ST_MIN:
-          //POLL_ST_MIN:
-          break;
-        case PID_APPLICATION_SOFTWARE_FINGERPRINT:
-          //POLL_APPLICATION_SOFTWARE_FINGERPRINT:
-          break;
-        case PID_VEHICLE_IDENTIFICATION_NUMBER:
-          //POLL_VEHICLE_IDENTIFICATION_NUMBER:
-          break;
-        default:
-          break;
-      }
-      break;
     default:
       //logging.printf("Received unexpected CAN frame with ID: 0x%03X\n", rx_frame.ID);
       break;
@@ -544,37 +302,62 @@ void FiskerOceanBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
 }
 
 void FiskerOceanBattery::transmit_can(unsigned long currentMillis) {
-  // Send 200ms CAN Message
-  if (currentMillis - previousMillis200 >= INTERVAL_200_MS) {
-    previousMillis200 = currentMillis;
+  auto& fisker = datalayer_extended.fiskerOcean;
 
-    // Update current poll from the array
-    currentpoll = poll_commands[poll_index];
-    poll_index = (poll_index + 1) % 36;
-
-    FISKER_PID_REQUEST.data.u8[2] = (uint8_t)((currentpoll & 0xFF00) >> 8);
-    FISKER_PID_REQUEST.data.u8[3] = (uint8_t)(currentpoll & 0x00FF);
-
-    transmit_can_frame(&FISKER_PID_REQUEST);
-  }
-  // Send 1000ms CAN Message
-  if (currentMillis - previousMillis1000 >= INTERVAL_1_S) {
-    previousMillis1000 = currentMillis;
-
-    if (UserRequestDTCreset) {
-      transmit_can_frame(&FISKER_DTC_RESET);
-      UserRequestDTCreset = false;
+  if (fisker.wake_transmit_active) {
+    if (currentMillis - previousMillis093 >= 16) {
+      previousMillis093 = currentMillis;
+      transmit_ready_frame(&FISKER_READY_093, fisker.wake_093_counter, 0xE0, 0xBB);
+    }
+    if (currentMillis - previousMillis333 >= 48) {
+      previousMillis333 = currentMillis;
+      transmit_ready_frame(&FISKER_READY_333, fisker.wake_333_counter, 0xD0, 0x34);
     }
   }
+
+  transmit_uds_can(currentMillis);
 }
 
-void FiskerOceanBattery::setup(void) {  // Performs one time setup at startup
+void FiskerOceanBattery::setup() {
   strncpy(datalayer.system.info.battery_protocol, Name, 63);
   datalayer.system.info.battery_protocol[63] = '\0';
-  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_113S_DV;  //Startout wide
-  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_106S_DV;  //Narrow later if we can detect pack size
+  datalayer.battery.info.max_design_voltage_dV = MAX_PACK_VOLTAGE_113S_DV;
+  datalayer.battery.info.min_design_voltage_dV = MIN_PACK_VOLTAGE_106S_DV;
   datalayer.battery.info.max_cell_voltage_mV = MAX_CELL_VOLTAGE_MV;
   datalayer.battery.info.min_cell_voltage_mV = MIN_CELL_VOLTAGE_MV;
   datalayer.battery.info.max_cell_voltage_deviation_mV = MAX_CELL_DEVIATION_MV;
   datalayer.system.status.battery_allows_contactor_closing = true;
+
+  auto& fisker = datalayer_extended.fiskerOcean;
+  for (uint8_t i = 0; i < DATALAYER_INFO_FISKER_OCEAN::DID_COUNT; i++) {
+    fisker.did_results[i].did = poll_commands[i];
+  }
+
+  setup_uds(0x7E1, 0x7E9);
+  set_pid_scan_list(poll_commands, DATALAYER_INFO_FISKER_OCEAN::DID_COUNT);
+  reset_DTC();
+}
+
+uint16_t FiskerOceanBattery::handle_pid(uint16_t pid, uint32_t value, const uint8_t* data, uint16_t length) {
+  (void)value;
+  for (uint8_t i = 0; i < DATALAYER_INFO_FISKER_OCEAN::DID_COUNT; i++) {
+    auto& result = datalayer_extended.fiskerOcean.did_results[i];
+    if (result.did != pid)
+      continue;
+
+    result.payload_length = min(length, static_cast<uint16_t>(DATALAYER_INFO_FISKER_OCEAN::MAX_DID_PAYLOAD));
+    memcpy(result.payload, data, result.payload_length);
+    result.last_update_ms = millis();
+    result.valid = true;
+    break;
+  }
+  return 0;
+}
+
+void FiskerOceanBattery::transmit_ready_frame(CAN_frame* frame, uint8_t& counter, uint8_t high_nibble,
+                                              uint8_t xor_out) {
+  frame->data.u8[1] = high_nibble | counter;
+  frame->data.u8[0] = expected_CRC(frame, xor_out);
+  transmit_can_frame(frame);
+  counter = counter >= 0x0E ? 0 : counter + 1;
 }

--- a/Software/src/battery/FISKER-OCEAN-BATTERY.h
+++ b/Software/src/battery/FISKER-OCEAN-BATTERY.h
@@ -1,259 +1,66 @@
 #ifndef FISKER_OCEAN_BATTERY_H
 #define FISKER_OCEAN_BATTERY_H
 
-#include "CanBattery.h"
+#include "FISKER-OCEAN-HTML.h"
+#include "UdsCanBattery.h"
 
-class FiskerOceanBattery : public CanBattery {
+class FiskerOceanBattery : public UdsCanBattery {
  public:
-  virtual void setup(void);
-  virtual void handle_incoming_can_frame(CAN_frame rx_frame);
-  virtual void update_values();
-  virtual void transmit_can(unsigned long currentMillis);
+  FiskerOceanBattery() : renderer(&datalayer_extended.fiskerOcean) { dtc = &datalayer.battery.dtc; }
+
+  void setup() override;
+  void handle_incoming_can_frame(CAN_frame rx_frame) override;
+  void update_values() override;
+  void transmit_can(unsigned long currentMillis) override;
   static constexpr const char* Name = "Fisker Ocean 113/106kWh battery";
 
-  bool supports_reset_DTC() { return true; }
-  void reset_DTC() { UserRequestDTCreset = true; }
+  bool supports_contactor_close() override { return true; }
+  void request_open_contactors() override { datalayer_extended.fiskerOcean.wake_transmit_active = false; }
+  void request_close_contactors() override { datalayer_extended.fiskerOcean.wake_transmit_active = true; }
+  BatteryHtmlRenderer& get_status_renderer() override { return renderer; }
+
+ protected:
+  uint16_t handle_pid(uint16_t pid, uint32_t value, const uint8_t* data, uint16_t length) override;
 
  private:
-  bool UserRequestDTCreset = true;       //Default on to always clear DTC once on startup
-  unsigned long previousMillis200 = 0;   // will store last time a 200ms CAN Message was send
-  unsigned long previousMillis1000 = 0;  // will store last time a 1s CAN Message was sent
+  FiskerOceanHtmlRenderer renderer;
+  unsigned long previousMillis093 = 0;
+  unsigned long previousMillis333 = 0;
 
-  const uint16_t CELLVOLTAGE_FRAME_START = 0x6B0;
-  const uint16_t CELLVOLTAGE_FRAME_END = 0x6C9;  // last frame, only 2 valid cells
-  const uint16_t NUM_CELLS = 102;
+  static constexpr uint16_t CELLVOLTAGE_FRAME_START = 0x6B0;
+  static constexpr uint16_t NUM_CELLS = 102;
 
-  //113 kWh
-  static const int MAX_PACK_VOLTAGE_113S_DV = 5000;  //TODO
-  static const int MIN_PACK_VOLTAGE_113S_DV = 2500;  //TODO
-  static const int MAX_CAPACITY_113S_WH = 113000;
-  //106 kWh
-  static const int MAX_PACK_VOLTAGE_106S_DV = 5000;  //TODO
-  static const int MIN_PACK_VOLTAGE_106S_DV = 2500;  //TODO
-  static const int MAX_CAPACITY_106S_WH = 106000;
-  //Common
-  static const int MAX_CELL_DEVIATION_MV = 250;
-  static const int MAX_CELL_VOLTAGE_MV = 4250;
-  static const int MIN_CELL_VOLTAGE_MV = 2900;
+  static constexpr int MAX_PACK_VOLTAGE_113S_DV = 5000;
+  static constexpr int MIN_PACK_VOLTAGE_106S_DV = 2500;
+  static constexpr int MAX_CELL_DEVIATION_MV = 250;
+  static constexpr int MAX_CELL_VOLTAGE_MV = 4250;
+  static constexpr int MIN_CELL_VOLTAGE_MV = 2900;
 
   int16_t cell_temperature_max_C = 0;
   int16_t cell_temperature_min_C = 0;
   uint16_t pack_voltage = 37000;
 
-  static const uint16_t PID_BATTERY_SUM_VOLTAGE = 0x2003;
-  static const uint16_t PID_BATTERY_CURRENT = 0x2004;
-  static const uint16_t PID_BATTERY_CURRENT_VALID = 0x2005;
-  static const uint16_t PID_DISCHARGE_CURR_LIMIT = 0x2008;
-  static const uint16_t PID_CHARGE_CURR_LIMIT = 0x2009;
-  static const uint16_t PID_CHARGE_OVER_CURR_LIMIT = 0x2011;
-  static const uint16_t PID_HALL_SAMPLE_CURRENT = 0x2016;
-  static const uint16_t PID_CSU_SAMPLE_CURRENT = 0x2019;
-  static const uint16_t PID_CSU_CURRENT_STATE = 0x2024;
-  static const uint16_t PID_INLET_WATER_TEMP = 0x2026;
-  static const uint16_t PID_OUTLET_WATER_TEMP = 0x2027;
-  static const uint16_t PID_MAX_BALANCE_CIRCUIT_TEMP = 0x2031;
-  static const uint16_t PID_SA_LVMD_BAL_TEMP_VALID = 0x2032;
-  static const uint16_t PID_MAX_CHIP_TEMP = 0x2033;
-  static const uint16_t PID_SA_LVMD_CHIP_INSIDE_TEMP_VALID = 0x2034;
-  static const uint16_t PID_AVG_MODULE_TEMP = 0x2038;
-  static const uint16_t PID_MAX_MODULE_TEMP = 0x2039;
-  static const uint16_t PID_MIN_MODULE_TEMP = 0x2040;
-  static const uint16_t PID_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN = 0x2041;
-  static const uint16_t PID_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN = 0x2042;
-  static const uint16_t PID_MODULE_TEMP_VALID = 0x2043;
-  static const uint16_t PID_MAX_VOLT_CELL_SOC_PERCENT = 0x2047;
-  static const uint16_t PID_MIN_VOLT_CELL_SOC_PERCENT = 0x2048;
-  static const uint16_t PID_AVG_VOLT_CELL_SOC_PERCENT = 0x2049;
-  static const uint16_t PID_PACK_DISPLAY_SOC_PERCENT = 0x2050;
-  static const uint16_t PID_UNEXPECTED_POWER_DOWN_FAULT = 0x2053;
-  static const uint16_t PID_MODULE_TEMP_DAISYCHAIN_UPDATED = 0x2054;
-  static const uint16_t PID_CELL_VOLT_DAISYCHAIN_UPDATED = 0x2055;
-  static const uint16_t PID_CMC_RESET_ERR_FLAG = 0x2056;
-  static const uint16_t PID_VCU_CRASH_MESSAGE_STATUS = 0x2057;
-  static const uint16_t PID_HARDWARE_SIG_PWM_PERIOD = 0x2058;
-  static const uint16_t PID_HARDWARE_PWM_DUTY_CYCLE = 0x2059;
-  static const uint16_t PID_FORCE_FORBIDDEN_ISO_DETECT_CMD = 0x2060;
-  static const uint16_t PID_ISOLATION_MEAS_STATUS = 0x2061;
-  static const uint16_t PID_ISOLATION_MEAS_STATE = 0x2062;
-  static const uint16_t PID_POS_ISO_MEAS_VOLT_RAW = 0x2063;
-  static const uint16_t PID_NEG_ISO_MEAS_VOLT_RAW = 0x2064;
-  static const uint16_t PID_ISO_MEAS_POS_RES_KOHM = 0x2069;
-  static const uint16_t PID_ISO_MEAS_NEG_RES_KOHM = 0x2070;
-  static const uint16_t PID_BAL_CIRCUIT_OPEN_ERR_CMC_PSTN = 0x2078;
-  static const uint16_t PID_BAL_CIRCUIT_OPEN_ERR_CELL_PSTN = 0x2079;
-  static const uint16_t PID_BAL_CIRCUIT_SHORT_ERR_CMC_PSTN = 0x2080;
-  static const uint16_t PID_BAL_CIRCUIT_SHORT_ERR_CELL_PSTN = 0x2081;
-  static const uint16_t PID_VOLT_OR_CURR_CH0_HIGH_VOLT_MV = 0x2089;
-  static const uint16_t PID_VOLT_OR_CURR_CH1_HIGH_VOLT_MV = 0x2090;
-  static const uint16_t PID_BATTERY_TO_G0_VOLT = 0x2107;
-  static const uint16_t PID_PV_POS_TO_G0_VOLT = 0x2108;
-  static const uint16_t PID_MAIN_POS_TO_G0_VOLT = 0x2109;
-  static const uint16_t PID_MAIN_POS_TO_G1_VOLT = 0x2117;
-  static const uint16_t PID_KL30C_VOLTAGE = 0x2130;
-  static const uint16_t PID_MAX_CELL_VOLT_CMC_AND_POINT_PSTN = 0x2133;
-  static const uint16_t PID_MIN_CELL_VOLT_CMC_AND_POINT_PSTN = 0x2134;
-  static const uint16_t PID_AVG_CELL_VOLTAGE = 0x2136;
-  static const uint16_t PID_MAX_CELL_VOLTAGE = 0x2137;
-  static const uint16_t PID_MIN_CELL_VOLTAGE = 0x2138;
-  static const uint16_t PID_CELL_VOLT_VALID = 0x2143;
-  static const uint16_t PID_PV_POS_CONTACTOR_AGING = 0x2144;
-  static const uint16_t PID_PR_NEG_CONTACTOR_AGING = 0x2145;
-  static const uint16_t PID_TIME_STAMP = 0xEEF6;
-  static const uint16_t PID_VEHICLE_SPEED = 0xEEF7;
-  static const uint16_t PID_ST_MIN = 0xEFFE;
-  static const uint16_t PID_APPLICATION_SOFTWARE_FINGERPRINT = 0xF184;
-  static const uint16_t PID_VEHICLE_IDENTIFICATION_NUMBER = 0xF190;
+  static constexpr uint16_t poll_commands[DATALAYER_INFO_FISKER_OCEAN::DID_COUNT] = {
+      0x2003, 0x2004, 0x2005, 0x2008, 0x2009, 0x2011, 0x2016, 0x2019, 0x2024, 0x2026, 0x2027, 0x2031,
+      0x2032, 0x2033, 0x2034, 0x2038, 0x2039, 0x2040, 0x2041, 0x2042, 0x2043, 0x2047, 0x2048, 0x2049,
+      0x2050, 0x2053, 0x2054, 0x2055, 0x2056, 0x2057, 0x2058, 0x2059, 0x2060, 0x2061, 0x2062, 0x2063,
+      0x2064, 0x2069, 0x2070, 0x2078, 0x2079, 0x2080, 0x2081, 0x2089, 0x2090, 0x2091, 0x2092, 0x2093,
+      0x2094, 0x2107, 0x2108, 0x2109, 0x2117, 0x2130, 0x2133, 0x2134, 0x2136, 0x2137, 0x2138, 0x2143,
+      0x2144, 0x2145, 0xEFF6, 0xEFF7, 0xEFF8, 0xEFF9, 0xEFFE, 0xF040, 0xF055, 0xF060, 0xF184, 0xF190};
 
-  uint16_t POLL_BATTERY_SUM_VOLTAGE = 0;
-  int32_t POLL_BATTERY_CURRENT = 0;
-  bool POLL_BATTERY_CURRENT_VALID = 0;
-  uint16_t POLL_DISCHARGE_CURR_LIMIT = 0;
-  uint16_t POLL_CHARGE_CURR_LIMIT = 0;
-  uint16_t POLL_CHARGE_OVER_CURR_LIMIT = 0;
-  uint16_t POLL_HALL_SAMPLE_CURRENT = 0;
-  uint16_t POLL_CSU_SAMPLE_CURRENT = 0;
-  uint16_t POLL_CSU_CURRENT_STATE = 0;
-  uint16_t POLL_INLET_WATER_TEMP = 0;
-  uint16_t POLL_OUTLET_WATER_TEMP = 0;
-  uint16_t POLL_MAX_BALANCE_CIRCUIT_TEMP = 0;
-  uint64_t POLL_SA_LVMD_BAL_TEMP_VALID = 0;
-  int16_t POLL_MAX_CHIP_TEMP = 0;
-  uint64_t POLL_SA_LVMD_CHIP_INSIDE_TEMP_VALID = 0;
-  int16_t POLL_AVG_MODULE_TEMP = 0;
-  int16_t POLL_MAX_MODULE_TEMP = 0;
-  int16_t POLL_MIN_MODULE_TEMP = 0;
-  uint64_t POLL_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN = 0;
-  uint64_t POLL_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN = 0;
-  uint16_t POLL_MAX_VOLT_CELL_SOC_PERCENT = 0;
-  uint16_t POLL_MIN_VOLT_CELL_SOC_PERCENT = 0;
-  uint16_t POLL_AVG_VOLT_CELL_SOC_PERCENT = 0;
-  uint16_t POLL_PACK_DISPLAY_SOC_PERCENT = 0;
-  uint8_t POLL_UNEXPECTED_POWER_DOWN_FAULT = 0;
-  uint16_t POLL_MODULE_TEMP_DAISYCHAIN_UPDATED = 0;
-  uint16_t POLL_CELL_VOLT_DAISYCHAIN_UPDATED = 0;
-  uint16_t POLL_CMC_RESET_ERR_FLAG = 0;
-  uint16_t POLL_VCU_CRASH_MESSAGE_STATUS = 0;
-  uint16_t POLL_HARDWARE_SIG_PWM_PERIOD = 0;
-  uint16_t POLL_HARDWARE_PWM_DUTY_CYCLE = 0;
-  uint8_t POLL_FORCE_FORBIDDEN_ISO_DETECT_CMD = 0;
-  uint8_t POLL_ISOLATION_MEAS_STATUS = 0;
-  uint8_t POLL_ISOLATION_MEAS_STATE = 0;
-  uint16_t POLL_POS_ISO_MEAS_VOLT_RAW = 0;
-  uint16_t POLL_NEG_ISO_MEAS_VOLT_RAW = 0;
-  uint16_t POLL_ISO_MEAS_POS_RES_KOHM = 0;
-  uint16_t POLL_ISO_MEAS_NEG_RES_KOHM = 0;
-  uint16_t POLL_BAL_CIRCUIT_OPEN_ERR_CMC_PSTN = 0;
-  uint16_t POLL_BAL_CIRCUIT_OPEN_ERR_CELL_PSTN = 0;
-  uint16_t POLL_BAL_CIRCUIT_SHORT_ERR_CMC_PSTN = 0;
-  uint16_t POLL_BAL_CIRCUIT_SHORT_ERR_CELL_PSTN = 0;
-  uint16_t POLL_VOLT_OR_CURR_CH0_HIGH_VOLT_MV = 0;
-  uint16_t POLL_VOLT_OR_CURR_CH1_HIGH_VOLT_MV = 0;
-  uint16_t POLL_BATTERY_TO_G0_VOLT = 0;
-  uint16_t POLL_PV_POS_TO_G0_VOLT = 0;
-  uint16_t POLL_MAIN_POS_TO_G0_VOLT = 0;
-  uint16_t POLL_MAIN_POS_TO_G1_VOLT = 0;
-  uint16_t POLL_KL30C_VOLTAGE = 0;
-  uint16_t POLL_MAX_CELL_VOLT_CMC_AND_POINT_PSTN = 0;
-  uint16_t POLL_MIN_CELL_VOLT_CMC_AND_POINT_PSTN = 0;
-  uint16_t POLL_AVG_CELL_VOLTAGE = 0;
-  uint16_t POLL_MAX_CELL_VOLTAGE = 0;
-  uint16_t POLL_MIN_CELL_VOLTAGE = 0;
-  bool POLL_CELL_VOLT_VALID = 0;
-  uint16_t POLL_PV_POS_CONTACTOR_AGING = 0;
-  uint16_t POLL_PR_NEG_CONTACTOR_AGING = 0;
-  uint16_t POLL_TIME_STAMP = 0;
-  uint16_t POLL_VEHICLE_SPEED = 0;
-  uint16_t POLL_ST_MIN = 0;
-  uint16_t POLL_APPLICATION_SOFTWARE_FINGERPRINT = 0;
-  uint16_t POLL_VEHICLE_IDENTIFICATION_NUMBER = 0;
-
-  CAN_frame FISKER_PID_REQUEST = {.FD = false,
-                                  .ext_ID = false,
-                                  .DLC = 8,
-                                  .ID = 0x7E1,
-                                  .data = {0x03, 0x22, 0x20, 0x03, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FISKER_PID_ACK = {.FD = false,
-                              .ext_ID = false,
-                              .DLC = 8,
-                              .ID = 0x7E1,
-                              .data = {0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FISKER_DTC_RESET = {.FD = false,
+  CAN_frame FISKER_READY_093 = {
+      .FD = true,
+      .ext_ID = false,
+      .DLC = 16,
+      .ID = 0x093,
+      .data = {0x8A, 0xE0, 0x11, 0xFF, 0x22, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF}};
+  CAN_frame FISKER_READY_333 = {.FD = true,
                                 .ext_ID = false,
                                 .DLC = 8,
-                                .ID = 0x7E1,
-                                .data = {0x04, 0x14, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00}};
-  CAN_frame FISKER_EXTENDED_DIAG_SESSION = {.FD = false,
-                                            .ext_ID = false,
-                                            .DLC = 8,
-                                            .ID = 0x7E1,
-                                            .data = {0x02, 0x10, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}};
+                                .ID = 0x333,
+                                .data = {0x03, 0xD0, 0x55, 0xAD, 0x96, 0xFF, 0xFF, 0xFF}};
 
-  uint16_t currentpoll = PID_BATTERY_SUM_VOLTAGE;
-  uint16_t incoming_poll = 0;
-  uint8_t poll_index = 0;
-  const uint16_t poll_commands[63] = {PID_BATTERY_SUM_VOLTAGE,
-                                      PID_BATTERY_CURRENT,
-                                      PID_BATTERY_CURRENT_VALID,
-                                      PID_DISCHARGE_CURR_LIMIT,
-                                      PID_CHARGE_CURR_LIMIT,
-                                      PID_CHARGE_OVER_CURR_LIMIT,
-                                      PID_HALL_SAMPLE_CURRENT,
-                                      PID_CSU_SAMPLE_CURRENT,
-                                      PID_CSU_CURRENT_STATE,
-                                      PID_INLET_WATER_TEMP,
-                                      PID_OUTLET_WATER_TEMP,
-                                      PID_MAX_BALANCE_CIRCUIT_TEMP,
-                                      PID_SA_LVMD_BAL_TEMP_VALID,
-                                      PID_MAX_CHIP_TEMP,
-                                      PID_SA_LVMD_CHIP_INSIDE_TEMP_VALID,
-                                      PID_AVG_MODULE_TEMP,
-                                      PID_MAX_MODULE_TEMP,
-                                      PID_MIN_MODULE_TEMP,
-                                      PID_MAX_MODULE_TEMP_CMC_AND_POINT_PSTN,
-                                      PID_MIN_MODULE_TEMP_CMC_AND_POINT_PSTN,
-                                      PID_MODULE_TEMP_VALID,
-                                      PID_MAX_VOLT_CELL_SOC_PERCENT,
-                                      PID_MIN_VOLT_CELL_SOC_PERCENT,
-                                      PID_AVG_VOLT_CELL_SOC_PERCENT,
-                                      PID_PACK_DISPLAY_SOC_PERCENT,
-                                      PID_UNEXPECTED_POWER_DOWN_FAULT,
-                                      PID_MODULE_TEMP_DAISYCHAIN_UPDATED,
-                                      PID_CELL_VOLT_DAISYCHAIN_UPDATED,
-                                      PID_CMC_RESET_ERR_FLAG,
-                                      PID_VCU_CRASH_MESSAGE_STATUS,
-                                      PID_HARDWARE_SIG_PWM_PERIOD,
-                                      PID_HARDWARE_PWM_DUTY_CYCLE,
-                                      PID_FORCE_FORBIDDEN_ISO_DETECT_CMD,
-                                      PID_ISOLATION_MEAS_STATUS,
-                                      PID_ISOLATION_MEAS_STATE,
-                                      PID_POS_ISO_MEAS_VOLT_RAW,
-                                      PID_NEG_ISO_MEAS_VOLT_RAW,
-                                      PID_ISO_MEAS_POS_RES_KOHM,
-                                      PID_ISO_MEAS_NEG_RES_KOHM,
-                                      PID_BAL_CIRCUIT_OPEN_ERR_CMC_PSTN,
-                                      PID_BAL_CIRCUIT_OPEN_ERR_CELL_PSTN,
-                                      PID_BAL_CIRCUIT_SHORT_ERR_CMC_PSTN,
-                                      PID_BAL_CIRCUIT_SHORT_ERR_CELL_PSTN,
-                                      PID_VOLT_OR_CURR_CH0_HIGH_VOLT_MV,
-                                      PID_VOLT_OR_CURR_CH1_HIGH_VOLT_MV,
-                                      PID_BATTERY_TO_G0_VOLT,
-                                      PID_PV_POS_TO_G0_VOLT,
-                                      PID_MAIN_POS_TO_G0_VOLT,
-                                      PID_MAIN_POS_TO_G1_VOLT,
-                                      PID_KL30C_VOLTAGE,
-                                      PID_MAX_CELL_VOLT_CMC_AND_POINT_PSTN,
-                                      PID_MIN_CELL_VOLT_CMC_AND_POINT_PSTN,
-                                      PID_AVG_CELL_VOLTAGE,
-                                      PID_MAX_CELL_VOLTAGE,
-                                      PID_MIN_CELL_VOLTAGE,
-                                      PID_CELL_VOLT_VALID,
-                                      PID_PV_POS_CONTACTOR_AGING,
-                                      PID_PR_NEG_CONTACTOR_AGING,
-                                      PID_TIME_STAMP,
-                                      PID_VEHICLE_SPEED,
-                                      PID_ST_MIN,
-                                      PID_APPLICATION_SOFTWARE_FINGERPRINT,
-                                      PID_VEHICLE_IDENTIFICATION_NUMBER};
+  void transmit_ready_frame(CAN_frame* frame, uint8_t& counter, uint8_t high_nibble, uint8_t xor_out);
 };
 
 #endif

--- a/Software/src/battery/FISKER-OCEAN-HTML.h
+++ b/Software/src/battery/FISKER-OCEAN-HTML.h
@@ -1,0 +1,213 @@
+#ifndef FISKER_OCEAN_HTML_H
+#define FISKER_OCEAN_HTML_H
+
+#include <Arduino.h>
+#include "../datalayer/datalayer.h"
+#include "../datalayer/datalayer_extended.h"
+#include "../devboard/webserver/BatteryHtmlRenderer.h"
+
+class FiskerOceanHtmlRenderer : public BatteryHtmlRenderer {
+ public:
+  explicit FiskerOceanHtmlRenderer(DATALAYER_INFO_FISKER_OCEAN* data) : fisker(data) {}
+
+  bool renders_own_battery_data() { return true; }
+
+  String get_status_html() {
+    String content;
+    content.reserve(12000);
+    content += "<h4>State of charge: ";
+    content += fisker->broadcast_soc_valid ? String(fisker->broadcast_soc_percent) + "%" : "Not available";
+    content += "</h4>";
+
+    content +=
+        "<div style='overflow-x:auto'><table><thead><tr><th>PID</th><th>CAN response</th>"
+        "</tr></thead><tbody>";
+    for (uint8_t i = 0; i < DATALAYER_INFO_FISKER_OCEAN::DID_COUNT; i++) {
+      const auto& result = fisker->did_results[i];
+      add_did_row(content, result);
+    }
+    content += "</tbody></table></div>";
+    content += BatteryHtmlRenderer::render_dtc_section_html(datalayer.battery.dtc, "fisker_ocean_dtc.json", true);
+    return content;
+  }
+
+ private:
+  DATALAYER_INFO_FISKER_OCEAN* fisker;
+
+  static void add_did_row(String& content, const DATALAYER_INFO_FISKER_OCEAN::DID_RESULT& result) {
+    char did[7];
+    snprintf(did, sizeof(did), "0x%04X", result.did);
+    content += "<tr><td style='text-align:left'><strong>" + String(did_name(result.did)) + "</strong><br><code>" +
+               String(did) + "</code></td><td>";
+    content += "<code>" + can_response(result) + "</code></td></tr>";
+  }
+
+  static String can_response(const DATALAYER_INFO_FISKER_OCEAN::DID_RESULT& result) {
+    if (!result.valid)
+      return "No response";
+    String text = "0x7E9: 62 ";
+    char bytes[4];
+    snprintf(bytes, sizeof(bytes), "%02X ", result.did >> 8);
+    text += bytes;
+    snprintf(bytes, sizeof(bytes), "%02X", result.did & 0xFF);
+    text += bytes;
+    for (uint8_t i = 0; i < result.payload_length; i++) {
+      snprintf(bytes, sizeof(bytes), " %02X", result.payload[i]);
+      text += bytes;
+    }
+    return text;
+  }
+
+  static const char* did_name(uint16_t did) {
+    switch (did) {
+      case 0x2003:
+        return "BatterySumVoltage";
+      case 0x2004:
+        return "BatteryCurrent";
+      case 0x2005:
+        return "BatteryCurrentValid";
+      case 0x2008:
+        return "DischrgCurrLimShortValueBranch";
+      case 0x2009:
+        return "RechrgCurrLimShortValueShortBranch";
+      case 0x2011:
+        return "ChrgOverCurrLimtBranch";
+      case 0x2016:
+        return "HALLSampleCurrentBranchA";
+      case 0x2019:
+        return "CSUSampleCurrentBranchA";
+      case 0x2024:
+        return "CSUCurrentStateBranchA";
+      case 0x2026:
+        return "InletWaterTem";
+      case 0x2027:
+        return "OutletWaterTem";
+      case 0x2031:
+        return "MaxBalanceCircuitTem";
+      case 0x2032:
+        return "SaLVMD_BalTempVld";
+      case 0x2033:
+        return "MaxChipTemp";
+      case 0x2034:
+        return "SaLVMD_Chip17823InsideTempVld";
+      case 0x2038:
+        return "AvgModuleTempDegC";
+      case 0x2039:
+        return "MaxModuleTempDegC";
+      case 0x2040:
+        return "MinModuleTempDegC";
+      case 0x2041:
+        return "MaxModuleTempCMCAndPointPstn";
+      case 0x2042:
+        return "MinModuleTempCMCAndPointPstn";
+      case 0x2043:
+        return "ModuleTempVld";
+      case 0x2047:
+        return "MaxVoltCellSOCPct";
+      case 0x2048:
+        return "MinVoltCellSOCPct";
+      case 0x2049:
+        return "AvgVoltCellSOCPct";
+      case 0x2050:
+        return "PackDispSOCPct";
+      case 0x2053:
+        return "UnExpectPowerDownFlt";
+      case 0x2054:
+        return "ModuleTempDaisyChainUpdated";
+      case 0x2055:
+        return "CellVoltDaisyChainUpdated";
+      case 0x2056:
+        return "CMCResetErrFlag";
+      case 0x2057:
+        return "VCU_CrashMsg_St";
+      case 0x2058:
+        return "HardwireSigPWMPeriod";
+      case 0x2059:
+        return "HardwirePWMDutyCycle";
+      case 0x2060:
+        return "ForceForbidIsoDetectCmd";
+      case 0x2061:
+        return "IsoMeasStatus";
+      case 0x2062:
+        return "IsoMeasState";
+      case 0x2063:
+        return "PosIsoMeasVoltRaw";
+      case 0x2064:
+        return "NegIsoMeasVoltRaw";
+      case 0x2069:
+        return "IsoMeasPosResKOhm";
+      case 0x2070:
+        return "IsoMeasNegResKOhm";
+      case 0x2078:
+        return "BalCircuitOpenErrCMCPstn";
+      case 0x2079:
+        return "BalCircuitOpenErrCellPstn";
+      case 0x2080:
+        return "BalCircuitShortErrCMCPstn";
+      case 0x2081:
+        return "BalCircuitShortErrCellPstn";
+      case 0x2089:
+        return "VoltOrCurrCh0HighVoltMv";
+      case 0x2090:
+        return "VoltOrCurrCh1HighVoltMv";
+      case 0x2091:
+        return "VoltOrCurrCh2HighVoltMv";
+      case 0x2092:
+        return "VoltOrCurrCh0LowVoltMv";
+      case 0x2093:
+        return "VoltOrCurrCh1LowVoltMv";
+      case 0x2094:
+        return "VoltOrCurrCh2LowVoltMv";
+      case 0x2107:
+        return "BatteryToG0Volt";
+      case 0x2108:
+        return "PVPosToG0Volt";
+      case 0x2109:
+        return "MainPosToG0Volt";
+      case 0x2117:
+        return "MainPosToG1Volt";
+      case 0x2130:
+        return "KL30CVoltage";
+      case 0x2133:
+        return "MaxCellVoltCMCAndPointPstn";
+      case 0x2134:
+        return "MinCellVoltCMCAndPointPstn";
+      case 0x2136:
+        return "AvgCellVolt";
+      case 0x2137:
+        return "MaxCellVoltMv";
+      case 0x2138:
+        return "MinCellVoltMv";
+      case 0x2143:
+        return "CellVoltVld";
+      case 0x2144:
+        return "PVPosContactorAging";
+      case 0x2145:
+        return "PVNegContactorAging";
+      case 0xEFF6:
+        return "TimeStamp";
+      case 0xEFF7:
+        return "VehicleSpeed";
+      case 0xEFF8:
+        return "Mileage";
+      case 0xEFF9:
+        return "BatteryVoltage";
+      case 0xEFFE:
+        return "STMin";
+      case 0xF040:
+        return "PVIUcontrol";
+      case 0xF055:
+        return "shippingmode";
+      case 0xF060:
+        return "Contactor_Control_Read";
+      case 0xF184:
+        return "ApplicationSoftwareFingerprint";
+      case 0xF190:
+        return "VehicleIdentificationNumber";
+      default:
+        return "Unknown";
+    }
+  }
+};
+
+#endif

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -280,6 +280,26 @@ struct DATALAYER_INFO_CELLPOWER {
   bool warning_Charger_not_responding;
 };
 
+struct DATALAYER_INFO_FISKER_OCEAN {
+  static constexpr uint8_t DID_COUNT = 72;
+  static constexpr uint8_t MAX_DID_PAYLOAD = 40;
+
+  struct DID_RESULT {
+    uint16_t did;
+    uint8_t payload[MAX_DID_PAYLOAD];
+    uint8_t payload_length;
+    uint32_t last_update_ms;
+    bool valid;
+  };
+
+  DID_RESULT did_results[DID_COUNT];
+  bool wake_transmit_active;
+  uint8_t wake_093_counter;
+  uint8_t wake_333_counter;
+  uint8_t broadcast_soc_percent;
+  bool broadcast_soc_valid;
+};
+
 struct DATALAYER_INFO_CHADEMO {
   uint8_t CHADEMO_Status;
   uint8_t ControlProtocolNumberEV;
@@ -990,6 +1010,7 @@ class DataLayerExtended {
     DATALAYER_INFO_CHADEMO chademo;
     DATALAYER_INFO_ECMP stellantisECMP;
     DATALAYER_INFO_FORD_MACH_E fordMachE;
+    DATALAYER_INFO_FISKER_OCEAN fiskerOcean;
     DATALAYER_INFO_GEELY_GEOMETRY_C geometryC;
     struct {
       DATALAYER_INFO_KIAHYUNDAI64 KiaHyundai64;


### PR DESCRIPTION
Adds the confirmed Fisker Ocean development updates to PR #2416:\n\n- transmit CAN-FD READY frames 0x093 at 16 ms and 0x333 at 48 ms while contactor close is requested\n- regenerate the confirmed rolling counters and CRC-8 values\n- decode broadcast SOC from 0x2F5\n- use the shared UdsCanBattery framework for periodic DID polling, ISO-TP, retries, DTC reading and DTC clearing\n- retain the PR's one-time startup DTC clear\n- show all known Fisker DID names and raw responses in More Battery Info\n- use the existing Fisker DTC JSON descriptions and standard DTC controls\n\nValidation: pio run -e lilygo_2CAN_330 succeeds. Hardware validation against a Fisker pack remains required.