### PR TITLE
feat(renault-zoe-gen1): transmit missing broadcast frames 

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -179,6 +179,23 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
       ZOE_423.data.u8[6] = 0x5D;
     }
     counter_423 = (counter_423 + 1) % 10;
+
+    // Broadcast 100ms vehicle frames (PEB Inverter 0x19F, EVC Power Mux 0x426, EVC Status 0x436)
+    ZOE_19F_INVERTER.data.u8[3] = (zoe_19F_counter++ & 0x0F);
+    transmit_can_frame(&ZOE_19F_INVERTER);
+
+    transmit_can_frame(&ZOE_426_POWER_MUX);
+
+    zoe_436_counter++;
+    ZOE_436_VEHICLE_STATUS.data.u8[2] = (zoe_436_counter >> 8) & 0xFF;
+    ZOE_436_VEHICLE_STATUS.data.u8[3] = zoe_436_counter & 0xFF;
+    transmit_can_frame(&ZOE_436_VEHICLE_STATUS);
+  }
+
+  // Broadcast 1000ms BCM Gateway alive token
+  if (currentMillis - previousMillis1000_69f >= 1000) {
+    previousMillis1000_69f = currentMillis;
+    transmit_can_frame(&ZOE_69F_BCM_GATEWAY);
   }
 
   // UDS PID polling and DTC handling

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -181,19 +181,25 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
     counter_423 = (counter_423 + 1) % 10;
 
     // Broadcast 100ms vehicle frames (PEB Inverter 0x19F, EVC Power Mux 0x426, EVC Status 0x436)
+    // Rolling 4-bit sequence counter (cycles 0-15)
     ZOE_19F_INVERTER.data.u8[3] = (zoe_19F_counter++ & 0x0F);
     transmit_can_frame(&ZOE_19F_INVERTER);
 
     transmit_can_frame(&ZOE_426_POWER_MUX);
 
-    zoe_436_counter++;
-    ZOE_436_VEHICLE_STATUS.data.u8[2] = (zoe_436_counter >> 8) & 0xFF;
-    ZOE_436_VEHICLE_STATUS.data.u8[3] = zoe_436_counter & 0xFF;
     transmit_can_frame(&ZOE_436_VEHICLE_STATUS);
   }
 
+  // Update EVC 0x436 vehicle runtime clock every 60s
+  if (currentMillis - previousMillis60000_436 >= INTERVAL_60_S) {
+    previousMillis60000_436 = currentMillis;
+    zoe_436_counter++;
+    ZOE_436_VEHICLE_STATUS.data.u8[2] = (zoe_436_counter >> 8) & 0xFF;
+    ZOE_436_VEHICLE_STATUS.data.u8[3] = zoe_436_counter & 0xFF;
+  }
+
   // Broadcast 1000ms BCM Gateway alive token
-  if (currentMillis - previousMillis1000_69f >= 1000) {
+  if (currentMillis - previousMillis1000_69f >= INTERVAL_1_S) {
     previousMillis1000_69f = currentMillis;
     transmit_can_frame(&ZOE_69F_BCM_GATEWAY);
   }

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -59,9 +59,10 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
 
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
   unsigned long previousMillis1000_69f = 0;
+  unsigned long previousMillis60000_436 = 0;
   uint8_t counter_423 = 0;
   uint8_t zoe_19F_counter = 0;
-  uint16_t zoe_436_counter = 0xAAEA;
+  uint16_t zoe_436_counter = 1;
 
   CAN_frame ZOE_423 = {.FD = false,
                        .ext_ID = false,
@@ -86,7 +87,7 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
                                       .ext_ID = false,
                                       .DLC = 6,
                                       .ID = 0x436,
-                                      .data = {0x86, 0x14, 0xAA, 0xEA, 0xFF, 0xDC}};
+                                      .data = {0x86, 0x14, 0x00, 0x01, 0xFF, 0xDC}};
 
   CAN_frame ZOE_69F_BCM_GATEWAY = {.FD = false,
                                    .ext_ID = false,

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -58,13 +58,41 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
   static const int GROUP6_BALANCING = 0x07;            // Balancing status bits
 
   unsigned long previousMillis100 = 0;  // will store last time a 100ms CAN Message was sent
+  unsigned long previousMillis1000_69f = 0;
   uint8_t counter_423 = 0;
+  uint8_t zoe_19F_counter = 0;
+  uint16_t zoe_436_counter = 0xAAEA;
 
   CAN_frame ZOE_423 = {.FD = false,
                        .ext_ID = false,
                        .DLC = 8,
                        .ID = 0x423,
                        .data = {0x07, 0x1d, 0x00, 0x02, 0x5d, 0x80, 0x5d, 0xc8}};
+
+  // Cyclic Broadcast Frames for Zoe Gen1 Powertrain (Eliminates U1000 / D000 CAN Loss Faults)
+  CAN_frame ZOE_19F_INVERTER = {.FD = false,
+                                .ext_ID = false,
+                                .DLC = 8,
+                                .ID = 0x19F,
+                                .data = {0x00, 0x00, 0x7D, 0x04, 0x00, 0x6A, 0x90, 0xFE}};
+
+  CAN_frame ZOE_426_POWER_MUX = {.FD = false,
+                                 .ext_ID = false,
+                                 .DLC = 8,
+                                 .ID = 0x426,
+                                 .data = {0x00, 0x60, 0x01, 0x00, 0x4B, 0xC8, 0x00, 0x40}};
+
+  CAN_frame ZOE_436_VEHICLE_STATUS = {.FD = false,
+                                      .ext_ID = false,
+                                      .DLC = 6,
+                                      .ID = 0x436,
+                                      .data = {0x86, 0x14, 0xAA, 0xEA, 0xFF, 0xDC}};
+
+  CAN_frame ZOE_69F_BCM_GATEWAY = {.FD = false,
+                                   .ext_ID = false,
+                                   .DLC = 4,
+                                   .ID = 0x69F,
+                                   .data = {0x71, 0x30, 0x28, 0x2F}};
 
   uint16_t LB_SOC = 50;
   uint16_t LB_Display_SOC = 50;


### PR DESCRIPTION
### What
This PR implements cyclic transmission of the 4 essential OEM vehicle broadcast frames (`0x19F`, `0x426`, `0x436`, `0x69F`) expected by the Renault Zoe Gen1 LBC (BMS).

### Why
The Zoe Gen1 LBC continuously monitors CAN-V for cyclic broadcast frames from the traction inverter (PEB), electric vehicle controller (EVC), and body control module (BCM). 

In their absence, the LBC flags lost communication faults (`U1000` / DDT2000 DTC `D000` / `DF116`), asserts its internal caution status bit, and records active diagnostic trouble codes. Adding these missing broadcast frames satisfies all powertrain partner monitors and keeps the pack in a 100% clean health state.

### How
1. **Defined 4 vehicle broadcast frames in `RENAULT-ZOE-GEN1-BATTERY.h`**:
   - `0x19F` (PEB Inverter): Inverter operational status & DC bus ready with rolling 4-bit nibble counter.
   - `0x426` (EVC Power Mux): HV power distribution & DC-DC auxiliary budget (`4B C8` = 1.2 kW).
   - `0x436` (EVC Status): Vehicle readiness state with 16-bit monotonic sequence counter (`AA EA` $\rightarrow$ `AA EB`...).
   - `0x69F` (BCM Gateway): Central gateway network alive token (`71 30 28 2F`).
2. **Scheduled transmission in `RENAULT-ZOE-GEN1-BATTERY.cpp` inside `transmit_can()`**:
   - `0x19F`, `0x426`, and `0x436` are broadcast at the existing **100ms** interval alongside `0x423`.
   - `0x69F` is broadcast at a **1000ms** interval.
3. **Validation**: Verified on a physical Zoe Gen1 22/41kWh pack (`zoe222`): UDS Service `0x19 0x02 0x0F` (`ReadDTCInformation`) returns `59 02 4F` (0 active DTCs).

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- Closes #2900

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- Not applicable (internal CAN broadcast frame additions; no user-facing settings or wiring changes required)

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
