### PR TITLE
fix(safety): only run the CAN liveness watchdog on CAN batteries

### DIFF
--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -75,6 +75,9 @@ extern bool user_selected_triple_battery;
 
 extern battery_chemistry_enum user_selected_battery_chemistry;
 
+// The type of comm interface the battery is using. Mirrors InverterInterfaceType.
+enum class BatteryInterfaceType { Can, Rs485, Modbus };
+
 // Abstract base class for next-generation battery implementations.
 // Defines the interface to call battery specific functionality.
 class Battery {
@@ -84,6 +87,9 @@ class Battery {
 
   // The name of the comm interface the battery is using.
   virtual const char* interface_name() = 0;
+
+  // The type of the comm interface. Defaults to CAN; override in batteries that use another.
+  virtual BatteryInterfaceType interface_type() { return BatteryInterfaceType::Can; }
 
   // These are commands from external I/O (UI, MQTT etc.)
   // Override in battery if it supports them. Otherwise they are NOP.

--- a/Software/src/battery/RS485Battery.h
+++ b/Software/src/battery/RS485Battery.h
@@ -13,6 +13,7 @@ class RS485Battery : public Battery, Transmitter, Rs485Receiver {
   virtual void transmit_rs485(unsigned long currentMillis) = 0;
 
   const char* interface_name() { return "RS485"; }
+  BatteryInterfaceType interface_type() override { return BatteryInterfaceType::Rs485; }
 
   void transmit(unsigned long currentMillis) { transmit_rs485(currentMillis); }
 

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -360,8 +360,13 @@ void update_machineryprotection() {
 
     // Check that the BMS has been seen and is still sending CAN messages.
     // If we go 60s without messages we raise an error
-    check_can_component_alive(datalayer.battery.status.CAN_battery_still_alive, battery_detected,
-                              EVENT_CAN_BATTERY_DETECTED, EVENT_CAN_BATTERY_MISSING, can_config.battery);
+    // Only for batteries on CAN -- other interfaces never refresh this counter, so the
+    // check would raise a permanent error and the FAULT state would zero the power limits.
+    if (battery->interface_type() == BatteryInterfaceType::Can) {
+      check_can_component_alive(datalayer.battery.status.CAN_battery_still_alive, battery_detected,
+                                EVENT_CAN_BATTERY_DETECTED, EVENT_CAN_BATTERY_MISSING,
+                                can_config.battery);
+    }
   }
 
   if (inverter && inverter->interface_type() == InverterInterfaceType::Can) {

--- a/Software/src/devboard/safety/safety.cpp
+++ b/Software/src/devboard/safety/safety.cpp
@@ -364,8 +364,7 @@ void update_machineryprotection() {
     // check would raise a permanent error and the FAULT state would zero the power limits.
     if (battery->interface_type() == BatteryInterfaceType::Can) {
       check_can_component_alive(datalayer.battery.status.CAN_battery_still_alive, battery_detected,
-                                EVENT_CAN_BATTERY_DETECTED, EVENT_CAN_BATTERY_MISSING,
-                                can_config.battery);
+                                EVENT_CAN_BATTERY_DETECTED, EVENT_CAN_BATTERY_MISSING, can_config.battery);
     }
   }
 

--- a/test/battery_alive_tests.cpp
+++ b/test/battery_alive_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "../Software/src/battery/BATTERIES.h"
+#include "../Software/src/battery/DALY-BMS.h"
 #include "../Software/src/charger/CHARGERS.h"
 #include "../Software/src/charger/CanCharger.h"
 #include "../Software/src/datalayer/datalayer.h"
@@ -136,4 +137,55 @@ TEST_F(BatteryAliveTest, ChargerDetectionFiresOnRefresh) {
 
   EXPECT_TRUE(charger_detected);
   EXPECT_EQ(get_event_pointer(EVENT_CAN_CHARGER_DETECTED)->occurences, 1);
+}
+
+// A battery on a non-CAN interface never refreshes CAN_battery_still_alive, so running the
+// CAN liveness check on it raises EVENT_CAN_BATTERY_MISSING every cycle. That is an ERROR,
+// which puts system_status in FAULT, which zeroes both power limits on a healthy battery.
+TEST_F(BatteryAliveTest, NonCanBatteryIsNotPolicedByTheCanWatchdog) {
+  DalyBms rs485_battery;
+  Battery* saved = battery;
+  battery = &rs485_battery;
+
+  ASSERT_NE(battery->interface_type(), BatteryInterfaceType::Can);
+
+  // A healthy battery, so only the CAN watchdog is under test. The other checks in
+  // update_machineryprotection() zero the limits for under/overvoltage too.
+  auto& b = datalayer.battery;
+  b.info.min_design_voltage_dV = 3500;
+  b.info.max_design_voltage_dV = 4500;
+  b.info.min_cell_voltage_mV = 2700;
+  b.info.max_cell_voltage_mV = 4300;
+  b.info.max_cell_voltage_deviation_mV = 500;
+  b.status.voltage_dV = 4100;
+  b.status.cell_min_voltage_mV = 3700;
+  b.status.cell_max_voltage_mV = 3750;
+  b.status.temperature_min_dC = 250;
+  b.status.temperature_max_dC = 280;
+  b.status.reported_soc = 5000;
+  b.status.real_soc = 5000;
+  b.status.active_power_W = 0;
+
+  // The state a non-CAN battery is permanently in: the CAN counter is never refreshed.
+  b.status.CAN_battery_still_alive = 0;
+  b.status.max_charge_power_W = 5000;
+  b.status.max_discharge_power_W = 5000;
+
+  for (int cycle = 0; cycle < 3; cycle++) {
+    update_machineryprotection();
+  }
+
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_BATTERY_MISSING)->state, EVENT_STATE_INACTIVE);
+  EXPECT_EQ(datalayer.battery.status.max_charge_power_W, 5000u);
+  EXPECT_EQ(datalayer.battery.status.max_discharge_power_W, 5000u);
+
+  battery = saved;
+}
+
+// The guard above must not disable the check for batteries that do use CAN.
+TEST_F(BatteryAliveTest, CanBatteryIsStillPolicedByTheCanWatchdog) {
+  ASSERT_EQ(battery->interface_type(), BatteryInterfaceType::Can);
+  datalayer.battery.status.CAN_battery_still_alive = 0;
+  update_machineryprotection();
+  EXPECT_EQ(get_event_pointer(EVENT_CAN_BATTERY_MISSING)->state, EVENT_STATE_ACTIVE);
 }


### PR DESCRIPTION
### What

update_machineryprotection() guards the inverter liveness check on inverter->interface_type() == Can, but ran the battery check unconditionally.

A battery on a non-CAN interface never refreshes CAN_battery_still_alive, so the counter sits at 0 and EVENT_CAN_BATTERY_MISSING is raised on every cycle. That event is ERROR level, so system_status latches to FAULT, and the block at the top of the same function then zeroes max_charge_power_W and max_discharge_power_W. The result is a healthy battery reported to the inverter as accepting and delivering 0 W, with the status page pointing at CAN wiring that is not part of the setup. Clearing the event does not help, because the watchdog raises it again on the next cycle.

Battery gains interface_type(), mirroring InverterInterfaceType. It is defaulted to Can rather than pure virtual so every existing battery stays correct without a change, and only a non-CAN battery has to declare itself. RS485Battery declares Rs485, which covers DalyBms.

Adds two tests: a non-CAN battery is not policed by the CAN watchdog and keeps its power limits, and a CAN battery still is, so the guard is not a blanket disable.

### Why
Testing with an nonCAN data driven battery, a MQTT input data battery for testing, found the error.  Other existing battery types would be similarly affected.  Clearly most batteries use CAN data, hah!

### How
Only check CAN liveness for CAN batteries

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

### Checklist:

  - [x] The code change is tested and works locally.      Using a mqtt fed battery in BE found this bug and needed a fix. Claude finds that it would affect other existing battery types, so this might be of interest.

