### PR TITLE
Fix Kia E-GMP datalayer pointer initialization

### DIFF
--- a/Software/src/battery/KIA-E-GMP-BATTERY.h
+++ b/Software/src/battery/KIA-E-GMP-BATTERY.h
@@ -8,7 +8,10 @@ class KiaEGmpBattery : public UdsCanBattery {
  public:
   bool mandatory_charge_taper() { return true; }
   // Use the default constructor to create the first or single battery.
-  KiaEGmpBattery() { dtc = &datalayer_battery->dtc; }
+  KiaEGmpBattery() : UdsCanBattery() {
+    datalayer_battery = &datalayer.battery;
+    dtc = &datalayer_battery->dtc;
+  }
 
   virtual void setup(void);
   virtual void handle_incoming_can_frame(CAN_frame rx_frame);


### PR DESCRIPTION
Fixes RESET_PANIC when opening "More Battery Info".

Initializing datalayer_battery with &datalayer.battery before assigning dtc fixes the crash.

Tested on real hardware with E-GMP battery and Stark CMR.

Before fix: opening "More Battery Info" immediately caused RESET_PANIC.

After fix: the page opens normally and no RESET_PANIC occurs.