### PR TITLE
Fix PYLON-LV-CAN 0x359 over-current sign bug

### DIFF
--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -50,7 +50,15 @@ void PylonLvInverter::update_values() {
   PYLON_359.data.u8[6] = 0x4E;  //N
 
   // ERRORS
-  if (datalayer.battery.status.reported_current_dA >= (datalayer.battery.status.max_discharge_current_dA + 10))
+  // reported_current_dA follows the datalayer's "+ = charging" convention, so
+  // discharge current is negative and charge current is positive - the two
+  // over-current checks below must compare against opposite signs of their
+  // own limit, not the same sign. (Previously both compared as if positive
+  // current meant discharge, which made a charge-current check trigger on
+  // ordinary discharge instead - most visible as a false "charge over
+  // current" error the instant max_charge_current_dA reaches 0, e.g. a full
+  // battery discharging normally.)
+  if (datalayer.battery.status.reported_current_dA <= -1 * (datalayer.battery.status.max_discharge_current_dA + 10))
     PYLON_359.data.u8[0] |= 0x80;
   if (datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE)
     PYLON_359.data.u8[0] |= 0x10;
@@ -60,12 +68,12 @@ void PylonLvInverter::update_values() {
     PYLON_359.data.u8[0] |= 0x04;
   if (datalayer.system.status.system_status == FAULT)
     PYLON_359.data.u8[1] |= 0x80;
-  if (datalayer.battery.status.reported_current_dA <= -1 * datalayer.battery.status.max_charge_current_dA)
+  if (datalayer.battery.status.reported_current_dA >= datalayer.battery.status.max_charge_current_dA)
     PYLON_359.data.u8[1] |= 0x01;
 
   // WARNINGS (using same rules as errors but reporting earlier)
-  if (datalayer.battery.status.reported_current_dA >=
-      datalayer.battery.status.max_discharge_current_dA * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.reported_current_dA <=
+      -1 * (datalayer.battery.status.max_discharge_current_dA * WARNINGS_PERCENT / 100))
     PYLON_359.data.u8[2] |= 0x80;
   if (datalayer.battery.status.temperature_min_dC <=
       warning_threshold_of_min(BATTERY_MINTEMPERATURE, BATTERY_MAXTEMPERATURE))
@@ -76,8 +84,8 @@ void PylonLvInverter::update_values() {
                                                                       datalayer.battery.info.max_design_voltage_dV))
     PYLON_359.data.u8[2] |= 0x04;
   // we never set PYLON_359.data.u8[3] |= 0x80 called "BMS internal"
-  if (datalayer.battery.status.reported_current_dA <=
-      -1 * datalayer.battery.status.max_charge_current_dA * WARNINGS_PERCENT / 100)
+  if (datalayer.battery.status.reported_current_dA >=
+      datalayer.battery.status.max_charge_current_dA * WARNINGS_PERCENT / 100)
     PYLON_359.data.u8[3] |= 0x01;
 
   PYLON_35C.data.u8[0] = 0xC0;  // enable charging and discharging

--- a/Software/src/inverter/PYLON-LV-CAN.cpp
+++ b/Software/src/inverter/PYLON-LV-CAN.cpp
@@ -68,12 +68,19 @@ void PylonLvInverter::update_values() {
     PYLON_359.data.u8[0] |= 0x04;
   if (datalayer.system.status.system_status == FAULT)
     PYLON_359.data.u8[1] |= 0x80;
-  if (datalayer.battery.status.reported_current_dA >= datalayer.battery.status.max_charge_current_dA)
+  // +10 margin matches the discharge-side check above - without it, a fully
+  // charged battery sitting idle (current=0, max_charge_current_dA=0 since
+  // it's full) trips this on the exact "0 >= 0" boundary, which is a more
+  // common state than actively overcurrent-charging.
+  if (datalayer.battery.status.reported_current_dA >= (datalayer.battery.status.max_charge_current_dA + 10))
     PYLON_359.data.u8[1] |= 0x01;
 
   // WARNINGS (using same rules as errors but reporting earlier)
+  // +10 margin for the same "0 >= 0 at idle" reason as the charge checks -
+  // discharge can legitimately be 0 too (e.g. a real fault disabling it),
+  // and idle current shouldn't trip a warning on its own.
   if (datalayer.battery.status.reported_current_dA <=
-      -1 * (datalayer.battery.status.max_discharge_current_dA * WARNINGS_PERCENT / 100))
+      -1 * (datalayer.battery.status.max_discharge_current_dA * WARNINGS_PERCENT / 100 + 10))
     PYLON_359.data.u8[2] |= 0x80;
   if (datalayer.battery.status.temperature_min_dC <=
       warning_threshold_of_min(BATTERY_MINTEMPERATURE, BATTERY_MAXTEMPERATURE))
@@ -84,8 +91,10 @@ void PylonLvInverter::update_values() {
                                                                       datalayer.battery.info.max_design_voltage_dV))
     PYLON_359.data.u8[2] |= 0x04;
   // we never set PYLON_359.data.u8[3] |= 0x80 called "BMS internal"
+  // +10 margin for the same reason as the error check above - avoids firing
+  // at the "0 >= 0" boundary when the battery is full and idle.
   if (datalayer.battery.status.reported_current_dA >=
-      datalayer.battery.status.max_charge_current_dA * WARNINGS_PERCENT / 100)
+      (datalayer.battery.status.max_charge_current_dA * WARNINGS_PERCENT / 100 + 10))
     PYLON_359.data.u8[3] |= 0x01;
 
   PYLON_35C.data.u8[0] = 0xC0;  // enable charging and discharging


### PR DESCRIPTION
Fixes #2919.

## Summary
- `PYLON-LV-CAN.cpp`'s `0x359` over-current error/warning checks compared `reported_current_dA` against the wrong sign of their own limit. The datalayer's convention is **positive = charging**, so:
  - The discharge-overcurrent check needs to compare against `-max_discharge_current_dA` (discharge current is negative), not `+max_discharge_current_dA`.
  - The charge-overcurrent check needs to compare against `+max_charge_current_dA` (charge current is positive), not `-max_charge_current_dA`.
- As written, both checks tested the wrong direction. Most visible the instant `max_charge_current_dA` reaches 0 (e.g. battery at 100% SOC) - at that point any discharge current at all satisfies the old (broken) charge-overcurrent condition, firing a false error and warning on every cycle during completely normal operation.
- Same inversion existed in the WARNING block, fixed identically.
- Affects every battery type using `PYLON-LV-CAN`, not just any one driver.

## Test plan
- [x] Builds clean on `esp32devkit_330`
- [x] Reproduced and fixed live against a real Solis S6-EH1P8K-L-PLUS + Growatt GBLI6532 pairing (via #2913): confirmed the real BMS reported a fully healthy state (`chg_en=1 dis_en=1`, zero protection/warning bits, correct CCL/DCL) while the Solis raised a genuine "BMS error" purely from this sign bug. Alarm cleared immediately once the sign was corrected, confirmed on the real inverter's own display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)