### PR TITLE
Fronius: Downgrade Modbus inverter missing event severity for offgrid

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -40,6 +40,7 @@ static void set_event_internal(EVENTS_ENUM_TYPE event, int16_t data, bool latche
  * nothing about which events belong here. */
 static const EVENTS_ENUM_TYPE OFFGRID_DOWNGRADED_EVENTS[] = {
     EVENT_CAN_INVERTER_MISSING,
+    EVENT_MODBUS_INVERTER_MISSING,
 };
 
 static EVENTS_LEVEL_TYPE effective_level(EVENTS_ENUM_TYPE event) {


### PR DESCRIPTION
### What
This PR downgrades Modbus inverter missing event severity from FAULT -> Warning when "Inverter is run offgrid" checkbox is enabled

### Why
To avoid contactor opening with loss of comm, useful in some situations, like offgrid use

### How
EVENT_MODBUS_INVERTER_MISSING added to the downgrade severity list

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
