### PR TITLE
Pin platformio to 6.1.19 temporarily

### DIFF
--- a/.github/workflows/compile-common-image.yml
+++ b/.github/workflows/compile-common-image.yml
@@ -101,7 +101,8 @@ jobs:
         python-version: '3.13'
 
     - name: Install PlatformIO Core
-      run: pip install --upgrade platformio
+      #run: pip install --upgrade platformio
+      run: pip install --upgrade "platformio==6.1.19" # fix for No module named 'SCons.Tool.FortranCommon'
 
     # Add a line to print out the hash check values, to help debug why
     # PlatformIO might trigger a rebuild.


### PR DESCRIPTION
### What
Pin platformio to 6.1.19 temporarily. Likely an upstream change broke it

### Why
```
Building in release mode
*** [.pio/build/waveshare_330/firmware.elf] ModuleNotFoundError : No module named 'SCons.Tool.FortranCommon'
```

### How
In `.github/workflows/compile-common-image.yml `

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
