### PR TITLE
Stellantis Pro One: fix cell voltage scaling, pack voltage, SOC and precharge state

### DIFF
--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -60,7 +60,7 @@ enum class BatteryType {
   StellantisSmallWide4x4 = 53,
   ChargebyteCCSBattery = 54,
   VAGMqbEvo = 55,
-  StellantisProOne = 56,
+  StellantisProOne = 58,
   Highest
 };
 

--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
@@ -16,29 +16,17 @@ static uint8_t CalculateCRC8SAEJ1850(CAN_frame rx_frame, uint8_t length) {
   return crc ^ 0xFF;  // final XOR 0xFF
 }
 
-uint16_t estimate_SOC_based_on_v(uint16_t voltage) {
-  // Voltage ranges between 3780dV when full, and 2880dV when empty
-  // Range = 3780 - 2880 = 900dV → represents 100% SOC
-
-  if (voltage <= 2880)
-    return 0;
-  if (voltage >= 3780)
-    return 10000;
-
-  return (uint32_t)(voltage - 2880) * 10000 / 900;
-}
-
 void StellantisProOneBattery::
     update_values() {  //This function maps all the values fetched via CAN to the correct parameters used for modbus
 
   datalayer.battery.status.voltage_dV = pack_voltage;
 
-  datalayer.battery.status.real_soc =
-      estimate_SOC_based_on_v(datalayer.battery.status.voltage_dV);  //TODO, locate real SOC and don't estimate!
+  datalayer.battery.status.real_soc = soc_real_pptt;
 
   datalayer.battery.status.current_dA = battery_current;
 
-  if (contactor_status == CONTACTORS_OFF) {
+  //No power while the contactors are open or still precharging
+  if (contactor_status == CONTACTORS_OFF || contactor_status == CONTACTORS_PRECHARGE) {
     datalayer.battery.status.max_charge_power_W = 0;
     datalayer.battery.status.max_discharge_power_W = 0;
   } else {
@@ -118,7 +106,9 @@ String StellantisProOneBattery::get_uds_info_html() {
               "<h4>285_3chg?: " << unknown_285_2 << "</h4>"
               "<h4>281_1: " << unknown_281_0 << "</h4>"
               "<h4>281_2: " << unknown_281_1 << "</h4>"
-              "<h4>Contactor state: " << contactor_status << " (8off,10on)</h4>"
+              "<h4>281_3: " << unknown_281_2 << "</h4>"
+              "<h4>Contactor state: " << contactor_status << " (8 off, 9 precharge, 10 on)</h4>"
+              "<h4>Battery ready: " << (battery_ready ? "yes" : "no") << "</h4>"
               "<h4>Temperature sensors: </h4>"
            "<table style='border-collapse:collapse;font-size:0.85em;margin:auto'>";
 
@@ -151,6 +141,12 @@ void StellantisProOneBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (expectedCRC == rx_frame.data.u8[7]) {
         //Message is valid, process it
         battery_current = ((rx_frame.data.u8[0] << 8) | rx_frame.data.u8[1]) - 15000;
+        //Bytes 2-3 are pack voltage, 0.1V per bit with a +100V offset.
+        //Zero means the HV measurement module is not reporting - not 100.0V - so keep the last value.
+        uint16_t raw_pack_voltage = (uint16_t)(rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+        if (raw_pack_voltage != 0) {
+          pack_voltage = raw_pack_voltage + 1000;  //dV
+        }
         //counter_095 = (rx_frame.data.u8[6] & 0xF0) >> 4;
       } else {
         //CRC error, ignore message
@@ -169,7 +165,8 @@ void StellantisProOneBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       if (expectedCRC == rx_frame.data.u8[7]) {
         //Message is valid, process it
         contactor_status = (rx_frame.data.u8[5] & 0x0F);
-        if (contactor_status == CONTACTORS_OFF) {
+        battery_ready = (rx_frame.data.u8[3] & 0x40) != 0;
+        if (contactor_status == CONTACTORS_OFF || contactor_status == CONTACTORS_PRECHARGE) {
           datalayer.battery.status.max_charge_power_W = 0;
           datalayer.battery.status.max_discharge_power_W = 0;
         }
@@ -183,15 +180,17 @@ void StellantisProOneBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x220:  //Cellvoltages avg/min/max
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
-      cellvoltage_average_mV = (uint16_t)((rx_frame.data.u8[0] & 0x0F) << 8) | rx_frame.data.u8[1];
-      cellvoltage_max_mV = (uint16_t)((rx_frame.data.u8[2] & 0x0F) << 8) | rx_frame.data.u8[3];
-      cellvoltage_min_mV = (uint16_t)((rx_frame.data.u8[4] & 0x0F) << 8) | rx_frame.data.u8[5];
+      //These are full 16-bit values. Cells pass 4095mV near full charge, where a 12-bit
+      //mask silently drops the top bit (4096mV would decode as 0mV).
+      cellvoltage_average_mV = (uint16_t)(rx_frame.data.u8[0] << 8) | rx_frame.data.u8[1];
+      cellvoltage_max_mV = (uint16_t)(rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
+      cellvoltage_min_mV = (uint16_t)(rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
       break;
     case 0x281:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
       unknown_281_0 = rx_frame.data.u8[1];
       unknown_281_1 = (uint16_t)((rx_frame.data.u8[2] & 0x0F) << 8) | rx_frame.data.u8[3];
-      pack_voltage = (uint16_t)((((rx_frame.data.u8[4] & 0x0F) << 8) | rx_frame.data.u8[5]) * 1.25);
+      unknown_281_2 = (uint16_t)(rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
       break;
     case 0x285:  //Allowed Charge/Discharge?
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
@@ -201,6 +200,11 @@ void StellantisProOneBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x306:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      //Byte 4 is pack SOC, byte 5 tracks the weakest cell. Full scale 255 = 100%.
+      //Zero is only seen before the BMS has populated it, so keep the last value.
+      if (rx_frame.data.u8[4] != 0) {
+        soc_real_pptt = (uint16_t)((uint32_t)rx_frame.data.u8[4] * 10000u / 255u);
+      }
       unknown_306_0 = rx_frame.data.u8[4];
       unknown_306_1 = rx_frame.data.u8[5];
       unknown_306_2 = (uint16_t)((rx_frame.data.u8[6] & 0x0F) << 8) | rx_frame.data.u8[7];

--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
@@ -26,6 +26,7 @@ class StellantisProOneBattery : public UdsCanBattery {
   DATALAYER_BATTERY_TYPE* datalayer_battery;
 
   static const uint8_t CONTACTORS_OFF = 8;
+  static const uint8_t CONTACTORS_PRECHARGE = 9;
   static const uint8_t CONTACTORS_ON = 10;
 
   static const int MAX_PACK_VOLTAGE_DV = 3780;  //5000 = 500.0V
@@ -300,6 +301,8 @@ class StellantisProOneBattery : public UdsCanBattery {
   static const uint16_t PID_UNKNOWN_224 = 0xF806;
 
   uint8_t contactor_status = 0;
+  bool battery_ready = false;
+  uint16_t soc_real_pptt = 5000;
   uint16_t pack_voltage = 3700;
   int16_t battery_current = 0;
   int8_t celltemperatures[30] = {0};
@@ -320,6 +323,7 @@ class StellantisProOneBattery : public UdsCanBattery {
   uint16_t unknown_285_2 = 0;
   uint16_t unknown_281_0 = 0;
   uint16_t unknown_281_1 = 0;
+  uint16_t unknown_281_2 = 0;
   uint16_t cellvoltage_average_mV = 3700;
   uint16_t cellvoltage_max_mV = 3700;
   uint16_t cellvoltage_min_mV = 3700;


### PR DESCRIPTION
Additions to #2543, from reverse-engineering roughly 1.5 GB of CAN captures on a real Pro One pack: bench sessions, vehicle idle, a CATL BMU capture with the HV measurement module unplugged, and a complete 80-minute charge run to termination.

Happy to split this up, drop any part of it, or rework it if it collides with work you have locally.

## Cell voltages in 0x220 need to be read as full 16-bit

This is the one I would suggest taking regardless of the rest.

The field is currently masked to 12 bits, which drops the top bit as soon as a cell passes 4095 mV. That happens on **every charge above roughly 89 % SOC**, so it is not an edge case.

Observed live on a pack at 93 % SOC running this branch:

```
Cell min/max:  4092 mV / 0 mV
Cell delta:    61444 mV
System status: FAULT   (contactor closing blocked)
```

The true cell delta at that moment was **4 mV**. The highest cell had just reached 4096 mV = `0x1000`, which the mask decodes as 0. The lowest was 4092 mV, below the boundary, so it came through untouched — hence the wild disagreement.

The two different numbers on screen come from two code paths acting on the same bad value: `webserver.cpp:1162` subtracts in `uint16_t`, so `0 - 4092` underflows to 61444, while `safety.cpp:285` uses `std::abs` and gets 4092 — comfortably over `MAX_CELL_DEVIATION_MV` (250), so `EVENT_CELL_DEVIATION_HIGH` latches.

Measured across two logged charge sessions:

- the window where one cell is above 4096 mV and the other below lasted **433 s** and **841 s**, with the deviation event firing in **100 %** of `0x220` frames in that window
- once both cells pass 4096 mV the delta becomes correct again (both lose 4096), but the **minimum** then reads 0-10 mV instead of ~4150, latching `EVENT_CELL_UNDER_VOLTAGE` and `EVENT_CELL_CRITICAL_UNDER_VOLTAGE` and forcing discharge power to zero
- throughout, `cell_max` reads 0-77 mV against a 4250 mV limit, so **cell overvoltage cannot be detected at all** — in the charge log that was 9892 of 9892 frames

Worth noting that `A009` in the same file already reads the same max/min at full width into `polled_max_cellvoltage_mV` / `polled_min_cellvoltage_mV`. Those two are currently assigned but never used, so they become a ready-made cross-check once `0x220` is fixed.

## Pack voltage from 0x95 bytes 2-3

0.1 V per bit with a +100 V offset.

Checked frame by frame against 90 × cell average: 7596 paired samples across 9 logs, mean error −0.05 to +0.03 V. Re-checked on the charge logs at **369.8-374.7 V**, well outside the earlier range: mean error −0.015 V, worst single sample 0.07 V. It also agrees to **0.00 V** with UDS PID `A011` bytes 0-1, and reproduces the pack voltages two of our log filenames were named after to the exact tenth of a volt.

The previous source, `0x281 × 1.25`, is bit-frozen through entire captures while current is flowing, and in one log reports 327.2 V where two independent sources say 339.75 V. That field is kept on the info page as an unknown rather than deleted.

Raw zero means the HV measurement module is not reporting rather than 100.0 V. This was confirmed by a capture taken with that module physically unplugged, where `0x95` bytes 2-3, `0x281` and `0x285` all zeroed while everything sourced from the LTC chain kept running. The code now holds the last good value instead.

## SOC from 0x306 byte 4

Full scale 255 = 100 %. Smooth and monotone from 49.8 % to 98.4 % across 12 captures, roughly one count per 4 mV of cell voltage, and bit-identical to UDS `B005` byte 8. This replaces the linear voltage estimator, which is unreliable in the flat middle of the NMC curve.

**Caveat worth flagging:** the 255 full scale is inferred, not measured. A completed charge peaked at byte **251** and settled at **250** at rest across four separate captures, so the true full scale is either 250 or 255 — a 2 percentage point difference. If you have a way to read the vehicle-side display at the end of a charge, that settles it. We could not find any byte on the vehicle bus reading ~100.

## Contactor state 9 is precharge

Observed as **8 → 9 → 10** in five separate captures, lasting 170-290 ms, and it is when the inrush occurs — visible in `0x95` as 11.0 A decaying with τ = 35.9 ms (R² = 0.9949).

I noticed the earlier commit had `CONTACTORS_PRECHARGE` and it was dropped when the encoding was corrected to 8/10, so this just restores it with the observed value. Charge and discharge power are now held at zero during precharge as well as when open, since previously state 9 fell through to the `else` branch and allowed full power.

`0x150` byte 3 bit `0x40` is a readiness flag that sets about 3 s before the sequence starts; it is now surfaced on the info page.

## Integration id 56 → 58

56 now collides with `Akasol` on main, and 57 is taken by `GrowattLv`.

---

**I have not been able to compile this** — no local toolchain, and Actions did not run on the fork. The changes were reviewed by hand and the enum gap is safe (`enum_values_and_names` filters `nullptr`, and the gap at 46 has always existed), but CI on this PR is the first real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
