### PR TITLE
Disable ESPNow during OTA

### DIFF
--- a/Software/src/devboard/espnow/espnow.cpp
+++ b/Software/src/devboard/espnow/espnow.cpp
@@ -21,6 +21,7 @@
 #include "../utils/events.h"
 #include "../utils/logging.h"
 #include "../utils/millis64.h"
+#include "../webserver/webserver.h"
 #include "../wifi/wifi.h"
 #include "Arduino.h"
 
@@ -626,7 +627,7 @@ void init_espnow() {
 }
 
 void update_espnow() {
-  if (!espnow_initialized) {
+  if (!espnow_initialized || ota_active) {
     return;
   }
 


### PR DESCRIPTION
like MQTT to avoid errors like
```
    1336.649 OTA progress: 43.9% (861.3 / 1960.6 KB)
    1337.156 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.187 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.206 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.260 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.278 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.310 ESPNow send failed: ESP_ERR_ESPNOW_NO_MEM
    1337.650 OTA progress: 50.4% (987.4 / 1960.6 KB)
```