### PR TITLE
Stellantis Pro One: report SOH from 0x359 and add BPCM DTC descriptions

### DIFF
--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
@@ -41,8 +41,7 @@ void StellantisProOneBattery::
     datalayer.battery.status.soh_pptt =
         (uint16_t)((uint32_t)pack_capacity_ah_tenths * 10000u / NOMINAL_CAPACITY_AH_TENTHS);
     //Energy = capacity x nominal pack voltage. (tenths/10) Ah x (centivolt/100) V = tenths * cV / 1000
-    datalayer.battery.info.total_capacity_Wh =
-        (uint32_t)pack_capacity_ah_tenths * NOMINAL_PACK_VOLTAGE_CV / 1000u;
+    datalayer.battery.info.total_capacity_Wh = (uint32_t)pack_capacity_ah_tenths * NOMINAL_PACK_VOLTAGE_CV / 1000u;
     datalayer.battery.status.remaining_capacity_Wh =
         (uint32_t)((uint64_t)datalayer.battery.status.real_soc * datalayer.battery.info.total_capacity_Wh / 10000u);
   }

--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.cpp
@@ -36,9 +36,17 @@ void StellantisProOneBattery::
         datalayer.battery.status.override_discharge_power_W;  //TODO: locate
   }
 
-  //datalayer.battery.status.soh_pptt; //TODO: locate
+  if (pack_capacity_ah_tenths > 0) {
+    //SOH against the cell nominal. 3340 = 334.0Ah = 100.00%
+    datalayer.battery.status.soh_pptt =
+        (uint16_t)((uint32_t)pack_capacity_ah_tenths * 10000u / NOMINAL_CAPACITY_AH_TENTHS);
+    //Energy = capacity x nominal pack voltage. (tenths/10) Ah x (centivolt/100) V = tenths * cV / 1000
+    datalayer.battery.info.total_capacity_Wh =
+        (uint32_t)pack_capacity_ah_tenths * NOMINAL_PACK_VOLTAGE_CV / 1000u;
+    datalayer.battery.status.remaining_capacity_Wh =
+        (uint32_t)((uint64_t)datalayer.battery.status.real_soc * datalayer.battery.info.total_capacity_Wh / 10000u);
+  }
 
-  //datalayer.battery.status.remaining_capacity_Wh; //TODO: locate
   //datalayer.battery.status.max_discharge_power_W; //TODO: locate
   //datalayer.battery.status.max_charge_power_W; //TODO: locate
 
@@ -223,6 +231,9 @@ void StellantisProOneBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       break;
     case 0x359:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+      //Bytes 2-3 are the pack capacity in 0.1Ah. Constant within a session and different per pack:
+      //observed 3340/3339 (two packs at nominal), 3235 and 3052 (two aged packs).
+      pack_capacity_ah_tenths = (uint16_t)(rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
       break;
     case 0x3E8:
       datalayer.battery.status.CAN_battery_still_alive = CAN_STILL_ALIVE;

--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
@@ -29,6 +29,11 @@ class StellantisProOneBattery : public UdsCanBattery {
   static const uint8_t CONTACTORS_PRECHARGE = 9;
   static const uint8_t CONTACTORS_ON = 10;
 
+  //Nominal figures from the cell datasheet, not read from the bus. Used only to turn the
+  //capacity the BMS reports into a percentage and an energy figure.
+  static const uint16_t NOMINAL_CAPACITY_AH_TENTHS = 3340;  //334.0Ah cell, 90S1P
+  static const uint16_t NOMINAL_PACK_VOLTAGE_CV = 33120;    //90 x 3.68V = 331.2V, in centivolt
+
   static const int MAX_PACK_VOLTAGE_DV = 3780;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2880;
   static const int MAX_CELL_DEVIATION_MV = 250;
@@ -302,6 +307,7 @@ class StellantisProOneBattery : public UdsCanBattery {
 
   uint8_t contactor_status = 0;
   bool battery_ready = false;
+  uint16_t pack_capacity_ah_tenths = 0;
   uint16_t soc_real_pptt = 5000;
   uint16_t pack_voltage = 3700;
   int16_t battery_current = 0;

--- a/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
+++ b/Software/src/battery/STELLANTIS-PRO-ONE-BATTERY.h
@@ -16,6 +16,9 @@ class StellantisProOneBattery : public UdsCanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Stellantis Pro One 110kWh (E-Ducato/ProMaster/Proace)";
 
+  //BPCM codes from the 2024 ProMaster EV service documentation.
+  const char* get_dtc_json_filename() override { return "stellantis_pro_one_dtc.json"; }
+
   String get_uds_info_html() override;
 
  protected:

--- a/web_data/dtc/stellantis_pro_one_dtc.json
+++ b/web_data/dtc/stellantis_pro_one_dtc.json
@@ -1,0 +1,450 @@
+[
+  {
+    "dtc": "P0AA100",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A STUCK CLOSED"
+  },
+  {
+    "dtc": "P0AA200",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A STUCK OPEN"
+  },
+  {
+    "dtc": "P0AA400",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A STUCK CLOSED"
+  },
+  {
+    "dtc": "P0AA500",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A STUCK OPEN"
+  },
+  {
+    "dtc": "P0AD900",
+    "l_dsc": "HYBRID BATTERY POSITIVE CONTACTOR CONTROL CIRCUIT/OPEN"
+  },
+  {
+    "dtc": "P0ADB00",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A CONTROL CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0ADC00",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A CONTROL CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0ADD00",
+    "l_dsc": "HYBRID BATTERY NEGATIVE CONTACTOR CONTROL CIRCUIT/OPEN"
+  },
+  {
+    "dtc": "P0ADF00",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A CONTROL CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0AE000",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A CONTROL CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0AE300",
+    "l_dsc": "HYBRID/EV BATTERY PRECHARGE CONTACTOR CIRCUIT STUCK OPEN"
+  },
+  {
+    "dtc": "P0AE600",
+    "l_dsc": "HYBRID/EV BATTERY PRECHARGE CONTACTOR CONTROL CIRCUIT A LOW"
+  },
+  {
+    "dtc": "P0AE700",
+    "l_dsc": "HYBRID/EV BATTERY PRECHARGE CONTACTOR CONTROL CIRCUIT A HIGH"
+  },
+  {
+    "dtc": "P0C7700",
+    "l_dsc": "HV BATTERY SYSTEM PRECHARGE TIME TOO SHORT"
+  },
+  {
+    "dtc": "P0C7800",
+    "l_dsc": "HYBRID/EV BATTERY SYSTEM PRECHARGE A TIME TOO LONG"
+  },
+  {
+    "dtc": "P0D0800",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A STUCK CLOSED"
+  },
+  {
+    "dtc": "P0D0900",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A STUCK OPEN"
+  },
+  {
+    "dtc": "P0D0A00",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A CONTROL CIRCUIT OPEN"
+  },
+  {
+    "dtc": "P0D0C00",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A CONTROL CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0D0D00",
+    "l_dsc": "HYBRID/EV BATTERY POSITIVE CONTACTOR A CONTROL CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0D0F00",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A STUCK CLOSED"
+  },
+  {
+    "dtc": "P0D1000",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A STUCK OPEN"
+  },
+  {
+    "dtc": "P0D1100",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A CONTROL CIRCUIT/OPEN"
+  },
+  {
+    "dtc": "P0D1300",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A CONTROL CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0D1400",
+    "l_dsc": "HYBRID/EV BATTERY NEGATIVE CONTACTOR A CONTROL CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0E6D00",
+    "l_dsc": "BATTERY CHARGING SYSTEM PRECHARGE CONTACTOR CONTROL CIRCUIT/OPEN"
+  },
+  {
+    "dtc": "P1A2000",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE HYBRID BATTERY SYSTEM PRECHARGE TIME TOO LONG"
+  },
+  {
+    "dtc": "P1A2100",
+    "l_dsc": "HV BATTERY CONTACTOR CONTROL SEQUENCE INCORRECT"
+  },
+  {
+    "dtc": "P2C8900",
+    "l_dsc": "HYBRID/EV BATTERY SYSTEM PRECHARGE A CURRENT TOO HIGH"
+  },
+  {
+    "dtc": "P2C9400",
+    "l_dsc": "HYBRID/EV BATTERY CONTACTOR CONTROL SUPPLY CIRCUIT LOW"
+  },
+  {
+    "dtc": "P2C9500",
+    "l_dsc": "HYBRID/EV BATTERY CONTACTOR CONTROL SUPPLY CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0A7F00",
+    "l_dsc": "HYBRID/EV BATTERY PACK DETERIORATION"
+  },
+  {
+    "dtc": "P0BBD00",
+    "l_dsc": "HYBRID BATTERY PACK VOLTAGE VARIATION EXCEEDED LIMIT"
+  },
+  {
+    "dtc": "P0BBE00",
+    "l_dsc": "HYBRID BATTERY PACK VOLTAGE VARIATION"
+  },
+  {
+    "dtc": "P0DAF00",
+    "l_dsc": "HYBRID/EV BATTERY CELL BALANCING CIRCUIT A RANGE/PERFORMANCE"
+  },
+  {
+    "dtc": "P0DE600",
+    "l_dsc": "HYBRID/EV BATTERY PACK CELL VOLTAGE LOW"
+  },
+  {
+    "dtc": "P0DE700",
+    "l_dsc": "HYBRID/EV BATTERY PACK CELL VOLTAGE HIGH"
+  },
+  {
+    "dtc": "P1A2900",
+    "l_dsc": "CELL SUPERVISORY CIRCUIT A FAILURE"
+  },
+  {
+    "dtc": "P29FF00",
+    "l_dsc": "HYBRID/EV BATTERY THERMAL RUNAWAY DETECTED"
+  },
+  {
+    "dtc": "P0AC000",
+    "l_dsc": "HYBRID BATTERY PACK CURRENT SENSOR 1 CIRCUIT PERFORMANCE"
+  },
+  {
+    "dtc": "P0AC100",
+    "l_dsc": "HYBRID BATTERY PACK CURRENT SENSOR 1 CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0AC200",
+    "l_dsc": "HYBRID BATTERY PACK CURRENT SENSOR 1 CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0B0F00",
+    "l_dsc": "HYBRID/EV BATTERY PACK CURRENT SENSOR 2 CIRCUIT PERFORMANCE"
+  },
+  {
+    "dtc": "P0B1000",
+    "l_dsc": "HYBRID/EV BATTERY PACK CURRENT SENSOR 2 CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0B1100",
+    "l_dsc": "HYBRID/EV BATTERY PACK CURRENT SENSOR 2 CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0B1300",
+    "l_dsc": "HYBRID/EV BATTERY PACK CURRENT SENSOR 1/2 CORRELATION"
+  },
+  {
+    "dtc": "P0ABA00",
+    "l_dsc": "HYBRID/EV BATTERY PACK VOLTAGE SENSE A CIRCUIT"
+  },
+  {
+    "dtc": "P0B1400",
+    "l_dsc": "HYBRID/EV BATTERY PACK VOLTAGE SENSE B CIRCUIT"
+  },
+  {
+    "dtc": "P0B3D00",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE SENSE 1 CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0B3E00",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE SENSE 1 CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0C6E00",
+    "l_dsc": "HYBRID BATTERY TEMPERATURE SENSOR A/B CORRELATION"
+  },
+  {
+    "dtc": "P0ECA00",
+    "l_dsc": "HYBRID/EV BATTERY TEMPERATURE SENSOR SYSTEM-MULTIPLE SENSOR CORRELATION"
+  },
+  {
+    "dtc": "P0ECB00",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE SENSOR SYSTEM-MULTIPLE SENSOR CORRELATION"
+  },
+  {
+    "dtc": "P1C0000",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE SENSE 1 OUT OF RANGE LOW"
+  },
+  {
+    "dtc": "P1C0100",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE SENSE 1 OUT OF RANGE HIGH"
+  },
+  {
+    "dtc": "P1E1500",
+    "l_dsc": "BATTERY CURRENT SENSOR"
+  },
+  {
+    "dtc": "P0CA600",
+    "l_dsc": "HYBRID/EV BATTERY CHARGING CURRENT HIGH"
+  },
+  {
+    "dtc": "P0CA700",
+    "l_dsc": "HYBRID/EV BATTERY DISCHARGING CURRENT HIGH"
+  },
+  {
+    "dtc": "P0D3500",
+    "l_dsc": "HYBRID/EV BATTERY SYSTEM CURRENT UNSTABLE"
+  },
+  {
+    "dtc": "P0A0A00",
+    "l_dsc": "HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT A"
+  },
+  {
+    "dtc": "P0A0B00",
+    "l_dsc": "HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT A PERFORMANCE"
+  },
+  {
+    "dtc": "P0A0C00",
+    "l_dsc": "HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT A LOW"
+  },
+  {
+    "dtc": "P0A0D00",
+    "l_dsc": "HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT A HIGH"
+  },
+  {
+    "dtc": "P0A9500",
+    "l_dsc": "HIGH VOLTAGE FUSE A"
+  },
+  {
+    "dtc": "P0E2F00",
+    "l_dsc": "HIGH VOLTAGE FUSE B"
+  },
+  {
+    "dtc": "P0E3000",
+    "l_dsc": "HIGH VOLTAGE FUSE C"
+  },
+  {
+    "dtc": "P0AA600",
+    "l_dsc": "HYBRID BATTERY VOLTAGE SYSTEM ISOLATION FAULT"
+  },
+  {
+    "dtc": "P0AA700",
+    "l_dsc": "HYBRID/EV BATTERY VOLTAGE ISOLATION SENSOR CIRCUIT"
+  },
+  {
+    "dtc": "P0AA800",
+    "l_dsc": "HYBRID/EV BATTERY PACK A VOLTAGE ISOLATION SENSOR CIRCUIT RANGE/PERFORMANCE"
+  },
+  {
+    "dtc": "P0B3300",
+    "l_dsc": "HIGH VOLTAGE SERVICE DISCONNECT CIRCUIT"
+  },
+  {
+    "dtc": "P0B3500",
+    "l_dsc": "HIGH VOLTAGE SERVICE DISCONNECT CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0B3600",
+    "l_dsc": "HIGH VOLTAGE SERVICE DISCONNECT CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P1AE200",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT"
+  },
+  {
+    "dtc": "P1AE300",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT LOW"
+  },
+  {
+    "dtc": "P1AE400",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE HIGH VOLTAGE SYSTEM INTERLOCK CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P1E1B00",
+    "l_dsc": "HYBRID/EV BATTERY SIDE VOLTAGE SYSTEM ISOLATION"
+  },
+  {
+    "dtc": "P066800",
+    "l_dsc": "CONTROL MODULE INTERNAL TEMPERATURE SENSOR 1 CIRCUIT LOW"
+  },
+  {
+    "dtc": "P063400",
+    "l_dsc": "CONTROL MODULE INTERNAL TEMPERATURE 1 TOO HIGH"
+  },
+  {
+    "dtc": "P0A7E00",
+    "l_dsc": "HYBRID/EV BATTERY PACK A OVER TEMPERATURE"
+  },
+  {
+    "dtc": "P0A9B00",
+    "l_dsc": "HYBRID BATTERY TEMPERATURE SENSOR A CIRCUIT"
+  },
+  {
+    "dtc": "P0A9D00",
+    "l_dsc": "HYBRID/EV BATTERY TEMPERATURE SENSOR 1 CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0A9E00",
+    "l_dsc": "HYBRID/EV BATTERY TEMPERATURE SENSOR 1 CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0C4400",
+    "l_dsc": "HYBRID BATTERY PACK COOLANT INLET TEMPERATURE SENSOR CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0C4500",
+    "l_dsc": "HYBRID BATTERY PACK COOLANT INLET TEMPERATURE SENSOR CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P0CD700",
+    "l_dsc": "HYBRID BATTERY PACK COOLANT OUTLET TEMPERATURE SENSOR CIRCUIT LOW"
+  },
+  {
+    "dtc": "P0CD800",
+    "l_dsc": "HYBRID BATTERY PACK COOLANT OUTLET TEMPERATURE SENSOR CIRCUIT HIGH"
+  },
+  {
+    "dtc": "P1A9A00",
+    "l_dsc": "HYBRID/EV BATTERY TEMPERATURE SENSOR 1 OUT OF RANGE LOW"
+  },
+  {
+    "dtc": "P1A9B00",
+    "l_dsc": "HYBRID/EV BATTERY TEMPERATURE SENSOR 1 OUT OF RANGE HIGH"
+  },
+  {
+    "dtc": "B1CE900",
+    "l_dsc": "DIGITAL CRASH OUTPUT CONTROL CIRCUIT PERFORMANCE"
+  },
+  {
+    "dtc": "B273C00",
+    "l_dsc": "DIGITAL CRASH INPUT"
+  },
+  {
+    "dtc": "P0A1F00",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE A INTERNAL PERFORMANCE"
+  },
+  {
+    "dtc": "P161400",
+    "l_dsc": "ECU RESET/RECOVERY OCCURRED"
+  },
+  {
+    "dtc": "P167B00",
+    "l_dsc": "CONTROLLED SYSTEM SHUTDOWN"
+  },
+  {
+    "dtc": "P1A0100",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE EEPROM FAILURE"
+  },
+  {
+    "dtc": "P1A0600",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE READ ONLY MEMORY (ROM)"
+  },
+  {
+    "dtc": "P1A0C00",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE SYSTEM VOLTAGE LOW"
+  },
+  {
+    "dtc": "P1A0D00",
+    "l_dsc": "BATTERY ENERGY CONTROL MODULE SYSTEM VOLTAGE HIGH"
+  },
+  {
+    "dtc": "P1DAF00",
+    "l_dsc": "INCOMPATIBLE LIMP IN ACTION REQUESTED"
+  },
+  {
+    "dtc": "P1E1A00",
+    "l_dsc": "HYBRID/EV BATTERY CONTROL BOARD HARDWARE PERFORMANCE"
+  },
+  {
+    "dtc": "P1E2500",
+    "l_dsc": "HYBRID/EV BATTERY FAILURE LEVEL 2"
+  },
+  {
+    "dtc": "P2D3A00",
+    "l_dsc": "FORCED HYBRID/EV SYSTEM SHUTDOWN"
+  },
+  {
+    "dtc": "U007400",
+    "l_dsc": "DEDICATED POWERTRAIN-D-PT-CAN BUS OFF"
+  },
+  {
+    "dtc": "U007700",
+    "l_dsc": "CONTROL MODULE COMMUNICATION BUS OFF"
+  },
+  {
+    "dtc": "U015100",
+    "l_dsc": "LOST COMMUNICATION WITH OCCUPANT RESTRAINT CONTROLLER (ORC)"
+  },
+  {
+    "dtc": "U029300",
+    "l_dsc": "LOST COMMUNICATION WITH HYBRID CONTROL MODULE"
+  },
+  {
+    "dtc": "U029400",
+    "l_dsc": "LOST COMMUNICATION WITH POWERTRAIN CONTROL MONITOR MODULE"
+  },
+  {
+    "dtc": "U02AE00",
+    "l_dsc": "LOST COMMUNICATIONS WITH HYBRID/EV BATTERY COOLANT PUMP"
+  },
+  {
+    "dtc": "U059400",
+    "l_dsc": "IMPLAUSIBLE DATA RECEIVED FROM HYBRID CONTROL MODULE"
+  },
+  {
+    "dtc": "U059500",
+    "l_dsc": "INVALID DATA RECEIVED FROM POWERTRAIN CONTROL MONITOR MODULE"
+  },
+  {
+    "dtc": "U069E00",
+    "l_dsc": "LOST COMMUNICATION WITH COOLANT HEATER B"
+  },
+  {
+    "dtc": "U100800",
+    "l_dsc": "LIN 1 BUS"
+  },
+  {
+    "dtc": "U301700",
+    "l_dsc": "CONTROL MODULE TIMER/CLOCK PERFORMANCE"
+  }
+]


### PR DESCRIPTION
Follow-up to #2926, on the same branch. Two independent changes.

## 1. SOH and pack energy from `0x359` bytes 2-3

Bytes 2-3 of `0x359` hold the pack capacity in 0.1 Ah.

Evidence from the captures:

- **Constant within every session**, in all 25 logs.
- **Differs per pack**: 3340 and 3339 on two packs at nominal, 3235 and 3052 on two aged ones.
- **Independent of SOC**: unchanged over a 13-point SOC span on one pack and 8.6 points on another.
- **Matches UDS `DA75`** in every log where both are present.
- Present in the battery-only captures too, so it is BPCM-sourced rather than vehicle data.

| b2b3 | Ah | soh_pptt | total_capacity_Wh |
|---|---|---|---|
| 3340 | 334.0 | 100.00 % | 110 620 |
| 3339 | 333.9 | 99.97 % | 110 587 |
| 3235 | 323.5 | 96.85 % | 107 143 |
| 3052 | 305.2 | 91.37 % | 101 082 |

**Caveat worth flagging in review:** the two denominators are datasheet nominals, not bus readings —
3340 = 334.0 Ah cell, 33120 = 90 × 3.68 V = 331.2 V. The 0.1 Ah reading itself is what the evidence
supports; the conversion to a *percentage* rests on the assumption that a healthy pack reports 3340. The
resulting 110.6 kWh against the pack's nameplate 110.55 kWh is a consistency check on those nominals, not
an independent confirmation of them. Happy to drop the percentage and keep only the raw capacity if you
would rather not bake in the assumption.

## 2. DTC descriptions for the BPCM

The integration already reads DTCs through `UdsCanBattery` and already sets `dtc = &datalayer_battery->dtc`,
but with no description file the web UI renders every code as "Unknown". This adds the 112 BPCM codes from
the 2024 Ram ProMaster EV service documentation, which uses the same pack.

- Keyed by the 7-character SAE string the renderer emits, so `P0AA1-00` becomes `"P0AA100"`.
- **BPCM codes only.** The integration queries `0x7E7`, so the IDCM and EVCU codes in the same index can
  never come back here; leaving them out keeps the file lean as `web_data/dtc/README.md` asks.
- Descriptions are left in the documentation's original uppercase rather than title-cased, to avoid
  mangling `HV`, `EV`, `HYBRID/EV` and the `A`/`B` designators.
- Passes `tools/validate_dtc_json.py` with 0 errors and 0 warnings.

Same pattern as `mg_dtc.json` and `renault_zoe_gen1_dtc.json`: one data file plus a
`get_dtc_json_filename()` override.

Note the loader fetches from `raw.githubusercontent.com/dalathegreat/Battery-Emulator/main/`, so the
descriptions only reach users once this lands on `main`; until then the page's file picker loads a local
copy.

## Testing

Decoding was derived and cross-checked against ~1.5 GB of CAN captures (bench, vehicle, CATL 4-channel,
and a complete 80-minute charge to termination). The DTC JSON is validated by the repo's own validator.
Not yet run on hardware — worth a check on a live pack before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
