### PR TITLE
Fix SOL-ARK-LV-CAN 0x359 over-current sign bug

### DIFF
--- a/Software/src/inverter/SOL-ARK-LV-CAN.cpp
+++ b/Software/src/inverter/SOL-ARK-LV-CAN.cpp
@@ -54,7 +54,10 @@ void SolArkLvInverter::update_values() {
   SOLARK_359.data.u8[7] = 0x00;  //Unused, should be 00
 
   // Protection Byte 1 Bitfield: (If a bit is set, one of these caused batt self-protection mode)
-  if (datalayer.battery.status.reported_current_dA >= (datalayer.battery.status.max_discharge_current_dA + 50))
+  // reported_current_dA is positive while charging and negative while discharging, so the discharge
+  // over-current check has to compare against the negated discharge limit. Comparing against the
+  // positive limit tested a charging current against the discharge limit instead.
+  if (datalayer.battery.status.reported_current_dA <= -1 * (datalayer.battery.status.max_discharge_current_dA + 50))
     SOLARK_359.data.u8[0] |= 0x80;
   if (datalayer.battery.status.temperature_min_dC <= BATTERY_MINTEMPERATURE)
     SOLARK_359.data.u8[0] |= 0x10;
@@ -64,7 +67,11 @@ void SolArkLvInverter::update_values() {
     SOLARK_359.data.u8[0] |= 0x04;
   if (datalayer.system.status.system_status == FAULT)
     SOLARK_359.data.u8[1] |= 0x80;
-  if (datalayer.battery.status.reported_current_dA <= -1 * datalayer.battery.status.max_charge_current_dA)
+  // Charge current is the positive direction, so this one compares against the plain charge limit.
+  // The +50 margin matches the discharge check above: without it a full pack, which reports
+  // max_charge_current_dA 0, sat on the 0 >= 0 boundary and flagged charge over-current while idle
+  // or while discharging normally.
+  if (datalayer.battery.status.reported_current_dA >= (datalayer.battery.status.max_charge_current_dA + 50))
     SOLARK_359.data.u8[1] |= 0x01;
 
   // WARNINGS (using same rules as errors but reporting earlier)

--- a/test/solark_lv_overcurrent_tests.cpp
+++ b/test/solark_lv_overcurrent_tests.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/utils/types.h"
+#include "../Software/src/inverter/SOL-ARK-LV-CAN.h"
+
+// Regression tests for the two over-current bits the Sol-Ark LV protocol
+// publishes in 0x359: byte 0 bit 7 (discharge over-current protection) and
+// byte 1 bit 0 (charge over-current protection).
+//
+// datalayer.h documents the current sign as "Positive value = Battery
+// Charging / Negative value = Battery Discharging", so the discharge check
+// must compare against the negative of max_discharge_current_dA and the
+// charge check against the positive of max_charge_current_dA. Both compared
+// against the wrong sign, which is what these tests pin down. Same bug and
+// same two bits as the Pylon LV fix in #2920; SOL-ARK-LV-CAN.cpp was copied
+// from PYLON-LV-CAN.cpp and kept the "See Pylon protocol for example
+// integration" comment, but not the fix.
+
+void clear_transmitted_frames();
+const std::vector<CAN_frame>& get_transmitted_frames();
+
+namespace {
+
+constexpr uint8_t kDischargeOverCurrentBit = 0x80;  // 0x359 byte 0, bit 7
+constexpr uint8_t kChargeOverCurrentBit = 0x01;     // 0x359 byte 1, bit 0
+
+// The margin SOL-ARK-LV-CAN.cpp adds on top of each limit before it calls the
+// current an over-current, in dA.
+constexpr int16_t kMarginDA = 50;
+
+class SolArkLvOverCurrent : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer = DataLayer();
+    // Keep the temperature and under-voltage bits in byte 0 clear so the only
+    // thing that can set a bit under test is the current comparison.
+    datalayer.battery.status.temperature_min_dC = 200;
+    datalayer.battery.status.temperature_max_dC = 300;
+    datalayer.battery.info.min_design_voltage_dV = 400;
+    datalayer.battery.info.max_design_voltage_dV = 580;
+    datalayer.battery.status.voltage_dV = 520;
+    clear_transmitted_frames();
+  }
+
+  // Runs one publish cycle and returns the 0x359 frame that went out.
+  CAN_frame publish() {
+    SolArkLvInverter inverter;
+    inverter.update_values();
+    inverter.transmit_can(INTERVAL_1_S);
+    for (const CAN_frame& frame : get_transmitted_frames()) {
+      if (frame.ID == 0x359) {
+        return frame;
+      }
+    }
+    ADD_FAILURE() << "no 0x359 frame was transmitted";
+    return CAN_frame{};
+  }
+};
+
+}  // namespace
+
+// A full pack reports max_charge_current_dA == 0 while it keeps supplying the
+// house. The charge over-current bit must stay clear: the pack is discharging,
+// which cannot be a charge over-current no matter what the charge limit is.
+TEST_F(SolArkLvOverCurrent, FullPackDischargingDoesNotClaimChargeOverCurrent) {
+  datalayer.battery.status.max_charge_current_dA = 0;
+  datalayer.battery.status.max_discharge_current_dA = 1000;
+  datalayer.battery.status.reported_current_dA = -300;  // 30.0 A out of the pack
+
+  EXPECT_EQ(publish().data.u8[1] & kChargeOverCurrentBit, 0)
+      << "a discharging pack must not raise the charge over-current bit";
+}
+
+// An idle pack draws no current at all. Neither bit may be set.
+TEST_F(SolArkLvOverCurrent, IdlePackRaisesNoOverCurrentBits) {
+  datalayer.battery.status.max_charge_current_dA = 0;
+  datalayer.battery.status.max_discharge_current_dA = 0;
+  datalayer.battery.status.reported_current_dA = 0;
+
+  CAN_frame frame = publish();
+  EXPECT_EQ(frame.data.u8[0] & kDischargeOverCurrentBit, 0);
+  EXPECT_EQ(frame.data.u8[1] & kChargeOverCurrentBit, 0);
+}
+
+TEST_F(SolArkLvOverCurrent, ChargingPastTheChargeLimitRaisesChargeOverCurrent) {
+  datalayer.battery.status.max_charge_current_dA = 500;
+  datalayer.battery.status.max_discharge_current_dA = 500;
+  datalayer.battery.status.reported_current_dA = 500 + kMarginDA + 10;  // charging past the limit
+
+  EXPECT_EQ(publish().data.u8[1] & kChargeOverCurrentBit, kChargeOverCurrentBit);
+}
+
+TEST_F(SolArkLvOverCurrent, DischargingPastTheDischargeLimitRaisesDischargeOverCurrent) {
+  datalayer.battery.status.max_charge_current_dA = 500;
+  datalayer.battery.status.max_discharge_current_dA = 500;
+  datalayer.battery.status.reported_current_dA = -(500 + kMarginDA + 10);  // discharging past the limit
+
+  EXPECT_EQ(publish().data.u8[0] & kDischargeOverCurrentBit, kDischargeOverCurrentBit);
+}
+
+// Charging hard is not a discharge over-current, and discharging hard is not a
+// charge over-current. These are the two cross-checks the wrong signs failed.
+TEST_F(SolArkLvOverCurrent, HeavyChargingDoesNotClaimDischargeOverCurrent) {
+  datalayer.battery.status.max_charge_current_dA = 2000;
+  datalayer.battery.status.max_discharge_current_dA = 500;
+  datalayer.battery.status.reported_current_dA = 1500;  // well inside the charge limit
+
+  EXPECT_EQ(publish().data.u8[0] & kDischargeOverCurrentBit, 0);
+}
+
+TEST_F(SolArkLvOverCurrent, HeavyDischargingDoesNotClaimChargeOverCurrent) {
+  datalayer.battery.status.max_charge_current_dA = 500;
+  datalayer.battery.status.max_discharge_current_dA = 2000;
+  datalayer.battery.status.reported_current_dA = -1500;  // well inside the discharge limit
+
+  EXPECT_EQ(publish().data.u8[1] & kChargeOverCurrentBit, 0);
+}
+
+// Right at the limit is not yet over it: the margin exists so that a pack
+// sitting exactly on its own limit is not reported as protecting itself.
+TEST_F(SolArkLvOverCurrent, CurrentExactlyAtEitherLimitRaisesNothing) {
+  datalayer.battery.status.max_charge_current_dA = 500;
+  datalayer.battery.status.max_discharge_current_dA = 500;
+
+  datalayer.battery.status.reported_current_dA = 500;
+  EXPECT_EQ(publish().data.u8[1] & kChargeOverCurrentBit, 0);
+
+  clear_transmitted_frames();
+  datalayer.battery.status.reported_current_dA = -500;
+  EXPECT_EQ(publish().data.u8[0] & kDischargeOverCurrentBit, 0);
+}


### PR DESCRIPTION
### What
This PR fixes the two over-current bits in the Sol-Ark LV 0x359 frame, which were compared against the wrong sign of their own limit, and adds unit tests covering them.

### Why
`datalayer.h` says the current sign is positive while charging and negative while discharging. Both checks in `SolArkLvInverter::update_values()` read it the other way round:

`Software/src/inverter/SOL-ARK-LV-CAN.cpp:57` raised discharge over-current (byte 0, bit 7) when `reported_current_dA` rose above `+max_discharge_current_dA`, which is a charging current, so heavy charging was reported as a discharge over-current and heavy discharging was never reported at all.

`Software/src/inverter/SOL-ARK-LV-CAN.cpp:67` raised charge over-current (byte 1, bit 0) when `reported_current_dA` fell below `-max_charge_current_dA`, which is a discharging current. A full pack reports `max_charge_current_dA` 0, so that check reduced to `reported_current_dA <= 0` and stayed true for the whole time the pack sat idle or supplied the house. The Sol-Ark reads that bit as the battery having entered self-protection.

`SOL-ARK-LV-CAN.cpp` was copied from `PYLON-LV-CAN.cpp` and still carries its "See Pylon protocol for example integration" comment. Pylon had the identical inversion and #2920 fixed it two days ago; the Sol-Ark copy did not get the fix.

### How
The discharge check now compares against the negated discharge limit and the charge check against the plain charge limit, matching what #2920 did for Pylon. The +50 dA margin this file already had on the discharge side is kept, and the charge side gets the same margin, so a full idle pack no longer sits exactly on the `0 >= 0` boundary. `test/solark_lv_overcurrent_tests.cpp` builds one 0x359 frame per case through `update_values()` and `transmit_can()` and asserts the two bits directly, including the full-pack-discharging case, the idle case and both cross-direction cases.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)
- [x] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- same bug as #2919, in the Sol-Ark copy of the Pylon code

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- not applicable, no user facing behaviour or setting changes

### Checklist:

  - [x] The code change is tested and works locally.

I do not have a Sol-Ark, so this is verified in the host unit test suite rather than on hardware. Built and run with `cd test && mkdir build && cd build && cmake .. && cmake --build .` then `ctest`, the same commands as `.github/workflows/unit-tests.yml`. On unmodified `main` six of the seven new cases fail. With the fix the whole suite is 263 tests, 262 passed, 1 pre-existing skip, and `ctest` reports `100% tests passed, 0 tests failed out of 263`. Also ran the workflow's order independence step, `./tests` plus `--gtest_shuffle` with seeds 1, 7, 42, 1234 and 99999, all green, and `pre-commit run --files` on both changed files, which clang-format passes without reformatting.
