### PR TITLE
Support DNS lookup for Syslog servers

### DIFF
--- a/Software/src/devboard/utils/logging.cpp
+++ b/Software/src/devboard/utils/logging.cpp
@@ -2,8 +2,8 @@
 #include "../../datalayer/datalayer.h"
 #include "../sdcard/sdcard.h"
 
+#include <NetworkUdp.h>
 #include <WiFi.h>
-#include <WiFiUdp.h>
 #include "../network/hostname.h"        // active_hostname()
 #include "../network/network_status.h"  // network_connected()
 
@@ -47,7 +47,7 @@ uint8_t syslog_facility = 1;  // 1 = user-level
 
 static const uint8_t SYSLOG_DEFAULT_SEVERITY = 7;  // debug — for messages without an event level
 static int syslog_next_severity = -1;              // -1 = use default; set per-line by set_next_severity()
-static WiFiUDP syslogUdp;
+static NetworkUDP syslogUdp;
 #define SYSLOG_LINE_MAX 240
 static char syslogLine[SYSLOG_LINE_MAX];
 static size_t syslogLineLen = 0;
@@ -80,12 +80,11 @@ static bool syslog_online(void) {
 
 // Called ONLY from syslog_task, and never with the mutex held.
 static void syslog_send(uint8_t sev, const char* proc, const char* msg) {
-  IPAddress dst;
-  if (!dst.fromString(syslog_ip.c_str())) {  // empty or invalid IP -> skip
+  if (syslog_ip.empty()) {
     return;
   }
   uint8_t pri = (uint8_t)((syslog_facility & 0x1F) * 8 + (sev & 0x07));
-  if (syslogUdp.beginPacket(dst, syslog_port)) {
+  if (syslogUdp.beginPacket(syslog_ip.c_str(), syslog_port)) {
     // RFC 5424: <PRI>1 TIMESTAMP HOSTNAME APP PROCID MSGID MSG
     // NILVALUE '-' timestamp -> the syslog server stamps on receipt.
     // APP-NAME carries the FreeRTOS task that produced the line.
@@ -122,8 +121,7 @@ static void syslog_queue_push(uint8_t sev, const char* msg) {
   }
 
   if (syslogQueue == nullptr) {
-    IPAddress dst;
-    if (!dst.fromString(syslog_ip.c_str())) {
+    if (syslog_ip.empty()) {
       xSemaphoreGive(syslogMutex);  // no syslog server configured -> never allocate
       return;
     }

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1244,9 +1244,10 @@ const char* getCANInterfaceName(CAN_Interface interface) {
               title="Send general logging as UDP syslog datagrams (RFC 5424) to a remote server. Events use their own severity; other lines are sent as debug." />
 
         <div class='if-syslogen'>
-        <label>Syslog server IP: </label>
-        <input type='text' name='SYSLOGIP' value="%SYSLOGIP%" pattern="%IPPATTERN%"
-              inputmode="decimal" title="IPv4 address of the syslog server" />
+        <label>Syslog server: </label>
+        <input type='text' name='SYSLOGIP' value="%SYSLOGIP%"
+        pattern="[A-Za-z0-9.\-]+"
+        title="Hostname (letters, numbers, '.', '-')" />
         <label>Syslog UDP port: </label>
         <input type='number' name='SYSLOGPORT' value="%SYSLOGPORT%"
               min="1" max="65535" step="1" title="UDP port (default 514)" />


### PR DESCRIPTION
### What
I noticed that syslog unlike MQTT does not support hostnames. This PR fixes that. The main downside of using a DNS record is that the lookup takes time and can fail. But on a healthy network this should not be an issue since there is a built-in DNS chache.
While testing I also noticed that syslog does not retry send failures. I will open a follow-up PR for that after this one.

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [x] Code quality improvements to existing code or addition of tests

### Checklist:

  - x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
