### PR TITLE
Optional Inverter Modbus gateway (RS485 ⇄ Modbus-TCP)

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -653,7 +653,7 @@ void core_loop(void*) {
       previousMillisUpdateVal = currentMillis;  // Order matters on the update_loop!
       START_TIME_MEASUREMENT(values);
       modbus_gateway_loop();  // Bind Modbus-TCP gateway once WiFi is up (no-op otherwise)
-      update_pause_state();  // Check if we are OK to send CAN or need to pause
+      update_pause_state();   // Check if we are OK to send CAN or need to pause
 
       // Fetch battery values
       if (battery) {

--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -12,6 +12,7 @@
 #include "src/communication/can/comm_can.h"
 #include "src/communication/contactorcontrol/comm_contactorcontrol.h"
 #include "src/communication/equipmentstopbutton/comm_equipmentstopbutton.h"
+#include "src/communication/modbus_gateway/modbus_gateway.h"
 #include "src/communication/nvm/comm_nvm.h"
 #include "src/communication/precharge_control/precharge_control.h"
 #include "src/communication/rs485/comm_rs485.h"
@@ -651,6 +652,7 @@ void core_loop(void*) {
     if (currentMillis - previousMillisUpdateVal >= INTERVAL_1_S && loopPhase == 1) {
       previousMillisUpdateVal = currentMillis;  // Order matters on the update_loop!
       START_TIME_MEASUREMENT(values);
+      modbus_gateway_loop();  // Bind Modbus-TCP gateway once WiFi is up (no-op otherwise)
       update_pause_state();  // Check if we are OK to send CAN or need to pause
 
       // Fetch battery values
@@ -780,6 +782,11 @@ void setup() {
   setup_charger();
   setup_inverter();
   setup_battery();
+
+  // Optional Modbus gateway (build-gated). Must run after setup_inverter() so the
+  // free-RS485 gate can read the active inverter interface type. No-op if the bus
+  // is busy or the feature is compiled out.
+  modbus_gateway_init();
 
   /* Some battery types mandate the SOC-based charge power taper. Enforce at
      runtime regardless of stored settings, and restrict the start SOC to

--- a/Software/src/communication/modbus_gateway/modbus_gateway.cpp
+++ b/Software/src/communication/modbus_gateway/modbus_gateway.cpp
@@ -94,12 +94,14 @@ static std::vector<uint8_t> parse_slave_ids(const String& csv) {
   int start = 0;
   while (start < (int)csv.length()) {
     int comma = csv.indexOf(',', start);
-    if (comma < 0) comma = csv.length();
+    if (comma < 0)
+      comma = csv.length();
     String tok = csv.substring(start, comma);
     tok.trim();
     if (tok.length()) {
       int v = tok.toInt();
-      if (v >= 1 && v <= 247) ids.push_back((uint8_t)v);
+      if (v >= 1 && v <= 247)
+        ids.push_back((uint8_t)v);
     }
     start = comma + 1;
   }
@@ -107,7 +109,8 @@ static std::vector<uint8_t> parse_slave_ids(const String& csv) {
 }
 
 static bool ip_allowed(const String& ip) {
-  if (g_cfg.ip_allow.length() == 0) return true;  // empty allowlist = allow all
+  if (g_cfg.ip_allow.length() == 0)
+    return true;  // empty allowlist = allow all
   String csv = g_cfg.ip_allow;
   csv.replace(" ", "");
   return ("," + csv + ",").indexOf("," + ip + ",") >= 0;
@@ -248,11 +251,15 @@ void modbus_gateway_register_routes(AsyncWebServer& server) {
   // Anti-replay: nonce must strictly exceed the last accepted nonce (kept in NVS).
   server.on("/modbus/write", HTTP_POST, [](AsyncWebServerRequest* request) {
     auto getp = [&](const char* n) -> String {
-      if (request->hasParam(n, true)) return request->getParam(n, true)->value();
-      if (request->hasParam(n)) return request->getParam(n)->value();
+      if (request->hasParam(n, true))
+        return request->getParam(n, true)->value();
+      if (request->hasParam(n))
+        return request->getParam(n)->value();
       return String();
     };
-    auto has = [&](const char* n) -> bool { return request->hasParam(n, true) || request->hasParam(n); };
+    auto has = [&](const char* n) -> bool {
+      return request->hasParam(n, true) || request->hasParam(n);
+    };
     String ip = request->client() ? request->client()->remoteIP().toString() : String("?");
     auto deny = [&](int code, const char* txt, uint8_t id, uint16_t addr, uint16_t val) {
       audit_add(ip, id, addr, val, code);
@@ -322,8 +329,10 @@ void modbus_gateway_register_routes(AsyncWebServer& server) {
     for (int k = 0; k < GW_AUDIT_N; k++) {
       int idx = (g_audit_head - 1 - k + 2 * GW_AUDIT_N) % GW_AUDIT_N;  // newest first
       const AuditEntry& e = g_audit[idx];
-      if (e.ms == 0) continue;
-      if (!first) j += ",";
+      if (e.ms == 0)
+        continue;
+      if (!first)
+        j += ",";
       first = false;
       j += "{\"ms\":" + String(e.ms) + ",\"ip\":\"" + json_escape(e.ip) + "\",\"id\":" + String(e.id) +
            ",\"addr\":" + String(e.addr) + ",\"val\":" + String(e.val) + ",\"code\":" + String(e.code) + "}";

--- a/Software/src/communication/modbus_gateway/modbus_gateway.cpp
+++ b/Software/src/communication/modbus_gateway/modbus_gateway.cpp
@@ -1,0 +1,343 @@
+#include "modbus_gateway.h"
+
+// Built in on boards with enough flash; compiled out on 4 MB / SMALL_FLASH_DEVICE
+// boards so it costs them nothing. Activation is still runtime-gated (enabled in
+// settings + RS485 present + inverter link is CAN).
+#ifndef SMALL_FLASH_DEVICE
+
+#include <Arduino.h>
+#include <Preferences.h>
+#include <WiFi.h>
+#include <esp_random.h>
+#include <mbedtls/md.h>
+
+#include <vector>
+
+#include "../../communication/nvm/comm_nvm.h"  // BatteryEmulatorSettingsStore
+#include "../../devboard/hal/hal.h"
+#include "../../inverter/InverterProtocol.h"  // extern InverterProtocol* inverter; InverterInterfaceType
+#include "../../lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
+#include "../../lib/eModbus-eModbus/ModbusClientRTU.h"
+#include "../../lib/eModbus-eModbus/ModbusServerWiFi.h"
+#include "../rs485/comm_rs485.h"
+
+using namespace Modbus;  // FunctionCode / Error enums (READ_HOLD_REGISTER, ...)
+
+// The eModbus objects are constructed with a compile-time DE pin. Mirror
+// ModbusInverterProtocol: pass -1 and let rs485_begin()'s UART half-duplex mode
+// (boards with a real DE pin) or the auto-direction transceiver (LilyGo, no DE
+// pin) drive the bus direction. Do NOT let eModbus toggle a GPIO here.
+#ifndef RS485_DE_PIN
+#define RS485_DE_PIN -1
+#endif
+
+// ---- Fixed tuning (not user-configurable) -----------------------------------
+static constexpr uint8_t GW_MAX_CLIENTS = 1;       // only the platform poller
+static constexpr uint32_t GW_TCP_TIMEOUT = 10000;  // ms idle before drop
+static constexpr uint32_t GW_RTU_TIMEOUT = 1000;   // ms per RTU transaction
+
+// ---- Persistent config (NVS namespace "mbgw"), edited via the web UI ---------
+// Secure by default: the gateway is OFF and writes are DISABLED until an admin
+// enables them. The HMAC secret is generated randomly on first boot.
+struct GwConfig {
+  bool enable = false;         // master enable for the whole gateway
+  bool allow_write = false;    // permit the authenticated write endpoint
+  uint16_t tcp_port = 502;     // Modbus-TCP listen port
+  uint32_t baud = 9600;        // RS485 baud (GoodWe 247 / DEYE 1 are both 9600 8N1)
+  String slave_ids = "247,1";  // CSV of RTU slave IDs exposed for reads
+  String secret;               // HMAC secret (random hex, generated if empty)
+  String ip_allow;             // CSV of client IPs allowed to WRITE; empty = allow all
+};
+static GwConfig g_cfg;
+
+static ModbusClientRTU* g_master = nullptr;
+static ModbusServerWiFi g_tcp;
+static bool g_master_ready = false;  // RTU master + RS485 up, workers registered
+static bool g_tcp_started = false;   // TCP server bound (only once WiFi is connected)
+
+static String random_hex(int bytes) {
+  static const char* hx = "0123456789abcdef";
+  String s;
+  s.reserve(bytes * 2);
+  for (int i = 0; i < bytes; i++) {
+    uint8_t b = static_cast<uint8_t>(esp_random());
+    s += hx[b >> 4];
+    s += hx[b & 0x0F];
+  }
+  return s;
+}
+
+// Config lives in the emulator's own settings store (BatteryEmulatorSettingsStore,
+// keys GW*) so it is edited from the standard /settings page, persisted by
+// /saveSettings, and wiped by factory reset — like every other setting. Changes
+// take effect on reboot (same as the rest of the settings page). Keys:
+//   GWENAB(bool) GWWRITE(bool) GWPORT(uint) GWBAUD(uint)
+//   GWSLAVES(str) GWSECRET(str) GWIPALLOW(str)
+static void cfg_load() {
+  BatteryEmulatorSettingsStore s;
+  g_cfg.enable = s.getBool("GWENAB", false);
+  g_cfg.allow_write = s.getBool("GWWRITE", false);
+  g_cfg.tcp_port = (uint16_t)s.getUInt("GWPORT", 502);
+  g_cfg.baud = s.getUInt("GWBAUD", 9600);
+  g_cfg.slave_ids = s.getString("GWSLAVES", "247,1");
+  g_cfg.ip_allow = s.getString("GWIPALLOW", "");
+  g_cfg.secret = s.getString("GWSECRET", "");
+  if (g_cfg.secret.length() == 0) {
+    g_cfg.secret = random_hex(16);  // 32 hex chars, generated once on first boot
+    s.saveString("GWSECRET", g_cfg.secret.c_str());
+  }
+}
+
+// Parse a CSV like "247, 1" into a small list of slave IDs.
+static std::vector<uint8_t> parse_slave_ids(const String& csv) {
+  std::vector<uint8_t> ids;
+  int start = 0;
+  while (start < (int)csv.length()) {
+    int comma = csv.indexOf(',', start);
+    if (comma < 0) comma = csv.length();
+    String tok = csv.substring(start, comma);
+    tok.trim();
+    if (tok.length()) {
+      int v = tok.toInt();
+      if (v >= 1 && v <= 247) ids.push_back((uint8_t)v);
+    }
+    start = comma + 1;
+  }
+  return ids;
+}
+
+static bool ip_allowed(const String& ip) {
+  if (g_cfg.ip_allow.length() == 0) return true;  // empty allowlist = allow all
+  String csv = g_cfg.ip_allow;
+  csv.replace(" ", "");
+  return ("," + csv + ",").indexOf("," + ip + ",") >= 0;
+}
+
+// ---- In-RAM audit ring for write attempts -----------------------------------
+struct AuditEntry {
+  uint32_t ms = 0;
+  String ip;
+  uint8_t id = 0;
+  uint16_t addr = 0;
+  uint16_t val = 0;
+  int code = 0;  // HTTP status of the attempt
+};
+static const int GW_AUDIT_N = 16;
+static AuditEntry g_audit[GW_AUDIT_N];
+static int g_audit_head = 0;
+
+static void audit_add(const String& ip, uint8_t id, uint16_t addr, uint16_t val, int code) {
+  g_audit[g_audit_head] = AuditEntry{millis(), ip, id, addr, val, code};
+  g_audit_head = (g_audit_head + 1) % GW_AUDIT_N;
+}
+
+// Transparent read worker: forward the TCP request verbatim to the RTU master
+// and return its response (or a device-failure error if the master is absent).
+static ModbusMessage gw_forward(ModbusMessage request) {
+  static uint32_t token = 0;
+  if (!g_master) {
+    ModbusMessage err;
+    err.setError(request.getServerID(), request.getFunctionCode(), SERVER_DEVICE_FAILURE);
+    return err;
+  }
+  return g_master->syncRequest(request, token++);
+}
+
+void modbus_gateway_init() {
+  if (g_master_ready) {
+    return;
+  }
+
+  cfg_load();  // load config (and generate the HMAC secret on first boot)
+
+  if (!g_cfg.enable) {
+    return;  // secure default: gateway stays off until enabled in the web UI
+  }
+
+  // Only boards that actually have an RS485 interface can host the gateway.
+  // The base HAL returns GPIO_NUM_NC for RS485 pins; boards with RS485 override it.
+  if (esp32hal->RS485_RX_PIN() == GPIO_NUM_NC || esp32hal->RS485_TX_PIN() == GPIO_NUM_NC) {
+    return;  // no RS485 on this board — feature unsupported
+  }
+
+  // Free-bus gate: only claim RS485 when the inverter link is NOT RS485/Modbus.
+  // A CAN inverter link (or no inverter selected) leaves RS485 idle and ours.
+  if (inverter && inverter->interface_type() != InverterInterfaceType::Can) {
+    return;  // RS485 busy serving the battery/inverter Modbus role; do not contend.
+  }
+
+  // Open UART2 for RS485 the same way every RS485 user does (sets pins and, on
+  // boards with a DE pin, UART half-duplex mode).
+  if (!rs485_begin("ModbusGateway", Serial2, g_cfg.baud, SERIAL_8N1)) {
+    return;
+  }
+
+  g_master = new ModbusClientRTU(RS485_DE_PIN);
+  g_master->setTimeout(GW_RTU_TIMEOUT);
+  g_master->begin(Serial2, esp32hal->MODBUS_CORE());
+
+  // Read-only over TCP: register only read function codes. Write FCs are
+  // deliberately left unregistered, so the server answers ILLEGAL_FUNCTION to
+  // any write over the raw TCP port. Writes go through the HMAC endpoint only.
+  for (uint8_t id : parse_slave_ids(g_cfg.slave_ids)) {
+    g_tcp.registerWorker(id, READ_HOLD_REGISTER, &gw_forward);
+    g_tcp.registerWorker(id, READ_INPUT_REGISTER, &gw_forward);
+  }
+
+  // The TCP server is NOT started here: WiFi is brought up asynchronously by the
+  // connectivity task and is not connected yet at setup() time. It is started
+  // from modbus_gateway_loop() once WiFi reports connected.
+  g_master_ready = true;
+}
+
+void modbus_gateway_loop() {
+  // Bind the Modbus-TCP server once, after WiFi is up (WiFiServer needs an IP).
+  if (g_master_ready && !g_tcp_started && WiFi.status() == WL_CONNECTED) {
+    g_tcp.start(g_cfg.tcp_port, GW_MAX_CLIENTS, GW_TCP_TIMEOUT, esp32hal->MODBUS_CORE());
+    g_tcp_started = true;
+  }
+}
+
+// ---- Authenticated write path (HTTP + HMAC-SHA256, never over raw :502) ------
+
+static String hmac_sha256_hex(const String& key, const String& msg) {
+  uint8_t out[32];
+  const mbedtls_md_info_t* info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  mbedtls_md_hmac(info, reinterpret_cast<const uint8_t*>(key.c_str()), key.length(),
+                  reinterpret_cast<const uint8_t*>(msg.c_str()), msg.length(), out);
+  static const char* hx = "0123456789abcdef";
+  String s;
+  s.reserve(64);
+  for (int i = 0; i < 32; i++) {
+    s += hx[out[i] >> 4];
+    s += hx[out[i] & 0x0F];
+  }
+  return s;
+}
+
+// Constant-time-ish string compare (avoid leaking match length via early exit).
+static bool ct_equal(const String& a, const String& b) {
+  if (a.length() != b.length()) {
+    return false;
+  }
+  uint8_t diff = 0;
+  for (size_t i = 0; i < a.length(); i++) {
+    diff |= static_cast<uint8_t>(a[i] ^ b[i]);
+  }
+  return diff == 0;
+}
+
+static String json_escape(const String& s) {
+  String o;
+  o.reserve(s.length() + 4);
+  for (size_t i = 0; i < s.length(); i++) {
+    char c = s[i];
+    if (c == '"' || c == '\\') {
+      o += '\\';
+      o += c;
+    } else if (c >= 0x20) {
+      o += c;
+    }
+  }
+  return o;
+}
+
+void modbus_gateway_register_routes(AsyncWebServer& server) {
+  // ---- POST /modbus/write?id=&addr=&val=&nonce=&sig= --------------------------
+  // sig = lowercase hex HMAC-SHA256(secret, "id:addr:val:nonce").
+  // Anti-replay: nonce must strictly exceed the last accepted nonce (kept in NVS).
+  server.on("/modbus/write", HTTP_POST, [](AsyncWebServerRequest* request) {
+    auto getp = [&](const char* n) -> String {
+      if (request->hasParam(n, true)) return request->getParam(n, true)->value();
+      if (request->hasParam(n)) return request->getParam(n)->value();
+      return String();
+    };
+    auto has = [&](const char* n) -> bool { return request->hasParam(n, true) || request->hasParam(n); };
+    String ip = request->client() ? request->client()->remoteIP().toString() : String("?");
+    auto deny = [&](int code, const char* txt, uint8_t id, uint16_t addr, uint16_t val) {
+      audit_add(ip, id, addr, val, code);
+      request->send(code, "text/plain", txt);
+    };
+
+    if (!g_cfg.allow_write) {
+      deny(403, "writes disabled", 0, 0, 0);
+      return;
+    }
+    if (!ip_allowed(ip)) {
+      deny(403, "ip not allowed", 0, 0, 0);
+      return;
+    }
+    if (!(has("id") && has("addr") && has("val") && has("nonce") && has("sig"))) {
+      deny(400, "missing params", 0, 0, 0);
+      return;
+    }
+    uint8_t id = static_cast<uint8_t>(strtoul(getp("id").c_str(), nullptr, 10));
+    uint16_t addr = static_cast<uint16_t>(strtoul(getp("addr").c_str(), nullptr, 10));
+    uint16_t val = static_cast<uint16_t>(strtoul(getp("val").c_str(), nullptr, 10));
+    uint32_t nonce = strtoul(getp("nonce").c_str(), nullptr, 10);
+    String sig = getp("sig");
+    sig.toLowerCase();
+
+    if (!g_master) {
+      deny(503, "master not ready", id, addr, val);
+      return;
+    }
+
+    Preferences prefs;
+    prefs.begin("mbgw", false);
+    uint32_t last_nonce = prefs.getULong("nonce", 0);
+    if (nonce <= last_nonce) {
+      prefs.end();
+      deny(409, "stale nonce", id, addr, val);
+      return;
+    }
+    String msg = String(id) + ":" + String(addr) + ":" + String(val) + ":" + String(nonce);
+    if (!ct_equal(hmac_sha256_hex(g_cfg.secret, msg), sig)) {
+      prefs.end();
+      deny(401, "bad signature", id, addr, val);
+      return;
+    }
+    prefs.putULong("nonce", nonce);  // burn the nonce only after auth succeeds
+    prefs.end();
+
+    // FC06 write single holding register through the RTU master.
+    ModbusMessage resp = g_master->syncRequest(nonce, id, WRITE_HOLD_REGISTER, addr, val);
+    Error err = resp.getError();
+    if (err != SUCCESS) {
+      deny(502, (String("rtu error 0x") + String(err, HEX)).c_str(), id, addr, val);
+      return;
+    }
+    audit_add(ip, id, addr, val, 200);
+    request->send(200, "text/plain", "OK");
+  });
+
+  // Config (enable / port / baud / slave IDs / secret / IP-allowlist / allow-write)
+  // lives in the standard /settings page (BatteryEmulatorSettingsStore, GW* keys) —
+  // no separate config page here.
+
+  // ---- GET /modbus/audit : last write attempts as JSON ------------------------
+  server.on("/modbus/audit", HTTP_GET, [](AsyncWebServerRequest* request) {
+    String j = "[";
+    bool first = true;
+    for (int k = 0; k < GW_AUDIT_N; k++) {
+      int idx = (g_audit_head - 1 - k + 2 * GW_AUDIT_N) % GW_AUDIT_N;  // newest first
+      const AuditEntry& e = g_audit[idx];
+      if (e.ms == 0) continue;
+      if (!first) j += ",";
+      first = false;
+      j += "{\"ms\":" + String(e.ms) + ",\"ip\":\"" + json_escape(e.ip) + "\",\"id\":" + String(e.id) +
+           ",\"addr\":" + String(e.addr) + ",\"val\":" + String(e.val) + ",\"code\":" + String(e.code) + "}";
+    }
+    j += "]";
+    request->send(200, "application/json", j);
+  });
+}
+
+#else  // SMALL_FLASH_DEVICE — feature compiled out entirely.
+
+class AsyncWebServer;
+void modbus_gateway_init() {}
+void modbus_gateway_loop() {}
+void modbus_gateway_register_routes(AsyncWebServer&) {}
+
+#endif  // !SMALL_FLASH_DEVICE

--- a/Software/src/communication/modbus_gateway/modbus_gateway.h
+++ b/Software/src/communication/modbus_gateway/modbus_gateway.h
@@ -1,0 +1,34 @@
+#ifndef _MODBUS_GATEWAY_H_
+#define _MODBUS_GATEWAY_H_
+
+// Inverter Modbus gateway (compiled in except on SMALL_FLASH_DEVICE/4 MB boards).
+//
+// When the inverter link uses CAN, the RS485/UART2 port is idle. This feature
+// turns that idle RS485 into a transparent Modbus gateway to whatever Modbus
+// device is wired to it (typically the inverter's Modbus/COM port): an eModbus
+// RTU master owns the bus, and a Modbus-TCP server forwards network requests to
+// it. Protocol-agnostic passthrough — no per-inverter register knowledge lives
+// here; the meaning of registers stays with the network client.
+//
+// Phase 1 (this file): read-only transparent bridge, gated on a free RS485 bus.
+// Phase 2 (later): HMAC-authenticated writes via the web API, IP-allowlist,
+// audit, NVM/web configuration. Write function codes are intentionally NOT
+// served here, so the raw TCP port is read-only.
+
+// Call once from setup(), AFTER setup_inverter() (so the active inverter
+// interface type is known for the free-bus gate). No-op on SMALL_FLASH_DEVICE
+// boards, or unless the feature is enabled and the RS485 bus is free.
+void modbus_gateway_init();
+
+// Reserved for periodic housekeeping; currently a no-op (master and TCP server
+// each run on their own task).
+void modbus_gateway_loop();
+
+// Register the HMAC-authenticated write endpoint (POST /modbus/write) on the
+// emulator webserver. Call from init_webserver(). Writes never go over the raw
+// Modbus-TCP port (that stays read-only); they are authenticated with an
+// HMAC-SHA256 signature + monotonic nonce. No-op on SMALL_FLASH_DEVICE boards.
+class AsyncWebServer;  // forward declaration to avoid pulling the async header here
+void modbus_gateway_register_routes(AsyncWebServer& server);
+
+#endif  // _MODBUS_GATEWAY_H_

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -745,6 +745,30 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
   if (var == "SYSLOGFAC") {
     return String(settings.getUInt("SYSLOGFAC", 1));
   }
+#ifndef SMALL_FLASH_DEVICE
+  // Inverter Modbus gateway
+  if (var == "GWENAB") {
+    return settings.getBool("GWENAB") ? "checked" : "";
+  }
+  if (var == "GWWRITE") {
+    return settings.getBool("GWWRITE") ? "checked" : "";
+  }
+  if (var == "GWPORT") {
+    return String(settings.getUInt("GWPORT", 502));
+  }
+  if (var == "GWBAUD") {
+    return String(settings.getUInt("GWBAUD", 9600));
+  }
+  if (var == "GWSLAVES") {
+    return settings.getString("GWSLAVES", "247,1");
+  }
+  if (var == "GWSECRET") {
+    return settings.getString("GWSECRET");
+  }
+  if (var == "GWIPALLOW") {
+    return settings.getString("GWIPALLOW");
+  }
+#endif  // !SMALL_FLASH_DEVICE
   if (var == "ESPNOWENABLED") {
     return settings.getBool("ESPNOWENABLED") ? "checked" : "";
   }
@@ -1256,6 +1280,41 @@ const char* getCANInterfaceName(CAN_Interface interface) {
               title="0=kern, 1=user, 3=daemon, 16-23=local0-7 (default 1)" />
         </div>
   )rawliteral"
+
+// Inverter Modbus gateway — its own settings card (proper 2-col grid).
+// Compiled out unless the feature is enabled, so the settings page costs
+// nothing on SMALL_FLASH_DEVICE (4 MB) boards.
+#ifndef SMALL_FLASH_DEVICE
+#define GATEWAY_SETTING_HTML \
+  R"rawliteral(
+        <div class="settings-card">
+        <h3>Inverter Modbus gateway</h3>
+        <div style='display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; align-items: center;'>
+        <label>Enable gateway: </label>
+        <input type='checkbox' name='GWENAB' value='on' %GWENAB%
+              title="Expose the inverter over Modbus-TCP via the free RS485 port. Only activates when the inverter link is CAN (RS485 idle)." />
+        <label>Allow writes (HMAC-signed): </label>
+        <input type='checkbox' name='GWWRITE' value='on' %GWWRITE%
+              title="Permit authenticated register writes via POST /modbus/write. The raw Modbus-TCP port stays read-only." />
+        <label>Modbus-TCP port: </label>
+        <input type='number' name='GWPORT' value="%GWPORT%" min="1" max="65535" step="1" title="Default 502" />
+        <label>RS485 baud: </label>
+        <input type='number' name='GWBAUD' value="%GWBAUD%" min="1200" max="115200" step="1"
+              title="GoodWe/DEYE default 9600 (8N1)" />
+        <label>Slave IDs (CSV): </label>
+        <input type='text' name='GWSLAVES' value="%GWSLAVES%" title="RTU slave IDs exposed for reads, e.g. 247,1" />
+        <label>Passphrase (HMAC secret): </label>
+        <input type='text' name='GWSECRET' value="%GWSECRET%"
+              title="Shared secret used to sign writes. Auto-generated on first boot; edit to rotate." />
+        <label>Write IP allowlist (CSV, empty = any): </label>
+        <input type='text' name='GWIPALLOW' value="%GWIPALLOW%"
+              title="Only these client IPs may write. Empty = allow all." />
+        </div>
+        </div>
+  )rawliteral"
+#else
+#define GATEWAY_SETTING_HTML ""
+#endif  // !SMALL_FLASH_DEVICE
 
 #define SETTINGS_HTML_SCRIPTS \
   R"rawliteral(
@@ -2323,6 +2382,8 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
         </div>
         </div>
+
+        )rawliteral" GATEWAY_SETTING_HTML R"rawliteral(
 
         <div class="settings-card">
         <h3>Debug options</h3>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -472,7 +472,7 @@ void init_webserver() {
       "SYSLOGEN",     "PERBMSDEFSOC", "PERBMSSKIPBAL", "INVOFFGRID",  "CHGESTIMATED",  "MQTTHEAP",     "HADISCFWU",
       "INVACCREB",
 #ifndef SMALL_FLASH_DEVICE
-      "GWENAB", "GWWRITE",
+      "GWENAB",       "GWWRITE",
 #endif
 #ifdef SDCARD
       "SDLOGENABLED", "CANLOGSD",
@@ -489,15 +489,15 @@ void init_webserver() {
       "INVICNT",    "FOXESSTYPE",   "FOXESSSUBTYPE", "FOXESSMODULES", "CHGTAPERSTART", "CHGTAPERFLOOR", "SYSLOGPORT",
       "SYSLOGFAC",  "PERBMSRESETH",
 #ifndef SMALL_FLASH_DEVICE
-      "GWPORT", "GWBAUD",
+      "GWPORT",     "GWBAUD",
 #endif
   };
 
-  const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER",  "MQTTPASSWORD",
-                                      "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",   "SUBNET",
-                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS",
+  const char* stringSettingNames[] = {
+      "APPASSWORD", "HOSTNAME", "MQTTSERVER", "MQTTUSER", "MQTTPASSWORD", "HTTPUSER", "HTTPPASS",
+      "LOCALIP",    "GATEWAY",  "SUBNET",     "DNS",      "HADISCTOPIC",  "SYSLOGIP", "ESPNOWMACS",
 #ifndef SMALL_FLASH_DEVICE
-                                      "GWSLAVES", "GWSECRET", "GWIPALLOW",
+      "GWSLAVES",   "GWSECRET", "GWIPALLOW",
 #endif
   };
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -8,6 +8,7 @@
 #include "../../communication/can/comm_can.h"
 #include "../../communication/contactorcontrol/comm_contactorcontrol.h"
 #include "../../communication/equipmentstopbutton/comm_equipmentstopbutton.h"
+#include "../../communication/modbus_gateway/modbus_gateway.h"
 #include "../../communication/nvm/comm_nvm.h"
 #include "../../datalayer/datalayer.h"
 #include "../../datalayer/datalayer_extended.h"
@@ -201,6 +202,9 @@ void init_webserver() {
     web_auth_middleware.setAuthType(AsyncAuthType::AUTH_BASIC);
     server.addMiddleware(&web_auth_middleware);
   }
+
+  // Optional Modbus gateway write endpoint (build-gated; no-op if disabled).
+  modbus_gateway_register_routes(server);
 
   server
       .on("/logout", HTTP_GET,
@@ -467,6 +471,9 @@ void init_webserver() {
       "PRIMOGEN24",   "CTINVERT",     "LOWPASSFILTER", "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP",
       "SYSLOGEN",     "PERBMSDEFSOC", "PERBMSSKIPBAL", "INVOFFGRID",  "CHGESTIMATED",  "MQTTHEAP",     "HADISCFWU",
       "INVACCREB",
+#ifndef SMALL_FLASH_DEVICE
+      "GWENAB", "GWWRITE",
+#endif
 #ifdef SDCARD
       "SDLOGENABLED", "CANLOGSD",
 #endif  // SDCARD
@@ -481,11 +488,18 @@ void init_webserver() {
       "DALYPWRPCT", "DALYPWRDV",    "DALYDVSTART",   "DALYPWRDEG",    "DALYPWR0C",     "GPIOOPT5",      "GPIOOPT6",
       "INVICNT",    "FOXESSTYPE",   "FOXESSSUBTYPE", "FOXESSMODULES", "CHGTAPERSTART", "CHGTAPERFLOOR", "SYSLOGPORT",
       "SYSLOGFAC",  "PERBMSRESETH",
+#ifndef SMALL_FLASH_DEVICE
+      "GWPORT", "GWBAUD",
+#endif
   };
 
   const char* stringSettingNames[] = {"APPASSWORD", "HOSTNAME",    "MQTTSERVER", "MQTTUSER",  "MQTTPASSWORD",
                                       "HTTPUSER",   "HTTPPASS",    "LOCALIP",    "GATEWAY",   "SUBNET",
-                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS"};
+                                      "DNS",        "HADISCTOPIC", "SYSLOGIP",   "ESPNOWMACS",
+#ifndef SMALL_FLASH_DEVICE
+                                      "GWSLAVES", "GWSECRET", "GWIPALLOW",
+#endif
+  };
 
   // Handles the form POST from UI to save settings of the common image
   server.on("/saveSettings", HTTP_POST,

--- a/Software/src/lib/eModbus-eModbus/Logging.h
+++ b/Software/src/lib/eModbus-eModbus/Logging.h
@@ -1,0 +1,56 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+//
+// Battery-Emulator vendored eModbus is size-trimmed: the server sources had all logging removed by
+// hand. The added master (ModbusClient*) and TCP-server (ModbusServerTCPtemp) sources are kept
+// byte-identical to upstream so they stay easy to diff/merge; this no-op shim compiles their
+// LOG_*/LOGRAW_*/HEXDUMP_* calls out to nothing (zero flash, --gc-sections drops the rest).
+// If you ever want real logging, replace this file with the upstream Logging.{h,cpp}.
+
+#ifndef _MODBUS_LOGGING
+#define _MODBUS_LOGGING
+
+// Log-level constants (kept so references like LOG_LEVEL_VERBOSE resolve)
+#define LOG_LEVEL_NONE (0)
+#define LOG_LEVEL_CRITICAL (1)
+#define LOG_LEVEL_ERROR (2)
+#define LOG_LEVEL_WARNING (3)
+#define LOG_LEVEL_INFO (4)
+#define LOG_LEVEL_DEBUG (5)
+#define LOG_LEVEL_VERBOSE (6)
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_LEVEL_NONE
+#endif
+#ifndef LOCAL_LOG_LEVEL
+#define LOCAL_LOG_LEVEL LOG_LEVEL
+#endif
+
+// All logging macros expand to nothing.
+#define LOG_C(...) do {} while (0)
+#define LOG_E(...) do {} while (0)
+#define LOG_W(...) do {} while (0)
+#define LOG_N(...) do {} while (0)
+#define LOG_I(...) do {} while (0)
+#define LOG_D(...) do {} while (0)
+#define LOG_V(...) do {} while (0)
+
+#define LOGRAW_C(...) do {} while (0)
+#define LOGRAW_E(...) do {} while (0)
+#define LOGRAW_W(...) do {} while (0)
+#define LOGRAW_N(...) do {} while (0)
+#define LOGRAW_I(...) do {} while (0)
+#define LOGRAW_D(...) do {} while (0)
+#define LOGRAW_V(...) do {} while (0)
+
+#define HEXDUMP_C(...) do {} while (0)
+#define HEXDUMP_E(...) do {} while (0)
+#define HEXDUMP_W(...) do {} while (0)
+#define HEXDUMP_N(...) do {} while (0)
+#define HEXDUMP_I(...) do {} while (0)
+#define HEXDUMP_D(...) do {} while (0)
+#define HEXDUMP_V(...) do {} while (0)
+
+#endif  // _MODBUS_LOGGING

--- a/Software/src/lib/eModbus-eModbus/ModbusClient.cpp
+++ b/Software/src/lib/eModbus-eModbus/ModbusClient.cpp
@@ -1,0 +1,110 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#include "ModbusClient.h"
+#undef LOCAL_LOG_LEVEL
+#include "Logging.h"
+
+uint16_t ModbusClient::instanceCounter = 0;
+
+// Default constructor: set the default timeout to 2000ms, zero out all other 
+ModbusClient::ModbusClient() :
+  messageCount(0),
+  errorCount(0),
+  #if HAS_FREERTOS
+  worker(NULL),
+  #elif IS_LINUX
+  worker(0),
+  #endif
+  onData(nullptr),
+  onError(nullptr),
+  onResponse(nullptr) { instanceCounter++; }
+
+// Default destructor: reduce number of clients by one
+ModbusClient::~ModbusClient() {
+  if (instanceCounter) {
+    instanceCounter--;
+  }
+}
+
+// onDataHandler: register callback for data responses
+bool ModbusClient::onDataHandler(MBOnData handler) {
+  if (onData) {
+    LOG_W("onData handler was already claimed\n");
+  } else if (onResponse) {
+    LOG_E("onData handler is unavailable with an onResponse handler\n");
+    return false;
+  }
+  onData = handler;
+  return true;
+}
+
+// onErrorHandler: register callback for error responses
+bool ModbusClient::onErrorHandler(MBOnError handler) {
+  if (onError) {
+    LOG_W("onError handler was already claimed\n");
+  } else if (onResponse) {
+    LOG_E("onError handler is unavailable with an onResponse handler\n");
+    return false;
+  } 
+  onError = handler;
+  return true;
+}
+
+// onResponseHandler: register callback for error responses
+bool ModbusClient::onResponseHandler(MBOnResponse handler) {
+  if (onError || onData) {
+    LOG_E("onResponse handler is unavailable with an onData or onError handler\n");
+    return false;
+  } 
+  onResponse = handler;
+  return true;
+}
+
+// getMessageCount: return message counter value
+uint32_t ModbusClient::getMessageCount() {
+  return messageCount;
+}
+
+// getErrorCount: return error counter value
+uint32_t ModbusClient::getErrorCount() {
+  return errorCount;
+}
+
+// resetCounts: Set both message and error counts to zero
+void ModbusClient::resetCounts() {
+  {
+    LOCK_GUARD(cntLock, countAccessM);
+    messageCount = 0;
+    errorCount = 0;
+  }
+}
+
+// waitSync: wait for response on syncRequest to arrive
+ModbusMessage ModbusClient::waitSync(uint8_t serverID, uint8_t functionCode, uint32_t token) {
+  ModbusMessage response;
+  unsigned long lostPatience = millis();
+ 
+  // Default response is TIMEOUT
+  response.setError(serverID, functionCode, TIMEOUT);
+
+  // Loop 60 seconds, if unlucky
+  while (millis() - lostPatience < 60000) {
+    {
+      LOCK_GUARD(lg, syncRespM);
+      // Look for the token
+      auto sR = syncResponse.find(token);
+      // Is it there?
+      if (sR != syncResponse.end()) {
+        // Yes. get the response, delete it from the map and return
+        response = sR->second;
+        syncResponse.erase(sR);
+        break;
+      }
+    }
+    // Give the watchdog time to act
+    delay(10);
+  }
+  return response;
+}

--- a/Software/src/lib/eModbus-eModbus/ModbusClient.h
+++ b/Software/src/lib/eModbus-eModbus/ModbusClient.h
@@ -1,0 +1,119 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#ifndef _MODBUS_CLIENT_H
+#define _MODBUS_CLIENT_H
+
+#include <functional> 
+#include <map>
+#include "options.h"
+#include "ModbusMessage.h"
+
+#if HAS_FREERTOS
+extern "C" {
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+}
+#elif IS_LINUX
+#include <pthread.h>
+#endif
+
+#if USE_MUTEX
+#include <mutex>                    // NOLINT
+using std::mutex;
+using std::lock_guard;
+#endif
+
+typedef std::function<void(ModbusMessage msg, uint32_t token)> MBOnData;
+typedef std::function<void(Modbus::Error errorCode, uint32_t token)> MBOnError;
+typedef std::function<void(ModbusMessage msg, uint32_t token)> MBOnResponse;
+
+class ModbusClient {
+public:
+  bool onDataHandler(MBOnData handler);   // Accept onData handler 
+  bool onErrorHandler(MBOnError handler); // Accept onError handler 
+  bool onResponseHandler(MBOnResponse handler); // Accept onResponse handler 
+  uint32_t getMessageCount();             // Informative: return number of messages created
+  uint32_t getErrorCount();              // Informative: return number of errors received
+  void resetCounts();                    // Set both message and error counts to zero
+  inline Error addRequest(const ModbusMessage& m, uint32_t token) { return addRequestM(m, token); }
+  inline ModbusMessage syncRequest(const ModbusMessage& m, uint32_t token) { return syncRequestM(m, token); }
+
+  // Template function to generate syncRequest functions as long as there is a 
+  // matching ModbusMessage::setMessage() call
+  template <typename... Args>
+  ModbusMessage syncRequest(uint32_t token, Args&&... args) {
+    Error rc = SUCCESS;
+    // Create request, if valid
+    ModbusMessage m;
+    rc = m.setMessage(std::forward<Args>(args) ...);
+
+    // Add it to the queue and wait for a response, if valid
+    if (rc == SUCCESS) {
+      return syncRequestM(m, token);
+    } 
+    // Else return the error as a message
+    return buildErrorMsg(rc, std::forward<Args>(args) ...);
+  }
+
+  // Template function to create an error response message from a variadic pattern
+  template <typename... Args>
+  ModbusMessage buildErrorMsg(Error e, uint8_t serverID, uint8_t functionCode, Args&&... args) {
+    ModbusMessage m;
+    m.setError(serverID, functionCode, e);
+    return m;
+  }
+
+  // Template function to generate addRequest functions as long as there is a 
+  // matching ModbusMessage::setMessage() call
+  template <typename... Args>
+  Error addRequest(uint32_t token, Args&&... args) {
+    Error rc = SUCCESS;        // Return value
+
+    // Create request, if valid
+    ModbusMessage m;
+    rc = m.setMessage(std::forward<Args>(args) ...);
+
+    // Add it to the queue, if valid
+    if (rc == SUCCESS) {
+      return addRequestM(m, token);
+    }
+    // Else return the error
+    return rc;
+  }
+
+protected:
+  ModbusClient();             // Default constructor
+  virtual ~ModbusClient();            // Destructor
+  ModbusMessage waitSync(uint8_t serverID, uint8_t functionCode, uint32_t token); // wait for syncRequest response to arrive
+  // Virtual addRequest variant needed internally. All others done by template!
+  virtual Error addRequestM(ModbusMessage msg, uint32_t token) = 0;
+  // Virtual syncRequest variant following the same pattern
+  virtual ModbusMessage syncRequestM(ModbusMessage msg, uint32_t token) = 0;
+  // Prevent copy construction or assignment
+  ModbusClient(ModbusClient& other) = delete;
+  ModbusClient& operator=(ModbusClient& other) = delete;
+
+  uint32_t messageCount;           // Number of requests generated. Used for transactionID in TCPhead
+  uint32_t errorCount;             // Number of errors received
+#if HAS_FREERTOS
+  TaskHandle_t worker;             // Interface instance worker task
+#elif IS_LINUX
+  pthread_t worker;
+#endif
+  MBOnData onData;                 // Data response handler
+  MBOnError onError;               // Error response handler
+  MBOnResponse onResponse;         // Uniform response handler
+  static uint16_t instanceCounter; // Number of ModbusClients created
+  std::map<uint32_t, ModbusMessage> syncResponse; // Map to hold response messages on synchronous requests
+#if USE_MUTEX
+  std::mutex syncRespM;            // Mutex protecting syncResponse map against race conditions
+  std::mutex countAccessM;         // Mutex protecting access to the message and error counts
+#endif
+
+  // Let any ModbusBridge class use protected members
+  template<typename SERVERCLASS> friend class ModbusBridge;
+};
+
+#endif

--- a/Software/src/lib/eModbus-eModbus/ModbusClientRTU.cpp
+++ b/Software/src/lib/eModbus-eModbus/ModbusClientRTU.cpp
@@ -1,0 +1,358 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#include "ModbusClientRTU.h"
+
+#if HAS_FREERTOS
+
+#undef LOCAL_LOG_LEVEL
+// #define LOCAL_LOG_LEVEL LOG_LEVEL_VERBOSE
+#include "Logging.h"
+
+// Constructor takes an optional DE/RE pin and queue size
+ModbusClientRTU::ModbusClientRTU(int8_t rtsPin, uint16_t queueLimit) :
+  ModbusClient(),
+  MR_serial(nullptr),
+  MR_lastMicros(micros()),
+  MR_interval(2000),
+  MR_rtsPin(rtsPin),
+  MR_qLimit(queueLimit),
+  MR_timeoutValue(DEFAULTTIMEOUT),
+  MR_useASCII(false),
+  MR_skipLeadingZeroByte(false) {
+    if (MR_rtsPin >= 0) {
+      pinMode(MR_rtsPin, OUTPUT);
+      MTRSrts = [this](bool level) {
+        digitalWrite(MR_rtsPin, level);
+      };
+      MTRSrts(LOW);
+    } else {
+      MTRSrts = RTUutils::RTSauto;
+    }
+}
+
+// Alternative constructor takes an RTS callback function
+ModbusClientRTU::ModbusClientRTU(RTScallback rts, uint16_t queueLimit) :
+  ModbusClient(),
+  MR_serial(nullptr),
+  MR_lastMicros(micros()),
+  MR_interval(2000),
+  MTRSrts(rts),
+  MR_qLimit(queueLimit),
+  MR_timeoutValue(DEFAULTTIMEOUT),
+  MR_useASCII(false),
+  MR_skipLeadingZeroByte(false) {
+    MR_rtsPin = -1;
+    MTRSrts(LOW);
+}
+
+// Destructor: clean up queue, task etc.
+ModbusClientRTU::~ModbusClientRTU() {
+  // Kill worker task and clean up request queue
+  end();
+}
+
+// begin: start worker task - general version
+void ModbusClientRTU::begin(Stream& serial, uint32_t baudRate, int coreID, uint32_t userInterval) {
+  MR_serial = &serial;
+  doBegin(baudRate, coreID, userInterval);
+}
+
+// begin: start worker task - HardwareSerial version
+void ModbusClientRTU::begin(HardwareSerial& serial, int coreID, uint32_t userInterval) {
+  MR_serial = &serial;
+  uint32_t baudRate = serial.baudRate();
+  serial.setRxFIFOFull(1);
+  doBegin(baudRate, coreID, userInterval);
+}
+
+void ModbusClientRTU::doBegin(uint32_t baudRate, int coreID, uint32_t userInterval) {
+  // Task already running? End it in case
+  end();
+
+  // Pull down RTS toggle, if necessary
+  MTRSrts(LOW);
+
+  // Set minimum interval time
+  MR_interval = RTUutils::calculateInterval(baudRate);
+
+  // If user defined interval is longer, use that
+  if (MR_interval < userInterval) {
+    MR_interval = userInterval;
+  }
+
+  // Create unique task name
+  char taskName[18];
+  snprintf(taskName, 18, "Modbus%02XRTU", instanceCounter);
+  // Start task to handle the queue
+  xTaskCreatePinnedToCore((TaskFunction_t)&handleConnection, taskName, CLIENT_TASK_STACK, this, 6, &worker, coreID >= 0 ? coreID : tskNO_AFFINITY);
+
+  LOG_D("Client task %d started. Interval=%d\n", (uint32_t)worker, MR_interval);
+}
+
+// end: stop worker task
+void ModbusClientRTU::end() {
+  if (worker) {
+    // Clean up queue
+    {
+      // Safely lock access
+      LOCK_GUARD(lockGuard, qLock);
+      // Get all queue entries one by one
+      while (!requests.empty()) {
+        // Remove front entry
+        requests.pop();
+      }
+    }
+    // Kill task
+    vTaskDelete(worker);
+    LOG_D("Client task %d killed.\n", (uint32_t)worker);
+    worker = nullptr;
+  }
+}
+
+// setTimeOut: set/change the default interface timeout
+void ModbusClientRTU::setTimeout(uint32_t TOV) {
+  MR_timeoutValue = TOV;
+  LOG_D("Timeout set to %d\n", TOV);
+}
+
+// Toggle protocol to ModbusASCII
+void ModbusClientRTU::useModbusASCII(unsigned long timeout) {
+  MR_useASCII = true;
+  MR_timeoutValue = timeout; // Switch timeout to ASCII's value
+  LOG_D("Protocol mode: ASCII\n");
+}
+
+// Toggle protocol to ModbusRTU
+void ModbusClientRTU::useModbusRTU() {
+  MR_useASCII = false;
+  LOG_D("Protocol mode: RTU\n");
+}
+
+// Inquire protocol mode
+bool ModbusClientRTU::isModbusASCII() {
+  return MR_useASCII;
+}
+
+// Toggle skipping of leading 0x00 byte
+void ModbusClientRTU::skipLeading0x00(bool onOff) {
+  MR_skipLeadingZeroByte = onOff;
+  LOG_D("Skip leading 0x00 mode = %s\n", onOff ? "ON" : "OFF");
+}
+
+// Return number of unprocessed requests in queue
+uint32_t ModbusClientRTU::pendingRequests() {
+  return requests.size();
+}
+
+// Remove all pending request from queue
+void ModbusClientRTU::clearQueue()
+{
+  std::queue<RequestEntry> empty;
+  LOCK_GUARD(lockGuard, qLock);
+  // Empty queue
+  std::swap(requests, empty);
+}
+
+// Base addRequest taking a preformatted data buffer and length as parameters
+Error ModbusClientRTU::addRequestM(ModbusMessage msg, uint32_t token) {
+  Error rc = SUCCESS;        // Return value
+
+  LOG_D("request for %02X/%02X\n", msg.getServerID(), msg.getFunctionCode());
+
+  // Add it to the queue, if valid
+  if (msg) {
+    // Queue add successful?
+    if (!addToQueue(token, msg)) {
+      // No. Return error after deleting the allocated request.
+      rc = REQUEST_QUEUE_FULL;
+    }
+  }
+
+  LOG_D("RC=%02X\n", rc);
+  return rc;
+}
+
+// Base syncRequest follows the same pattern
+ModbusMessage ModbusClientRTU::syncRequestM(ModbusMessage msg, uint32_t token) {
+  ModbusMessage response;
+
+  if (msg) {
+    // Queue add successful?
+    if (!addToQueue(token, msg, true)) {
+      // No. Return error after deleting the allocated request.
+      response.setError(msg.getServerID(), msg.getFunctionCode(), REQUEST_QUEUE_FULL);
+    } else {
+      // Request is queued - wait for the result.
+      response = waitSync(msg.getServerID(), msg.getFunctionCode(), token);
+    }
+  } else {
+    response.setError(msg.getServerID(), msg.getFunctionCode(), EMPTY_MESSAGE);
+  }
+  return response;
+}
+
+// addBroadcastMessage: create a fire-and-forget message to all servers on the RTU bus
+Error ModbusClientRTU::addBroadcastMessage(const uint8_t *data, uint8_t len) {
+  Error rc = SUCCESS;        // Return value
+
+  LOG_D("Broadcast request of length %d\n", len);
+
+  // We do only accept requests with data, 0 byte, data and CRC must fit into 256 bytes.
+  if (len && len < 254) {
+    // Create a "broadcast token"
+    uint32_t token = (millis() & 0xFFFFFF) | 0xBC000000;
+    ModbusMessage msg;
+    
+    // Server ID is 0x00 for broadcast
+    msg.add((uint8_t)0x00);
+    // Append data
+    msg.add(data, len);
+
+    // Queue add successful?
+    if (!addToQueue(token, msg)) {
+      // No. Return error after deleting the allocated request.
+      rc = REQUEST_QUEUE_FULL;
+    }
+  } else {
+    rc =  BROADCAST_ERROR;
+  }
+
+  LOG_D("RC=%02X\n", rc);
+  return rc;
+}
+
+
+// addToQueue: send freshly created request to queue
+bool ModbusClientRTU::addToQueue(uint32_t token, ModbusMessage request, bool syncReq) {
+  bool rc = false;
+  // Did we get one?
+  if (request) {
+    RequestEntry re(token, request, syncReq);
+    if (requests.size()<MR_qLimit) {
+      // Yes. Safely lock queue and push request to queue
+      rc = true;
+      LOCK_GUARD(lockGuard, qLock);
+      requests.push(re);
+    }
+    {
+      LOCK_GUARD(cntLock, countAccessM);
+      messageCount++;
+    }
+  }
+
+  LOG_D("RC=%02X\n", rc);
+  return rc;
+}
+
+// handleConnection: worker task
+// This was created in begin() to handle the queue entries
+void ModbusClientRTU::handleConnection(ModbusClientRTU *instance) {
+  // initially clean the serial buffer
+  while (instance->MR_serial->available()) instance->MR_serial->read();
+  delay(100);
+
+  // Loop forever - or until task is killed
+  while (1) {
+    // Do we have a reuest in queue?
+    if (!instance->requests.empty()) {
+      // Yes. pull it.
+      RequestEntry request = instance->requests.front();
+
+      LOG_D("Pulled request from queue\n");
+
+      // Send it via Serial
+      RTUutils::send(*(instance->MR_serial), instance->MR_lastMicros, instance->MR_interval, instance->MTRSrts, request.msg, instance->MR_useASCII);
+
+      LOG_D("Request sent.\n");
+      // HEXDUMP_V("Data", request.msg.data(), request.msg.size());
+
+      // For a broadcast, we will not wait for a response
+      if (request.msg.getServerID() != 0 || ((request.token & 0xFF000000) != 0xBC000000)) {
+        // This is a regular request, Get the response - if any
+        ModbusMessage response = RTUutils::receive(
+          'C',
+          *(instance->MR_serial), 
+          instance->MR_timeoutValue, 
+          instance->MR_lastMicros, 
+          instance->MR_interval, 
+          instance->MR_useASCII,
+          instance->MR_skipLeadingZeroByte);
+  
+        LOG_D("%s response (%d bytes) received.\n", response.size()>1 ? "Data" : "Error", response.size());
+        HEXDUMP_V("Data", response.data(), response.size());
+  
+        // No error in receive()?
+        if (response.size() > 1) {
+          // No. Check message contents
+          // Does the serverID match the requested?
+          if (request.msg.getServerID() != response.getServerID()) {
+            // No. Return error response
+            response.setError(request.msg.getServerID(), request.msg.getFunctionCode(), SERVER_ID_MISMATCH);
+          // ServerID ok, but does the FC match as well?
+          } else if (request.msg.getFunctionCode() != (response.getFunctionCode() & 0x7F)) {
+            // No. Return error response
+            response.setError(request.msg.getServerID(), request.msg.getFunctionCode(), FC_MISMATCH);
+          } 
+        } else {
+          // No, we got an error code from receive()
+          // Return it as error response
+          response.setError(request.msg.getServerID(), request.msg.getFunctionCode(), static_cast<Error>(response[0]));
+        }
+  
+        LOG_D("Response generated.\n");
+        HEXDUMP_V("Response packet", response.data(), response.size());
+
+        // If we got an error, count it
+        if (response.getError() != SUCCESS) {
+          instance->errorCount++;
+        }
+  
+        // Was it a synchronous request?
+        if (request.isSyncRequest) {
+          // Yes. Put it into the response map
+          {
+            LOCK_GUARD(sL, instance->syncRespM);
+            instance->syncResponse[request.token] = response;
+          }
+        // No, an async request. Do we have an onResponse handler?
+        } else if (instance->onResponse) {
+          // Yes. Call it
+          instance->onResponse(response, request.token);
+        } else {
+          // No, but we may have onData or onError handlers
+          // Did we get a normal response?
+          if (response.getError()==SUCCESS) {
+            // Yes. Do we have an onData handler registered?
+            if (instance->onData) {
+              // Yes. call it
+              instance->onData(response, request.token);
+            }
+          } else {
+            // No, something went wrong. All we have is an error
+            // Do we have an onError handler?
+            if (instance->onError) {
+              // Yes. Forward the error code to it
+              instance->onError(response.getError(), request.token);
+            }
+          }
+        }
+      }
+      // Clean-up time. 
+      {
+        // Safely lock the queue
+        LOCK_GUARD(lockGuard, instance->qLock);
+        
+        // Remove the front queue entry if the queue is not empty
+        if (!instance->requests.empty()) { 
+          instance->requests.pop();
+        }
+      }
+    } else {
+      delay(1);
+    }
+  }
+}
+
+#endif  // HAS_FREERTOS

--- a/Software/src/lib/eModbus-eModbus/ModbusClientRTU.h
+++ b/Software/src/lib/eModbus-eModbus/ModbusClientRTU.h
@@ -1,0 +1,110 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#ifndef _MODBUS_CLIENT_RTU_H
+#define _MODBUS_CLIENT_RTU_H
+
+#include "options.h"
+
+#if HAS_FREERTOS
+
+#include "ModbusClient.h"
+#include "Stream.h"
+#include "RTUutils.h"
+#include <queue>
+#include <vector>
+
+using std::queue;
+
+#define DEFAULTTIMEOUT 2000
+
+class ModbusClientRTU : public ModbusClient {
+public:
+  // Constructor takes an optional DE/RE pin and queue limit
+  explicit ModbusClientRTU(int8_t rtsPin = -1, uint16_t queueLimit = 100);
+
+  // Alternative Constructor takes an RTS line toggle callback
+  explicit ModbusClientRTU(RTScallback rts, uint16_t queueLimit = 100);
+
+  // Destructor: clean up queue, task etc.
+  ~ModbusClientRTU();
+
+  // begin: start worker task
+  void begin(Stream& serial, uint32_t baudrate, int coreID = -1, uint32_t userInterval = 0);
+  // Special variant for HardwareSerial
+  void begin(HardwareSerial& serial, int coreID = -1, uint32_t userInterval = 0);
+
+  // end: stop the worker
+  void end();
+
+  // Set default timeout value for interface
+  void setTimeout(uint32_t TOV);
+
+  // Toggle protocol to ModbusASCII
+  void useModbusASCII(unsigned long timeout = 1000);
+
+  // Toggle protocol to ModbusRTU
+  void useModbusRTU();
+
+  // Inquire protocol mode
+  bool isModbusASCII();
+
+  // Toggle skipping of leading 0x00 byte
+  void skipLeading0x00(bool onOff = true);
+
+  // Return number of unprocessed requests in queue
+  uint32_t pendingRequests();
+
+  // Remove all pending request from queue
+  void clearQueue();
+  
+  // addBroadcastMessage: create a fire-and-forget message to all servers on the RTU bus
+  Error addBroadcastMessage(const uint8_t *data, uint8_t len);
+
+protected:
+  struct RequestEntry {
+    uint32_t token;
+    ModbusMessage msg;
+    bool isSyncRequest;
+    RequestEntry(uint32_t t, const ModbusMessage& m, bool syncReq = false) :
+      token(t),
+      msg(m),
+      isSyncRequest(syncReq) {}
+  };
+
+  // Base addRequest and syncRequest must be present
+  Error addRequestM(ModbusMessage msg, uint32_t token) override;
+  ModbusMessage syncRequestM(ModbusMessage msg, uint32_t token) override;
+
+  // addToQueue: send freshly created request to queue
+  bool addToQueue(uint32_t token, ModbusMessage msg, bool syncReq = false);
+
+  // handleConnection: worker task method
+  static void handleConnection(ModbusClientRTU *instance);
+
+  // receive: get response via Serial
+  ModbusMessage receive(const ModbusMessage request);
+
+  // start background task
+  void doBegin(uint32_t baudRate, int coreID, uint32_t userInterval);
+
+  queue<RequestEntry> requests;   // Queue to hold requests to be processed
+  #if USE_MUTEX
+  mutex qLock;                    // Mutex to protect queue
+  #endif
+  Stream *MR_serial;              // Ptr to the serial interface used
+  unsigned long MR_lastMicros;    // Microseconds since last bus activity
+  uint32_t MR_interval;           // Modbus RTU bus quiet time
+  int8_t MR_rtsPin;               // GPIO pin to toggle RS485 DE/RE line. -1 if none.
+  RTScallback MTRSrts;            // RTS line callback function
+  uint16_t MR_qLimit;             // Maximum number of requests to hold in the queue
+  uint32_t MR_timeoutValue;       // Interface default timeout
+  bool MR_useASCII;               // true=ModbusASCII, false=ModbusRTU
+  bool MR_skipLeadingZeroByte;    // true=skip the first byte if it is 0x00, false=accept all bytes
+
+};
+
+#endif  // HAS_FREERTOS
+
+#endif  // INCLUDE GUARD

--- a/Software/src/lib/eModbus-eModbus/ModbusServerTCPtemp.h
+++ b/Software/src/lib/eModbus-eModbus/ModbusServerTCPtemp.h
@@ -1,0 +1,418 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#ifndef _MODBUS_SERVER_TCP_TEMP_H
+#define _MODBUS_SERVER_TCP_TEMP_H
+
+#include <Arduino.h>
+#include <mutex>  // NOLINT
+#include "ModbusServer.h"
+#undef LOCAL_LOG_LEVEL
+// #define LOCAL_LOG_LEVEL LOG_LEVEL_VERBOSE
+#include "Logging.h"
+
+extern "C" {
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+}
+
+using std::vector;
+using std::mutex;
+using std::lock_guard;
+
+template <typename ST, typename CT>
+class ModbusServerTCP : public ModbusServer {
+public:
+  // Constructor
+  ModbusServerTCP();
+
+  // Destructor: closes the connections
+  ~ModbusServerTCP();
+
+  // activeClients: return number of clients currently employed
+  uint16_t activeClients();
+
+  // start: create task with TCP server to accept requests
+  bool start(uint16_t port, uint8_t maxClients, uint32_t timeout, int coreID = -1);
+
+  // stop: drop all connections and kill server task
+  bool stop();
+
+protected:
+  // Prevent copy construction and assignment
+  ModbusServerTCP(ModbusServerTCP& m) = delete;
+  ModbusServerTCP& operator=(ModbusServerTCP& m) = delete;
+
+  uint8_t numClients;
+  TaskHandle_t serverTask;
+  uint16_t serverPort;
+  uint32_t serverTimeout;
+  bool serverGoDown;
+  mutex clientLock;
+
+  struct ClientData {
+    ClientData() : task(nullptr), client(0), timeout(0), parent(nullptr) {}
+    ClientData(TaskHandle_t t, CT& c, uint32_t to, ModbusServerTCP<ST, CT> *p) : 
+      task(t), client(c), timeout(to), parent(p) {}
+    ~ClientData() {
+      if (client) {
+        client.stop();
+      }
+      if (task != nullptr) {
+        vTaskDelete(task);
+        LOG_D("Killed client task %d\n", (uint32_t)task);
+      }
+    }
+    TaskHandle_t task;
+    CT client;
+    uint32_t timeout;
+    ModbusServerTCP<ST, CT> *parent;
+  };
+  ClientData **clients;
+
+  // serve: loop function for server task
+  static void serve(ModbusServerTCP<ST, CT> *myself);
+
+  // worker: loop function for client tasks
+  static void worker(ClientData *myData);
+
+  // receive: read data from TCP
+  ModbusMessage receive(CT& client, uint32_t timeWait);
+
+  // accept: start a task to receive requests and respond to a given client
+  bool accept(CT& client, uint32_t timeout, int coreID = -1);
+
+  // clientAvailable: return true,. if a client slot is currently unused
+  bool clientAvailable() { return (numClients - activeClients()) > 0; }
+};
+
+// Constructor
+template <typename ST, typename CT>
+ModbusServerTCP<ST, CT>::ModbusServerTCP() :
+  ModbusServer(),
+  numClients(0),
+  serverTask(nullptr),
+  serverPort(502),
+  serverTimeout(20000),
+  serverGoDown(false) {
+    clients = new ClientData*[numClients]();
+   }
+
+// Destructor: closes the connections
+template <typename ST, typename CT>
+ModbusServerTCP<ST, CT>::~ModbusServerTCP() {
+  for (uint8_t i = 0; i < numClients; ++i) {
+    if (clients[i] != nullptr) {
+      delete clients[i];
+    }
+  }
+  delete[] clients;
+  serverGoDown = true;
+}
+
+// activeClients: return number of clients currently employed
+template <typename ST, typename CT>
+uint16_t ModbusServerTCP<ST, CT>::activeClients() {
+  uint8_t cnt = 0;
+  for (uint8_t i = 0; i < numClients; ++i) {
+    // Current slot could have been previously used - look for cleared task handles
+    if (clients[i] != nullptr) {
+      // Empty task handle?
+      if (clients[i]->task == nullptr) {
+        // Yes. Delete entry and init client pointer
+        lock_guard<mutex> cL(clientLock);
+        delete clients[i];
+        LOG_V("Delete client %d\n", i);
+        clients[i] = nullptr;
+      }
+    }
+    if (clients[i] != nullptr) cnt++;
+  }
+  return cnt;
+}
+
+  // start: create task with TCP server to accept requests
+template <typename ST, typename CT>
+  bool ModbusServerTCP<ST, CT>::start(uint16_t port, uint8_t maxClients, uint32_t timeout, int coreID) {
+    // Task already running?
+    if (serverTask != nullptr) {
+      // Yes. stop it first
+      stop();
+    }
+    // Does the required number of slots fit?
+    if (numClients != maxClients) {
+      // No. Drop array and allocate a new one
+      delete[] clients;
+      // Now allocate a new one
+      numClients = maxClients;
+      clients = new ClientData*[numClients]();
+    }
+    serverPort = port;
+    serverTimeout = timeout;
+    serverGoDown = false;
+
+    // Create unique task name
+    char taskName[18];
+    snprintf(taskName, 18, "MBserve%04X", port);
+
+    // Start task to handle the client
+    xTaskCreatePinnedToCore((TaskFunction_t)&serve, taskName, SERVER_TASK_STACK, this, 5, &serverTask, coreID >= 0 ? coreID : tskNO_AFFINITY);
+    LOG_D("Server task %s started (%d).\n", taskName, (uint32_t)serverTask);
+
+    // Wait two seconds for it to establish
+    delay(2000);
+
+    return true;
+  }
+
+  // stop: drop all connections and kill server task
+template <typename ST, typename CT>
+  bool ModbusServerTCP<ST, CT>::stop() {
+    // Check for clients still connected
+    for (uint8_t i = 0; i < numClients; ++i) {
+      // Client is alive?
+      if (clients[i] != nullptr) {
+        // Yes. Close the connection
+        delete clients[i];
+        clients[i] = nullptr;
+      }
+    }
+    if (serverTask != nullptr) {
+      // Signal server task to stop
+      serverGoDown = true;
+      delay(5000);
+      LOG_D("Killed server task %d\n", (uint32_t)(serverTask));
+      serverTask = nullptr;
+      serverGoDown = false;
+    }
+    return true;
+  }
+
+// accept: start a task to receive requests and respond to a given client
+template <typename ST, typename CT>
+bool ModbusServerTCP<ST, CT>::accept(CT& client, uint32_t timeout, int coreID) {
+  // Look for an empty client slot
+  for (uint8_t i = 0; i < numClients; ++i) {
+    // Empty slot?
+    if (clients[i] == nullptr) {
+      // Yes. allocate new client data in slot
+      clients[i] = new ClientData(0, client, timeout, this);
+
+      // Create unique task name
+      char taskName[18];
+      snprintf(taskName, 18, "MBsrv%02Xclnt", i);
+
+      // Start task to handle the client
+      xTaskCreatePinnedToCore((TaskFunction_t)&worker, taskName, SERVER_TASK_STACK, clients[i], 5, &clients[i]->task, coreID >= 0 ? coreID : tskNO_AFFINITY);
+      LOG_D("Started client %d task %d\n", i, (uint32_t)(clients[i]->task));
+
+      return true;
+    }
+  }
+  LOG_D("No client slot available.\n");
+  return false;
+}
+
+template <typename ST, typename CT>
+void ModbusServerTCP<ST, CT>::serve(ModbusServerTCP<ST, CT> *myself) {
+  // need a local scope here to delete the server at termination time
+  if (1) {
+    // Set up server with given port
+    ST server(myself->serverPort);
+
+    // Start it
+    server.begin();
+
+    // Loop until being killed
+    while (!myself->serverGoDown) {
+      // Do we have clients left to use?
+      if (myself->clientAvailable()) {
+        // Yes. accept one, when it connects
+        CT ec = server.accept();
+        // Did we get a connection?
+        if (ec) {
+          // Yes. Forward it to the Modbus server
+          myself->accept(ec, myself->serverTimeout, 0);
+          LOG_D("Accepted connection - %d clients running\n", myself->activeClients());
+        }
+      }
+      // Give scheduler room to breathe
+      delay(10);
+    }
+    LOG_E("Server going down\n");
+    // We must go down
+    SERVER_END;
+  }
+  vTaskDelete(NULL);
+}
+
+template <typename ST, typename CT>
+void ModbusServerTCP<ST, CT>::worker(ClientData *myData) {
+  // Get own reference data in handier form
+  CT myClient = myData->client;
+  uint32_t myTimeOut = myData->timeout;
+  // TaskHandle_t myTask = myData->task;
+  ModbusServerTCP<ST, CT> *myParent = myData->parent;
+  unsigned long myLastMessage = millis();
+
+  LOG_D("Worker started, timeout=%d\n", myTimeOut);
+
+  // loop forever, if timeout is 0, or until timeout was hit
+  while (myClient.connected() && (!myTimeOut || (millis() - myLastMessage < myTimeOut))) {
+    ModbusMessage response;               // Data buffer to hold prepared response
+    // Get a request
+    if (myClient.available()) {
+      response.clear();
+      ModbusMessage m = myParent->receive(myClient, 100);
+
+      // has it the minimal length (6 bytes TCP header plus serverID plus FC)?
+      if (m.size() >= 8) {
+        {
+          LOCK_GUARD(cntLock, myParent->m);
+          myParent->messageCount++;
+        }
+        // Extract request data
+        ModbusMessage request;
+        request.add(m.data() + 6, m.size() - 6);
+
+        // Protocol ID shall be 0x0000 - is it?
+        if (m[2] == 0 && m[3] == 0) {
+          // ServerID shall be at [6], FC at [7]. Check both
+          if (myParent->isServerFor(request.getServerID())) {
+            // Server is correct - in principle. Do we serve the FC?
+            MBSworker callBack = myParent->getWorker(request.getServerID(), request.getFunctionCode());
+            if (callBack) {
+              // Yes, we do.
+              // Invoke the worker method to get a response
+              ModbusMessage data = callBack(request);
+              // Process Response
+              // One of the predefined types?
+              if (data[0] == 0xFF && (data[1] == 0xF0 || data[1] == 0xF1)) {
+                // Yes. Check it
+                switch (data[1]) {
+                case 0xF0: // NIL
+                  response.clear();
+                  LOG_D("NIL response\n");
+                  break;
+                case 0xF1: // ECHO
+                  response = request;
+                  if (request.getFunctionCode() == WRITE_MULT_REGISTERS ||
+                      request.getFunctionCode() == WRITE_MULT_COILS) {
+                    response.resize(6);
+                  }
+                  LOG_D("ECHO response\n");
+                  break;
+                default:   // Will not get here!
+                  break;
+                }
+              } else {
+                // No. User provided data response
+                response = data;
+                LOG_D("Data response\n");
+              }
+            } else {
+              // No, function code is not served here
+              response.setError(request.getServerID(), request.getFunctionCode(), ILLEGAL_FUNCTION);
+            }
+          } else {
+            // No, serverID is not served here
+            response.setError(request.getServerID(), request.getFunctionCode(), INVALID_SERVER);
+          }
+        } else {
+          // No, protocol ID was something weird
+          response.setError(request.getServerID(), request.getFunctionCode(), TCP_HEAD_MISMATCH);
+        }
+      }
+      delay(1);
+      // Do we have a response to send?
+      if (response.size() >= 3) {
+        // Yes. Do it now.
+        // Cut off length and request data, then update TCP header
+        m.resize(4);
+        m.add(static_cast<uint16_t>(response.size()));
+        // Append response
+        m.append(response);
+        myClient.write(m.data(), m.size());
+        HEXDUMP_V("Response", m.data(), m.size());
+        // count error responses
+        if (response.getError() != SUCCESS) {
+          LOCK_GUARD(cntLock, myParent->m);
+          myParent->errorCount++;
+        }
+      }
+      // We did something communicationally - rewind timeout timer
+      myLastMessage = millis();
+    }
+    delay(1);
+  }
+
+  if (millis() - myLastMessage >= myTimeOut) {
+    // Timeout!
+    LOG_D("Worker stopping due to timeout.\n");
+  } else {
+    // Disconnected!
+    LOG_D("Worker stopping due to client disconnect.\n");
+  }
+
+  // Read away all that may still hang in the buffer
+  while (myClient.read() != -1) {}
+  // Now stop the client
+  myClient.stop();
+
+  {
+    lock_guard<mutex> cL(myParent->clientLock);
+    myData->task = nullptr;
+  }
+
+  delay(50);
+  vTaskDelete(NULL);
+}
+
+// receive: get request via Client connection
+template <typename ST, typename CT>
+ModbusMessage ModbusServerTCP<ST, CT>::receive(CT& client, uint32_t timeWait) {
+  unsigned long lastMillis = millis();     // Timer to check for timeout
+  ModbusMessage m;                    // to take read data
+  uint16_t lengthVal = 0;
+  uint16_t cnt = 0;
+  const uint16_t BUFFERSIZE(300);
+  uint8_t buffer[BUFFERSIZE];
+
+  // wait for sufficient packet data or timeout
+  while ((millis() - lastMillis < timeWait) && ((cnt < 6) || (cnt < lengthVal)) && (cnt < BUFFERSIZE)) 
+  {
+    // Is there data waiting?
+    if (client.available()) {
+        buffer[cnt] = client.read();
+        // Are we at the TCP header length field byte #1?
+        if (cnt == 4) lengthVal = buffer[cnt] << 8;
+        // Are we at the TCP header length field byte #2?
+        if (cnt == 5) {
+          lengthVal |= buffer[cnt];
+          lengthVal += 6;
+        }
+        cnt++;
+        // Rewind EOT and timeout timers
+        lastMillis = millis();
+    } else {
+      delay(1); // Give scheduler room to breathe
+    }
+  }
+  // Did we receive some data?
+  if (cnt) {
+    // Yes. Is it too much?
+    if (cnt >= BUFFERSIZE) {
+      // Yes, likely a buffer overflow of some sort
+      // Adjust message size in TCP header
+      buffer[4] = (cnt >> 8) & 0xFF;
+      buffer[5] = cnt & 0xFF;
+      LOG_E("Potential buffer overrun (>%d)!\n", cnt);
+    }
+    // Get as much buffer as was read
+    m.add(buffer, cnt);
+  }
+  return m;
+}
+
+#endif

--- a/Software/src/lib/eModbus-eModbus/ModbusServerWiFi.h
+++ b/Software/src/lib/eModbus-eModbus/ModbusServerWiFi.h
@@ -1,0 +1,16 @@
+// =================================================================================================
+// eModbus: Copyright 2020 by Michael Harwerth, Bert Melis and the contributors to eModbus
+//               MIT license - see license.md for details
+// =================================================================================================
+#ifndef _MODBUS_SERVER_WIFI_H
+#define _MODBUS_SERVER_WIFI_H
+#include "options.h"
+#include <WiFi.h>
+
+#undef SERVER_END
+#define SERVER_END server.end();
+
+#include "ModbusServerTCPtemp.h"
+using ModbusServerWiFi = ModbusServerTCP<WiFiServer, WiFiClient>;
+
+#endif


### PR DESCRIPTION
# Optional Inverter Modbus gateway (RS485 ⇄ Modbus-TCP)

## Summary
When the inverter link uses **CAN**, the board's RS485 port sits idle. This PR adds an
optional feature that turns that idle RS485 into a **transparent Modbus gateway** to the
device wired to it (typically the inverter's Modbus/COM port): an eModbus **RTU master**
owns the bus, and a **Modbus-TCP server** forwards network requests to it. This gives
local Modbus access to the inverter (Home Assistant, custom dashboards, local control)
without any extra hardware.

Per review feedback, the feature is gated on `#ifndef SMALL_FLASH_DEVICE`: it is
compiled **out entirely on 4 MB / SMALL_FLASH_DEVICE boards** (zero flash cost there)
and compiled **in by default on boards with enough flash**. It is still **inactive at
runtime** until enabled in settings, so there is no behavior change out of the box —
until a build enables it, and it never activates at runtime unless the RS485 bus is free.

## Design / principles
- **Protocol-agnostic passthrough** — the gateway forwards function codes (read FC03/04,
  write FC06) to the RTU device and returns the raw response. No per-inverter register
  knowledge lives here; meaning stays with the client.
- **Single bus owner** — one `ModbusClientRTU` owns UART2 (reuses the existing RS485
  init / DE handling). The TCP server and any future on-board logic submit through it.
- **RS485-only** — the gateway activates solely on boards that expose an RS485
  interface (`RS485_RX_PIN()/RS485_TX_PIN()` not `GPIO_NUM_NC` in the HAL); on
  boards without RS485 it's inert even where it is compiled in.
- **Mutual exclusion with the battery-slave role** — the gateway only starts when the
  active inverter interface is **not** RS485/Modbus (i.e. a CAN link, RS485 idle). It
  never contends with `ModbusInverterProtocol`.
- **Secure by default** — disabled out of the box; reads over TCP are **read-only**
  (write FCs are not registered); writes require an authenticated HTTP endpoint.
- **Fail-safe** — TCP server binds only after WiFi is up; on fault the bus goes quiet.

## Security model (all on-device, no external infra)
- **Off by default**, read-only by default.
- **Writes** go through `POST /modbus/write` (behind the existing web auth), signed with
  **HMAC-SHA256(secret, "id:addr:val:nonce")** + a monotonic **nonce** (anti-replay).
  The raw Modbus-TCP port stays read-only. Secret is auto-generated on first boot.
- **IP allowlist** for writes; **audit ring** of the last write attempts (`GET /modbus/audit`).
- Value/register whitelisting is intentionally left to the client (it owns the register map).

## Configuration
Native section **“Inverter Modbus gateway”** on the standard `/settings` page, stored in
`BatteryEmulatorSettingsStore` (keys `GWENAB / GWWRITE / GWPORT / GWBAUD / GWSLAVES /
GWSECRET / GWIPALLOW`) — so it's saved by `/saveSettings`, cleared by factory reset, and
applied on reboot like every other setting. No separate config page.

## Footprint
Measured on **LilyGo T-CAN485** (`lilygo_330`, esp32dev, min_spiffs, `SMALL_FLASH_DEVICE`):
baseline **95.1%** flash → with the feature **~96.3%** (**+~24 KB**), static RAM +~0.8 KB.
**Zero cost on SMALL_FLASH_DEVICE / 4 MB boards** (compiled out). On roomier boards the
code is compiled in but stays inactive until enabled in settings.

## eModbus additions
The vendored `lib/eModbus-eModbus/` is trimmed to the RTU server. This PR adds the
**master** (`ModbusClient.*`, `ModbusClientRTU.*`) and the **sync TCP server**
(`ModbusServerTCPtemp.h`, `ModbusServerWiFi.h`) from **eModbus v1.7.4** (byte-identical to
upstream), plus a **no-op `Logging.h` shim** so those files compile with logging stripped
to nothing — keeping the vendored copy's existing zero-logging style. Happy to change the
vendoring approach to whatever you prefer.

## Testing
Verified on hardware: LilyGo T-CAN485 emulating a battery over CAN, RS485 wired to a
**GoodWe GW10KN-ET** Modbus port. Reads through the gateway match direct Modbus-TCP to the
inverter (grid voltage, work mode, PV, etc.). HMAC-signed writes succeed; bad signature →
401, replayed/stale nonce → 409, raw-TCP writes rejected.

## Files
- `Software/src/communication/modbus_gateway/modbus_gateway.{h,cpp}` (new module)
- `Software/src/lib/eModbus-eModbus/{ModbusClient,ModbusClientRTU}.{h,cpp}`,
  `ModbusServerTCPtemp.h`, `ModbusServerWiFi.h`, `Logging.h` (eModbus 1.7.4 master + TCP server + shim)
- `Software/Software.cpp` — `modbus_gateway_init()` after `setup_inverter()`, `modbus_gateway_loop()` in `core_loop`
- `Software/src/devboard/webserver/webserver.cpp` — register `/modbus/write` + `/modbus/audit`; add GW* names to the save lists
- `Software/src/devboard/webserver/settings_html.cpp` — settings-card + processor cases

## Notes for review
- Built against the **12.4.0** release snapshot; the three edited files may need a trivial
  re-apply onto current `main`. The new files apply cleanly.
- Feature name / setting keys / default port (502) — open to your conventions.
