### PR TITLE
Stellantis eCMP multi-battery support fix + optional BMS contactor interlock

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -506,6 +506,27 @@ void update_calculated_values(uint32_t currentMillis) {
           datalayer.battery2.status.reported_remaining_capacity_Wh;
     }
 
+    if (battery3) {
+      // If battery info is valid
+      if (datalayer.battery3.info.total_capacity_Wh > 0 && datalayer.battery.status.real_soc > 0) {
+
+        datalayer.battery3.info.reported_total_capacity_Wh = scaled_total_capacity;
+        // Scale remaining capacity based on scaled SOC
+        datalayer.battery3.status.reported_remaining_capacity_Wh = (scaled_total_capacity * scaled_soc) / 10000;
+
+      } else {
+        // Fallback if scaling cannot be performed
+        datalayer.battery3.info.reported_total_capacity_Wh = datalayer.battery3.info.total_capacity_Wh;
+        datalayer.battery3.status.reported_remaining_capacity_Wh = datalayer.battery3.status.remaining_capacity_Wh;
+      }
+
+      //Triple battery: fold battery3 into the battery1 aggregate too, so the inverter sees all
+      //three packs as one large battery (matches the soc_scaling_active == false path below).
+      datalayer.battery.info.reported_total_capacity_Wh += datalayer.battery3.info.reported_total_capacity_Wh;
+      datalayer.battery.status.reported_remaining_capacity_Wh +=
+          datalayer.battery3.status.reported_remaining_capacity_Wh;
+    }
+
   } else {  // soc_scaling_active == false. No SOC window wanted. Set scaled SOC & capacity to same as real.
     datalayer.battery.status.reported_soc = datalayer.battery.status.real_soc;
 

--- a/Software/src/battery/BATTERIES.cpp
+++ b/Software/src/battery/BATTERIES.cpp
@@ -460,7 +460,8 @@ void setup_battery() {
           battery2 = new CmpSmartCarBattery(&datalayer.battery2, can_config.battery_double);
           break;
         case BatteryType::StellantisEcmp:
-          battery2 = new EcmpBattery(&datalayer.battery2, can_config.battery_double);
+          battery2 =
+              new EcmpBattery(&datalayer.battery2, &datalayer_extended.stellantisECMP_2, can_config.battery_double);
           break;
         // Double only: needs a CAN-FD bus of its own, and only two exist.
         // See the comment on battery_supports_triple() above.
@@ -526,7 +527,8 @@ void setup_battery() {
           battery3 = new CmpSmartCarBattery(&datalayer.battery3, can_config.battery_triple);
           break;
         case BatteryType::StellantisEcmp:
-          battery3 = new EcmpBattery(&datalayer.battery3, can_config.battery_triple);
+          battery3 =
+              new EcmpBattery(&datalayer.battery3, &datalayer_extended.stellantisECMP_3, can_config.battery_triple);
           break;
         case BatteryType::RelionBattery:
           battery3 = new RelionBattery(&datalayer.battery3, can_config.battery_triple,

--- a/Software/src/battery/Battery.h
+++ b/Software/src/battery/Battery.h
@@ -160,6 +160,22 @@ class Battery {
 
   virtual BatteryHtmlRenderer& get_status_renderer() { return defaultRenderer; }
 
+  // Real contactor state as reported by the BMS for THIS pack (not a commanded
+  // state and not the emulator's own contactor output). Display only - used by
+  // the main web page to show "Contactors: CLOSED/OPEN/UNKNOWN" per battery.
+  // Base returns UNKNOWN; a driver overrides it once it decodes real feedback.
+  enum class ContactorStatus : uint8_t { UNKNOWN = 0, OPEN, CLOSED };
+  virtual ContactorStatus contactor_status() { return ContactorStatus::UNKNOWN; }
+
+  // True for batteries whose contactor_status() reflects a real decoded BMS feedback signal
+  // (not the UNKNOWN default). The optional "require BMS contactors closed" GPIO interlock only
+  // considers batteries for which this is true, so other integrations are unaffected.
+  virtual bool reports_contactor_status() { return false; }
+
+  // BMS-reported reason code for the contactors being open, or -1 when the battery does not
+  // report one / it is not applicable. Raw code, shown next to an OPEN status on the main page.
+  virtual int16_t contactor_open_reason() { return -1; }
+
   /* Which pack this instance drives: 1, 2 or 3. The same driver code serves every pack, so a
      driver cannot name its own battery in an event without this. Assigned centrally in
      setup_battery() and passed to set_event() as the third argument. */

--- a/Software/src/battery/ECMP-BATTERY.cpp
+++ b/Software/src/battery/ECMP-BATTERY.cpp
@@ -225,11 +225,72 @@ void EcmpBattery::update_values() {
     clear_event(EVENT_12V_LOW);
   }
 
-  if (pid_reason_open == 7) {  //Invalid status
-    set_event(EVENT_CONTACTOR_OPEN, 0);
-  } else {
-    clear_event(EVENT_CONTACTOR_OPEN);
+  // Route the contactor-open event to the variant for this pack so the events page and MQTT
+  // show which of the up to three batteries opened. Detection condition is unchanged.
+  EVENTS_ENUM_TYPE contactor_open_event = EVENT_CONTACTOR_OPEN;
+  if (battery_index == 2) {
+    contactor_open_event = EVENT_CONTACTOR2_OPEN;
+  } else if (battery_index == 3) {
+    contactor_open_event = EVENT_CONTACTOR3_OPEN;
   }
+  if (pid_reason_open == 7) {  //Invalid status
+    set_event(contactor_open_event, 0);
+  } else {
+    clear_event(contactor_open_event);
+  }
+}
+
+Battery::ContactorStatus EcmpBattery::contactor_status() {
+  // Display-only helper for the main web page. Reads this instance's own extended-data struct,
+  // never the globals, so battery 2/3 report their own contactors.
+  //
+  // Source: the polled "Contactor positive" / "Contactor negative" feedback PIDs (0xD44D / 0xD44C),
+  // stored raw as received. On-vehicle testing on this system: 1 = CLOSED, 0 = OPEN, 255 = not
+  // sampled yet (NOT_SAMPLED_YET). These are the two fields that actually track contactor state on
+  // this battery; MainConnectorState (CAN 0x125) and the "power switch status" PIDs (0xD452/0xD453,
+  // which report 3 here) do not, so they are deliberately not used.
+  //
+  // CLOSED only when BOTH report closed. If either truly reports open the result is OPEN. Missing
+  // CAN, an unsampled value or any value that is not a clean 0/1 yields UNKNOWN - never CLOSED.
+  if (!datalayer_ecmp || !datalayer_battery) {
+    return ContactorStatus::UNKNOWN;
+  }
+  if (datalayer_battery->status.CAN_battery_still_alive == 0) {
+    return ContactorStatus::UNKNOWN;  // BMS silent -> feedback would be stale
+  }
+  // The contactor-feedback PIDs are only refreshed by the diagnostic poll, which transmit_can()
+  // stops while system_status == FAULT - exactly when the BMS is most likely to have just opened
+  // the contactors. If the last answer is old, report UNKNOWN rather than a stale CLOSED/OPEN.
+  // The full PID sweep takes ~30 s, so the contactor PIDs are answered about every 30 s in normal
+  // running. 45 s tolerates one missed cycle without flapping to UNKNOWN, yet ages the value out
+  // within a minute of a FAULT that stops the poll.
+  const unsigned long CONTACTOR_FEEDBACK_MAX_AGE_MS = 45000;
+  if (pid_contactor_feedback_millis == 0 ||
+      (millis() - pid_contactor_feedback_millis) > CONTACTOR_FEEDBACK_MAX_AGE_MS) {
+    return ContactorStatus::UNKNOWN;
+  }
+
+  const uint8_t pos = datalayer_ecmp->pid_contactor_positive;  // PID 0xD44D
+  const uint8_t neg = datalayer_ecmp->pid_contactor_negative;  // PID 0xD44C
+  const bool pos_valid = (pos == 0 || pos == 1);
+  const bool neg_valid = (neg == 0 || neg == 1);
+  if (!pos_valid || !neg_valid) {
+    return ContactorStatus::UNKNOWN;  // not sampled (255) or unexpected raw value
+  }
+  if (pos == 1 && neg == 1) {
+    return ContactorStatus::CLOSED;
+  }
+  return ContactorStatus::OPEN;  // at least one contactor confirmed open
+}
+
+int16_t EcmpBattery::contactor_open_reason() {
+  // Raw "Contactor opening reason" PID (0xD812). 255 = not sampled / not applicable.
+  // Same value shown as "Contactor opening reason" on the More Battery Info page.
+  if (!datalayer_ecmp) {
+    return -1;
+  }
+  const uint8_t r = datalayer_ecmp->pid_reason_open;
+  return (r == NOT_SAMPLED_YET) ? -1 : (int16_t)r;
 }
 
 void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
@@ -828,9 +889,11 @@ void EcmpBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
               break;
             case PID_CONTACTOR_NEGATIVE:
               pid_contactor_negative = (rx_frame.data.u8[4]);
+              pid_contactor_feedback_millis = millis();
               break;
             case PID_CONTACTOR_POSITIVE:
               pid_contactor_positive = (rx_frame.data.u8[4]);
+              pid_contactor_feedback_millis = millis();
               break;
             case PID_PRECHARGE_RELAY_CONTROL:
               pid_precharge_relay_control = (rx_frame.data.u8[4]);
@@ -1294,7 +1357,26 @@ void EcmpBattery::transmit_can(unsigned long currentMillis) {
 
     } else {  //Normal PID polling goes here
 
-      if (datalayer.system.status.system_status != FAULT) {  //Stop PID polling if we are in FAULT mode
+      if (datalayer.system.status.system_status == FAULT) {
+        // The full diagnostic sweep is suspended in FAULT, but keep a minimal rotation of just the
+        // contactor-feedback PIDs alive so the main page still shows which pack opened its
+        // contactors and why while faulted. Passive ReadDataByIdentifier reads only - no command,
+        // no effect on contactor control. One PID per 250 ms tick, so a full cycle every 750 ms.
+        uint16_t fault_pid;
+        if (fault_contactor_poll_state == 0) {
+          fault_pid = PID_CONTACTOR_POSITIVE;
+          fault_contactor_poll_state = 1;
+        } else if (fault_contactor_poll_state == 1) {
+          fault_pid = PID_CONTACTOR_NEGATIVE;
+          fault_contactor_poll_state = 2;
+        } else {
+          fault_pid = PID_CONT_REASON_OPEN;
+          fault_contactor_poll_state = 0;
+        }
+        ECMP_POLL.data.u8[2] = (uint8_t)((fault_pid & 0xFF00) >> 8);
+        ECMP_POLL.data.u8[3] = (uint8_t)(fault_pid & 0x00FF);
+        transmit_can_frame(&ECMP_POLL);
+      } else {  //Not in FAULT - run the normal full PID poll
 
         // Sample High Precison Current every other time
         if (HighPrecisionCurrentSampling) {

--- a/Software/src/battery/ECMP-BATTERY.h
+++ b/Software/src/battery/ECMP-BATTERY.h
@@ -9,14 +9,17 @@
 
 class EcmpBattery : public CanBattery {
  public:
-  // Use this constructor for the second/third battery.
-  EcmpBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, CAN_Interface targetCan) : CanBattery(targetCan) {
+  // Use this constructor for the second/third battery. Each additional battery
+  // gets its own extended-data struct so its More Battery Info diagnostics do
+  // not overwrite (or get overwritten by) battery 1.
+  EcmpBattery(DATALAYER_BATTERY_TYPE* datalayer_ptr, DATALAYER_INFO_ECMP* extended, CAN_Interface targetCan)
+      : CanBattery(targetCan), renderer(extended) {
     datalayer_battery = datalayer_ptr;
-    datalayer_ecmp = NULL;
+    datalayer_ecmp = extended;
   }
 
   // Use the default constructor to create the first or single battery.
-  EcmpBattery() {
+  EcmpBattery() : renderer(&datalayer_extended.stellantisECMP) {
     datalayer_battery = &datalayer.battery;
     datalayer_ecmp = &datalayer_extended.stellantisECMP;
   }
@@ -45,6 +48,11 @@ class EcmpBattery : public CanBattery {
 
   BatteryHtmlRenderer& get_status_renderer() { return renderer; }
 
+  // Real positive+negative contactor feedback from the Stellantis BMS for this pack.
+  ContactorStatus contactor_status() override;
+  int16_t contactor_open_reason() override;
+  bool reports_contactor_status() override { return true; }
+
  private:
   DATALAYER_BATTERY_TYPE* datalayer_battery;
   DATALAYER_INFO_ECMP* datalayer_ecmp;
@@ -63,6 +71,12 @@ class EcmpBattery : public CanBattery {
   unsigned long previousMillis500 = 0;   // will store last time a 500ms CAN Message was sent
   unsigned long previousMillis1000 = 0;  // will store last time a 1000ms CAN Message was sent
   unsigned long previousMillis5000 = 0;  // will store last time a 1000ms CAN Message was sent
+  // millis() of the last positive/negative contactor-feedback PID answer. Used only to age out
+  // the main-page "BMS contactors" line: the diagnostic poll is stopped while system_status is
+  // FAULT (see transmit_can), so without this the last-before-FAULT value would show forever.
+  unsigned long pid_contactor_feedback_millis = 0;
+  // Rotates 0->1->2 over PID_CONTACTOR_POSITIVE / _NEGATIVE / CONT_REASON_OPEN while faulted.
+  uint8_t fault_contactor_poll_state = 0;
   CAN_frame ECMP_010 = {.FD = false, .ext_ID = false, .DLC = 1, .ID = 0x010, .data = {0xB4}};  //VCU_BCM_Crash 100ms
   CAN_frame ECMP_0F0 = {.FD = false,  //VCU2_0F0 (Common) 20ms periodic (Perfectly emulated in Battery-Emulator)
                         .ext_ID = false,

--- a/Software/src/battery/ECMP-HTML.h
+++ b/Software/src/battery/ECMP-HTML.h
@@ -8,503 +8,344 @@
 
 class EcmpHtmlRenderer : public BatteryHtmlRenderer {
  public:
+  // Each EcmpBattery instance passes a pointer to its own extended-data struct
+  // (datalayer_extended.stellantisECMP / _2 / _3) so battery 2 and 3 render
+  // their own More Battery Info instead of battery 1's globals.
+  EcmpHtmlRenderer(DATALAYER_INFO_ECMP* dl) : ecmp(dl) {}
+
+  bool renders_own_battery_data() { return true; }
+
   String get_status_html() {
     String content;
+    if (!ecmp) {
+      return content;
+    }
     content += "<h4>Main Connector State: ";
-    if (datalayer_extended.stellantisECMP.MainConnectorState == 0) {
+    if (ecmp->MainConnectorState == 0) {
       content += "Contactors open</h4>";
-    } else if (datalayer_extended.stellantisECMP.MainConnectorState == 0x01) {
+    } else if (ecmp->MainConnectorState == 0x01) {
       content += "Precharged</h4>";
     } else {
       content += "Invalid</h4>";
     }
-    content +=
-        "<h4>Insulation Resistance: " + String(datalayer_extended.stellantisECMP.InsulationResistance) + "kOhm</h4>";
+    content += "<h4>Insulation Resistance: " + String(ecmp->InsulationResistance) + "kOhm</h4>";
     content += "<h4>Interlock:  ";
-    if (datalayer_extended.stellantisECMP.InterlockOpen == true) {
+    if (ecmp->InterlockOpen == true) {
       content += "BROKEN!</h4>";
     } else {
       content += "Seated OK</h4>";
     }
     content += "<h4>Insulation Diag: ";
-    if (datalayer_extended.stellantisECMP.InsulationDiag == 0) {
+    if (ecmp->InsulationDiag == 0) {
       content += "No failure</h4>";
-    } else if (datalayer_extended.stellantisECMP.InsulationDiag == 1) {
+    } else if (ecmp->InsulationDiag == 1) {
       content += "Symmetric failure</h4>";
     } else {  //4 Invalid, 5-7 illegal, wrap em under one text
       content += "N/A</h4>";
     }
     content += "<h4>Contactor weld check: ";
-    if (datalayer_extended.stellantisECMP.pid_welding_detection == 0) {
+    if (ecmp->pid_welding_detection == 0) {
       content += "OK</h4>";
-    } else if (datalayer_extended.stellantisECMP.pid_welding_detection == 255) {
+    } else if (ecmp->pid_welding_detection == 255) {
       content += "N/A</h4>";
     } else {  //Problem
-      content += "WELDED!" + String(datalayer_extended.stellantisECMP.pid_welding_detection) + "</h4>";
+      content += "WELDED!" + String(ecmp->pid_welding_detection) + "</h4>";
     }
 
     content += "<h4>Contactor opening reason: ";
-    if (datalayer_extended.stellantisECMP.pid_reason_open == 7) {
+    if (ecmp->pid_reason_open == 7) {
       content += "Invalid Status</h4>";
-    } else if (datalayer_extended.stellantisECMP.pid_reason_open == 255) {
+    } else if (ecmp->pid_reason_open == 255) {
       content += "N/A</h4>";
     } else {  //Problem (Also status 0 might be OK?)
-      content += "Unknown" + String(datalayer_extended.stellantisECMP.pid_reason_open) + "</h4>";
+      content += "Unknown" + String(ecmp->pid_reason_open) + "</h4>";
     }
 
     content += "<h4>Status of power switch: " +
-               (datalayer_extended.stellantisECMP.pid_contactor_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_contactor_status)) +
-               "</h4>";
+               (ecmp->pid_contactor_status == 255 ? "N/A" : String(ecmp->pid_contactor_status)) + "</h4>";
     content += "<h4>Negative power switch control: " +
-               (datalayer_extended.stellantisECMP.pid_negative_contactor_control == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_negative_contactor_control)) +
+               (ecmp->pid_negative_contactor_control == 255 ? "N/A" : String(ecmp->pid_negative_contactor_control)) +
                "</h4>";
     content += "<h4>Negative power switch status: " +
-               (datalayer_extended.stellantisECMP.pid_negative_contactor_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_negative_contactor_status)) +
+               (ecmp->pid_negative_contactor_status == 255 ? "N/A" : String(ecmp->pid_negative_contactor_status)) +
                "</h4>";
     content += "<h4>Positive power switch control: " +
-               (datalayer_extended.stellantisECMP.pid_positive_contactor_control == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_positive_contactor_control)) +
+               (ecmp->pid_positive_contactor_control == 255 ? "N/A" : String(ecmp->pid_positive_contactor_control)) +
                "</h4>";
     content += "<h4>Positive power switch status: " +
-               (datalayer_extended.stellantisECMP.pid_positive_contactor_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_positive_contactor_status)) +
+               (ecmp->pid_positive_contactor_status == 255 ? "N/A" : String(ecmp->pid_positive_contactor_status)) +
                "</h4>";
     content += "<h4>Contactor negative: " +
-               (datalayer_extended.stellantisECMP.pid_contactor_negative == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_contactor_negative)) +
-               "</h4>";
+               (ecmp->pid_contactor_negative == 255 ? "N/A" : String(ecmp->pid_contactor_negative)) + "</h4>";
     content += "<h4>Contactor positive: " +
-               (datalayer_extended.stellantisECMP.pid_contactor_positive == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_contactor_positive)) +
-               "</h4>";
+               (ecmp->pid_contactor_positive == 255 ? "N/A" : String(ecmp->pid_contactor_positive)) + "</h4>";
     content += "<h4>Precharge control: " +
-               (datalayer_extended.stellantisECMP.pid_precharge_relay_control == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_precharge_relay_control)) +
-               "</h4>";
+               (ecmp->pid_precharge_relay_control == 255 ? "N/A" : String(ecmp->pid_precharge_relay_control)) + "</h4>";
     content += "<h4>Precharge status: " +
-               (datalayer_extended.stellantisECMP.pid_precharge_relay_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_precharge_relay_status)) +
-               "</h4>";
-    content += "<h4>Recharge Status: " +
-               (datalayer_extended.stellantisECMP.pid_recharge_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_recharge_status)) +
-               "</h4>";
-    content += "<h4>Delta temperature: " +
-               (datalayer_extended.stellantisECMP.pid_delta_temperature == 127
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_delta_temperature)) +
-               "&deg;C</h4>";
-    content += "<h4>Lowest temperature: " +
-               (datalayer_extended.stellantisECMP.pid_lowest_temperature == 127
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_lowest_temperature)) +
-               "&deg;C</h4>";
-    content += "<h4>Average temperature: " +
-               (datalayer_extended.stellantisECMP.pid_average_temperature == 127
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_average_temperature)) +
-               "&deg;C</h4>";
-    content += "<h4>Highest temperature: " +
-               (datalayer_extended.stellantisECMP.pid_highest_temperature == 127
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_highest_temperature)) +
-               "&deg;C</h4>";
-    content += "<h4>Coldest module: " +
-               (datalayer_extended.stellantisECMP.pid_coldest_module == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_coldest_module)) +
-               "</h4>";
-    content += "<h4>Hottest module: " +
-               (datalayer_extended.stellantisECMP.pid_hottest_module == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_hottest_module)) +
-               "</h4>";
-    content += "<h4>Average cell voltage: " +
-               (datalayer_extended.stellantisECMP.pid_avg_cell_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_avg_cell_voltage)) +
-               " mV</h4>";
+               (ecmp->pid_precharge_relay_status == 255 ? "N/A" : String(ecmp->pid_precharge_relay_status)) + "</h4>";
     content +=
-        "<h4>High precision current: " +
-        (datalayer_extended.stellantisECMP.pid_current == 255 ? "N/A"
-                                                              : String(datalayer_extended.stellantisECMP.pid_current)) +
-        " mA</h4>";
+        "<h4>Recharge Status: " + (ecmp->pid_recharge_status == 255 ? "N/A" : String(ecmp->pid_recharge_status)) +
+        "</h4>";
+    content +=
+        "<h4>Delta temperature: " + (ecmp->pid_delta_temperature == 127 ? "N/A" : String(ecmp->pid_delta_temperature)) +
+        "&deg;C</h4>";
+    content += "<h4>Lowest temperature: " +
+               (ecmp->pid_lowest_temperature == 127 ? "N/A" : String(ecmp->pid_lowest_temperature)) + "&deg;C</h4>";
+    content += "<h4>Average temperature: " +
+               (ecmp->pid_average_temperature == 127 ? "N/A" : String(ecmp->pid_average_temperature)) + "&deg;C</h4>";
+    content += "<h4>Highest temperature: " +
+               (ecmp->pid_highest_temperature == 127 ? "N/A" : String(ecmp->pid_highest_temperature)) + "&deg;C</h4>";
+    content +=
+        "<h4>Coldest module: " + (ecmp->pid_coldest_module == 255 ? "N/A" : String(ecmp->pid_coldest_module)) + "</h4>";
+    content +=
+        "<h4>Hottest module: " + (ecmp->pid_hottest_module == 255 ? "N/A" : String(ecmp->pid_hottest_module)) + "</h4>";
+    content += "<h4>Average cell voltage: " +
+               (ecmp->pid_avg_cell_voltage == 255 ? "N/A" : String(ecmp->pid_avg_cell_voltage)) + " mV</h4>";
+    content +=
+        "<h4>High precision current: " + (ecmp->pid_current == 255 ? "N/A" : String(ecmp->pid_current)) + " mA</h4>";
     content += "<h4>Insulation resistance neg-gnd: " +
-               (datalayer_extended.stellantisECMP.pid_insulation_res_neg == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_insulation_res_neg)) +
-               " kOhm</h4>";
+               (ecmp->pid_insulation_res_neg == 255 ? "N/A" : String(ecmp->pid_insulation_res_neg)) + " kOhm</h4>";
     content += "<h4>Insulation resistance pos-gnd: " +
-               (datalayer_extended.stellantisECMP.pid_insulation_res_pos == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_insulation_res_pos)) +
-               " kOhm</h4>";
-    content += "<h4>Max current 10s: " +
-               (datalayer_extended.stellantisECMP.pid_max_current_10s == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_max_current_10s)) +
-               "</h4>";
+               (ecmp->pid_insulation_res_pos == 255 ? "N/A" : String(ecmp->pid_insulation_res_pos)) + " kOhm</h4>";
+    content +=
+        "<h4>Max current 10s: " + (ecmp->pid_max_current_10s == 255 ? "N/A" : String(ecmp->pid_max_current_10s)) +
+        "</h4>";
     content += "<h4>Max discharge power 10s: " +
-               (datalayer_extended.stellantisECMP.pid_max_discharge_10s == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_max_discharge_10s)) +
-               "</h4>";
+               (ecmp->pid_max_discharge_10s == 255 ? "N/A" : String(ecmp->pid_max_discharge_10s)) + "</h4>";
     content += "<h4>Max discharge power 30s: " +
-               (datalayer_extended.stellantisECMP.pid_max_discharge_30s == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_max_discharge_30s)) +
-               "</h4>";
-    content += "<h4>Max charge power 10s: " +
-               (datalayer_extended.stellantisECMP.pid_max_charge_10s == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_max_charge_10s)) +
-               "</h4>";
-    content += "<h4>Max charge power 30s: " +
-               (datalayer_extended.stellantisECMP.pid_max_charge_30s == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_max_charge_30s)) +
-               "</h4>";
-    content += "<h4>Energy capacity: " +
-               (datalayer_extended.stellantisECMP.pid_energy_capacity == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_energy_capacity)) +
-               "</h4>";
+               (ecmp->pid_max_discharge_30s == 255 ? "N/A" : String(ecmp->pid_max_discharge_30s)) + "</h4>";
+    content +=
+        "<h4>Max charge power 10s: " + (ecmp->pid_max_charge_10s == 255 ? "N/A" : String(ecmp->pid_max_charge_10s)) +
+        "</h4>";
+    content +=
+        "<h4>Max charge power 30s: " + (ecmp->pid_max_charge_30s == 255 ? "N/A" : String(ecmp->pid_max_charge_30s)) +
+        "</h4>";
+    content +=
+        "<h4>Energy capacity: " + (ecmp->pid_energy_capacity == 255 ? "N/A" : String(ecmp->pid_energy_capacity)) +
+        "</h4>";
     content += "<h4>Highest cell number: " +
-               (datalayer_extended.stellantisECMP.pid_highest_cell_voltage_num == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_highest_cell_voltage_num)) +
+               (ecmp->pid_highest_cell_voltage_num == 255 ? "N/A" : String(ecmp->pid_highest_cell_voltage_num)) +
                "</h4>";
     content += "<h4>Lowest cell voltage number: " +
-               (datalayer_extended.stellantisECMP.pid_lowest_cell_voltage_num == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_lowest_cell_voltage_num)) +
-               "</h4>";
-    content += "<h4>Sum of all cell voltages: " +
-               (datalayer_extended.stellantisECMP.pid_sum_of_cells == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_sum_of_cells)) +
-               " dV</h4>";
-    content += "<h4>Cell min capacity: " +
-               (datalayer_extended.stellantisECMP.pid_cell_min_capacity == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_cell_min_capacity)) +
-               "</h4>";
-    content += "<h4>Cell voltage measurement status: " +
-               (datalayer_extended.stellantisECMP.pid_cell_voltage_measurement_status == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_cell_voltage_measurement_status)) +
-               "</h4>";
+               (ecmp->pid_lowest_cell_voltage_num == 255 ? "N/A" : String(ecmp->pid_lowest_cell_voltage_num)) + "</h4>";
+    content +=
+        "<h4>Sum of all cell voltages: " + (ecmp->pid_sum_of_cells == 255 ? "N/A" : String(ecmp->pid_sum_of_cells)) +
+        " dV</h4>";
+    content +=
+        "<h4>Cell min capacity: " + (ecmp->pid_cell_min_capacity == 255 ? "N/A" : String(ecmp->pid_cell_min_capacity)) +
+        "</h4>";
+    content +=
+        "<h4>Cell voltage measurement status: " +
+        (ecmp->pid_cell_voltage_measurement_status == 255 ? "N/A" : String(ecmp->pid_cell_voltage_measurement_status)) +
+        "</h4>";
     content += "<h4>Battery Insulation Resistance: " +
-               (datalayer_extended.stellantisECMP.pid_insulation_res == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_insulation_res)) +
-               " kOhm</h4>";
-    content += "<h4>Pack voltage: " +
-               (datalayer_extended.stellantisECMP.pid_pack_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_pack_voltage)) +
-               " dV</h4>";
+               (ecmp->pid_insulation_res == 255 ? "N/A" : String(ecmp->pid_insulation_res)) + " kOhm</h4>";
+    content +=
+        "<h4>Pack voltage: " + (ecmp->pid_pack_voltage == 255 ? "N/A" : String(ecmp->pid_pack_voltage)) + " dV</h4>";
     content += "<h4>Highest cell voltage: " +
-               (datalayer_extended.stellantisECMP.pid_high_cell_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_high_cell_voltage)) +
-               " mV</h4>";
-    content += "<h4>Lowest cell voltage: " +
-               (datalayer_extended.stellantisECMP.pid_low_cell_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_low_cell_voltage)) +
-               " mV</h4>";
-    content += "<h4>Battery Energy: " +
-               (datalayer_extended.stellantisECMP.pid_battery_energy == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_battery_energy)) +
-               "</h4>";
+               (ecmp->pid_high_cell_voltage == 255 ? "N/A" : String(ecmp->pid_high_cell_voltage)) + " mV</h4>";
+    content +=
+        "<h4>Lowest cell voltage: " + (ecmp->pid_low_cell_voltage == 255 ? "N/A" : String(ecmp->pid_low_cell_voltage)) +
+        " mV</h4>";
+    content +=
+        "<h4>Battery Energy: " + (ecmp->pid_battery_energy == 255 ? "N/A" : String(ecmp->pid_battery_energy)) + "</h4>";
     content += "<h4>Collision information Counter: " +
-               (datalayer_extended.stellantisECMP.pid_crash_counter == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_crash_counter)) +
-               "</h4>";
+               (ecmp->pid_crash_counter == 255 ? "N/A" : String(ecmp->pid_crash_counter)) + "</h4>";
     content += "<h4>Collision Counter recieved by Wire: " +
-               (datalayer_extended.stellantisECMP.pid_wire_crash == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_wire_crash)) +
-               "</h4>";
+               (ecmp->pid_wire_crash == 255 ? "N/A" : String(ecmp->pid_wire_crash)) + "</h4>";
     content += "<h4>Collision data sent from car to battery: " +
-               (datalayer_extended.stellantisECMP.pid_CAN_crash == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_CAN_crash)) +
-               "</h4>";
-    content += "<h4>History data: " +
-               (datalayer_extended.stellantisECMP.pid_history_data == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_history_data)) +
-               "</h4>";
-    content += "<h4>Low SOC counter: " +
-               (datalayer_extended.stellantisECMP.pid_lowsoc_counter == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_lowsoc_counter)) +
+               (ecmp->pid_CAN_crash == 255 ? "N/A" : String(ecmp->pid_CAN_crash)) + "</h4>";
+    content +=
+        "<h4>History data: " + (ecmp->pid_history_data == 255 ? "N/A" : String(ecmp->pid_history_data)) + "</h4>";
+    content += "<h4>Low SOC counter: " + (ecmp->pid_lowsoc_counter == 255 ? "N/A" : String(ecmp->pid_lowsoc_counter)) +
                "</h4>";
     content += "<h4>Last CAN failure detail: " +
-               (datalayer_extended.stellantisECMP.pid_last_can_failure_detail == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_last_can_failure_detail)) +
-               "</h4>";
-    content += "<h4>HW version number: " +
-               (datalayer_extended.stellantisECMP.pid_hw_version_num == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_hw_version_num)) +
-               "</h4>";
-    content += "<h4>SW version number: " +
-               (datalayer_extended.stellantisECMP.pid_sw_version_num == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_sw_version_num)) +
-               "</h4>";
+               (ecmp->pid_last_can_failure_detail == 255 ? "N/A" : String(ecmp->pid_last_can_failure_detail)) + "</h4>";
+    content +=
+        "<h4>HW version number: " + (ecmp->pid_hw_version_num == 255 ? "N/A" : String(ecmp->pid_hw_version_num)) +
+        "</h4>";
+    content +=
+        "<h4>SW version number: " + (ecmp->pid_sw_version_num == 255 ? "N/A" : String(ecmp->pid_sw_version_num)) +
+        "</h4>";
     content += "<h4>Factory mode: " +
-               (datalayer_extended.stellantisECMP.pid_factory_mode_control == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_factory_mode_control)) +
-               "</h4>";
+               (ecmp->pid_factory_mode_control == 255 ? "N/A" : String(ecmp->pid_factory_mode_control)) + "</h4>";
     char readableSerialNumber[14];  // One extra space for null terminator
-    memcpy(readableSerialNumber, datalayer_extended.stellantisECMP.pid_battery_serial,
-           sizeof(datalayer_extended.stellantisECMP.pid_battery_serial));
+    memcpy(readableSerialNumber, ecmp->pid_battery_serial, sizeof(ecmp->pid_battery_serial));
     readableSerialNumber[13] = '\0';  // Null terminate the string
     content += "<h4>Battery serial: " + String(readableSerialNumber) + "</h4>";
-    uint8_t day = (datalayer_extended.stellantisECMP.pid_date_of_manufacture >> 16) & 0xFF;
-    uint8_t month = (datalayer_extended.stellantisECMP.pid_date_of_manufacture >> 8) & 0xFF;
-    uint8_t year = datalayer_extended.stellantisECMP.pid_date_of_manufacture & 0xFF;
+    uint8_t day = (ecmp->pid_date_of_manufacture >> 16) & 0xFF;
+    uint8_t month = (ecmp->pid_date_of_manufacture >> 8) & 0xFF;
+    uint8_t year = ecmp->pid_date_of_manufacture & 0xFF;
     content += "<h4>Date of manufacture: " + String(day) + "/" + String(month) + "/" + String(year) + "</h4>";
-    content += "<h4>Aux fuse state: " +
-               (datalayer_extended.stellantisECMP.pid_aux_fuse_state == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_aux_fuse_state)) +
-               "</h4>";
-    content += "<h4>Battery state: " +
-               (datalayer_extended.stellantisECMP.pid_battery_state == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_battery_state)) +
-               "</h4>";
+    content +=
+        "<h4>Aux fuse state: " + (ecmp->pid_aux_fuse_state == 255 ? "N/A" : String(ecmp->pid_aux_fuse_state)) + "</h4>";
+    content +=
+        "<h4>Battery state: " + (ecmp->pid_battery_state == 255 ? "N/A" : String(ecmp->pid_battery_state)) + "</h4>";
     content += "<h4>Precharge short circuit: " +
-               (datalayer_extended.stellantisECMP.pid_precharge_short_circuit == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_precharge_short_circuit)) +
-               "</h4>";
+               (ecmp->pid_precharge_short_circuit == 255 ? "N/A" : String(ecmp->pid_precharge_short_circuit)) + "</h4>";
     content += "<h4>Service plug state: " +
-               (datalayer_extended.stellantisECMP.pid_eservice_plug_state == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_eservice_plug_state)) +
-               "</h4>";
-    content += "<h4>Main fuse state: " +
-               (datalayer_extended.stellantisECMP.pid_mainfuse_state == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_mainfuse_state)) +
+               (ecmp->pid_eservice_plug_state == 255 ? "N/A" : String(ecmp->pid_eservice_plug_state)) + "</h4>";
+    content += "<h4>Main fuse state: " + (ecmp->pid_mainfuse_state == 255 ? "N/A" : String(ecmp->pid_mainfuse_state)) +
                "</h4>";
     content += "<h4>Most critical fault: " +
-               (datalayer_extended.stellantisECMP.pid_most_critical_fault == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_most_critical_fault)) +
-               "</h4>";
-    content += "<h4>Current time: " +
-               (datalayer_extended.stellantisECMP.pid_current_time == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_current_time)) +
-               " ticks</h4>";
-    content += "<h4>Time sent by car: " +
-               (datalayer_extended.stellantisECMP.pid_time_sent_by_car == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_time_sent_by_car)) +
-               " ticks</h4>";
+               (ecmp->pid_most_critical_fault == 255 ? "N/A" : String(ecmp->pid_most_critical_fault)) + "</h4>";
     content +=
-        "<h4>12V: " +
-        (datalayer_extended.stellantisECMP.pid_12v == 255 ? "N/A" : String(datalayer_extended.stellantisECMP.pid_12v)) +
-        "</h4>";
+        "<h4>Current time: " + (ecmp->pid_current_time == 255 ? "N/A" : String(ecmp->pid_current_time)) + " ticks</h4>";
+    content +=
+        "<h4>Time sent by car: " + (ecmp->pid_time_sent_by_car == 255 ? "N/A" : String(ecmp->pid_time_sent_by_car)) +
+        " ticks</h4>";
+    content += "<h4>12V: " + (ecmp->pid_12v == 255 ? "N/A" : String(ecmp->pid_12v)) + "</h4>";
     content += "<h4>12V abnormal: ";
-    if (datalayer_extended.stellantisECMP.pid_12v_abnormal == 255) {
+    if (ecmp->pid_12v_abnormal == 255) {
       content += "N/A</h4>";
-    } else if (datalayer_extended.stellantisECMP.pid_12v_abnormal == 0) {
+    } else if (ecmp->pid_12v_abnormal == 0) {
       content += "No</h4>";
     } else {
       content += "Yes</h4>";
     }
-    content += "<h4>HVIL IN Voltage: " +
-               (datalayer_extended.stellantisECMP.pid_hvil_in_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_hvil_in_voltage)) +
-               "mV</h4>";
-    content += "<h4>HVIL Out Voltage: " +
-               (datalayer_extended.stellantisECMP.pid_hvil_out_voltage == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_hvil_out_voltage)) +
-               "mV</h4>";
-    content += "<h4>HVIL State: " +
-               (datalayer_extended.stellantisECMP.pid_hvil_state == 255
-                    ? "N/A"
-                    : (datalayer_extended.stellantisECMP.pid_hvil_state == 0
-                           ? "OK"
-                           : String(datalayer_extended.stellantisECMP.pid_hvil_state))) +
-               "</h4>";
+    content +=
+        "<h4>HVIL IN Voltage: " + (ecmp->pid_hvil_in_voltage == 255 ? "N/A" : String(ecmp->pid_hvil_in_voltage)) +
+        "mV</h4>";
+    content +=
+        "<h4>HVIL Out Voltage: " + (ecmp->pid_hvil_out_voltage == 255 ? "N/A" : String(ecmp->pid_hvil_out_voltage)) +
+        "mV</h4>";
+    content +=
+        "<h4>HVIL State: " +
+        (ecmp->pid_hvil_state == 255 ? "N/A" : (ecmp->pid_hvil_state == 0 ? "OK" : String(ecmp->pid_hvil_state))) +
+        "</h4>";
     content += "<h4>BMS State: " +
-               (datalayer_extended.stellantisECMP.pid_bms_state == 255
-                    ? "N/A"
-                    : (datalayer_extended.stellantisECMP.pid_bms_state == 0
-                           ? "OK"
-                           : String(datalayer_extended.stellantisECMP.pid_bms_state))) +
+               (ecmp->pid_bms_state == 255 ? "N/A" : (ecmp->pid_bms_state == 0 ? "OK" : String(ecmp->pid_bms_state))) +
                "</h4>";
-    content += "<h4>Vehicle speed: " +
-               (datalayer_extended.stellantisECMP.pid_vehicle_speed == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_vehicle_speed)) +
+    content += "<h4>Vehicle speed: " + (ecmp->pid_vehicle_speed == 255 ? "N/A" : String(ecmp->pid_vehicle_speed)) +
                " km/h</h4>";
     content += "<h4>Time spent over 55c: " +
-               (datalayer_extended.stellantisECMP.pid_time_spent_over_55c == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_time_spent_over_55c)) +
-               " minutes</h4>";
+               (ecmp->pid_time_spent_over_55c == 255 ? "N/A" : String(ecmp->pid_time_spent_over_55c)) + " minutes</h4>";
     content += "<h4>Contactor lifetime closing counter: " +
-               (datalayer_extended.stellantisECMP.pid_contactor_closing_counter == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_contactor_closing_counter)) +
+               (ecmp->pid_contactor_closing_counter == 255 ? "N/A" : String(ecmp->pid_contactor_closing_counter)) +
                " cycles</h4>";
-    content += "<h4>State of Health Cell-1: " +
-               (datalayer_extended.stellantisECMP.pid_SOH_cell_1 == 255
-                    ? "N/A"
-                    : String(datalayer_extended.stellantisECMP.pid_SOH_cell_1)) +
-               "</h4>";
+    content +=
+        "<h4>State of Health Cell-1: " + (ecmp->pid_SOH_cell_1 == 255 ? "N/A" : String(ecmp->pid_SOH_cell_1)) + "</h4>";
 
-    if (datalayer_extended.stellantisECMP.MysteryVan) {
+    if (ecmp->MysteryVan) {
       content += "<h3>MysteryVan platform detected!</h3>";
       content += "<h4>Contactor State: ";
-      if (datalayer_extended.stellantisECMP.CONTACTORS_STATE == 0) {
+      if (ecmp->CONTACTORS_STATE == 0) {
         content += "Open";
-      } else if (datalayer_extended.stellantisECMP.CONTACTORS_STATE == 1) {
+      } else if (ecmp->CONTACTORS_STATE == 1) {
         content += "Precharge";
-      } else if (datalayer_extended.stellantisECMP.CONTACTORS_STATE == 2) {
+      } else if (ecmp->CONTACTORS_STATE == 2) {
         content += "Closed";
       }
       content += "</h4>";
       content += "<h4>Crash Memorized: ";
-      if (datalayer_extended.stellantisECMP.CrashMemorized) {
+      if (ecmp->CrashMemorized) {
         content += "Yes</h4>";
       } else {
         content += "No</h4>";
       }
       content += "<h4>Contactor Opening Reason: ";
-      if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 0) {
+      if (ecmp->CONTACTOR_OPENING_REASON == 0) {
         content += "No error";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 1) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 1) {
         content += "Crash!";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 2) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 2) {
         content += "12V supply source undervoltage";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 3) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 3) {
         content += "12V supply source overvoltage";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 4) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 4) {
         content += "Battery temperature";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 5) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 5) {
         content += "Interlock line open";
-      } else if (datalayer_extended.stellantisECMP.CONTACTOR_OPENING_REASON == 6) {
+      } else if (ecmp->CONTACTOR_OPENING_REASON == 6) {
         content += "e-Service plug disconnected";
       }
       content += "</h4>";
       content += "<h4>Battery fault type: ";
-      if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 0) {
+      if (ecmp->TBMU_FAULT_TYPE == 0) {
         content += "No fault";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 1) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 1) {
         content += "FirstLevelFault: Warning Lamp";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 2) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 2) {
         content += "SecondLevelFault: Stop Lamp";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 3) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 3) {
         content += "ThirdLevelFault: Stop Lamp + contactor opening (EPS shutdown)";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 4) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 4) {
         content += "FourthLevelFault: Stop Lamp + Active Discharge";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 5) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 5) {
         content += "Inhibition of powertrain activation";
-      } else if (datalayer_extended.stellantisECMP.TBMU_FAULT_TYPE == 6) {
+      } else if (ecmp->TBMU_FAULT_TYPE == 6) {
         content += "Reserved";
       }
       content += "</h4>";
-      content += "<h4>FC insulation minus resistance " +
-                 String(datalayer_extended.stellantisECMP.HV_BATT_FC_INSU_MINUS_RES) + " kOhm</h4>";
-      content += "<h4>FC insulation plus resistance " +
-                 String(datalayer_extended.stellantisECMP.HV_BATT_FC_INSU_PLUS_RES) + " kOhm</h4>";
-      content += "<h4>FC vehicle insulation plus resistance " +
-                 String(datalayer_extended.stellantisECMP.HV_BATT_FC_VHL_INSU_PLUS_RES) + " kOhm</h4>";
-      content += "<h4>FC vehicle insulation plus resistance " +
-                 String(datalayer_extended.stellantisECMP.HV_BATT_ONLY_INSU_MINUS_RES) + " kOhm</h4>";
+      content += "<h4>FC insulation minus resistance " + String(ecmp->HV_BATT_FC_INSU_MINUS_RES) + " kOhm</h4>";
+      content += "<h4>FC insulation plus resistance " + String(ecmp->HV_BATT_FC_INSU_PLUS_RES) + " kOhm</h4>";
+      content +=
+          "<h4>FC vehicle insulation plus resistance " + String(ecmp->HV_BATT_FC_VHL_INSU_PLUS_RES) + " kOhm</h4>";
+      content +=
+          "<h4>FC vehicle insulation plus resistance " + String(ecmp->HV_BATT_ONLY_INSU_MINUS_RES) + " kOhm</h4>";
     }
     content += "<h4>Alert Battery: ";
-    if (datalayer_extended.stellantisECMP.ALERT_BATT) {
+    if (ecmp->ALERT_BATT) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Low SOC: ";
-    if (datalayer_extended.stellantisECMP.ALERT_LOW_SOC) {
+    if (ecmp->ALERT_LOW_SOC) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert High SOC: ";
-    if (datalayer_extended.stellantisECMP.ALERT_HIGH_SOC) {
+    if (ecmp->ALERT_HIGH_SOC) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert SOC Jump: ";
-    if (datalayer_extended.stellantisECMP.ALERT_SOC_JUMP) {
+    if (ecmp->ALERT_SOC_JUMP) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Overcharge: ";
-    if (datalayer_extended.stellantisECMP.ALERT_OVERCHARGE) {
+    if (ecmp->ALERT_OVERCHARGE) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Temp Diff: ";
-    if (datalayer_extended.stellantisECMP.ALERT_TEMP_DIFF) {
+    if (ecmp->ALERT_TEMP_DIFF) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Temp High: ";
-    if (datalayer_extended.stellantisECMP.ALERT_HIGH_TEMP) {
+    if (ecmp->ALERT_HIGH_TEMP) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Overvoltage: ";
-    if (datalayer_extended.stellantisECMP.ALERT_OVERVOLTAGE) {
+    if (ecmp->ALERT_OVERVOLTAGE) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Cell Overvoltage: ";
-    if (datalayer_extended.stellantisECMP.ALERT_CELL_OVERVOLTAGE) {
+    if (ecmp->ALERT_CELL_OVERVOLTAGE) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Cell Undervoltage: ";
-    if (datalayer_extended.stellantisECMP.ALERT_CELL_UNDERVOLTAGE) {
+    if (ecmp->ALERT_CELL_UNDERVOLTAGE) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
     }
     content += "<h4>Alert Cell Poor Consistency: ";
-    if (datalayer_extended.stellantisECMP.ALERT_CELL_POOR_CONSIST) {
+    if (ecmp->ALERT_CELL_POOR_CONSIST) {
       content += "Yes</h4>";
     } else {
       content += "No</h4>";
@@ -512,6 +353,9 @@ class EcmpHtmlRenderer : public BatteryHtmlRenderer {
     content += "<h4>Remember to press Open Contactors from main menu before running the dianostic commands below:</h4>";
     return content;
   }
+
+ private:
+  DATALAYER_INFO_ECMP* ecmp;
 };
 
 #endif

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -15,6 +15,10 @@ bool contactor_control_enabled = false;         //Should GPIO contactor control 
 bool contactor_control_inverted_logic = false;  //Should we control NC contactors? Extremely rare option
 uint16_t precharge_time_ms = 100;               //Precharge time in ms. Adjust depending on capacitance in inverter
 bool pwm_contactor_control = false;             //Should the contactors be economized via PWM after they are engaged?
+#ifndef SMALL_FLASH_DEVICE
+bool require_bms_contactors_closed =
+    false;  //Hold GPIO contactor closing until every reporting battery's BMS contactors are CLOSED
+#endif      // SMALL_FLASH_DEVICE
 bool contactor_control_enabled_double_battery = false;  //Should a contactor for the secondary battery be operated?
 bool contactor_control_enabled_triple_battery = false;  //Should a contactor for the third battery be operated?
 bool remote_bms_reset = false;                          //Is it possible to actuate BMS reset via MQTT?
@@ -172,6 +176,99 @@ static void dbg_contactors(const char* state) {
   logging.println(state);
 }
 
+// The Stellantis eCMP multi-battery "Require BMS contactors closed" interlock is not built for
+// flash-limited boards - they cannot run three CAN buses, so triple-battery is unavailable there
+// anyway. On SMALL_FLASH_DEVICE the two probe functions below become no-ops that fold away.
+#ifndef SMALL_FLASH_DEVICE
+
+/* "Require BMS contactors closed" interlock (Minimal variant): only gates the DISCONNECTED ->
+   START_PRECHARGE transition. Returns 0 when the interlock is satisfied (feature disabled, or
+   every battery that reports a real contactor status has it CLOSED). Otherwise returns the pack
+   number (1/2/3) of the first battery holding it back, for the event data. Batteries that do not
+   report a contactor status (reports_contactor_status() == false) are ignored, so integrations
+   without this feedback are unaffected. */
+// millis() when every reporting battery first read CLOSED together, 0 when at least one is not.
+static uint32_t bms_all_closed_since_ms = 0;
+// After all packs report closed, wait this long (continuously closed) before allowing precharge.
+// A cold 3-pack start otherwise fires precharge the instant the BMS contactors click in, before
+// the pack voltages have settled, and trips straight back off.
+#define BMS_INTERLOCK_SETTLE_MS 8000
+// Sentinel returned by bms_contactor_interlock_blocker() for "all closed, still settling".
+#define BMS_INTERLOCK_SETTLING 0xFF
+
+static uint8_t bms_contactor_interlock_blocker() {
+  if (!require_bms_contactors_closed) {
+    return 0;
+  }
+  Battery* packs[3] = {battery, battery2, battery3};
+  bool any_reporting = false;
+  for (uint8_t i = 0; i < 3; i++) {
+    Battery* b = packs[i];
+    if (b && b->reports_contactor_status()) {
+      any_reporting = true;
+      if (b->contactor_status() != Battery::ContactorStatus::CLOSED) {
+        bms_all_closed_since_ms = 0;  // restart the settle timer
+        return (uint8_t)(i + 1);
+      }
+    }
+  }
+  if (!any_reporting) {
+    // No configured battery reports a real contactor status (e.g. the setting is left on but
+    // the battery type was changed away from eCMP). The interlock, including the settle wait,
+    // does nothing.
+    bms_all_closed_since_ms = 0;
+    return 0;
+  }
+  // Every reporting pack is closed - hold precharge until they have stayed closed for the
+  // settle period.
+  if (bms_all_closed_since_ms == 0) {
+    bms_all_closed_since_ms = millis();
+  }
+  if ((millis() - bms_all_closed_since_ms) < BMS_INTERLOCK_SETTLE_MS) {
+    return BMS_INTERLOCK_SETTLING;
+  }
+  return 0;
+}
+
+/* Same feature, running side: returns the pack number (1/2/3) of the first battery that has
+   CONFIRMED-open BMS contactors (ContactorStatus::OPEN, not UNKNOWN) while the GPIO contactors
+   are closed, or 0. UNKNOWN is deliberately ignored here so a brief diagnostic-poll gap cannot
+   trigger a shutdown; a real open reports OPEN from the polled per-switch feedback. Gated on the
+   same opt-in setting and only considers batteries that report a real contactor status. */
+static uint8_t running_battery_bms_open() {
+  if (!require_bms_contactors_closed) {
+    return 0;
+  }
+  Battery* packs[3] = {battery, battery2, battery3};
+  for (uint8_t i = 0; i < 3; i++) {
+    Battery* b = packs[i];
+    if (b && b->reports_contactor_status() && b->contactor_status() == Battery::ContactorStatus::OPEN) {
+      return (uint8_t)(i + 1);
+    }
+  }
+  return 0;
+}
+
+// Debounce for running_battery_bms_open(): millis() when a battery first read OPEN while running,
+// 0 when none is. A confirmed open needs BMS_CONTACTOR_OPEN_DEBOUNCE_MS of continuous OPEN so a
+// single spurious poll frame cannot drop the HV bus.
+static uint32_t bms_contactor_open_since_ms = 0;
+#define BMS_CONTACTOR_OPEN_DEBOUNCE_MS 2000
+// True while the battery pause below was issued by the BMS-open handler, so it (and only it) is
+// lifted again once every battery reads closed.
+static bool bms_open_pause_issued = false;
+
+#else  // SMALL_FLASH_DEVICE - interlock compiled out
+
+static inline uint8_t bms_contactor_interlock_blocker() {
+  return 0;
+}
+static inline uint8_t running_battery_bms_open() {
+  return 0;
+}
+
+#endif  // SMALL_FLASH_DEVICE
+
 // Main functions of the handle_contactors include checking if inverter allows for closing, checking battery 2, checking BMS power output, and actual contactor closing/precharge via GPIO
 void handle_contactors() {
   if (inverter && inverter->controls_contactor()) {
@@ -234,10 +331,65 @@ void handle_contactors() {
       set_indicator_led(IndicatorLed::CONTACTOR_POS, false);
       datalayer.system.status.contactors_engaged = 0;
 
-      if (datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active) {
+      // Optional interlock (eCMP, not built for SMALL_FLASH_DEVICE): hold here until every
+      // reporting battery's BMS contactors are CLOSED and have settled.
+#ifndef SMALL_FLASH_DEVICE
+      const uint8_t interlock_blocker = bms_contactor_interlock_blocker();
+      if (interlock_blocker) {
+        // Event data: 1/2/3 = that pack is not closed; 0 = all closed, still in the settle wait.
+        const int16_t ev_data = (interlock_blocker == BMS_INTERLOCK_SETTLING) ? 0 : (int16_t)interlock_blocker;
+        // Edge-triggered: this branch runs every tick while blocked, so only (re)raise the event
+        // when it is not already active or the reason changed - keeps the occurrence count sane.
+        const EVENTS_STRUCT_TYPE* e = get_event_pointer(EVENT_BMS_CONTACTOR_INTERLOCK);
+        if (e->state != EVENT_STATE_ACTIVE || e->data != ev_data) {
+          set_event(EVENT_BMS_CONTACTOR_INTERLOCK, ev_data);
+        }
+      } else {
+        // Transient "waiting for BMS contactors" state - wipe it so it does not linger in history.
+        reset_event(EVENT_BMS_CONTACTOR_INTERLOCK);
+      }
+#else
+      const uint8_t interlock_blocker = 0;
+#endif  // SMALL_FLASH_DEVICE
+
+      if (datalayer.system.status.inverter_allows_contactor_closing && !datalayer.system.info.equipment_stop_active &&
+          !interlock_blocker) {
+#ifndef SMALL_FLASH_DEVICE
+        bms_all_closed_since_ms = 0;  // require a fresh settle wait on any later re-close
+#endif
         contactorStatus = START_PRECHARGE;
       }
     }
+
+    // A battery that opened its own BMS contactors while running (eCMP, opt-in, not on
+    // SMALL_FLASH_DEVICE). Debounced so a brief poll gap does not count. Handled the same way as an
+    // equipment stop below: pause first, let the current fall, then open the GPIO contactors.
+    // Recoverable - once every battery reads CLOSED again the normal precharge sequence brings the
+    // bus back.
+#ifndef SMALL_FLASH_DEVICE
+    uint8_t bms_open_pack = running_battery_bms_open();
+    if (bms_open_pack) {
+      if (bms_contactor_open_since_ms == 0) {
+        bms_contactor_open_since_ms = millis();
+      }
+      if ((millis() - bms_contactor_open_since_ms) < BMS_CONTACTOR_OPEN_DEBOUNCE_MS) {
+        bms_open_pack = 0;  // not confirmed yet
+      }
+    } else {
+      // Every reporting battery reads closed again. If the BMS-open handler issued the pause and
+      // nothing else still needs it, lift it so the DISCONNECTED -> precharge sequence can bring
+      // the bus back.
+      if (bms_open_pause_issued && !datalayer.system.info.equipment_stop_active &&
+          datalayer.system.status.bms_reset_status == BMS_RESET_IDLE) {
+        setBatteryPause(false, false, EquipmentStop::UNCHANGED, false);
+      }
+      bms_open_pause_issued = false;
+      bms_contactor_open_since_ms = 0;
+      clear_event(EVENT_BMS_CONTACTOR_OPEN_SHUTDOWN);
+    }
+#else
+    const uint8_t bms_open_pack = 0;
+#endif  // SMALL_FLASH_DEVICE
 
     // In case the inverter or the equipment stop requests contactors to open, jump to Disconnected (recoverable)
     if (contactorStatus == COMPLETED) {
@@ -245,7 +397,7 @@ void handle_contactors() {
         // Inverter-commanded opening stays immediate: the inverter has already
         // stopped power transfer before revoking its permission
         contactorStatus = DISCONNECTED;
-      } else if (datalayer.system.info.equipment_stop_active) {
+      } else if (datalayer.system.info.equipment_stop_active || bms_open_pack) {
         // Equipment stop: every e-stop entry point also issues a battery pause,
         // so hold the contactors until the pause state machine reports PAUSED
         // (current below 1.8 A) - opening under load risks arcing/welding.
@@ -254,13 +406,21 @@ void handle_contactors() {
         uint32_t now = millis();
         if (estop_open_wait_start_ms == 0) {
           estop_open_wait_start_ms = now;
+#ifndef SMALL_FLASH_DEVICE
+          if (bms_open_pack && !datalayer.system.info.equipment_stop_active) {
+            // Equipment stop issues its own pause; only pause here for the BMS-open trigger.
+            setBatteryPause(true, false, EquipmentStop::UNCHANGED, false);
+            bms_open_pause_issued = true;
+            set_event(EVENT_BMS_CONTACTOR_OPEN_SHUTDOWN, bms_open_pack);
+          }
+#endif  // SMALL_FLASH_DEVICE
         }
         bool paused = (emulator_pause_status == PAUSED);
         bool timed_out = (now - estop_open_wait_start_ms) > ESTOP_OPEN_TIMEOUT_MS;
         if (paused || timed_out) {
           if (timed_out) {
             LOG_SET_NEXT_SEVERITY(4);  // warning
-            logging.printf("Contactors: Equipment stop wait timed out, opening under load\n");
+            logging.printf("Contactors: open wait timed out, opening under load\n");
             set_event(EVENT_ERROR_OPEN_CONTACTOR, 1);
           }
           estop_open_wait_start_ms = 0;

--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.h
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.h
@@ -10,6 +10,13 @@ extern bool contactor_control_inverted_logic;
 extern bool contactor_control_enabled_double_battery;
 extern bool contactor_control_enabled_triple_battery;
 extern bool pwm_contactor_control;
+#ifndef SMALL_FLASH_DEVICE
+// When true, the GPIO contactor sequence is not allowed to start unless every battery that
+// reports a real BMS contactor status has it CLOSED. Does not force contactors open once
+// engaged - that stays with the FAULT/equipment-stop logic. Default off. Stellantis eCMP only;
+// not built for flash-limited boards.
+extern bool require_bms_contactors_closed;
+#endif  // SMALL_FLASH_DEVICE
 extern bool periodic_bms_reset;
 // Interval between periodic BMS resets, in hours. Only 24 and 48 are offered in the UI.
 extern uint16_t periodic_bms_reset_interval_h;

--- a/Software/src/communication/nvm/comm_nvm.cpp
+++ b/Software/src/communication/nvm/comm_nvm.cpp
@@ -203,6 +203,9 @@ void init_stored_settings() {
   contactor_control_enabled_double_battery = settings.getBool("CNTCTRLDBL", false);
   contactor_control_enabled_triple_battery = settings.getBool("CNTCTRLTRI", false);
   pwm_contactor_control = settings.getBool("PWMCNTCTRL", false);
+#ifndef SMALL_FLASH_DEVICE
+  require_bms_contactors_closed = settings.getBool("REQBMSCONT", false);
+#endif  // SMALL_FLASH_DEVICE
   pwm_frequency = settings.getUInt("PWMFREQ", 20000);
   pwm_hold_duty = settings.getUInt("PWMHOLD", 250);
   periodic_bms_reset = settings.getBool("PERBMSRESET", false);

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -1062,7 +1062,11 @@ class DataLayerExtended {
     DATALAYER_INFO_BMWIX bmwix;
     DATALAYER_INFO_CELLPOWER cellpower;
     DATALAYER_INFO_CHADEMO chademo;
-    DATALAYER_INFO_ECMP stellantisECMP;
+    struct {
+      DATALAYER_INFO_ECMP stellantisECMP;
+      DATALAYER_INFO_ECMP stellantisECMP_2;
+      DATALAYER_INFO_ECMP stellantisECMP_3;
+    };
     DATALAYER_INFO_FORD_MACH_E fordMachE;
     DATALAYER_INFO_GEELY_GEOMETRY_C geometryC;
     struct {

--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -168,6 +168,12 @@ void init_events(void) {
   events.entries[EVENT_CAN_INVERTER_DETECTED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_CONTACTOR_WELDED].level = EVENT_LEVEL_WARNING;
   events.entries[EVENT_CONTACTOR_OPEN].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CONTACTOR2_OPEN].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_CONTACTOR3_OPEN].level = EVENT_LEVEL_WARNING;
+#ifndef SMALL_FLASH_DEVICE
+  events.entries[EVENT_BMS_CONTACTOR_INTERLOCK].level = EVENT_LEVEL_WARNING;
+  events.entries[EVENT_BMS_CONTACTOR_OPEN_SHUTDOWN].level = EVENT_LEVEL_WARNING;
+#endif  // SMALL_FLASH_DEVICE
   events.entries[EVENT_WATER_INGRESS].level = EVENT_LEVEL_ERROR;
   events.entries[EVENT_CHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
   events.entries[EVENT_DISCHARGE_LIMIT_EXCEEDED].level = EVENT_LEVEL_INFO;
@@ -392,6 +398,21 @@ void clear_event(EVENTS_ENUM_TYPE event) {
   }
 }
 
+/* Clear an event AND wipe its history (occurrence count, timestamp, data), so it disappears from
+   the events page entirely instead of lingering as an inactive row. For transient "waiting"
+   conditions that fire and clear on their own every boot and are not worth logging. Idempotent -
+   cheap no-op once the entry is already blank. */
+void reset_event(EVENTS_ENUM_TYPE event) {
+  if (events.entries[event].occurences == 0 && events.entries[event].state == EVENT_STATE_INACTIVE) {
+    return;
+  }
+  clear_event(event);
+  events.entries[event].occurences = 0;
+  events.entries[event].timestamp = 0;
+  events.entries[event].data = 0;
+  events.entries[event].MQTTpublished = false;
+}
+
 void ignore_can_errors_for(CAN_Interface interface, uint32_t duration_ms) {
   // Suppress the buffer-full / bus-error events of a single CAN interface for a while.
   if ((uint8_t)interface >= NO_CAN_INTERFACE) {
@@ -462,6 +483,19 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
       return "Contactors sticking/welded. Inspect battery with caution!";
     case EVENT_CONTACTOR_OPEN:
       return "Battery decided to open contactors. Inspect battery!";
+    case EVENT_CONTACTOR2_OPEN:
+      return "Battery 2 decided to open contactors. Inspect battery 2!";
+    case EVENT_CONTACTOR3_OPEN:
+      return "Battery 3 decided to open contactors. Inspect battery 3!";
+#ifndef SMALL_FLASH_DEVICE
+    case EVENT_BMS_CONTACTOR_INTERLOCK:
+      return "GPIO contactor closing held until every battery BMS reports its contactors closed "
+             "and has stayed closed for a few seconds. Event data: battery number not closed, or "
+             "0 = all closed, settling. See the BMS contactors line on the main page.";
+    case EVENT_BMS_CONTACTOR_OPEN_SHUTDOWN:
+      return "A battery opened its BMS contactors while running. Paused and opened the GPIO "
+             "contactors. Event data is the battery number. Recovers once every battery is closed again.";
+#endif  // SMALL_FLASH_DEVICE
     case EVENT_CHARGE_LIMIT_EXCEEDED:
       return "Inverter is charging faster than battery is allowing.";
     case EVENT_DISCHARGE_LIMIT_EXCEEDED:

--- a/Software/src/devboard/utils/events.h
+++ b/Software/src/devboard/utils/events.h
@@ -47,6 +47,10 @@
   XX(EVENT_CHARGE_LIMIT_EXCEEDED)        \
   XX(EVENT_CONTACTOR_WELDED)             \
   XX(EVENT_CONTACTOR_OPEN)               \
+  XX(EVENT_CONTACTOR2_OPEN)              \
+  XX(EVENT_CONTACTOR3_OPEN)              \
+  XX(EVENT_BMS_CONTACTOR_INTERLOCK)      \
+  XX(EVENT_BMS_CONTACTOR_OPEN_SHUTDOWN)  \
   XX(EVENT_DISCHARGE_LIMIT_EXCEEDED)     \
   XX(EVENT_WATER_INGRESS)                \
   XX(EVENT_12V_LOW)                      \
@@ -262,6 +266,9 @@ void set_event(EVENTS_ENUM_TYPE event, int16_t data, uint8_t battery);
 void set_event_latched(EVENTS_ENUM_TYPE event, int16_t data, uint8_t battery);
 void clear_event(EVENTS_ENUM_TYPE event, uint8_t battery);
 void clear_event(EVENTS_ENUM_TYPE event);
+// Clear an event and also wipe its history so it no longer shows on the events page at all.
+// For transient conditions that are not worth keeping a record of.
+void reset_event(EVENTS_ENUM_TYPE event);
 // Suppress a CAN interface's buffer-full / bus-error events for duration_ms from now.
 void ignore_can_errors_for(CAN_Interface interface, uint32_t duration_ms);
 void reset_all_events();

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -603,6 +603,12 @@ String raw_settings_processor(const String& var, BatteryEmulatorSettingsStore& s
     return settings.getBool("PWMCNTCTRL") ? "checked" : "";
   }
 
+#ifndef SMALL_FLASH_DEVICE
+  if (var == "REQBMSCONT") {
+    return settings.getBool("REQBMSCONT") ? "checked" : "";
+  }
+#endif  // SMALL_FLASH_DEVICE
+
   if (var == "PERBMSRESET") {
     return settings.getBool("PERBMSRESET") ? "checked" : "";
   }
@@ -1257,6 +1263,20 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         </div>
   )rawliteral"
 
+// Stellantis eCMP only, and not built for flash-limited boards.
+#ifndef SMALL_FLASH_DEVICE
+#define REQBMSCONT_SETTING_HTML \
+  R"rawliteral(
+            <div class="if-ecmp">
+                <label>Require battery BMS contactors closed: </label>
+                <input type='checkbox' name='REQBMSCONT' value='on' %REQBMSCONT%
+                title="Hold GPIO contactor closing until every Stellantis eCMP battery reports its BMS contactors CLOSED and settled. Does not force contactors open once engaged." />
+            </div>
+  )rawliteral"
+#else
+#define REQBMSCONT_SETTING_HTML ""
+#endif  // SMALL_FLASH_DEVICE
+
 #define SETTINGS_HTML_SCRIPTS \
   R"rawliteral(
     <script>
@@ -1474,6 +1494,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
 
     form .if-daly { display: none; }
     form[data-battery="23"] .if-daly {
+      display: contents;
+    }
+
+    form .if-ecmp { display: none; }
+    form[data-battery="13"] .if-ecmp {
       display: contents;
     }
 
@@ -2195,11 +2220,11 @@ const char* getCANInterfaceName(CAN_Interface interface) {
             title="Frequency in Hz used for PWM" />
 
             <label>PWM Hold 1-1023: </label>
-            <input type='number' name='PWMHOLD' value="%PWMHOLD%" 
+            <input type='number' name='PWMHOLD' value="%PWMHOLD%"
             min="1" max="1023" step="1"
             title="1-1023 , lower value = lower power consumption" />
               </div>
-
+  )rawliteral" REQBMSCONT_SETTING_HTML R"rawliteral(
         </div>
 
         <label>Periodic BMS reset: </label>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -467,6 +467,9 @@ void init_webserver() {
       "PRIMOGEN24",   "CTINVERT",     "LOWPASSFILTER", "WEBAUTH",     "SLOWCANINV",    "CHGTAPERSOC",  "MEASURECPUTEMP",
       "SYSLOGEN",     "PERBMSDEFSOC", "PERBMSSKIPBAL", "INVOFFGRID",  "CHGESTIMATED",  "MQTTHEAP",     "HADISCFWU",
       "INVACCREB",
+#ifndef SMALL_FLASH_DEVICE
+      "REQBMSCONT",
+#endif  // SMALL_FLASH_DEVICE
 #ifdef SDCARD
       "SDLOGENABLED", "CANLOGSD",
 #endif  // SDCARD
@@ -1050,6 +1053,98 @@ String get_firmware_info_processor(const String& var) {
   return String();
 }
 
+// --- Per-battery main-page display helpers ---------------------------------------------------
+// Display only. These never write the datalayer and have no effect on inverter or contactor
+// control. They let each battery card show ITS OWN scaled values instead of battery 1 / the
+// aggregate. The formulas mirror update_calculated_values() in Software.cpp; only the inputs
+// differ (each pack's own real SOC / real capacity, one shared SOC window from settings).
+
+// Scaled SOC in pptt (0..10000) for one pack from its own real SOC.
+static int32_t dashboard_scaled_soc_pptt(int32_t real_soc_pptt) {
+  const int32_t min_pct = datalayer.battery.settings.min_percentage;
+  const int32_t max_pct = datalayer.battery.settings.max_percentage;
+  const int32_t delta = max_pct - min_pct;
+  if (delta <= 0) {
+    return 0;
+  }
+  int32_t clamped = real_soc_pptt;
+  if (clamped < min_pct) {
+    clamped = min_pct;
+  }
+  if (clamped > max_pct) {
+    clamped = max_pct;
+  }
+  return (10000 * (clamped - min_pct)) / delta;
+}
+
+// Scaled usable total capacity in Wh for one pack from its own real total capacity.
+static uint32_t dashboard_scaled_total_capacity_Wh(uint32_t real_total_capacity_Wh) {
+  const int32_t delta =
+      (int32_t)datalayer.battery.settings.max_percentage - (int32_t)datalayer.battery.settings.min_percentage;
+  if (delta <= 0 || real_total_capacity_Wh == 0) {
+    return real_total_capacity_Wh;
+  }
+  return (uint32_t)(((uint64_t)real_total_capacity_Wh * (uint32_t)delta) / 10000);
+}
+
+// Scaled remaining capacity in Wh for one pack from its own scaled total capacity and scaled SOC.
+static uint32_t dashboard_scaled_remaining_capacity_Wh(uint32_t scaled_total_capacity_Wh, int32_t scaled_soc_pptt) {
+  return (uint32_t)(((uint64_t)scaled_total_capacity_Wh * (uint32_t)scaled_soc_pptt) / 10000);
+}
+
+// Configured (user Settings) charge/discharge limits, formatted for a battery card. Shows the
+// raw user setting (max_user_set_charge_dA / max_user_set_discharge_dA, deci-amps) as amps, plus
+// an approximate power using the same A->W conversion the rest of the firmware uses (live pack
+// voltage, or design max voltage as fallback). Display only.
+static String battery_configured_limits_html() {
+  const float chargeA = datalayer.battery.settings.max_user_set_charge_dA / 10.0f;
+  const float dischargeA = datalayer.battery.settings.max_user_set_discharge_dA / 10.0f;
+  uint16_t conv_dV = datalayer.battery.status.voltage_dV;
+  if (conv_dV <= 10) {
+    conv_dV = datalayer.battery.info.max_design_voltage_dV;
+  }
+  String out;
+  out += "<h4 style='color: white;'>Configured max charge: " + String(chargeA, 1) + " A";
+  if (conv_dV > 10) {
+    out += " (" +
+           formatPowerValue((uint32_t)(((uint32_t)datalayer.battery.settings.max_user_set_charge_dA * conv_dV) / 100),
+                            "", 1) +
+           ")";
+  }
+  out += "</h4>";
+  out += "<h4 style='color: white;'>Configured max discharge: " + String(dischargeA, 1) + " A";
+  if (conv_dV > 10) {
+    out += " (" +
+           formatPowerValue(
+               (uint32_t)(((uint32_t)datalayer.battery.settings.max_user_set_discharge_dA * conv_dV) / 100), "", 1) +
+           ")";
+  }
+  out += "</h4>";
+  return out;
+}
+
+// "CLOSED" / "OPEN" / "UNKNOWN" from a battery instance's real BMS contactor feedback.
+// When OPEN and the battery reports an opening-reason code, it is appended as " (reason: N)".
+static String dashboard_contactor_text(Battery* b) {
+  if (!b) {
+    return String("UNKNOWN");
+  }
+  switch (b->contactor_status()) {
+    case Battery::ContactorStatus::CLOSED:
+      return String("CLOSED");
+    case Battery::ContactorStatus::OPEN: {
+      String s = "OPEN";
+      const int16_t reason = b->contactor_open_reason();
+      if (reason >= 0) {
+        s += " (reason: " + String(reason) + ")";
+      }
+      return s;
+    }
+    default:
+      return String("UNKNOWN");
+  }
+}
+
 String processor(const String& var) {
   if (var == "X") {
     String content = "";
@@ -1257,8 +1352,10 @@ String processor(const String& var) {
       // Display battery statistics within this block
       float socRealFloat =
           static_cast<float>(datalayer.battery.status.real_soc) / 100.0f;  // Convert to float and divide by 100
-      float socScaledFloat =
-          static_cast<float>(datalayer.battery.status.reported_soc) / 100.0f;  // Convert to float and divide by 100
+      // Per-card scaled SOC: computed from THIS pack's own real SOC (not battery.reported_soc,
+      // which for multi-battery is the aggregate/extreme-pack value the inverter sees).
+      int32_t scaledSocPptt = dashboard_scaled_soc_pptt(datalayer.battery.status.real_soc);
+      float socScaledFloat = static_cast<float>(scaledSocPptt) / 100.0f;
       float sohFloat =
           static_cast<float>(datalayer.battery.status.soh_pptt) / 100.0f;  // Convert to float and divide by 100
       float voltageFloat =
@@ -1286,16 +1383,22 @@ String processor(const String& var) {
                  " V &nbsp; Current: " + String(currentFloat, 1) + " A</h4>";
       content += formatPowerValue("Power", powerFloat, "", 1);
 
+      // Per-card scaled capacity: computed from THIS pack's own real capacity, so battery 1 shows
+      // its own ~42.5 kWh and not battery.info.reported_total_capacity_Wh (the aggregate the
+      // inverter is fed). The aggregate datalayer value is left untouched.
+      uint32_t scaledTotalCapacityWh = dashboard_scaled_total_capacity_Wh(datalayer.battery.info.total_capacity_Wh);
+      uint32_t scaledRemainingCapacityWh = dashboard_scaled_remaining_capacity_Wh(scaledTotalCapacityWh, scaledSocPptt);
+
       if (datalayer.battery.settings.soc_scaling_active)
-        content += "<h4 style='color: white;'>Scaled total capacity: " +
-                   formatPowerValue(datalayer.battery.info.reported_total_capacity_Wh, "h", 1) +
-                   " (real: " + formatPowerValue(datalayer.battery.info.total_capacity_Wh, "h", 1) + ")</h4>";
+        content +=
+            "<h4 style='color: white;'>Scaled total capacity: " + formatPowerValue(scaledTotalCapacityWh, "h", 1) +
+            " (real: " + formatPowerValue(datalayer.battery.info.total_capacity_Wh, "h", 1) + ")</h4>";
       else
         content += formatPowerValue("Total capacity", datalayer.battery.info.total_capacity_Wh, "h", 1);
 
       if (datalayer.battery.settings.soc_scaling_active)
         content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                   formatPowerValue(datalayer.battery.status.reported_remaining_capacity_Wh, "h", 1) +
+                   formatPowerValue(scaledRemainingCapacityWh, "h", 1) +
                    " (real: " + formatPowerValue(datalayer.battery.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
       else
         content += formatPowerValue("Remaining capacity", datalayer.battery.status.remaining_capacity_Wh, "h", 1);
@@ -1391,6 +1494,14 @@ String processor(const String& var) {
       }
       content += "</h4>";
 
+      // Configured (user Settings) charge/discharge limits + real BMS contactor feedback.
+      // Same "Configured" values on every card (one system-wide setting), shown verbatim
+      // regardless of BMS/taper/FAULT. Display only, not a control value.
+      content += battery_configured_limits_html();
+      if (battery->reports_contactor_status()) {
+        content += "<h4>BMS contactors: " + String(dashboard_contactor_text(battery)) + "</h4>";
+      }
+
       // Close the block
       content += "</div>";
 
@@ -1413,7 +1524,11 @@ String processor(const String& var) {
         // Display battery statistics within this block
         socRealFloat =
             static_cast<float>(datalayer.battery2.status.real_soc) / 100.0f;  // Convert to float and divide by 100
-        //socScaledFloat; // Same value used for bat2
+        // Per-card scaled values from battery 2's OWN real SOC / real capacity.
+        scaledSocPptt = dashboard_scaled_soc_pptt(datalayer.battery2.status.real_soc);
+        socScaledFloat = static_cast<float>(scaledSocPptt) / 100.0f;
+        scaledTotalCapacityWh = dashboard_scaled_total_capacity_Wh(datalayer.battery2.info.total_capacity_Wh);
+        scaledRemainingCapacityWh = dashboard_scaled_remaining_capacity_Wh(scaledTotalCapacityWh, scaledSocPptt);
         sohFloat =
             static_cast<float>(datalayer.battery2.status.soh_pptt) / 100.0f;  // Convert to float and divide by 100
         voltageFloat =
@@ -1437,15 +1552,15 @@ String processor(const String& var) {
         content += formatPowerValue("Power", powerFloat, "", 1);
 
         if (datalayer.battery.settings.soc_scaling_active)
-          content += "<h4 style='color: white;'>Scaled total capacity: " +
-                     formatPowerValue(datalayer.battery2.info.reported_total_capacity_Wh, "h", 1) +
-                     " (real: " + formatPowerValue(datalayer.battery2.info.total_capacity_Wh, "h", 1) + ")</h4>";
+          content +=
+              "<h4 style='color: white;'>Scaled total capacity: " + formatPowerValue(scaledTotalCapacityWh, "h", 1) +
+              " (real: " + formatPowerValue(datalayer.battery2.info.total_capacity_Wh, "h", 1) + ")</h4>";
         else
           content += formatPowerValue("Total capacity", datalayer.battery2.info.total_capacity_Wh, "h", 1);
 
         if (datalayer.battery.settings.soc_scaling_active)
           content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                     formatPowerValue(datalayer.battery2.status.reported_remaining_capacity_Wh, "h", 1) +
+                     formatPowerValue(scaledRemainingCapacityWh, "h", 1) +
                      " (real: " + formatPowerValue(datalayer.battery2.status.remaining_capacity_Wh, "h", 1) + ")</h4>";
         else
           content += formatPowerValue("Remaining capacity", datalayer.battery2.status.remaining_capacity_Wh, "h", 1);
@@ -1481,6 +1596,10 @@ String processor(const String& var) {
         } else {  // > 0
           content += "<h4>Battery charging!</h4>";
         }
+        content += battery_configured_limits_html();
+        if (battery2->reports_contactor_status()) {
+          content += "<h4>BMS contactors: " + String(dashboard_contactor_text(battery2)) + "</h4>";
+        }
         content += "</div>";
         if (battery3) {
           content += "<div style='flex: 1; background-color: ";
@@ -1501,7 +1620,11 @@ String processor(const String& var) {
           // Display battery statistics within this block
           socRealFloat =
               static_cast<float>(datalayer.battery3.status.real_soc) / 100.0f;  // Convert to float and divide by 100
-          //socScaledFloat; // Same value used for bat2
+          // Per-card scaled values from battery 3's OWN real SOC / real capacity.
+          scaledSocPptt = dashboard_scaled_soc_pptt(datalayer.battery3.status.real_soc);
+          socScaledFloat = static_cast<float>(scaledSocPptt) / 100.0f;
+          scaledTotalCapacityWh = dashboard_scaled_total_capacity_Wh(datalayer.battery3.info.total_capacity_Wh);
+          scaledRemainingCapacityWh = dashboard_scaled_remaining_capacity_Wh(scaledTotalCapacityWh, scaledSocPptt);
           sohFloat =
               static_cast<float>(datalayer.battery3.status.soh_pptt) / 100.0f;  // Convert to float and divide by 100
           voltageFloat =
@@ -1525,15 +1648,15 @@ String processor(const String& var) {
           content += formatPowerValue("Power", powerFloat, "", 1);
 
           if (datalayer.battery.settings.soc_scaling_active)
-            content += "<h4 style='color: white;'>Scaled total capacity: " +
-                       formatPowerValue(datalayer.battery3.info.reported_total_capacity_Wh, "h", 1) +
-                       " (real: " + formatPowerValue(datalayer.battery3.info.total_capacity_Wh, "h", 1) + ")</h4>";
+            content +=
+                "<h4 style='color: white;'>Scaled total capacity: " + formatPowerValue(scaledTotalCapacityWh, "h", 1) +
+                " (real: " + formatPowerValue(datalayer.battery3.info.total_capacity_Wh, "h", 1) + ")</h4>";
           else
             content += formatPowerValue("Total capacity", datalayer.battery3.info.total_capacity_Wh, "h", 1);
 
           if (datalayer.battery.settings.soc_scaling_active)
             content += "<h4 style='color: white;'>Scaled remaining capacity: " +
-                       formatPowerValue(datalayer.battery3.status.reported_remaining_capacity_Wh, "h", 1) +
+                       formatPowerValue(scaledRemainingCapacityWh, "h", 1) +
                        " (real: " + formatPowerValue(datalayer.battery3.status.remaining_capacity_Wh, "h", 1) +
                        ")</h4>";
           else
@@ -1569,6 +1692,10 @@ String processor(const String& var) {
             content += "<h4>Battery discharging!</h4>";
           } else {  // > 0
             content += "<h4>Battery charging!</h4>";
+          }
+          content += battery_configured_limits_html();
+          if (battery3->reports_contactor_status()) {
+            content += "<h4>BMS contactors: " + String(dashboard_contactor_text(battery3)) + "</h4>";
           }
           content += "</div>";
           content += "</div>";


### PR DESCRIPTION
> **Note:** most of this code was written with the help of Claude (AI), guided
> and tested by me on my own hardware. It builds and works on my 3-battery
> setup, but please review it carefully - I do not fully trust AI-written code
> yet and I could easily have missed something. I am happy to change anything.

### What

Makes the Stellantis eCMP battery work properly when you run 2 or 3 eCMP packs
at the same time. The project already supports multi-battery; the eCMP part
only half worked. Each point below is a separate problem and its fix.

---

**1. "More Battery Info" page only worked for battery 1**

Problem: the eCMP page used one shared data block. Battery 2 and 3 got a NULL
pointer instead, so they never filled it in, and the page showed "Advanced
detailed info is limited to the Main Battery".

Fix: three separate data blocks (`stellantisECMP` / `_2` / `_3`), same as how
the Nissan LEAF already does it. Battery 2 and 3 each get their own, so their
data can't overwrite battery 1's.

**2. "Contactor opened" event didn't tell you which battery**

Problem: all 3 packs used the same event.

Fix: added `EVENT_CONTACTOR2_OPEN` and `EVENT_CONTACTOR3_OPEN`. The condition
that triggers it is unchanged.

**3. Battery 2 and 3 cards showed battery 1's numbers**

Problem: on the main page, Scaled SOC / scaled total capacity / scaled
remaining capacity were calculated once for battery 1 and then just copied onto
the battery 2 and 3 cards. Battery 1's card showed the combined
(battery1 + battery2) capacity as if it were its own. Battery 3's card showed a
leftover default of 30 kWh.

Fix: each card now calculates its own numbers from that battery's own real SOC
and capacity. This is display only - nothing the inverter uses is changed here.

**4. Cards didn't show the configured (Settings) limits**

Fix: added a "Configured max charge / discharge" line to every battery card. It
shows the value from Settings, the same on every card, always visible even
during a fault. The existing live "Max ... power" lines stay.

**5. No contactor state on the main page**

Fix: added "BMS contactors: CLOSED / OPEN (reason: N) / UNKNOWN" to each eCMP
card. It reads the battery's own "Contactor positive" and "Contactor negative"
feedback (PID 0xD44D / 0xD44C, 1 = closed, 0 = open). Shows UNKNOWN if the CAN
is missing or the value is old - it never shows a stale CLOSED.

**6. Contactor state got stuck during a fault**

Problem: the eCMP diagnostic polling stops completely when the system is in
FAULT. Contactors usually open *because* of a fault, so the contactor readout
froze on its old value ("CLOSED") right when it mattered.

Fix: during a fault the driver keeps asking for just 3 PIDs (contactor positive,
contactor negative, opening reason). Everything else stays stopped. These are
read-only requests - they don't command anything.

**7. Battery 3 was left out of the inverter's capacity total (bug)**

Problem: in `update_calculated_values()`, when SOC scaling is on, the code adds
battery 2 into the total the inverter sees but there was no code for battery 3.
So with 3 packs the inverter was told it had less capacity than it really did.

Fix: added the missing battery 3 block, same as the battery 2 one. SOC %,
current and power limits are not changed.

**8. New optional Setting: "Require battery BMS contactors closed"**

eCMP only, off by default, not built on 4 MB boards (they can't run 3 CAN buses
anyway).

- Won't start the GPIO contactor precharge until all eCMP packs report their
  BMS contactors closed, and have stayed closed for about 8 seconds. This stops
  a cold 3-pack start from starting precharge too early and tripping straight
  back off.
- If a pack opens its BMS contactors while running, the emulator pauses (power
  to 0), waits for the current to drop, then opens the GPIO contactors. It's a
  warning, not a fault, so no reboot is needed - it recovers on its own once
  every pack is closed again.
- The "waiting" event disappears from the events page once it clears, instead
  of staying as an old entry.

Side effect I noticed while testing: starting all 3 packs is easier now. Before,
after the contactors had opened I usually had to clear events and power-cycle
the whole emulator, and it wasn't obvious why it eventually came back. Now it is
usually just: Open Contactors, Close Contactors, reboot the emulator, wait - and
the system comes up. No full power cycle needed most of the time.

---

### Why
With 3 eCMP packs: battery 2 and 3 diagnostics were missing, the dashboard
showed battery 1's numbers everywhere, the inverter was told the wrong total
capacity, and there was no way to see which battery opened its contactors.

### How
See the list above. The CAN/UDS messages, the DID decoding, precharge timing,
welding protection, the equipment-stop handling and the 60 s CAN timeout are
not touched. With the new Setting off, and on any non-eCMP battery, GPIO
contactor control works exactly as before. Tested on a real system with 3 eCMP
packs. Builds clean for `lilygo_2CAN_330` and the 4 MB `esp32devkit_330`.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Code quality improvements

### Checklist:

  - [x] The code change is tested and works locally.