### PR TITLE
BYD: announce a capability while waiting for inverter permission

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -256,18 +256,15 @@ void BydAttoBattery::
   }
 
   // ...unless only the inverter's permission is missing. Some inverters won't command the close for
-  // a pack reporting 0A both ways, so zeroing here deadlocks. Nothing flows through an open pack; an
-  // open in flight, a fault, the stop and the balancing hold all stay at zero.
-  const bool idle_open = (contactorState == CONTACTORS_STANDBY || contactorState == CONTACTORS_BOOT_ESTOP) &&
-                         !(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) && lastContactorFeedbackMillis != 0;
-  if (idle_open && !datalayer.system.status.inverter_allows_contactor_closing &&
+  // a pack reporting 0A both ways, so zeroing here deadlocks.
+  const bool waiting_permission = (contactorState == CONTACTORS_STANDBY || contactorState == CONTACTORS_BOOT_ESTOP) &&
+                                  lastContactorFeedbackMillis != 0 &&
+                                  !datalayer.system.status.inverter_allows_contactor_closing;
+  if (!(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) &&
+      (waiting_permission || contactorState == CONTACTORS_CLOSING) &&
       !datalayer.system.info.equipment_stop_active && datalayer.system.status.system_status != FAULT) {
-    if (datalayer_battery->status.max_charge_power_W < ANNOUNCE_OPEN_POWER_W) {
-      datalayer_battery->status.max_charge_power_W = ANNOUNCE_OPEN_POWER_W;
-    }
-    if (datalayer_battery->status.max_discharge_power_W < ANNOUNCE_OPEN_POWER_W) {
-      datalayer_battery->status.max_discharge_power_W = ANNOUNCE_OPEN_POWER_W;
-    }
+    datalayer_battery->status.max_charge_power_W = ANNOUNCE_OPEN_POWER_W;
+    datalayer_battery->status.max_discharge_power_W = ANNOUNCE_OPEN_POWER_W;
   }
 
   // Pack-internal contactors: DC bus is live once the pack confirms the main contactor

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -261,8 +261,8 @@ void BydAttoBattery::
                                   lastContactorFeedbackMillis != 0 &&
                                   !datalayer.system.status.inverter_allows_contactor_closing;
   if (!(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) &&
-      (waiting_permission || contactorState == CONTACTORS_CLOSING) &&
-      !datalayer.system.info.equipment_stop_active && datalayer.system.status.system_status != FAULT) {
+      (waiting_permission || contactorState == CONTACTORS_CLOSING) && !datalayer.system.info.equipment_stop_active &&
+      datalayer.system.status.system_status != FAULT) {
     datalayer_battery->status.max_charge_power_W = ANNOUNCE_OPEN_POWER_W;
     datalayer_battery->status.max_discharge_power_W = ANNOUNCE_OPEN_POWER_W;
   }

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -255,6 +255,21 @@ void BydAttoBattery::
     datalayer_battery->status.max_discharge_power_W = 0;
   }
 
+  // ...unless only the inverter's permission is missing. Some inverters won't command the close for
+  // a pack reporting 0A both ways, so zeroing here deadlocks. Nothing flows through an open pack; an
+  // open in flight, a fault, the stop and the balancing hold all stay at zero.
+  const bool idle_open = (contactorState == CONTACTORS_STANDBY || contactorState == CONTACTORS_BOOT_ESTOP) &&
+                         !(contactor_feedback & BMS_FEEDBACK_MAIN_CLOSED) && lastContactorFeedbackMillis != 0;
+  if (idle_open && !datalayer.system.status.inverter_allows_contactor_closing &&
+      !datalayer.system.info.equipment_stop_active && datalayer.system.status.system_status != FAULT) {
+    if (datalayer_battery->status.max_charge_power_W < ANNOUNCE_OPEN_POWER_W) {
+      datalayer_battery->status.max_charge_power_W = ANNOUNCE_OPEN_POWER_W;
+    }
+    if (datalayer_battery->status.max_discharge_power_W < ANNOUNCE_OPEN_POWER_W) {
+      datalayer_battery->status.max_discharge_power_W = ANNOUNCE_OPEN_POWER_W;
+    }
+  }
+
   // Pack-internal contactors: DC bus is live once the pack confirms the main contactor
   // closed (same 0x344 bit7 feedback used to gate power above). Guarded so the GPIO
   // contactor state machine stays authoritative when enabled.

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -191,6 +191,9 @@ class BydAttoBattery : public CanBattery {
   //Max 0x438-vs-0x444 disagreement before 0x438 is treated as not carrying pack voltage
   static const uint16_t VOLTAGE_CROSSCHECK_TOLERANCE_DV = 50;
 
+  //Capability announced while the pack waits for the inverter to permit closing, ~5A at pack voltage
+  static const uint16_t ANNOUNCE_OPEN_POWER_W = 2000;
+
   /* Native BMS termination (on by default, see handle_charge_session). Runs a real AC charge session on
   the pack bus so the BMS ends the charge itself and recalibrates SOC to 100%, instead of BE stopping the
   charge at its own cell clamp. An insulation fault keeps the BMS out of the charge context; the


### PR DESCRIPTION
### What
Lets BE announce a small charge/discharge capability while the pack sits open waiting for inverter permission to close, instead of reporting 0A

### Why
Some inverters won't command the contactor close for a pack reporting 0A both ways, which deadlocks the contactor closing.

### How
Adds a 2000W floor, applied only when the state machine and the BMS 0x344 feedback both report the pack idle and open and inverter permission is the only thing missing.

### Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [X] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
