### PR TITLE
Nissan LEAF 🔋: derive total capacity and SOH from the measured pack capacity

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -39,17 +39,16 @@ void NissanLeafBattery::
     update_values() { /* This function maps all the values fetched via CAN to the correct parameters used for modbus */
   /* Start with mapping all values */
 
-  //State of health comes from the polled health block when the LBC has answered it, since that
-  //carries hundredths of a percent. Until then the broadcast value in 0x5BC stands in, at whole
-  //percent. Before either has arrived nothing is published: soh_pptt keeps its safe default for
-  //the inverter and safety paths, and soh_available stays false so the info page and MQTT say
-  //"unknown" rather than showing a 99% that was never read from the pack.
+  //The state of health the LBC itself publishes: the polled health block when it has answered,
+  //since that carries hundredths of a percent, otherwise the broadcast value in 0x5BC at whole
+  //percent. This figure is erased along with the degradation data, so a pack that has had its
+  //degradation reset publishes 100% regardless of what it still holds. It is therefore kept for
+  //display next to the raw figure only, and no longer feeds soh_pptt - see the capacity block
+  //below for what does.
   if (battery_SOH_pptt_g61 != 0) {
-    datalayer_battery->status.soh_pptt = battery_SOH_pptt_g61;
-    datalayer_battery->status.soh_available = true;
+    battery_SOH_avg_pptt = battery_SOH_pptt_g61;
   } else if (battery_StateOfHealth != 0) {
-    datalayer_battery->status.soh_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
-    datalayer_battery->status.soh_available = true;
+    battery_SOH_avg_pptt = (battery_StateOfHealth * 100);  //Increase range from 99% -> 99.00%
   }
 
   datalayer_battery->status.real_soc = (battery_SOC * 10);
@@ -60,12 +59,29 @@ void NissanLeafBattery::
   datalayer_battery->status.current_dA =
       (battery_Current2 * 5);  //0.5A/bit, multiply by 5 to get Amp+1decimal (5,5A = 11)
 
-  //Held at the last known value until an SOH is available, rather than collapsing to zero for the
-  //first seconds after boot. Now scaled from soh_pptt, so a polled SOH feeds through at its full
-  //hundredths-of-a-percent resolution instead of being rounded to whole percent first.
-  if (datalayer_battery->status.soh_available) {
-    datalayer_battery->info.total_capacity_Wh =
-        (uint32_t)(((uint32_t)battery_Max_GIDS * WH_PER_GID * datalayer_battery->status.soh_pptt) / 10000u);
+  //Capacity as new: the nameplate energy of this pack size, from the GID count the LBC reports at
+  //full charge. It is a constant per pack (273 on ZE0, from the max mux in 0x5BC on the 30/40/62
+  //kWh packs) rather than something that tracks wear, which is what makes it usable as the
+  //reference the measured capacity is judged against.
+  const uint32_t capacity_as_new_Wh = (uint32_t)battery_Max_GIDS * WH_PER_GID;
+
+  //Actual capacity, and the state of health that follows from it. The capacity the LBC measures
+  //survives a degradation reset, so a pack that has had one still reports what it actually holds
+  //here even though the SOH it publishes has gone back to 100%. Comparing the two capacities is
+  //therefore the only figure that stays truthful on a reset pack.
+  //Held at the last known value until a capacity has been read, rather than collapsing to zero for
+  //the first seconds after boot.
+  if (battery_capacity_cAh != 0) {
+    //Hundredths of an Ah times deciVolts gives milliWatt-hours, so divide by a thousand.
+    const uint16_t nominal_dV =
+        (LEAF_battery_Type == ZE1_BATTERY) ? NOMINAL_VOLTAGE_DV_ZE1 : NOMINAL_VOLTAGE_DV_ZE0_AZE0;
+    battery_capacity_Wh = ((uint32_t)battery_capacity_cAh * nominal_dV) / 1000u;
+    datalayer_battery->info.total_capacity_Wh = battery_capacity_Wh;
+
+    if (capacity_as_new_Wh != 0) {
+      datalayer_battery->status.soh_pptt = (uint16_t)(((uint64_t)battery_capacity_Wh * 10000ull) / capacity_as_new_Wh);
+      datalayer_battery->status.soh_available = true;
+    }
   }
 
   datalayer_battery->status.remaining_capacity_Wh = battery_Wh_Remaining;
@@ -319,12 +335,8 @@ void NissanLeafBattery::
     datalayer_nissan->Interlock = battery_Interlock;
     datalayer_nissan->Insulation = battery_insulation;
     datalayer_nissan->CapacityCAh = battery_capacity_cAh;
-    if (battery_capacity_cAh != 0) {
-      //Hundredths of an Ah times deciVolts gives milliWatt-hours, so divide by a thousand.
-      const uint16_t nominal_dV =
-          (LEAF_battery_Type == ZE1_BATTERY) ? NOMINAL_VOLTAGE_DV_ZE1 : NOMINAL_VOLTAGE_DV_ZE0_AZE0;
-      datalayer_nissan->CapacityWh = ((uint32_t)battery_capacity_cAh * nominal_dV) / 1000u;
-    }
+    datalayer_nissan->CapacityWh = battery_capacity_Wh;
+    datalayer_nissan->CapacityAsNewWh = capacity_as_new_Wh;
     datalayer_nissan->VBAT_mV = battery_vbat_mV;
     datalayer_nissan->RelayCutRequest = battery_Relay_Cut_Request;
     datalayer_nissan->FailsafeStatus = battery_Failsafe_Status;
@@ -336,6 +348,7 @@ void NissanLeafBattery::
     datalayer_nissan->HeatingStart = battery_Heating_Start;
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
     datalayer_nissan->battery_SOHraw_pptt = battery_SOHraw_pptt;
+    datalayer_nissan->battery_SOHavg_pptt = battery_SOH_avg_pptt;
     datalayer_nissan->battery_SOH_flags = battery_SOH_flags;
     datalayer_nissan->battery_HX_pptt = (battery_HX_pptt_g61 != 0) ? battery_HX_pptt_g61 : battery_HX_pptt;
     datalayer_nissan->ChargeCountQC = battery_charge_count_qc;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -79,12 +79,26 @@ void NissanLeafBattery::
     datalayer_battery->info.total_capacity_Wh = battery_capacity_Wh;
 
     if (capacity_as_new_Wh != 0) {
-      datalayer_battery->status.soh_pptt = (uint16_t)(((uint64_t)battery_capacity_Wh * 10000ull) / capacity_as_new_Wh);
+      //Capped at 100%. Anything above that is not a pack in better than new condition, it is the
+      //two capacities being measured differently: a GID counts usable energy, while the capacity
+      //the LBC reports is the pack's gross charge capacity, so the ratio sits above unity on a
+      //healthy pack. Reporting more than 100% would also put a figure on the wire that several
+      //inverter protocols have no room for.
+      const uint32_t soh_pptt = (uint32_t)(((uint64_t)battery_capacity_Wh * 10000ull) / capacity_as_new_Wh);
+      datalayer_battery->status.soh_pptt = (uint16_t)((soh_pptt > 10000u) ? 10000u : soh_pptt);
       datalayer_battery->status.soh_available = true;
     }
-  }
 
-  datalayer_battery->status.remaining_capacity_Wh = battery_Wh_Remaining;
+    //Remaining energy has to be measured against the same capacity as the total above, or the two
+    //contradict each other. The GID count the LBC broadcasts is derived from its own capacity
+    //figure, and a degradation reset puts that back to nameplate, so on a reset pack the GIDs
+    //claim more energy left than the pack is able to hold.
+    datalayer_battery->status.remaining_capacity_Wh =
+        (uint32_t)(((uint64_t)battery_capacity_Wh * datalayer_battery->status.real_soc) / 10000u);
+  } else {
+    //No measured capacity yet, so the GID count is all there is to go on.
+    datalayer_battery->status.remaining_capacity_Wh = battery_Wh_Remaining;
+  }
 
   //Update temperature readings. Method depends on which generation LEAF battery is used
   if (LEAF_battery_Type == ZE0_BATTERY) {
@@ -349,7 +363,6 @@ void NissanLeafBattery::
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
     datalayer_nissan->battery_SOHraw_pptt = battery_SOHraw_pptt;
     datalayer_nissan->battery_SOHavg_pptt = battery_SOH_avg_pptt;
-    datalayer_nissan->battery_SOH_flags = battery_SOH_flags;
     datalayer_nissan->battery_HX_pptt = (battery_HX_pptt_g61 != 0) ? battery_HX_pptt_g61 : battery_HX_pptt;
     datalayer_nissan->ChargeCountQC = battery_charge_count_qc;
     datalayer_nissan->ChargeCountL1L2 = battery_charge_count_l1l2;
@@ -885,17 +898,16 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           //  payload[7..8]  SOH_raw        the unfiltered state of health
           //  payload[9..10] SOH_Internal   the filtered figure, same value the pack publishes
           //  payload[11]    two status bits, in the low two bits of the byte
-          //Only the two that carry something the pack does not already report are read. Bench
-          //captures put BarCount_SOH at 0xFF on both a degraded and a freshly reset pack, so it
-          //is not populated with the pack off a car, and SOH_Internal came back bit-identical to
-          //the SOH above it on both.
+          //Only SOH_raw carries something the pack does not already report. Bench captures put
+          //BarCount_SOH at 0xFF on both a degraded and a freshly reset pack, so it is not
+          //populated with the pack off a car; SOH_Internal came back bit-identical to the SOH
+          //above it on both; and the status bits said nothing that the figures themselves do not.
           //Same hundredths scale as that SOH: a pack with its degradation just reset reports
           //exactly 10000 here, which is the firmware's own 100.00 %.
           uint16_t soh_raw = (uint16_t)((rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3]);
           if ((soh_raw > 0u) && (soh_raw <= 10000u)) {
             battery_SOHraw_pptt = soh_raw;
           }
-          battery_SOH_flags = (uint8_t)(rx_frame.data.u8[6] & 0x03);
         }
 
         if (group_7bb_frame == 2) {  //Third frame, payload[13..19] in u8[1..7]

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -331,7 +331,6 @@ class NissanLeafBattery : public CanBattery {
   //that group has answered. Kept apart from the group 0x01 Hx so the health block always wins when
   //it is available, rather than the two sources overwriting each other in polling order.
   uint16_t battery_SOHraw_pptt = 0;  //Unfiltered SOH from the health block, 0 until read
-  uint8_t battery_SOH_flags = 0;     //Two status bits the health block carries after the SOH figures
   uint16_t battery_HX_pptt_g61 = 0;
   uint16_t battery_SOH_pptt_g61 = 0;
   uint16_t battery_capacity_cAh = 0;  //Pack capacity in hundredths of an Ah, 0 until read

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -157,12 +157,15 @@ class NissanLeafBattery : public CanBattery {
                         .ID = 0x626,
                         .data = {0x02, 0x00, 0xff, 0x1d, 0x20, 0x00}};
   // Active polling messages
-  //Ordered so the values that identify an unknown pack come out first. The three static groups
-  //(0x62 charge counters, 0x84 serial number, 0x83 part number) are read once and then skipped,
-  //leaving 0x04/0x01/0x02/0x06/0x61 as the recurring rotation. Group 0x61 is the LBC's health
-  //block and is the only reply that runs past 255 bytes, so its first frame carries PCI 0x11
-  //rather than 0x10 - see the masked first-frame test in handle_incoming_can_frame().
-  uint8_t PIDgroups[8] = {0x62, 0x84, 0x04, 0x01, 0x02, 0x06, 0x61, 0x83};
+  //Ordered so the pack capacity comes out first: it is what the reported capacity and the derived
+  //state of health are built from, and neither is published until it has been read. It sits in
+  //group 0x01 on ZE0/AZE0 and in the health block 0x61 on ZE1, so both lead the rotation and the
+  //generation in use gets its answer on the first or second poll rather than most of a minute in.
+  //The three static groups (0x62 charge counters, 0x84 serial number, 0x83 part number) are read
+  //once and then skipped, leaving 0x01/0x61/0x04/0x02/0x06 as the recurring rotation. Group 0x61
+  //is the only reply that runs past 255 bytes, so its first frame carries PCI 0x11 rather than
+  //0x10 - see the masked first-frame test in handle_incoming_can_frame().
+  uint8_t PIDgroups[8] = {0x01, 0x61, 0x62, 0x84, 0x04, 0x02, 0x06, 0x83};
   //Start on the last entry so the first rotation step wraps to index 0.
   uint8_t PIDindex = sizeof(PIDgroups) / sizeof(PIDgroups[0]) - 1;
   uint8_t poll_burst_remaining = sizeof(PIDgroups) / sizeof(PIDgroups[0]);
@@ -332,7 +335,12 @@ class NissanLeafBattery : public CanBattery {
   uint16_t battery_HX_pptt_g61 = 0;
   uint16_t battery_SOH_pptt_g61 = 0;
   uint16_t battery_capacity_cAh = 0;  //Pack capacity in hundredths of an Ah, 0 until read
-  uint16_t battery_vbat_mV = 0;       //12 V accessory battery level in mV, 0 until read
+  uint32_t battery_capacity_Wh = 0;   //Energy equivalent of the above at nominal voltage, 0 until read
+  //The state of health the LBC publishes, health block first and the 0x5BC broadcast otherwise, in
+  //hundredths of a percent. Shown on the info page beside the raw figure; the SOH the rest of the
+  //system uses is derived from the capacities instead, since this one is erased by a reset.
+  uint16_t battery_SOH_avg_pptt = 0;
+  uint16_t battery_vbat_mV = 0;  //12 V accessory battery level in mV, 0 until read
   //Set when a complete cell reply came back with no readable cell at all. Stands in for the 12 V
   //level on any pack that never reports one.
   bool battery_cells_unreadable = false;

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -46,27 +46,34 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         "<h4>Hx: " +
         (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
         "</h4>";
-    //Pack capacity as the LBC reports it, with the energy that works out to at the pack's nominal
+    //What the pack held when new, from the GID count the LBC reports at full charge. Constant per
+    //pack size rather than something that tracks wear, which is what makes it the reference the
+    //measured capacity below is judged against.
+    content +=
+        "<h4>Capacity as new: " +
+        (nissan_dl->CapacityAsNewWh ? String(nissan_dl->CapacityAsNewWh / 1000.0f, 2) + " kWh" : String("Unknown")) +
+        "</h4>";
+    //Pack capacity as the LBC measures it, with the energy that works out to at the pack's nominal
     //voltage alongside it. The nominal differs by generation (96 cells at 3.75 V on ZE0/AZE0,
     //3.65 V on ZE1), so this is a nameplate-style figure and deliberately not derived from the live
-    //pack voltage, which would make it swing with SoC. It is not the same number as the GID-derived
-    //capacity the inverter is told about, which tracks usable energy.
+    //pack voltage, which would make it swing with SoC. The bracketed energy is the total capacity
+    //the rest of the system works from, and the ratio of it to the line above is the reported SOH.
     if (nissan_dl->CapacityCAh) {
-      const float capacity_Ah = nissan_dl->CapacityCAh / 100.0f;
-      const float nominal_V = (nissan_dl->LEAF_gen == 2) ? 350.4f : 360.0f;
-      content += "<h4>Actual capacity: " + String(capacity_Ah, 2) + " Ah (" +
-                 String((capacity_Ah * nominal_V) / 1000.0f, 2) + " kWh)</h4>";
+      content += "<h4>Actual capacity: " + String(nissan_dl->CapacityCAh / 100.0f, 2) + " Ah (" +
+                 String(nissan_dl->CapacityWh / 1000.0f, 2) + " kWh)</h4>";
     } else {
       content += String("<h4>Actual capacity: Unknown</h4>");
     }
-    //The unfiltered state of health, with the two status bits that sit beside it in the same
-    //block. Both bits come back clear on a pack whose degradation has just been reset and set on
-    //one with history, so they are shown raw rather than interpreted.
+    //The two state of health figures the LBC publishes for itself: the unfiltered one, and the
+    //filtered figure it settles onto, which is the value the pack reports as its SOH. The raw one
+    //moves first while a pack relearns after a degradation reset, so seeing the pair side by side
+    //shows that relearning happening. Neither is the SOH shown on the status page - both are
+    //erased by a degradation reset, so that one is derived from the capacities above instead.
     if (nissan_dl->battery_SOHraw_pptt) {
-      char soh_flags[8];
-      snprintf(soh_flags, sizeof(soh_flags), "0x%02X", nissan_dl->battery_SOH_flags);
-      content +=
-          "<h4>SOH raw: " + String(nissan_dl->battery_SOHraw_pptt / 100.0f, 2) + " (" + String(soh_flags) + ")</h4>";
+      content += "<h4>SOH raw: " + String(nissan_dl->battery_SOHraw_pptt / 100.0f, 2) + "% (avg " +
+                 (nissan_dl->battery_SOHavg_pptt ? String(nissan_dl->battery_SOHavg_pptt / 100.0f, 2) + "%"
+                                                 : String("Unknown")) +
+                 ")</h4>";
     } else {
       content += String("<h4>SOH raw: Unknown</h4>");
     }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -765,6 +765,10 @@ struct DATALAYER_INFO_NISSAN_LEAF {
    * voltage is stated once.
    */
   uint32_t CapacityWh;
+  /** Nameplate energy of this pack size, max GIDs times WH_PER_GID, in Wh. Fixed per pack rather
+   * than tracking wear, so it serves as the reference CapacityWh is compared against.
+   */
+  uint32_t CapacityAsNewWh;
 
   /** 77Wh per gid. LEAF specific unit */
   uint16_t GIDS;
@@ -777,6 +781,11 @@ struct DATALAYER_INFO_NISSAN_LEAF {
    * pack is relearning after a degradation reset.
    */
   uint16_t battery_SOHraw_pptt;
+  /** State of health as the LBC itself publishes it, in hundredths of a percent. 0 until read.
+   * Erased along with the degradation data, so it reads 100% on a pack that has had a reset no
+   * matter what the pack still holds. Shown for reference only.
+   */
+  uint16_t battery_SOHavg_pptt;
   /** Insulation resistance, most likely kOhm */
   uint16_t Insulation;
   /** Pack capacity in hundredths of an Ah (11544 = 115.44 Ah), 0 until read from the battery */

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -792,10 +792,6 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   uint16_t CapacityCAh;
   /** 12 V accessory battery level in mV, 0 until read from the battery */
   uint16_t VBAT_mV;
-  /** Two status bits the health block carries after the SOH figures. Both clear on a pack that
-   * has just had its degradation reset, both set on one with history.
-   */
-  uint8_t battery_SOH_flags;
   /** Lifetime number of quick (CHAdeMO) charges, 0 until read from the battery */
   uint16_t ChargeCountQC;
   /** Lifetime number of L1/L2 (AC) charges, 0 until read from the battery */

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -125,22 +125,10 @@ TEST(NissanLeafHealthTests, ShouldDecodeTrailingHealthBlockFields) {
   battery->update_values();
 
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHraw_pptt, 9800u);
-  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOH_flags, 0x03u);
 
   // The fields ahead of them are untouched by the second frame.
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 11000u);
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);
-}
-
-// Only the low two bits of that byte are defined by the handler.
-TEST(NissanLeafHealthTests, ShouldMaskUndefinedHealthBlockFlagBits) {
-  auto battery = battery_polling();
-
-  battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
-  battery->handle_incoming_can_frame(leaf_7bb_frame({0x21, 0x0C, 0x26, 0x48, 0x25, 0xE4, 0xFE, 0x00}));
-  battery->update_values();
-
-  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOH_flags, 0x02u);
 }
 
 // A freshly reset pack reports exactly 10000 in both SOH fields, the firmware's own 100.00 %.
@@ -153,7 +141,6 @@ TEST(NissanLeafHealthTests, ShouldDecodeResetPackHealthBlock) {
 
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHraw_pptt, 10000u);
-  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOH_flags, 0x00u);
 }
 
 // Hx above 100 % is a normal reading on a healthy pack and must survive intact.
@@ -216,6 +203,52 @@ TEST(NissanLeafHealthTests, ShouldIgnorePublishedStateOfHealthOnResetPack) {
 
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);  // What the pack claims
   EXPECT_EQ(datalayer.battery.status.soh_pptt, 5671u);                   // What it actually holds
+}
+
+// Builds a 0x55B carrying the given state of charge in tenths of a percent, signed with the CRC
+// the driver checks before it will read anything out of the frame.
+void feed_state_of_charge(NissanLeafBattery* battery, uint16_t tenths_percent) {
+  CAN_frame frame = leaf_frame(0x55B, {(uint8_t)(tenths_percent >> 2), (uint8_t)((tenths_percent & 0x03) << 6), 0x00,
+                                       0x00, 0x00, 0x00, 0x00, 0x00});
+  frame.data.u8[7] = battery->calculate_crc(frame);
+  battery->handle_incoming_can_frame(frame);
+}
+
+// Above 100% is the two capacities being measured on different bases, not a pack in better than
+// new condition, and several inverter protocols have no room for it either.
+TEST(NissanLeafHealthTests, ShouldCapDerivedStateOfHealthAtOneHundredPercent) {
+  auto battery = battery_polling();
+
+  feed_pack_capacity(battery, 662500);  // 66.25 Ah is 23850 Wh against a 21021 Wh reference
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.info.total_capacity_Wh, 23850u);  // Not capped, it is a measurement
+  EXPECT_EQ(datalayer.battery.status.soh_pptt, 10000u);
+}
+
+// Remaining energy comes off the measured capacity, not the GID count. A degradation reset puts
+// the LBC's own capacity figure back to nameplate and the GIDs with it, so on a reset pack the
+// broadcast count claims more energy left than the pack can physically hold.
+TEST(NissanLeafHealthTests, ShouldDeriveRemainingCapacityFromMeasuredCapacity) {
+  auto battery = battery_polling();
+
+  feed_state_of_charge(battery, 950);   // 95.0 %
+  feed_pack_capacity(battery, 331250);  // 33.12 Ah, 11923 Wh
+  battery->update_values();
+
+  EXPECT_EQ(datalayer.battery.status.real_soc, 9500u);
+  EXPECT_EQ(datalayer.battery.status.remaining_capacity_Wh, 11326u);  // 95 % of 11923 Wh
+  EXPECT_LE(datalayer.battery.status.remaining_capacity_Wh, datalayer.battery.info.total_capacity_Wh);
+}
+
+// Until a capacity has been read there is nothing else to go on, so the GID count still stands in.
+TEST(NissanLeafHealthTests, ShouldFallBackToGidsForRemainingCapacityBeforeCapacityIsRead) {
+  auto battery = battery_polling();
+
+  battery->update_values();
+
+  // battery_polling() broadcasts 320 GIDs in 0x5BC.
+  EXPECT_EQ(datalayer.battery.status.remaining_capacity_Wh, 24640u);  // 320 GIDs at 77 Wh
 }
 
 // The max GID count is broadcast with the mux bit set, and only by the 30/40/62 kWh packs.

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -107,8 +107,10 @@ TEST(NissanLeafHealthTests, ShouldDecodeHealthBlockFromLongFirstFrame) {
   battery->update_values();
 
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 11000u);
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 10000u);
-  EXPECT_TRUE(datalayer.battery.status.soh_available);
+  //The SOH the block carries is kept for display, and does not by itself make a state of health
+  //available: that is derived from the capacities.
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);
+  EXPECT_FALSE(datalayer.battery.status.soh_available);
 }
 
 // The LBC's PID 0x61 handler writes BarCount_SOH, SOH_raw, SOH_Internal and two status bits
@@ -127,7 +129,7 @@ TEST(NissanLeafHealthTests, ShouldDecodeTrailingHealthBlockFields) {
 
   // The fields ahead of them are untouched by the second frame.
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 11000u);
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 10000u);
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);
 }
 
 // Only the low two bits of that byte are defined by the handler.
@@ -149,7 +151,7 @@ TEST(NissanLeafHealthTests, ShouldDecodeResetPackHealthBlock) {
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x21, 0xFF, 0x27, 0x10, 0x27, 0x10, 0x00, 0x00}));
   battery->update_values();
 
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 10000u);
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHraw_pptt, 10000u);
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOH_flags, 0x00u);
 }
@@ -161,8 +163,70 @@ TEST(NissanLeafHealthTests, ShouldNotClampHxAboveOneHundredPercent) {
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x30, 0xD4, 0x25, 0x8A}));
   battery->update_values();
 
-  EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 12500u);  // 0x30D4
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 9610u);               // 0x258A
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 12500u);     // 0x30D4
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 9610u);  // 0x258A
+}
+
+// Feeds a group 0x01 reply far enough to deliver the pack capacity, which sits in the sixth frame
+// at payload[34..37] as a u32 in ten-thousandths of an Ah. 0x29 is the ZE0 layout, 0x2B the AZE0.
+void feed_pack_capacity(NissanLeafBattery* battery, uint32_t ten_thousandths_Ah, uint8_t layout_length = 0x2B) {
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, layout_length, 0x61, 0x01, 0x00, 0x00, 0x00, 0x00}));
+  for (uint8_t frame = 0x21; frame <= 0x24; frame++) {
+    battery->handle_incoming_can_frame(leaf_7bb_frame({frame, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+  }
+  battery->handle_incoming_can_frame(
+      leaf_7bb_frame({0x25, (uint8_t)(ten_thousandths_Ah >> 24), (uint8_t)(ten_thousandths_Ah >> 16),
+                      (uint8_t)(ten_thousandths_Ah >> 8), (uint8_t)ten_thousandths_Ah, 0x00, 0x00, 0x00}));
+}
+
+// The measured capacity at the pack's nominal voltage is what the rest of the system is told the
+// battery holds, in place of the GID count scaled by a state of health the pack can have had erased.
+TEST(NissanLeafHealthTests, ShouldReportTotalCapacityFromMeasuredPackCapacity) {
+  auto battery = battery_polling();
+
+  feed_pack_capacity(battery, 662500);  // 66.25 Ah
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.CapacityCAh, 6625u);
+  EXPECT_EQ(datalayer_extended.nissanleaf.CapacityWh, 23850u);  // 66.25 Ah at 360.0 V
+  EXPECT_EQ(datalayer.battery.info.total_capacity_Wh, 23850u);
+}
+
+// Capacity as new comes from the max GID count, which stays put as the pack ages. Nothing in
+// battery_polling() sets the max mux in 0x5BC, so the pack is on the 24 kWh startup default of 273.
+TEST(NissanLeafHealthTests, ShouldDeriveStateOfHealthFromCapacityRatio) {
+  auto battery = battery_polling();
+
+  feed_pack_capacity(battery, 331250);  // 33.125 Ah, half of a new 24 kWh pack
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.CapacityAsNewWh, 21021u);  // 273 GIDs at 77 Wh
+  EXPECT_TRUE(datalayer.battery.status.soh_available);
+  EXPECT_EQ(datalayer.battery.status.soh_pptt, 5671u);  // 11923 Wh of 21021 Wh
+}
+
+// The whole point of the change: a pack whose degradation has been reset publishes 100 %, while
+// the capacity it measures is untouched and still shows what it holds.
+TEST(NissanLeafHealthTests, ShouldIgnorePublishedStateOfHealthOnResetPack) {
+  auto battery = battery_polling();
+
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x27, 0x10, 0x27, 0x10}));
+  feed_pack_capacity(battery, 331250);
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 10000u);  // What the pack claims
+  EXPECT_EQ(datalayer.battery.status.soh_pptt, 5671u);                   // What it actually holds
+}
+
+// The max GID count is broadcast with the mux bit set, and only by the 30/40/62 kWh packs.
+TEST(NissanLeafHealthTests, ShouldTakeCapacityAsNewFromBroadcastMaxGids) {
+  auto battery = battery_polling();
+
+  // Byte 5 bit 4 marks the max GID mux; 356 GIDs is a 30 kWh pack.
+  battery->handle_incoming_can_frame(leaf_frame(0x5BC, {0x59, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.CapacityAsNewWh, 27412u);  // 356 GIDs at 77 Wh
 }
 
 // Nothing has been read from the pack yet, so no state of health is invented.
@@ -175,18 +239,18 @@ TEST(NissanLeafHealthTests, ShouldReportStateOfHealthUnknownBeforeAnyReading) {
 }
 
 // The broadcast value in 0x5BC stands in at whole-percent resolution until the health block
-// answers, and is then superseded by it.
+// answers, and is then superseded by it. This is the figure the pack publishes for itself, shown
+// on the info page beside the raw one; what the system reports as SOH comes from the capacities.
 TEST(NissanLeafHealthTests, ShouldPreferPolledStateOfHealthOverBroadcast) {
   auto battery = battery_polling();
 
   battery->handle_incoming_can_frame(leaf_frame(0x5BC, {0x50, 0x00, 0x00, 0x00, 0xBE, 0x00, 0x00, 0x00}));
   battery->update_values();
-  EXPECT_TRUE(datalayer.battery.status.soh_available);
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 9500u);  // 0xBE >> 1 = 95 %
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 9500u);  // 0xBE >> 1 = 95 %
 
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x25, 0x2C}));
   battery->update_values();
-  EXPECT_EQ(datalayer.battery.status.soh_pptt, 9516u);  // 0x252C = 95.16 %
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 9516u);  // 0x252C = 95.16 %
 }
 
 // A rejected request is a single frame, not group data. Letting it through would leave the


### PR DESCRIPTION
## What
Report Total capacity from the pack capacity the LBC measures in Ah instead of GIDS*SOH; derives SOH from that against a new "Capacity as new" reference.
Add a "Capacity as new" row to More Battery Info, and shows the LBC's own figures as `SOH raw: xx.xx% (avg xx.xx%)` as reference.
Moves the capacity-carrying groups to the front of the poll rotation.

## Why
The SOH the LBC publishes is erased along with the degradation data, so a pack that has had a reset reports 100% no matter what it still holds.
The measured capacity in Ah survives that reset, so comparing it against the as-new nameplate gives a figure that stays truthful.
Inverter, MQTT and web all get a capacity that reflects the pack instead of a GID count scaled by an erased SOH.

## How
`total_capacity_Wh = capacity_cAh * nominal_dV / 1000`, and `soh_pptt` = that over `max GIDs * WH_PER_GID`.
The LBC-published SOH moves to a display-only field; the SOC scaling path is untouched.
`PIDgroups` reordered to lead with 0x01 and 0x61 so both generations answer within the startup burst; unit tests updated and extended.


### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes https://github.com/dalathegreat/Battery-Emulator/issues/1822, https://github.com/dalathegreat/Battery-Emulator/issues/900, https://github.com/dalathegreat/Battery-Emulator/issues/2620

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR https://github.com/dalathegreat/Battery-Emulator-Wiki/pull/55

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
