### PR TITLE
Nissan Leaf🔋: Increase MAX_CELL_DEVIATION_MV from 150 to 400

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -80,7 +80,7 @@ class NissanLeafBattery : public CanBattery {
   static const uint16_t LOW_12V_HYSTERESIS_MV = 200;
   static const int MAX_PACK_VOLTAGE_DV = 4055;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2400;
-  static const int MAX_CELL_DEVIATION_MV = 350;
+  static const int MAX_CELL_DEVIATION_MV = 400;
   static const int MAX_CELL_VOLTAGE_MV = 4224;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2500;  //Battery is put into emergency stop if one cell goes below this value
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -80,7 +80,7 @@ class NissanLeafBattery : public CanBattery {
   static const uint16_t LOW_12V_HYSTERESIS_MV = 200;
   static const int MAX_PACK_VOLTAGE_DV = 4055;  //5000 = 500.0V
   static const int MIN_PACK_VOLTAGE_DV = 2400;
-  static const int MAX_CELL_DEVIATION_MV = 150;
+  static const int MAX_CELL_DEVIATION_MV = 350;
   static const int MAX_CELL_VOLTAGE_MV = 4224;  //Battery is put into emergency stop if one cell goes over this value
   static const int MIN_CELL_VOLTAGE_MV = 2500;  //Battery is put into emergency stop if one cell goes below this value
 


### PR DESCRIPTION
### What
Avoid panic'ing users with `Large cell voltage deviation! Check balancing of cells` event on Nissan Leaf, as another user on ran into this.

### Why
150mv is an optimistic limit - higher cell deviations can be perfectly fine while cell vmin and vmax are not reached (as these would raise a FAULT state anyway).  

### How
Change the value to 400mv.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes https://discordapp.com/channels/775038294655762433/1299436954328502333/1541167740684079124

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [ ] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
