### PR TITLE
OTA rollback version number log entry print correction

### DIFF
--- a/Software/src/devboard/utils/ota_rollback.cpp
+++ b/Software/src/devboard/utils/ota_rollback.cpp
@@ -60,7 +60,7 @@ void report_ota_rollback(void) {
   if (esp_ota_get_partition_description(other, &failed) == ESP_OK) {
     LOG_SET_NEXT_SEVERITY(4);  // warning
     logging.printf("Firmware %s failed to start and was rolled back; running %s instead\n", failed.version,
-                   esp_app_get_description()->version);
+                   version_number);
   } else {
     LOG_SET_NEXT_SEVERITY(4);  // warning
     logging.println("A firmware update failed to start and was rolled back to this version");
@@ -93,7 +93,7 @@ void mark_ota_image_valid(void) {
   if (esp_ota_mark_app_valid_cancel_rollback() == ESP_OK) {
     LOG_SET_NEXT_SEVERITY(5);  // notice
     logging.printf("Firmware %s started cleanly and is now confirmed; rollback window closed\n",
-                   esp_app_get_description()->version);
+                   version_number);
   } else {
     /* Nothing to do about it here, but say so: the image stays pending, so the
      * next reset - however ordinary - will roll it back, and that is otherwise

--- a/Software/src/devboard/utils/ota_rollback.cpp
+++ b/Software/src/devboard/utils/ota_rollback.cpp
@@ -92,8 +92,7 @@ void mark_ota_image_valid(void) {
   }
   if (esp_ota_mark_app_valid_cancel_rollback() == ESP_OK) {
     LOG_SET_NEXT_SEVERITY(5);  // notice
-    logging.printf("Firmware %s started cleanly and is now confirmed; rollback window closed\n",
-                   version_number);
+    logging.printf("Firmware %s started cleanly and is now confirmed; rollback window closed\n", version_number);
   } else {
     /* Nothing to do about it here, but say so: the image stays pending, so the
      * next reset - however ordinary - will roll it back, and that is otherwise

--- a/Software/src/devboard/utils/ota_rollback.h
+++ b/Software/src/devboard/utils/ota_rollback.h
@@ -40,4 +40,6 @@ void ota_confirm_service(void);
 // run is the whole defect this exists to fix.
 void mark_ota_image_valid(void);
 
+extern const char* version_number;  // The current software version
+
 #endif  // OTA_ROLLBACK_H


### PR DESCRIPTION
### What
Use the same variable version_number in OTA rollback logger print.

### Why
OTA Rollback logs version numbers inconsistently (and errorneously):
```
       2.766 Bootup complete, running version v12.5.0dev-ae37674 (#2941)
... 
      42.022 Firmware v12.2.0-131-gf85a159c started cleanly and is now confirmed; rollback window closed
```

### How
The code already uses a var for this, just use that here too.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [ ] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
