### PR TITLE
Fix phantom BYD Atto 3 temperature sensor 13

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -318,7 +318,8 @@ void BydAttoBattery::
     datalayer_bydatto->insulation_valid = battery_insulation_valid;
     datalayer_bydatto->iso_status_valid = (last_35E_ms != 0) && ((millis() - last_35E_ms) < 3000);
     datalayer_bydatto->iso_measurement_active = battery_iso_measurement_active;
-    memcpy(datalayer_bydatto->battery_temperatures, battery_daughterboard_temperatures, sizeof(battery_daughterboard_temperatures));
+    memcpy(datalayer_bydatto->battery_temperatures, battery_daughterboard_temperatures,
+           sizeof(battery_daughterboard_temperatures));
 
     datalayer_bydatto->BMS_capacity_original_calibration = BMS_capacity_original_calibration;
     datalayer_bydatto->BMC_SOC_original_calibration = BMC_SOC_original_calibration;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -318,19 +318,8 @@ void BydAttoBattery::
     datalayer_bydatto->insulation_valid = battery_insulation_valid;
     datalayer_bydatto->iso_status_valid = (last_35E_ms != 0) && ((millis() - last_35E_ms) < 3000);
     datalayer_bydatto->iso_measurement_active = battery_iso_measurement_active;
-    datalayer_bydatto->battery_temperatures[0] = battery_daughterboard_temperatures[0];
-    datalayer_bydatto->battery_temperatures[1] = battery_daughterboard_temperatures[1];
-    datalayer_bydatto->battery_temperatures[2] = battery_daughterboard_temperatures[2];
-    datalayer_bydatto->battery_temperatures[3] = battery_daughterboard_temperatures[3];
-    datalayer_bydatto->battery_temperatures[4] = battery_daughterboard_temperatures[4];
-    datalayer_bydatto->battery_temperatures[5] = battery_daughterboard_temperatures[5];
-    datalayer_bydatto->battery_temperatures[6] = battery_daughterboard_temperatures[6];
-    datalayer_bydatto->battery_temperatures[7] = battery_daughterboard_temperatures[7];
-    datalayer_bydatto->battery_temperatures[8] = battery_daughterboard_temperatures[8];
-    datalayer_bydatto->battery_temperatures[9] = battery_daughterboard_temperatures[9];
-    datalayer_bydatto->battery_temperatures[10] = battery_daughterboard_temperatures[10];
-    datalayer_bydatto->battery_temperatures[11] = battery_daughterboard_temperatures[11];
-    datalayer_bydatto->battery_temperatures[12] = battery_daughterboard_temperatures[12];
+    memcpy(datalayer_bydatto->battery_temperatures, battery_daughterboard_temperatures, sizeof(battery_daughterboard_temperatures));
+
     datalayer_bydatto->BMS_capacity_original_calibration = BMS_capacity_original_calibration;
     datalayer_bydatto->BMC_SOC_original_calibration = BMC_SOC_original_calibration;
     datalayer_bydatto->BMS_capacity_current_calibration = BMS_capacity_current_calibration;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -466,7 +466,7 @@ class BydAttoBattery : public CanBattery {
   unsigned long last_35E_ms = 0;                // 0 = 0x35E not yet received (staleness)
   bool calibrationAH_seeded = false;
 
-  int16_t battery_daughterboard_temperatures[13] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};
+  int16_t battery_daughterboard_temperatures[12] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};
   uint16_t battery_cellvoltages[MAX_AMOUNT_CELLS] = {0};
 
   /* Extra CAN info 

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -135,7 +135,8 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
       if (byd_datalayer->battery_temperatures[i] == 215) {
         break;
       }
-      content += "<h4>Temperature sensor " + String(i + 1) + ": " + String(byd_datalayer->battery_temperatures[i]) + " &deg;C</h4>";
+      content += "<h4>Temperature sensor " + String(i + 1) + ": " + String(byd_datalayer->battery_temperatures[i]) +
+                 " &deg;C</h4>";
     }
 
     content += "<h4>Max discharge power: " + String(BMS_maxDischargePower) + " kW</h4>";

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -128,45 +128,16 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += "Not received</h4>";
     }
-    if (byd_datalayer->battery_temperatures[0] != 215) {
-      content += "<h4>Temperature sensor 1: " + String(byd_datalayer->battery_temperatures[0]) + " &deg;C</h4>";
+
+    static const size_t TEMPERATURE_SENSOR_COUNT =
+        sizeof(byd_datalayer->battery_temperatures) / sizeof(byd_datalayer->battery_temperatures[0]);
+    for (size_t i = 0; i < TEMPERATURE_SENSOR_COUNT; ++i) {
+      if (byd_datalayer->battery_temperatures[i] == 215) {
+        break;
+      }
+      content += "<h4>Temperature sensor " + String(i + 1) + ": " + String(byd_datalayer->battery_temperatures[i]) + " &deg;C</h4>";
     }
-    if (byd_datalayer->battery_temperatures[1] != 215) {
-      content += "<h4>Temperature sensor 2: " + String(byd_datalayer->battery_temperatures[1]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[2] != 215) {
-      content += "<h4>Temperature sensor 3: " + String(byd_datalayer->battery_temperatures[2]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[3] != 215) {
-      content += "<h4>Temperature sensor 4: " + String(byd_datalayer->battery_temperatures[3]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[4] != 215) {
-      content += "<h4>Temperature sensor 5: " + String(byd_datalayer->battery_temperatures[4]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[5] != 215) {
-      content += "<h4>Temperature sensor 6: " + String(byd_datalayer->battery_temperatures[5]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[6] != 215) {
-      content += "<h4>Temperature sensor 7: " + String(byd_datalayer->battery_temperatures[6]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[7] != 215) {
-      content += "<h4>Temperature sensor 8: " + String(byd_datalayer->battery_temperatures[7]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[8] != 215) {
-      content += "<h4>Temperature sensor 9: " + String(byd_datalayer->battery_temperatures[8]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[9] != 215) {
-      content += "<h4>Temperature sensor 10: " + String(byd_datalayer->battery_temperatures[9]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[10] != 215) {
-      content += "<h4>Temperature sensor 11: " + String(byd_datalayer->battery_temperatures[10]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[11] != 215) {
-      content += "<h4>Temperature sensor 12: " + String(byd_datalayer->battery_temperatures[11]) + " &deg;C</h4>";
-    }
-    if (byd_datalayer->battery_temperatures[12] != 215) {
-      content += "<h4>Temperature sensor 13: " + String(byd_datalayer->battery_temperatures[12]) + " &deg;C</h4>";
-    }
+
     content += "<h4>Max discharge power: " + String(BMS_maxDischargePower) + " kW</h4>";
     content += "<h4>Max charge (regen) power: " + String(BMS_maxChargePower) + " kW</h4>";
     content += "<h4>Total charged: " + String(byd_datalayer->total_charged_kwh) + " kWh</h4>";

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -151,7 +151,7 @@ struct DATALAYER_INFO_BYDATTO3 {
 
   /** int16_t */
   /** All the temperature sensors inside the battery pack*/
-  int16_t battery_temperatures[13];
+  int16_t battery_temperatures[12];
 
   uint8_t discharge_status;
   uint8_t BMS_min_cell_voltage_number;


### PR DESCRIPTION
### What

Fix the BYD Atto 3 advanced page displaying a phantom temperature
sensor 13 at a constant -40°C.

### Why

The driver allocated 13 temperature slots, but the 0x43C decoder only
populates 12: six readings from each of two multiplexer values.
The thirteenth slot therefore retained its initial value of -40°C.

This was previously hidden by filtering out -40. When the renderer
changed to filter 215, the decoded 0xFF unused-channel marker, the
unpopulated slot became visible as an apparent temperature reading.

### How

- Reduce the driver and BYD extended datalayer arrays to 12 entries.
- Replace individual temperature assignments with memcpy.
- Render temperatures in a loop bounded by the array size.
- Stop at the first unused-channel marker, assuming unused channels
  are trailing entries.

Temperature initialisation, CAN decoding and the separate battery
minimum/maximum temperature reporting are unchanged.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)
- [x] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

No existing issue found. Observed on a live BYD Atto 3 installation.

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

Not applicable; this corrects existing diagnostic display behaviour.

### Checklist:

- [ ] The code change is tested and works locally.

### Validation

- Confirmed the original symptom on a live BYD Atto 3 installation.
- Traced the cause through the decoder, datalayer and renderer.
- Whitespace checks passed.
- Firmware build and runtime validation of this patch are pending.
