### PR TITLE
feat(renault-zoe-gen1): enable generic balancing buttons by stopping 423 sends.

### DIFF
--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -169,16 +169,22 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
   // receives this wakeup frame)
   if (currentMillis - previousMillis100 >= INTERVAL_100_MS) {
     previousMillis100 = currentMillis;
-    transmit_can_frame(&ZOE_423);
-
-    if ((counter_423 / 5) % 2 == 0) {  // Alternate every 5 messages between these two
-      ZOE_423.data.u8[4] = 0xB2;
-      ZOE_423.data.u8[6] = 0xB2;
+    if (quiet_balancing_mode) {
+      // Mute 0x423 so the LBC can sleep and balance. Keep partner frames and
+      // the liveness counter so the safety layer does not trip.
+      datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
     } else {
-      ZOE_423.data.u8[4] = 0x5D;
-      ZOE_423.data.u8[6] = 0x5D;
+      transmit_can_frame(&ZOE_423);
+
+      if ((counter_423 / 5) % 2 == 0) {  // Alternate every 5 messages between these two
+        ZOE_423.data.u8[4] = 0xB2;
+        ZOE_423.data.u8[6] = 0xB2;
+      } else {
+        ZOE_423.data.u8[4] = 0x5D;
+        ZOE_423.data.u8[6] = 0x5D;
+      }
+      counter_423 = (counter_423 + 1) % 10;
     }
-    counter_423 = (counter_423 + 1) % 10;
 
     // Broadcast 100ms vehicle frames (PEB Inverter 0x19F, EVC Power Mux 0x426, EVC Status 0x436)
     // Rolling 4-bit sequence counter (cycles 0-15)
@@ -205,7 +211,9 @@ void RenaultZoeGen1Battery::transmit_can(unsigned long currentMillis) {
   }
 
   // UDS PID polling and DTC handling
-  transmit_uds_can(currentMillis);
+  if (!quiet_balancing_mode) {
+    transmit_uds_can(currentMillis);
+  }
 }
 
 template <typename T>

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.cpp
@@ -23,9 +23,18 @@ void RenaultZoeGen1Battery::
   datalayer_battery->status.remaining_capacity_Wh = static_cast<uint32_t>(
       (static_cast<double>(datalayer_battery->status.real_soc) / 10000) * datalayer_battery->info.total_capacity_Wh);
 
-  datalayer_battery->status.max_discharge_power_W = LB_Discharge_allowed_W;
-
-  datalayer_battery->status.max_charge_power_W = LB_Regen_allowed_W;
+  if (quiet_balancing_mode) {
+    // Park the inverter while 0x423 is muted (i3-style). GPIO contactors stay
+    // as they are; the LBC may still drop pack HV if it sleeps.
+    datalayer_battery->status.max_discharge_power_W = 0;
+    datalayer_battery->status.max_charge_power_W = 0;
+    if (datalayer.system.status.system_status != FAULT) {
+      datalayer.system.status.system_status = STANDBY;
+    }
+  } else {
+    datalayer_battery->status.max_discharge_power_W = LB_Discharge_allowed_W;
+    datalayer_battery->status.max_charge_power_W = LB_Regen_allowed_W;
+  }
 
   datalayer_battery->status.temperature_min_dC = LB_Cell_minimum_temperature * 10;
   datalayer_battery->status.temperature_max_dC = LB_Cell_maximum_temperature * 10;

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -27,6 +27,14 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
   virtual void transmit_can(unsigned long currentMillis);
   static constexpr const char* Name = "Renault Zoe Gen1 22/40kWh";
 
+  bool supports_balancing() { return true; }
+  bool is_balancing_active() { return quiet_balancing_mode; }
+  void initiate_balancing() {
+    quiet_balancing_mode = true;
+    datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+  }
+  void end_balancing() { quiet_balancing_mode = false; }
+
   String get_uds_info_html() override;
   const char* get_dtc_json_filename() override { return "renault_zoe_gen1_dtc.json"; }
   bool get_dtc_standard_code_string() override { return false; }
@@ -61,6 +69,7 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
   unsigned long previousMillis1000_69f = 0;
   unsigned long previousMillis60000_436 = 0;
   uint8_t counter_423 = 0;
+  bool quiet_balancing_mode = false;
   uint8_t zoe_19F_counter = 0;
   uint16_t zoe_436_counter = 1;
 

--- a/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
+++ b/Software/src/battery/RENAULT-ZOE-GEN1-BATTERY.h
@@ -32,8 +32,18 @@ class RenaultZoeGen1Battery : public UdsCanBattery {
   void initiate_balancing() {
     quiet_balancing_mode = true;
     datalayer_battery->status.CAN_battery_still_alive = CAN_STILL_ALIVE;
+    datalayer_battery->status.max_discharge_power_W = 0;
+    datalayer_battery->status.max_charge_power_W = 0;
+    if (datalayer.system.status.system_status != FAULT) {
+      datalayer.system.status.system_status = STANDBY;
+    }
   }
-  void end_balancing() { quiet_balancing_mode = false; }
+  void end_balancing() {
+    quiet_balancing_mode = false;
+    if (datalayer.system.status.system_status == STANDBY) {
+      datalayer.system.status.system_status = ACTIVE;
+    }
+  }
 
   String get_uds_info_html() override;
   const char* get_dtc_json_filename() override { return "renault_zoe_gen1_dtc.json"; }


### PR DESCRIPTION
### What
This PR enables the generic More Battery Info Start/Stop Balancing buttons on Renault Zoe Gen1 (22/40 kWh).

### Why
The LBC has no start/stop balancing DID. LBC decides what cells to start balancing and initiates it only during sleep, and `0x423` is the diagnostic wakeup that keeps it awake. Gen1 balancing is still listed as unconfirmed ([discussion #2411](https://github.com/dalathegreat/Battery-Emulator/discussions/2411)).

### How
Start mutes `0x423` + UDS, keeps `0x19F`/`0x426`/`0x436`/`0x69F`, refreshes `CAN_battery_still_alive`, and parks the inverter (0 W / `STANDBY`). Stop resumes `0x423` and returns to `ACTIVE`. GPIO contactors are not opened.

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- related https://github.com/dalathegreat/Battery-Emulator/discussions/2411

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR (none yet; Gen1 wiki still says balancing unconfirmed)

### Checklist:

  - [ ] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
>
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)