### PR TITLE
Leaf: bench experiment, synthesise inverter 0x1DA towards LBC

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -9,6 +9,14 @@
 #include "../devboard/utils/events.h"
 #include "../devboard/utils/logging.h"
 
+/* BENCH EXPERIMENT, NOT FOR MERGE.
+   Synthesises the traction inverter's 0x1DA towards the LBC, to find out whether the pack's
+   U1000 supervision is waiting for a frame that simply does not exist outside a car. Comment
+   the line out to go back to stock behaviour. If this does turn out to clear U1000, the signal
+   layout below has to be validated against the pack CAN databook before it becomes a feature,
+   and it wants to be a user setting rather than a compile-time define. */
+#define LEAF_EXPERIMENT_TX_1DA
+
 uint16_t Temp_fromRAW_to_F(uint16_t temperature);
 //Cryptographic functions
 void decodeChallengeData(unsigned int SeedInput, unsigned char* Crypt_Output_Buffer);
@@ -1113,6 +1121,24 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       if (!charger || charger->type() != ChargerType::NissanLeaf) {
         transmit_can_frame(&LEAF_1D4);
       }
+
+#ifdef LEAF_EXPERIMENT_TX_1DA
+      /* MG_InputVoltage is assumed here to be the same 10-bit, 0.5V/bit encoding the LBC uses
+         for LB_Total_Voltage in 0x1DB, starting at byte 0. That is an assumption from logs, not
+         from a spec: check the 0x1DA row on the Rx sheet of the pack CAN databook (NISSAN byte
+         position / start bit / data length) and move the two lines below if it disagrees.
+         battery_Total_Voltage2 is the raw value straight off the LBC, so what the inverter
+         "measures" tracks what the pack itself reports, which is what a real car looks like. */
+      if (battery_Total_Voltage2 != 0x3FF) {  //0x3FF is the pack's "measurement unavailable" code
+        LEAF_1DA.data.u8[0] = (battery_Total_Voltage2 >> 2) & 0xFF;
+        LEAF_1DA.data.u8[1] = (LEAF_1DA.data.u8[1] & 0x3F) | ((battery_Total_Voltage2 & 0x03) << 6);
+      }
+      //2-bit rolling counter. Byte position is a guess as well, same caveat as above.
+      LEAF_1DA.data.u8[6] = (LEAF_1DA.data.u8[6] & 0xFC) | mprun10_1DA;
+      LEAF_1DA.data.u8[7] = calculate_crc(LEAF_1DA);
+      transmit_can_frame(&LEAF_1DA);
+      mprun10_1DA = (mprun10_1DA + 1) % 4;
+#endif
 
       //The low nibble of byte 7 is the Nissan nibble checksum over the rest of the message. The
       //constants below are the ones for CHG_STA_RQ=00b; the selected request is applied, checksum

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -108,6 +108,7 @@ class NissanLeafBattery : public CanBattery {
   uint8_t mprun10 = 0;      //counter 0-3
   uint8_t mprun100 = 0;     //counter 0-3
   uint8_t counter_3B8 = 0;  //counter 0-14
+  uint8_t mprun10_1DA = 0;  //counter 0-3, EXPERIMENT ONLY (see LEAF_EXPERIMENT_TX_1DA)
   bool flip_3B8 = false;
 
   static const uint8_t ZE0_BATTERY = 0;
@@ -138,6 +139,15 @@ class NissanLeafBattery : public CanBattery {
                         .DLC = 8,
                         .ID = 0x1D4,
                         .data = {0x6E, 0x6E, 0x00, 0x04, 0x07, 0x46, 0xE0, 0x44}};
+  /* EXPERIMENT ONLY, enabled by LEAF_EXPERIMENT_TX_1DA in the .cpp. 0x1DA is the traction
+     inverter's frame. In a car the LBC hears it every 10ms; in a stationary setup nothing
+     sends it. Payload is deliberately inert: zero torque, zero rpm, MG_InputVoltage mirrored
+     from the pack's own reported voltage, Nissan CRC in byte 7. */
+  CAN_frame LEAF_1DA = {.FD = false,
+                        .ext_ID = false,
+                        .DLC = 8,
+                        .ID = 0x1DA,
+                        .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
   // Extra CAN messages for ZE1 batteries
   CAN_frame LEAF_355 = {.FD = false,
                         .ext_ID = false,


### PR DESCRIPTION
### What
Tests whether the LBC's U1000 supervision is waiting for 0x1DA, which nothing sends in a stationary setup. Signal layout is an assumption pending validation against the pack CAN databook.

### Why
Try eliminating DTC U1000.

### How
Send a heartbeat.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [ ] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
