### PR TITLE
Fix: multi-pack battery info crashes with tabs and streaming

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -12,9 +12,23 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
 
   bool renders_own_battery_data() { return true; }
 
+  bool html_render_failed() const override { return render_failed; }
+
+  String get_dtc_html() override {
+    auto& dtc = s.length() ? datalayer.battery2.dtc : datalayer.battery.dtc;
+    String content = render_dtc_section_html(dtc, "byd_atto3_dtc.json", true);
+    render_failed = content.isEmpty();
+    return content;
+  }
+
   String get_status_html() {
-    String content;
-    content.reserve(16000);
+    render_failed = false;
+    CheckedHtml content;
+    const bool reserved = content.reserve(16000);
+    if (!reserved) {
+      render_failed = true;
+      return String();
+    }
 
     const auto& dl_bat = s.length() ? datalayer.battery2 : datalayer.battery;
     content += "<h4>Detected cells: " + String(dl_bat.info.number_of_cells) + "</h4>";
@@ -730,14 +744,14 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
 
     append_balance_time_html(content);
 
-    auto& dtc = s.length() ? datalayer.battery2.dtc : datalayer.battery.dtc;
-    content += BatteryHtmlRenderer::render_dtc_section_html(dtc, "byd_atto3_dtc.json", true);
-
-    return content;
+    render_failed = !content.good();
+    return content.take();
   }
 
  private:
-  void append_balance_time_html(String& out) const {
+  bool render_failed = false;
+
+  void append_balance_time_html(CheckedHtml& out) const {
     out +=
         "<h4 style='margin-top:18px'><button onclick=\"window.location.href='/bydbalance'\">"
         "&#9889; Cell Balance Timers</button></h4>";

--- a/Software/src/devboard/webserver/BatteryHtmlRenderer.h
+++ b/Software/src/devboard/webserver/BatteryHtmlRenderer.h
@@ -6,12 +6,18 @@
 #include <Arduino.h>
 #include <WString.h>
 #include <stdio.h>
+#include "checked_html.h"
 
 // Each battery can implement this interface to render more battery specific HTML
 // content
 class BatteryHtmlRenderer {
  public:
   virtual String get_status_html() = 0;
+  // Optional diagnostics, rendered after the status buffer is released.
+  // Empty means none unless html_render_failed() reports a failure.
+  virtual String get_dtc_html() { return String(); }
+  // Reports failure of the most recent status or diagnostics render.
+  virtual bool html_render_failed() const { return false; }
 
   // Returns true when this renderer reads the data of its own battery instance
   // (e.g. via a datalayer pointer supplied at construction), rather than the
@@ -23,7 +29,7 @@ class BatteryHtmlRenderer {
 
   static String render_dtc_section_html(DATALAYER_BATTERY_DTC_TYPE& dtc, const char* json_filename,
                                         bool standard_code_string) {
-    String content;
+    CheckedHtml content;
 
     // Reserve enough space to avoid reallocs
     content.reserve(3300 + dtc.dtc_count * 320);
@@ -99,10 +105,14 @@ class BatteryHtmlRenderer {
         content += "' style='padding:8px 18px;border-top:1px solid #3a4750;'>Unknown</td></tr>";
       }
       content += "</tbody></table></div>";
-      content += get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, json_filename);
+      String loader = get_dtc_json_loader_html(GITHUB_RAW_BASE_URL, json_filename);
+      if (loader.isEmpty()) {
+        return String();
+      }
+      content += loader;
     }
 
-    return content;
+    return content.take();
   }
 
   // Base URL for the upstream GitHub repository's data folder.
@@ -123,7 +133,7 @@ class BatteryHtmlRenderer {
   //   On a successful GitHub fetch the file picker is hidden automatically.
   //   On failure the file picker is revealed so the user can load a local copy.
   static String get_dtc_json_loader_html(const char* base_url = "", const char* filename = "") {
-    String s;
+    CheckedHtml s;
     s.reserve(4096);  // avoid repeated 16-byte realloc steps while building the loader
     s += "<div style='margin-top:15px;padding:12px;background:#1e1e2e;border:1px solid #444;border-radius:8px;'>";
     s += "<p id='dtcJsonStatus' style='margin:0 0 8px 0;color:#aaa;font-size:.95em;'></p>";
@@ -279,7 +289,7 @@ class BatteryHtmlRenderer {
          "catch(err){S.textContent='Parse error: '+err.message;S.style.color='#d32f2f';}};"
          "R.onerror=function(){S.textContent='File read error';S.style.color='#d32f2f';};"
          "R.readAsText(f);});})();</script>";
-    return s;
+    return s.take();
   }
 };
 

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -1,9 +1,16 @@
 #include "advanced_battery_html.h"
 #include <Arduino.h>
+#include <algorithm>
+#include <atomic>
+#include <new>
 #include <vector>
 #include "../../battery/BATTERIES.h"
 #include "../../datalayer/datalayer.h"
 #include "../../datalayer/datalayer_extended.h"
+#include "../../lib/ESP32Async-ESPAsyncWebServer/src/ESPAsyncWebServer.h"
+#include "../../lib/ESP32Async-ESPAsyncWebServer/src/WebResponseImpl.h"
+#include "checked_html.h"
+#include "index_html.h"
 
 // Available generic battery commands that are taken into use based on what the selected battery supports.
 std::vector<BatteryCommand> battery_commands = {
@@ -63,95 +70,223 @@ std::vector<BatteryCommand> battery_commands = {
      [](Battery* b) { b->reset_energy_saving_mode(); }},
 };
 
-String advanced_battery_processor(const String& var) {
-  if (var == "X") {
-    String content = "";
-    //Page format
-    content += "<style>";
-    content += "body { background-color: black; color: white; }";
-    content +=
-        "button { background-color: #505E67; color: white; border: none; padding: 10px 20px; margin: 5px; "
-        "cursor: pointer; border-radius: 10px; }";
-    content += "button:hover { background-color: #3A4A52; }";
-    content += "h4 { margin: 0.6em 0; line-height: 1.2; }";
-    content += "</style>";
-    content += "<button onclick='goToMainPage()'>Back to main page</button>";
+namespace {
+std::atomic<bool> advanced_page_busy{false};
 
-    // Start a new block with a specific background color
-    content += "<div style='background-color: #303E47; padding: 10px; margin-bottom: 10px;border-radius: 50px'>";
+Battery* battery_at(unsigned index) {
+  switch (index) {
+    case 0:
+      return battery;
+    case 1:
+      return battery2;
+    case 2:
+      return battery3;
+    default:
+      return nullptr;
+  }
+}
 
-    // Render buttons dynamically based on what commands the battery supports.
-    auto render_command_buttons = [&content](Battery* batt, int ix) {
-      for (const auto& cmd : battery_commands) {
-        if (cmd.condition(batt)) {
-          // Button for user action
-          content += "<button onclick='ask" + String(cmd.identifier) + "(" + String(ix) + ")'>" + String(cmd.title) +
-                     "</button>";
+const char page_start[] = INDEX_HTML_HEADER R"html(
+<style>
+body{background:black;color:white}h4{margin:.6em 0;line-height:1.2}
+button,.battery-tab{background:#505E67;color:white;border:0;padding:10px 20px;margin:5px;
+cursor:pointer;border-radius:10px;display:inline-block;text-decoration:none;font:inherit}
+button:hover,.battery-tab:hover{background:#3A4A52}
+.battery-tab[aria-current=page]{background:#287c58;outline:2px solid #69c999}
+.battery-panel{background:#303E47;padding:10px;margin-bottom:10px;border-radius:24px}
+</style>
+<script>
+function goToMainPage(){window.location.href='/';}
+function exportLog(){window.location.href='/export_log';}
+</script>
+<button onclick='goToMainPage()'>Back to main page</button>
+<nav aria-label='Battery selection'>
+)html";
+const char page_end[] = "</div>" INDEX_HTML_FOOTER;
+const char render_error[] = "<p role='alert'>Battery information could not be loaded. Please reload this page.</p>";
 
-          // Script that calls the backend to perform the command
-          content += "<script>";
-          content += "function ask" + String(cmd.identifier) + "(batteryNum) { ";
+// No template processor: transmit each fragment directly from flash or the owned section buffer.
+class AdvancedBatteryResponse : public AsyncAbstractResponse {
+ public:
+  AdvancedBatteryResponse(unsigned index, uint8_t http_version) : AsyncAbstractResponse(nullptr), selected(index) {
+    _code = 200;
+    _contentType = "text/html";
+    _sendContentLength = false;
+    _chunked = http_version != 0;
+  }
 
-          if (cmd.prompt) {
-            content += "if (window.confirm('Are you sure you want to " + String(cmd.prompt) + "'))";
-          }
+  ~AdvancedBatteryResponse() override {
+    section = static_cast<const char*>(nullptr);
+    release();
+  }
+  bool _sourceValid() const override { return true; }
 
-          content += "{" + String(cmd.identifier) + "(batteryNum); } }";
-          content += "function " + String(cmd.identifier) + "(batteryNum) {";
-          content += "  var xhr = new XMLHttpRequest();";
-          content += "  xhr.open('PUT', '/" + String(cmd.identifier) + "', true);";
-          if (cmd.reload_after) {
-            content += "  xhr.onload = function(){ setTimeout(function(){ location.reload(); }, 1500); };";
-          }
-          // Send index of the battery as PUT content
-          content += "  xhr.send(batteryNum);";
-          content += "}";
-          content += "</script>";
+  size_t _fillBuffer(uint8_t* data, size_t len) override {
+    if (!len) {
+      return RESPONSE_TRY_AGAIN;
+    }
+    size_t written = 0;
+    while (written < len) {
+      if (offset == fragment_length) {
+        // Drop the previous allocation before rendering the next fragment.
+        // Assigning an empty String retains its capacity on ESP32; null releases it.
+        section = static_cast<const char*>(nullptr);
+        if (!next_fragment()) {
+          release();
+          break;
+        }
+        offset = 0;
+        fragment_length = strlen(fragment);
+        if (!fragment_length) {
+          continue;
         }
       }
-    };
-
-    // Renders battery specific status for battery 2/3. Only renderers that
-    // read per-instance data (renders_own_battery_data) are used; legacy
-    // renderers hardcode the main battery datalayer and would show battery 1
-    // values here, so a notice is shown instead until they are reworked.
-    auto render_secondary_battery_status = [&content](Battery* batt) {
-      BatteryHtmlRenderer& renderer = batt->get_status_renderer();
-      if (renderer.renders_own_battery_data()) {
-        content += renderer.get_status_html();
-      } else {
-        content +=
-            "<h4 style='color: #f39c12;'>⚠️ Advanced detailed info is currently limited to the Main Battery.</h4>";
-      }
-    };
-
-    if (battery) {
-      content += battery->get_status_renderer().get_status_html();
-      render_command_buttons(battery, 0);
+      const size_t count = std::min(len - written, fragment_length - offset);
+      memcpy(data + written, fragment + offset, count);
+      offset += count;
+      written += count;
     }
-
-    if (battery2) {
-      content += "<hr>";
-      content += "<h4>Values from battery 2</h4>";
-      render_secondary_battery_status(battery2);
-      render_command_buttons(battery2, 1);
-    }
-
-    if (battery3) {
-      content += "<hr>";
-      content += "<h4>Values from battery 3</h4>";
-      render_secondary_battery_status(battery3);
-      render_command_buttons(battery3, 2);
-    }
-
-    content += "</div>";
-
-    content += "<script>";
-    content += "function exportLog() { window.location.href = '/export_log'; }";
-    content += "function goToMainPage() { window.location.href = '/'; }";
-    content += "</script>";
-
-    return content;
+    return written;
   }
-  return String();
+
+ private:
+  enum class Stage { Start, Tabs, Heading, Status, Dtc, Commands, End, Done };
+  Stage stage = Stage::Start;
+  unsigned selected;
+  unsigned tab = 0;
+  size_t command = 0;
+  bool failed = false;
+  bool owns_slot = true;
+  String section;
+  char small[192];
+  const char* fragment = "";
+  size_t offset = 0;
+  size_t fragment_length = 0;
+
+  void release() {
+    if (owns_slot) {
+      owns_slot = false;
+      advanced_page_busy.store(false);
+    }
+  }
+
+  bool next_fragment() {
+    Battery* batt = battery_at(selected);
+    while (true) {
+      switch (stage) {
+        case Stage::Start:
+          fragment = page_start;
+          stage = Stage::Tabs;
+          return true;
+        case Stage::Tabs:
+          while (tab < 3) {
+            const unsigned current = tab++;
+            if (battery_at(current)) {
+              snprintf(small, sizeof(small), "<a class='battery-tab' href='/advanced?battery=%u'%s>Battery %u</a>",
+                       current + 1, current == selected ? " aria-current='page'" : "", current + 1);
+              fragment = small;
+              return true;
+            }
+          }
+          stage = Stage::Heading;
+          break;
+        case Stage::Heading:
+          snprintf(small, sizeof(small), "</nav><div class='battery-panel'><h3>Battery %u</h3>", selected + 1);
+          fragment = small;
+          stage = Stage::Status;
+          return true;
+        case Stage::Status: {
+          stage = Stage::Dtc;
+          BatteryHtmlRenderer& renderer = batt->get_status_renderer();
+          if (selected && !renderer.renders_own_battery_data()) {
+            fragment = "<p>Advanced detailed information is currently available only for Battery 1.</p>";
+          } else {
+            section = renderer.get_status_html();
+            failed = renderer.html_render_failed() || !section;
+            fragment = failed ? render_error : section.c_str();
+          }
+          return true;
+        }
+        case Stage::Dtc: {
+          stage = Stage::Commands;
+          // Diagnostics are built only after the status buffer has been freed.
+          BatteryHtmlRenderer& renderer = batt->get_status_renderer();
+          if (!failed && (!selected || renderer.renders_own_battery_data())) {
+            section = renderer.get_dtc_html();
+            failed = renderer.html_render_failed() || !section;
+            fragment = failed ? render_error : section.c_str();
+            return true;
+          }
+          break;
+        }
+        case Stage::Commands:
+          while (!failed && command < battery_commands.size()) {
+            const auto& cmd = battery_commands[command++];
+            if (cmd.condition(batt)) {
+              section = command_html(cmd);
+              if (section.isEmpty()) {
+                failed = true;
+                fragment = render_error;
+              } else {
+                fragment = section.c_str();
+              }
+              return true;
+            }
+          }
+          stage = Stage::End;
+          break;
+        case Stage::End:
+          fragment = page_end;
+          stage = Stage::Done;
+          return true;
+        case Stage::Done:
+          return false;
+      }
+    }
+  }
+
+  String command_html(const BatteryCommand& cmd) const {
+    CheckedHtml html;
+    html.reserve(1024);
+    html += "<button onclick='ask" + String(cmd.identifier) + "(" + String(selected) + ")'>" + cmd.title +
+            "</button><script>function ask" + cmd.identifier + "(batteryNum){";
+    if (cmd.prompt) {
+      html += "if(window.confirm('Are you sure you want to " + String(cmd.prompt) + "'))";
+    }
+    html += "{" + String(cmd.identifier) + "(batteryNum);}}function " + cmd.identifier +
+            "(batteryNum){var xhr=new XMLHttpRequest();xhr.open('PUT','/" + cmd.identifier + "',true);";
+    if (cmd.reload_after) {
+      html += "xhr.onload=function(){setTimeout(function(){location.reload();},1500);};";
+    }
+    html += "xhr.send(batteryNum);}</script>";
+    return html.take();
+  }
+};
+}  // namespace
+
+void send_advanced_battery_page(AsyncWebServerRequest* request) {
+  unsigned selected = 0;
+  if (request->hasParam("battery")) {
+    const String value = request->getParam("battery")->value();
+    if (value.length() != 1 || value[0] < '1' || value[0] > '3') {
+      request->send(400, "text/plain", "Invalid battery selection.");
+      return;
+    }
+    selected = value[0] - '1';
+  }
+  if (!battery_at(selected)) {
+    request->send(404, "text/plain", "This battery is not configured.");
+    return;
+  }
+  if (advanced_page_busy.exchange(true)) {
+    request->send(503, "text/plain", "Battery information is busy. Please try again.");
+    return;
+  }
+  auto* response = new (std::nothrow) AdvancedBatteryResponse(selected, request->version());
+  if (!response) {
+    advanced_page_busy.store(false);
+    request->send(503, "text/plain", "Battery information could not be loaded. Please try again.");
+    return;
+  }
+  request->send(response);
 }

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -176,7 +176,7 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
       switch (stage) {
         case Stage::Start:
           fragment = page_start;
-          stage = Stage::Tabs;
+          stage = (battery2 || battery3) ? Stage::Tabs : Stage::Heading;
           return true;
         case Stage::Tabs:
           while (tab < 3) {

--- a/Software/src/devboard/webserver/advanced_battery_html.h
+++ b/Software/src/devboard/webserver/advanced_battery_html.h
@@ -2,16 +2,11 @@
 #define ADVANCEDBATTERY_H
 
 #include <Arduino.h>
-#include <string>
+#include <functional>
+#include <vector>
 
-/**
- * @brief Replaces placeholder with content section in web page
- *
- * @param[in] var
- *
- * @return String
- */
-String advanced_battery_processor(const String& var);
+class AsyncWebServerRequest;
+void send_advanced_battery_page(AsyncWebServerRequest* request);
 
 class Battery;
 

--- a/Software/src/devboard/webserver/checked_html.h
+++ b/Software/src/devboard/webserver/checked_html.h
@@ -1,0 +1,35 @@
+#ifndef CHECKED_HTML_H
+#define CHECKED_HTML_H
+
+#include <Arduino.h>
+#include <utility>
+
+// Retain the first allocation failure instead of returning partially built HTML.
+// Appends accept text (const char* or String); convert numeric values explicitly.
+class CheckedHtml : public String {
+ public:
+  bool reserve(unsigned int size) {
+    valid = valid && String::reserve(size);
+    return valid;
+  }
+  CheckedHtml& operator+=(const char* value) {
+    valid = valid && concat(value);
+    return *this;
+  }
+  CheckedHtml& operator+=(const String& value) {
+    valid = valid && value && concat(value);
+    return *this;
+  }
+  bool good() const { return valid; }
+  String take() {
+    if (!valid) {
+      return String();
+    }
+    return std::move(static_cast<String&>(*this));
+  }
+
+ private:
+  bool valid = true;
+};
+
+#endif

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -250,9 +250,8 @@ void init_webserver() {
   });
 
   // Route for going to advanced battery info web page
-  def_route_with_auth("/advanced", server, HTTP_GET, [](AsyncWebServerRequest* request) {
-    request->send(200, "text/html", index_html, advanced_battery_processor);
-  });
+  def_route_with_auth("/advanced", server, HTTP_GET,
+                      [](AsyncWebServerRequest* request) { send_advanced_battery_page(request); });
 
   // Served pre-compressed from flash rather than the template processor, so it never competes
   // for heap and costs a third of the space the plain HTML would.

--- a/test/checked_html_tests.cpp
+++ b/test/checked_html_tests.cpp
@@ -1,0 +1,35 @@
+#include <WString.h>
+#include <gtest/gtest.h>
+
+#include "../Software/src/devboard/webserver/checked_html.h"
+
+TEST(CheckedHtmlTest, EmptyStringIsValid) {
+  const String empty;
+  EXPECT_TRUE(static_cast<bool>(empty));
+  EXPECT_TRUE(empty.isEmpty());
+
+  CheckedHtml html;
+  html += empty;
+  EXPECT_TRUE(html.good());
+  EXPECT_TRUE(html.take().isEmpty());
+}
+
+TEST(CheckedHtmlTest, AppendsTextAndTransfersResult) {
+  CheckedHtml html;
+  ASSERT_TRUE(html.reserve(32));
+  html += "<p>";
+  html += String("Battery 2");
+  html += "</p>";
+  EXPECT_TRUE(html.good());
+  EXPECT_STREQ(html.take().c_str(), "<p>Battery 2</p>");
+}
+
+TEST(CheckedHtmlTest, FailedAppendDiscardsPartialOutput) {
+  CheckedHtml html;
+  html += "partial";
+  html += static_cast<const char*>(nullptr);
+  html += "later";
+  EXPECT_FALSE(html.good());
+  EXPECT_FALSE(html.reserve(64));
+  EXPECT_TRUE(html.take().isEmpty());
+}

--- a/test/emul/WString.h
+++ b/test/emul/WString.h
@@ -41,6 +41,9 @@ class String {
   // Conversion operator to std::string
   operator std::string() const { return data; }
 
+  // This host shim does not simulate allocation failures; empty strings are valid too.
+  explicit operator bool() const { return true; }
+
   // Accessor
   const std::string& str() const { return data; }
 
@@ -55,6 +58,19 @@ class String {
   String operator+(const char* rhs) const { return String(data + std::string(rhs)); }
 
   // Append
+  bool concat(const char* rhs) {
+    if (!rhs) {
+      return false;
+    }
+    data += rhs;
+    return true;
+  }
+
+  bool concat(const String& rhs) {
+    data += rhs.data;
+    return true;
+  }
+
   String& operator+=(const String& rhs) {
     data += rhs.data;
     return *this;
@@ -72,6 +88,7 @@ class String {
 
   // Arduino-like methods (example)
   int length() const { return static_cast<int>(data.length()); }
+  bool isEmpty() const { return data.empty(); }
   const char* c_str() const { return data.c_str(); }
 
   // Arduino String::reserve returns bool; pre-allocates capacity.


### PR DESCRIPTION
### What
Fix missing battery details and crashes when opening “More Battery Info” with multiple packs.

### Why
Building every pack’s details into one large page can exhaust heap, especially with MQTT running.

### How
Add battery tabs and stream one pack’s page in smaller sections. BYD diagnostics stay on the page but are built after the main status buffer is freed. Show an error if allocation fails.

Adds about 1.4 KiB of flash and 8 bytes of static RAM on LilyGo.

Sample of more batt info page for dual battery:
<img width="847" height="271" alt="image" src="https://github.com/user-attachments/assets/a4501c8b-8208-4f52-baa0-b5f166f0560d" />

Single pack:
<img width="832" height="328" alt="image" src="https://github.com/user-attachments/assets/6309fda1-3ee2-467c-b237-3fc4b3f68920" />

### Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [X] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes https://github.com/dalathegreat/Battery-Emulator/issues/2940

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR n/a

### Checklist:

  - [X] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
