### PR TITLE
Add BYD Atto 3 external DC voltage telemetry

### DIFF
--- a/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.cpp
@@ -314,6 +314,9 @@ void BydAttoBattery::
     datalayer_bydatto->SOC_polled = BMS_SOC;
     //Resolved voltage, not raw 0x438, so the page matches the main view when 0x438 is rejected
     datalayer_bydatto->pack_voltage_dV = datalayer_battery->status.voltage_dV;
+    datalayer_bydatto->external_dc_voltage_dV = battery_external_dc_voltage_dV;
+    datalayer_bydatto->external_dc_voltage_valid =
+        last_35E_ms != 0 && static_cast<uint32_t>(millis() - last_35E_ms) < 3000;
     datalayer_bydatto->insulation_ohm_per_volt = battery_insulation_ohm_per_volt;
     datalayer_bydatto->insulation_valid = battery_insulation_valid;
     datalayer_bydatto->iso_status_valid = (last_35E_ms != 0) && ((millis() - last_35E_ms) < 3000);
@@ -572,6 +575,7 @@ void BydAttoBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       // b0 bit 0x80 = isolation measurement active (set = running, clear = disabled/idle)
       if (rx_frame.data.u8[7] == computeBydChecksum(rx_frame.data.u8)) {
         battery_iso_measurement_active = (rx_frame.data.u8[0] & 0x80) != 0;
+        battery_external_dc_voltage_dV = rx_frame.data.u8[3] | (static_cast<uint16_t>(rx_frame.data.u8[4]) << 8);
         last_35E_ms = millis();
       } else {
         datalayer_battery->status.CAN_error_counter++;

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -466,7 +466,6 @@ class BydAttoBattery : public CanBattery {
   unsigned long last_35E_ms = 0;                // 0 = 0x35E not yet received (staleness)
   uint16_t battery_external_dc_voltage_dV = 0;  // Deci-volts from 0x35E, bytes 3-4 (little-endian)
 
-
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[12] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};

--- a/Software/src/battery/BYD-ATTO-3-BATTERY.h
+++ b/Software/src/battery/BYD-ATTO-3-BATTERY.h
@@ -464,6 +464,9 @@ class BydAttoBattery : public CanBattery {
   bool battery_insulation_valid = false;        // Zero is a valid 0x43A fault reading, so track receipt separately
   bool battery_iso_measurement_active = false;  // 0x35E b0 bit0x80
   unsigned long last_35E_ms = 0;                // 0 = 0x35E not yet received (staleness)
+  uint16_t battery_external_dc_voltage_dV = 0;  // Deci-volts from 0x35E, bytes 3-4 (little-endian)
+
+
   bool calibrationAH_seeded = false;
 
   int16_t battery_daughterboard_temperatures[12] = {-40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40, -40};

--- a/Software/src/battery/BYD-ATTO-3-HTML.h
+++ b/Software/src/battery/BYD-ATTO-3-HTML.h
@@ -128,6 +128,12 @@ class BydAtto3HtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += "Not received</h4>";
     }
+    content += "<h4>External DC voltage: ";
+    if (byd_datalayer->external_dc_voltage_valid) {
+      content += String(byd_datalayer->external_dc_voltage_dV / 10.0f, 1) + " V</h4>";
+    } else {
+      content += "Unavailable (no recent data)</h4>";
+    }
 
     static const size_t TEMPERATURE_SENSOR_COUNT =
         sizeof(byd_datalayer->battery_temperatures) / sizeof(byd_datalayer->battery_temperatures[0]);

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -128,6 +128,10 @@ struct DATALAYER_INFO_BYDATTO3 {
   uint16_t SOC_polled;
   /** Pack voltage from 0x438, deci-volts. Zero until the frame is received */
   uint16_t pack_voltage_dV;
+  /** External DC voltage from 0x35E, deci-volts. Telemetry only */
+  uint16_t external_dc_voltage_dV = 0;
+  /** A checksum-valid reading arrived within three seconds; zero volts is valid */
+  bool external_dc_voltage_valid = false;
   /** Insulation resistance from 0x43A, Ohm per volt. Multiply by pack voltage for Ohms. Zero is a valid fault reading */
   uint16_t insulation_ohm_per_volt;
   /** True once a checksum-valid 0x43A has been seen */

--- a/Software/src/devboard/mqtt/mqtt.cpp
+++ b/Software/src/devboard/mqtt/mqtt.cpp
@@ -241,6 +241,7 @@ static const SensorConfig batterySensorConfigTemplate[] = {
     {"autocal_soc_drift", "BYD Auto-cal: SOC Drift", "%", "", supports_byd_autocal_metrics},
     {"min_cell_number", "Min Cell Number", "", "", supports_byd_metrics},
     {"max_cell_number", "Max Cell Number", "", "", supports_byd_metrics},
+    {"external_dc_voltage", "External DC Voltage", "V", "voltage", supports_byd_metrics},
     {"leaf_hx", "Hx", "%", "", supports_leaf_metrics},
     {"leaf_soh_raw", "State of Health (raw)", "%", "", supports_leaf_metrics},
     {"leaf_vbat", "VBAT +12 level", "V", "voltage", supports_leaf_metrics},
@@ -475,6 +476,10 @@ void set_battery_attributes(JsonDocument& doc, const DATALAYER_BATTERY_TYPE& bat
         (battery_index == 2) ? datalayer_extended.bydAtto3_2 : datalayer_extended.bydAtto3;
     doc["min_cell_number"] = byd.BMS_min_cell_voltage_number;
     doc["max_cell_number"] = byd.BMS_max_cell_voltage_number;
+    // Omit missing or stale readings so HA shows unknown; zero volts is valid.
+    if (byd.external_dc_voltage_valid) {
+      doc["external_dc_voltage"] = static_cast<float>(byd.external_dc_voltage_dV) / 10.0f;
+    }
   }
   if (supports_leaf_metrics(::battery)) {
     const DATALAYER_INFO_NISSAN_LEAF& leaf = (battery_index == 3)   ? datalayer_extended.nissanleaf_3

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "../../Software/src/battery/BATTERIES.h"
 #include "../../Software/src/battery/BYD-ATTO-3-BATTERY.h"
@@ -82,6 +83,136 @@ CAN_frame contactor_feedback_frame(uint8_t mode) {
 }
 
 }  // namespace
+
+// Captured open/precharge/closed samples decode in tenths of a volt, including the low byte.
+TEST(BydAtto3Tests, DecodesCapturedExternalDcVoltagesAndZero) {
+  reset_byd_state();
+  set_millis64(1000);
+  BydAttoBattery battery;
+  battery.setup();
+  const struct {
+    CAN_frame frame;
+    uint16_t expected_dV;
+  } samples[] = {
+      {byd_frame(0x35E, {0x01, 0x00, 0xB8, 0x40, 0x00, 0x00, 0x00, 0x06}), 64},
+      {byd_frame(0x35E, {0x01, 0x00, 0x5C, 0x97, 0x00, 0x00, 0x00, 0x0B}), 151},
+      {byd_frame(0x35E, {0x01, 0x00, 0x60, 0x3C, 0x06, 0x00, 0x00, 0x5C}), 1596},
+      {byd_frame(0x35E, {0x01, 0x00, 0x60, 0x35, 0x10, 0x00, 0x00, 0x59}), 4149},
+      {byd_frame(0x35E, {0x01, 0x00, 0x60, 0xAD, 0x10, 0x00, 0x00, 0xE1}), 4269},
+      {byd_checksummed_frame(0x35E, {0x01, 0, 0, 0, 0, 0, 0}), 0},
+  };
+  for (const auto& sample : samples) {
+    SCOPED_TRACE(sample.expected_dV);
+    battery.handle_incoming_can_frame(sample.frame);
+    battery.update_values();
+    EXPECT_TRUE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+    EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, sample.expected_dV);
+  }
+}
+
+
+
+// External DC voltage is published and displayed for each valid sample,
+// including zero volts.
+TEST(BydAtto3Tests, PublishesAndDisplaysExternalDcVoltage) {
+  reset_byd_state();
+  set_millis64(0);
+  BydAttoBattery battery;
+  battery.setup();
+  battery.handle_incoming_can_frame(byd_checksummed_frame(0x444, {0xA2, 0x01, 0x88, 0x13, 0x64, 0x50, 0x00}));
+  battery.update_values();
+  EXPECT_FALSE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_NE(std::string(battery.get_status_renderer().get_status_html().c_str())
+                .find("External DC voltage: Unavailable (no recent data)</h4>"),
+            std::string::npos);
+
+  const struct {
+    uint8_t low;
+    uint8_t high;
+    uint16_t expected_dV;
+    const char* expected_display;
+  } samples[] = {
+      {0x00, 0x00, 0, "0.0 V"},      {0x60, 0x00, 96, "9.6 V"},     {0x2B, 0x07, 1835, "183.5 V"},
+      {0x01, 0x10, 4097, "409.7 V"}, {0x60, 0x10, 4192, "419.2 V"},
+  };
+  uint32_t now = 1;
+  for (const auto& sample : samples) {
+    SCOPED_TRACE(sample.expected_dV);
+    set_millis64(now);
+    battery.handle_incoming_can_frame(byd_checksummed_frame(0x35E, {0x01, 0, 0x60, sample.low, sample.high, 0, 0}));
+    battery.update_values();
+    EXPECT_TRUE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+    EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, sample.expected_dV);
+    EXPECT_EQ(datalayer_extended.bydAtto3.pack_voltage_dV, 4180);
+    const std::string expected = std::string("External DC voltage: ") + sample.expected_display + "</h4>";
+    EXPECT_NE(std::string(battery.get_status_renderer().get_status_html().c_str()).find(expected), std::string::npos);
+    now += 100;
+  }
+  set_millis64(0);
+}
+
+// Invalid frames neither overwrite a reading nor keep stale voltage visible on the advanced page.
+TEST(BydAtto3Tests, ExpiresExternalDcVoltageWithoutValidFramesAndRecovers) {
+  reset_byd_state();
+  set_millis64(1000);
+  BydAttoBattery battery;
+  battery.setup();
+  battery.handle_incoming_can_frame(byd_checksummed_frame(0x35E, {0x01, 0, 0x60, 0x60, 0x10, 0, 0}));
+
+  set_millis64(3999);
+  battery.handle_incoming_can_frame(byd_corrupt_frame(0x35E, {0x01, 0, 0x60, 0x60, 0, 0, 0}));
+  battery.update_values();
+  EXPECT_TRUE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, 4192);
+
+  set_millis64(4000);
+  battery.handle_incoming_can_frame(byd_corrupt_frame(0x35E, {0x01, 0, 0x60, 0x60, 0, 0, 0}));
+  battery.update_values();
+  EXPECT_FALSE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, 4192);
+  EXPECT_EQ(datalayer.battery.status.CAN_error_counter, 2);
+  EXPECT_NE(std::string(battery.get_status_renderer().get_status_html().c_str())
+                .find("External DC voltage: Unavailable (no recent data)</h4>"),
+            std::string::npos);
+
+  set_millis64(4100);
+  battery.handle_incoming_can_frame(byd_checksummed_frame(0x35E, {0x01, 0, 0x60, 0x2B, 0x07, 0, 0}));
+  battery.update_values();
+  EXPECT_TRUE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, 1835);
+  set_millis64(0);
+}
+
+// Separate battery instances retain their own readings and freshness when the 32-bit clock wraps.
+TEST(BydAtto3Tests, KeepsExternalDcVoltageIndependentAcrossBatteriesAndMillisWrap) {
+  reset_byd_state();
+  datalayer_extended.bydAtto3_2 = DATALAYER_INFO_BYDATTO3{};
+  BydAttoBattery first;
+  BydAttoBattery second(&datalayer.battery2, &datalayer_extended.bydAtto3_2, CAN_ADDON_MCP2515);
+  first.setup();
+  second.setup();
+  const uint64_t start = std::numeric_limits<uint32_t>::max() - 1000;
+  set_millis64(start);
+  first.handle_incoming_can_frame(byd_checksummed_frame(0x35E, {0x01, 0, 0x60, 0x60, 0, 0, 0}));
+  first.update_values();
+  second.update_values();
+  EXPECT_TRUE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_FALSE(datalayer_extended.bydAtto3_2.external_dc_voltage_valid);
+
+  set_millis64(start + 200);
+  second.handle_incoming_can_frame(byd_checksummed_frame(0x35E, {0x01, 0, 0x60, 0x60, 0x10, 0, 0}));
+  set_millis64(start + 3000);
+  first.update_values();
+  second.update_values();
+  EXPECT_FALSE(datalayer_extended.bydAtto3.external_dc_voltage_valid);
+  EXPECT_TRUE(datalayer_extended.bydAtto3_2.external_dc_voltage_valid);
+  EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, 96);
+  EXPECT_EQ(datalayer_extended.bydAtto3_2.external_dc_voltage_dV, 4192);
+  EXPECT_NE(std::string(second.get_status_renderer().get_status_html().c_str())
+                .find("External DC voltage: 419.2 V</h4>"),
+            std::string::npos);
+  set_millis64(0);
+}
 
 TEST(BydAtto3BalanceApiTests, RejectsUnconfiguredBatteryIndices) {
   user_selected_battery_type = BatteryType::BydAtto3;

--- a/test/battery/BydAtto3Test.cpp
+++ b/test/battery/BydAtto3Test.cpp
@@ -110,8 +110,6 @@ TEST(BydAtto3Tests, DecodesCapturedExternalDcVoltagesAndZero) {
   }
 }
 
-
-
 // External DC voltage is published and displayed for each valid sample,
 // including zero volts.
 TEST(BydAtto3Tests, PublishesAndDisplaysExternalDcVoltage) {
@@ -208,9 +206,9 @@ TEST(BydAtto3Tests, KeepsExternalDcVoltageIndependentAcrossBatteriesAndMillisWra
   EXPECT_TRUE(datalayer_extended.bydAtto3_2.external_dc_voltage_valid);
   EXPECT_EQ(datalayer_extended.bydAtto3.external_dc_voltage_dV, 96);
   EXPECT_EQ(datalayer_extended.bydAtto3_2.external_dc_voltage_dV, 4192);
-  EXPECT_NE(std::string(second.get_status_renderer().get_status_html().c_str())
-                .find("External DC voltage: 419.2 V</h4>"),
-            std::string::npos);
+  EXPECT_NE(
+      std::string(second.get_status_renderer().get_status_html().c_str()).find("External DC voltage: 419.2 V</h4>"),
+      std::string::npos);
   set_millis64(0);
 }
 


### PR DESCRIPTION
## Summary

Add external DC voltage telemetry for BYD Atto 3 batteries, showing the
voltage on the connected equipment side separately from pack voltage.

Decode bytes 3–4 of CAN frame `0x35E` as a little-endian value in
decivolts, based on captured readings.

## Changes

- Display **External DC voltage** on the battery status page.
- Publish `external_dc_voltage` over MQTT in volts.
- Add an **External DC Voltage** sensor to Home Assistant discovery.
- Treat readings as stale after three seconds without a checksum-valid
  `0x35E` frame. The status page shows unavailable, and MQTT omits the
  value so Home Assistant shows unknown.
- Preserve valid zero-volt readings and independent data for dual BYD
  battery setups.

The value is telemetry-only. Pack voltage reporting, precharge and
contactor control are unchanged.

<img width="284" height="68" alt="Screenshot 2026-09-10 at 9 10 53 am" src="https://github.com/user-attachments/assets/11bcbcdf-59c7-4b76-bc9c-aff6c5165f8d" />

## Testing

Manual testing on the battery confirms that opening the contactors makes
external DC voltage drop low, and closing them shows the voltage rising
again as precharge completes.

Added unit tests covering:

- Captured voltage samples and zero-volt readings.
- Status-page output.
- Checksum rejection, stale readings and recovery.
- Independent readings for two batteries and timer wraparound.

`git diff --check` passed. Unit tests and firmware builds have not been
run in the local agent environment because CMake and PlatformIO were
unavailable. MQTT discovery and dual-battery publishing still require
runtime verification.