### PR TITLE
Nissan LEAF: lifetime usage histograms + Charge to full and Turtle count

### DIFF
--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -363,7 +363,7 @@ void NissanLeafBattery::
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
     datalayer_nissan->battery_SOHraw_pptt = battery_SOHraw_pptt;
     datalayer_nissan->battery_SOHavg_pptt = battery_SOH_avg_pptt;
-    datalayer_nissan->battery_HX_pptt = (battery_HX_pptt_g61 != 0) ? battery_HX_pptt_g61 : battery_HX_pptt;
+    datalayer_nissan->battery_HX_pptt = battery_HX_pptt;
     datalayer_nissan->ChargeCountQC = battery_charge_count_qc;
     datalayer_nissan->ChargeCountL1L2 = battery_charge_count_l1l2;
     datalayer_nissan->temperature1 = ((Temp_fromRAW_to_F(battery_temp_raw_1) - 320) * 5) / 9;  //Convert from F to C
@@ -675,18 +675,14 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
           }
         }
 
-        if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame
-          // Hx sits at a different payload offset and uses a different scale depending on which
-          // layout the LBC answered with, so the reply length decides how to read it:
-          //   0x29 (ZE0 24kWh) / 0x2B (AZE0 30kWh) -> payload[26..27], already in hundredths of a %
-          //   0x35 (ZE1 40/62kWh)                  -> payload[28..29], raw / 102.4 = percent
-          // This frame carries payload[25..31] in u8[1..7]. Any other length is a layout we do not
-          // know (a ZE1 answers 0x2C shortly after wakeup), so leave the last good value in place.
-          if (group_7bb_length == 0x35) {  //ZE1
-            uint16_t battery_HX_raw = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
-            //raw / 102.4 * 100 == raw * 125 / 128, rounded to nearest
-            battery_HX_pptt = (uint16_t)(((uint32_t)battery_HX_raw * 125u + 64u) / 128u);
-          } else if (group_7bb_length == 0x29 || group_7bb_length == 0x2B) {  //ZE0 / AZE0
+        if (rx_frame.data.u8[0] == 0x24) {  // Fifth frame, payload[27..33] in u8[1..7]
+          //Hx, on the ZE0 (0x29) and AZE0 (0x2B) layouts only: payload[28..29], a u16 in hundredths
+          //of a percent, so the firmware's 100 % is 10000 and a healthy pack reads above it. This is
+          //where the LBC history guide takes the ZE0/AZE0 Hx from. ZE1 (0x35) has its Hx in the
+          //health block instead (group 0x61, same scale), so nothing in this layout is read as Hx,
+          //and no divide by 1024 is involved on either. Any other length is a layout we do not
+          //know (a ZE1 answers 0x2C shortly after wakeup), so leave the last good value in place.
+          if (group_7bb_length == 0x29 || group_7bb_length == 0x2B) {
             battery_HX_pptt = (rx_frame.data.u8[2] << 8) | rx_frame.data.u8[3];
           }
         }
@@ -876,17 +872,17 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
       }
 
-      if (group_7bb == 0x61) {  //Health block: Hx, SOH and, on ZE1, pack capacity
+      if (group_7bb == 0x61) {  //Health block: SOH and, on ZE1, Hx and the pack capacity
         //Percentages here are stored as hundredths, so the firmware's 100% is 10000. Hx above
         //100% is normal on a healthy pack and is deliberately not clamped; the range checks below
         //only reject values that cannot be a reading at all.
         if (group_7bb_frame == 0) {  //First frame, payload[0..5] in u8[2..7]
           uint16_t hx_raw = (uint16_t)((rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5]);   //payload[2..3]
           uint16_t soh_raw = (uint16_t)((rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7]);  //payload[4..5]
-          //ZE1 keeps the Hx it already decodes from group 0x01, on its own scale. Only ZE0/AZE0
-          //take Hx from here.
-          if ((LEAF_battery_Type != ZE1_BATTERY) && (hx_raw > 0u) && (hx_raw <= 20000u)) {
-            battery_HX_pptt_g61 = hx_raw;
+          //Only ZE1 takes its Hx from here, as the LBC history guide lays out; ZE0/AZE0 read theirs
+          //from group 0x01. The capture in the guide, 61 61 2A F8, is 11000: 110.00 %.
+          if ((LEAF_battery_Type == ZE1_BATTERY) && (hx_raw > 0u) && (hx_raw <= 20000u)) {
+            battery_HX_pptt = hx_raw;
           }
           if ((soh_raw > 0u) && (soh_raw <= 10000u)) {
             battery_SOH_pptt_g61 = soh_raw;
@@ -935,13 +931,17 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
             battery_charge_count_l1l2 = count_l1l2;
             battery_charge_count_qc = count_qc;
           }
-        } else if (datalayer_nissan && (uint8_t)(group_7bb_frame - 1) < 14) {
-          //Consecutive frames 1-14 carry payload[6..103], seven bytes each. That span holds the six
-          //usage histograms on either layout, so it is stored raw and the page applies the
-          //generation's offset. Only a reply that got as far as frame 14 takes the group out of
-          //the rotation; one cut short is asked for again.
-          memcpy(&datalayer_nissan->UsageHistograms[(group_7bb_frame - 1) * 7], &rx_frame.data.u8[1], 7);
-          battery_usage_histograms_read = (group_7bb_frame == 14);
+        } else {
+          //Consecutive frames 1-17 carry payload[6..124], seven bytes each. That span holds all
+          //seven usage tables on either layout, the six histograms and the charge-to-full table
+          //after them, so it is stored raw and the page applies the generation's offset.
+          if (datalayer_nissan && (uint8_t)(group_7bb_frame - 1) < 17) {
+            memcpy(&datalayer_nissan->UsageHistograms[(group_7bb_frame - 1) * 7], &rx_frame.data.u8[1], 7);
+          }
+          //A reply of L bytes ends on consecutive frame L / 7: frame 16 on ZE0/AZE0 (0x76), 17 on
+          //ZE1 (0x78). Only a reply that got that far takes the group out of the rotation; one
+          //cut short is asked for again.
+          battery_usage_history_read = (group_7bb_frame == group_7bb_length / 7);
         }
       }
 
@@ -1351,13 +1351,13 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
         // pack is powered, so each is asked for only until its data is in, after which the
         // recurring groups come round faster. Testing the data itself rather than a "seen" flag
         // means a reply that arrived while another tool was polling the bus counts just as well.
-        // For group 0x62 that is the reply having reached its last histogram byte, since the
-        // counters in its first frame say nothing about the frames after it.
+        // For group 0x62 that is the whole reply having arrived, since the counters in its first
+        // frame say nothing about the frames after it.
         // After a BMS reset the skipping is suspended for one pass, so the new session answers
         // them once more. Previous values stay on display until the fresh reply overwrites them.
         do {
           PIDindex = (PIDindex + 1) % (sizeof(PIDgroups) / sizeof(PIDgroups[0]));
-        } while (!repoll_static_groups && ((PIDgroups[PIDindex] == 0x62 && battery_usage_histograms_read) ||
+        } while (!repoll_static_groups && ((PIDgroups[PIDindex] == 0x62 && battery_usage_history_read) ||
                                            (PIDgroups[PIDindex] == 0x84 && BatterySerialNumber[0] != 0) ||
                                            (PIDgroups[PIDindex] == 0x83 && BatteryPartNumber[0] != 0)));
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -361,6 +361,7 @@ void NissanLeafBattery::
     datalayer_nissan->HeatingStop = battery_Heating_Stop;
     datalayer_nissan->HeatingStart = battery_Heating_Start;
     datalayer_nissan->HeaterSendRequest = battery_Batt_Heater_Mail_Send_Request;
+    datalayer_nissan->StatusSeen = battery_status_seen;
     datalayer_nissan->battery_SOHraw_pptt = battery_SOHraw_pptt;
     datalayer_nissan->battery_SOHavg_pptt = battery_SOH_avg_pptt;
     datalayer_nissan->battery_HX_pptt = battery_HX_pptt;
@@ -412,6 +413,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_MainRelayOn_flag = (bool)((rx_frame.data.u8[3] & 0x20) >> 5);
       battery_Full_CHARGE_flag = (bool)((rx_frame.data.u8[3] & 0x10) >> 4);
       battery_Interlock = (bool)((rx_frame.data.u8[3] & 0x08) >> 3);
+      battery_status_seen |= 0x01;
       break;
     case 0x1DC:
       if (is_message_corrupt(rx_frame)) {
@@ -432,6 +434,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         battery_SOC = battery_TEMP;
       }
       battery_Capacity_Empty = (bool)((rx_frame.data.u8[6] & 0x80) >> 7);
+      battery_status_seen |= 0x02;
       break;
     case 0x5BC:
       battery_can_alive = true;
@@ -473,6 +476,7 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
       battery_Heating_Stop = ((rx_frame.data.u8[0] & 0x10) >> 4);
       battery_Heating_Start = ((rx_frame.data.u8[0] & 0x20) >> 5);
       battery_Batt_Heater_Mail_Send_Request = (rx_frame.data.u8[1] & 0x01);
+      battery_status_seen |= 0x04;
 
       break;
     case 0x59E:

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -968,29 +968,18 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23000000000080FF)
         }
       }
-      if (group_7bb == 0x84) {              //BatterySerialNumber
-        if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 16 61 84 32 33 30 55)
-          BatterySerialNumber[0] = rx_frame.data.u8[7];
+      //BatterySerialNumber: 16 ASCII characters at payload[2..17], straight after the 61 84 header.
+      //The capture 10 16 61 84 32 33 30 55 | 21 4B 31 31 39 32 45 30 | 22 30 31 34 38 32 20 A0 reads
+      //230UK1192E001482; the space and 0xA0 after it are not part of the serial.
+      if (group_7bb == 0x84) {
+        if (rx_frame.data.u8[0] == 0x10) {  //First frame, payload[0..5] in u8[2..7]
+          memcpy(&BatterySerialNumber[0], &rx_frame.data.u8[4], 4);
         }
-        if (rx_frame.data.u8[0] == 0x21) {  //Second frame (21 4B 31 31 39 32 45 30)
-          BatterySerialNumber[1] = rx_frame.data.u8[1];
-          BatterySerialNumber[2] = rx_frame.data.u8[2];
-          BatterySerialNumber[3] = rx_frame.data.u8[3];
-          BatterySerialNumber[4] = rx_frame.data.u8[4];
-          BatterySerialNumber[5] = rx_frame.data.u8[5];
-          BatterySerialNumber[6] = rx_frame.data.u8[6];
-          BatterySerialNumber[7] = rx_frame.data.u8[7];
+        if (rx_frame.data.u8[0] == 0x21) {  //Second frame, payload[6..12] in u8[1..7]
+          memcpy(&BatterySerialNumber[4], &rx_frame.data.u8[1], 7);
         }
-        if (rx_frame.data.u8[0] == 0x22) {  //Third frame (22 30 31 34 38 32 20 A0)
-          BatterySerialNumber[8] = rx_frame.data.u8[1];
-          BatterySerialNumber[9] = rx_frame.data.u8[2];
-          BatterySerialNumber[10] = rx_frame.data.u8[3];
-          BatterySerialNumber[11] = rx_frame.data.u8[4];
-          BatterySerialNumber[12] = rx_frame.data.u8[5];
-          BatterySerialNumber[13] = rx_frame.data.u8[6];
-          BatterySerialNumber[14] = rx_frame.data.u8[7];
-        }
-        if (rx_frame.data.u8[0] == 0x23) {  //Fourth frame (23 00 00 00 00 00 00 00)
+        if (rx_frame.data.u8[0] == 0x22) {  //Third frame, payload[13..19]: the serial ends at [17]
+          memcpy(&BatterySerialNumber[11], &rx_frame.data.u8[1], 5);
         }
       }
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.cpp
@@ -898,18 +898,25 @@ void NissanLeafBattery::handle_incoming_can_frame(CAN_frame rx_frame) {
         }
       }
 
-      if (group_7bb == 0x62) {              //Lifetime charge counters
+      if (group_7bb == 0x62) {              //Lifetime charge counters and usage histograms
         if (rx_frame.data.u8[0] == 0x10) {  //First frame (10 76 61 62 08 00 01 5A)
-          //Both counters are carried in the first frame, no need to walk the rest of the reply:
-          //payload[0..1] holds the L1/L2 (AC) charges, payload[2..3] the quick (CHAdeMO) charges.
-          //A counter the LBC has no value for reads back as 0xFFFF. A used pack always has AC
-          //charges, so a zero L1/L2 count means "not read yet" and keeps the group in the rotation.
+          //Both counters are carried in the first frame: payload[2..3] holds the L1/L2 (AC)
+          //charges, payload[4..5] the quick (CHAdeMO) charges. A counter the LBC has no value for
+          //reads back as 0xFFFF. A used pack always has AC charges, so a zero L1/L2 count means
+          //"not read yet".
           uint16_t count_l1l2 = (rx_frame.data.u8[4] << 8) | rx_frame.data.u8[5];
           uint16_t count_qc = (rx_frame.data.u8[6] << 8) | rx_frame.data.u8[7];
           if (count_l1l2 != 0xFFFF && count_qc != 0xFFFF) {
             battery_charge_count_l1l2 = count_l1l2;
             battery_charge_count_qc = count_qc;
           }
+        } else if (datalayer_nissan && (uint8_t)(group_7bb_frame - 1) < 14) {
+          //Consecutive frames 1-14 carry payload[6..103], seven bytes each. That span holds the six
+          //usage histograms on either layout, so it is stored raw and the page applies the
+          //generation's offset. Only a reply that got as far as frame 14 takes the group out of
+          //the rotation; one cut short is asked for again.
+          memcpy(&datalayer_nissan->UsageHistograms[(group_7bb_frame - 1) * 7], &rx_frame.data.u8[1], 7);
+          battery_usage_histograms_read = (group_7bb_frame == 14);
         }
       }
 
@@ -1315,15 +1322,17 @@ void NissanLeafBattery::transmit_can(unsigned long currentMillis) {
       if (!stop_battery_query && !dtc_operation_pending) {
 
         // Move to the next group, skipping the static ones that already answered. The charge
-        // counters and the two identity strings cannot change while the pack is powered, so each
-        // is asked for only until its data is in, after which the recurring groups come round
-        // faster. Testing the data itself rather than a "seen" flag means a reply that arrived
-        // while another tool was polling the bus counts just as well.
+        // counters with the usage histograms and the two identity strings cannot change while the
+        // pack is powered, so each is asked for only until its data is in, after which the
+        // recurring groups come round faster. Testing the data itself rather than a "seen" flag
+        // means a reply that arrived while another tool was polling the bus counts just as well.
+        // For group 0x62 that is the reply having reached its last histogram byte, since the
+        // counters in its first frame say nothing about the frames after it.
         // After a BMS reset the skipping is suspended for one pass, so the new session answers
         // them once more. Previous values stay on display until the fresh reply overwrites them.
         do {
           PIDindex = (PIDindex + 1) % (sizeof(PIDgroups) / sizeof(PIDgroups[0]));
-        } while (!repoll_static_groups && ((PIDgroups[PIDindex] == 0x62 && battery_charge_count_l1l2 != 0) ||
+        } while (!repoll_static_groups && ((PIDgroups[PIDindex] == 0x62 && battery_usage_histograms_read) ||
                                            (PIDgroups[PIDindex] == 0x84 && BatterySerialNumber[0] != 0) ||
                                            (PIDgroups[PIDindex] == 0x83 && BatteryPartNumber[0] != 0)));
         LEAF_GROUP_REQUEST.data.u8[2] = PIDgroups[PIDindex];

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -274,6 +274,9 @@ class NissanLeafBattery : public CanBattery {
   bool battery_Heating_Stop = false;   //When transitioning from 0->1, signals a STOP heat request
   bool battery_Heating_Start = false;  //When transitioning from 1->0, signals a START heat request
   bool battery_Batt_Heater_Mail_Send_Request = false;  //Stores info when a heat request is happening
+  //Which status broadcasts have arrived since boot: bit 0 0x1DB, bit 1 0x55B, bit 2 0x5C0. Until
+  //then the flags above are only their initial values, so the page shows them as unknown.
+  uint8_t battery_status_seen = 0;
 
   // Nissan LEAF battery data from polled CAN messages
   uint8_t battery_request_idx = 0;

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -362,7 +362,7 @@ class NissanLeafBattery : public CanBattery {
   uint16_t battery_temp_raw_min = 0;
   int16_t battery_temp_polled_max = 0;
   int16_t battery_temp_polled_min = 0;
-  uint8_t BatterySerialNumber[15] = {0};  // Stores raw HEX values for ASCII chars
+  uint8_t BatterySerialNumber[16] = {0};  // 16 ASCII characters, not null-terminated
   uint8_t BatteryPartNumber[7] = {0};     // Stores raw HEX values for ASCII chars
   uint8_t stateMachineClearSOH = 0xFF;
 

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -158,7 +158,7 @@ class NissanLeafBattery : public CanBattery {
                         .data = {0x02, 0x00, 0xff, 0x1d, 0x20, 0x00}};
   // Active polling messages
   //Ordered so the values that identify an unknown pack come out first. The three static groups
-  //(0x62 charge counters, 0x84 serial number, 0x83 part number) are read once and then skipped,
+  //(0x62 charge counters/histograms, 0x84 serial number, 0x83 part number) are read once and then skipped,
   //leaving 0x04/0x01/0x02/0x06/0x61 as the recurring rotation. Group 0x61 is the LBC's health
   //block and is the only reply that runs past 255 bytes, so its first frame carries PCI 0x11
   //rather than 0x10 - see the masked first-frame test in handle_incoming_can_frame().
@@ -336,6 +336,8 @@ class NissanLeafBattery : public CanBattery {
   //Set when a complete cell reply came back with no readable cell at all. Stands in for the 12 V
   //level on any pack that never reports one.
   bool battery_cells_unreadable = false;
+  //Set once the group 0x62 reply has arrived as far as its last usage histogram byte
+  bool battery_usage_histograms_read = false;
   uint16_t battery_insulation = 0;         //Insulation resistance
   uint16_t battery_charge_count_qc = 0;    //Lifetime number of quick (CHAdeMO) charges
   uint16_t battery_charge_count_l1l2 = 0;  //Lifetime number of L1/L2 (AC) charges

--- a/Software/src/battery/NISSAN-LEAF-BATTERY.h
+++ b/Software/src/battery/NISSAN-LEAF-BATTERY.h
@@ -326,12 +326,14 @@ class NissanLeafBattery : public CanBattery {
   void set_balancing_status(balancing_status_enum new_status);
   uint8_t battery_cellcounter = 0;
   uint16_t battery_min_max_voltage[2] = {0};  //contains cell min[0] and max[1] values in mV
-  uint16_t battery_HX_pptt = 0;               //Pack conductance estimate (Hx), in hundredths of a percent
-  //Hx and SOH as read from the health block (group 0x61), both in hundredths of a percent, 0 until
-  //that group has answered. Kept apart from the group 0x01 Hx so the health block always wins when
-  //it is available, rather than the two sources overwriting each other in polling order.
+  //Pack conductance estimate (Hx), in hundredths of a percent, 0 until read. Where it comes from
+  //depends on the generation, as the LBC history guide lays out: group 0x01 on ZE0/AZE0, the health
+  //block (group 0x61) on ZE1. Each ignores the other's source, so the two never compete.
+  uint16_t battery_HX_pptt = 0;
+  //SOH as read from the health block (group 0x61), in hundredths of a percent, 0 until that group
+  //has answered. Kept apart from the 0x5BC broadcast figure so the health block always wins when
+  //it is available.
   uint16_t battery_SOHraw_pptt = 0;  //Unfiltered SOH from the health block, 0 until read
-  uint16_t battery_HX_pptt_g61 = 0;
   uint16_t battery_SOH_pptt_g61 = 0;
   uint16_t battery_capacity_cAh = 0;  //Pack capacity in hundredths of an Ah, 0 until read
   uint32_t battery_capacity_Wh = 0;   //Energy equivalent of the above at nominal voltage, 0 until read
@@ -343,8 +345,8 @@ class NissanLeafBattery : public CanBattery {
   //Set when a complete cell reply came back with no readable cell at all. Stands in for the 12 V
   //level on any pack that never reports one.
   bool battery_cells_unreadable = false;
-  //Set once the group 0x62 reply has arrived as far as its last usage histogram byte
-  bool battery_usage_histograms_read = false;
+  //Set once the group 0x62 reply has arrived in full, down to its last frame
+  bool battery_usage_history_read = false;
   uint16_t battery_insulation = 0;         //Insulation resistance
   uint16_t battery_charge_count_qc = 0;    //Lifetime number of quick (CHAdeMO) charges
   uint16_t battery_charge_count_l1l2 = 0;  //Lifetime number of L1/L2 (AC) charges

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -83,6 +83,19 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
         "</h4>";
     content += "<h4>AC charge count: " +
                (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountL1L2) : String("Unknown")) + "</h4>";
+    //The usage tables from the rest of the same reply. They start at [0] on ZE0/AZE0 and at [2] on
+    //ZE1, whose extra counter ahead of them moves them along by one count.
+    const uint8_t* history = nissan_dl->UsageHistograms + ((nissan_dl->LEAF_gen == 2) ? 2 : 0);
+    //The last table is not a plain histogram: its top bin counts charges to 100 % and the one below
+    //it the times the pack was run down to turtle. Provisional, per the LBC history guide, and on
+    //ZE1 read from the matching table by its parallel with ZE0.
+    if (nissan_dl->ChargeCountL1L2) {
+      content += "<h4>Charge to full count: ";
+      content += (history[110] << 8) | history[111];
+      content += "</h4><h4>Turtle count: ";
+      content += (history[108] << 8) | history[109];
+      content += "</h4>";
+    }
     content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
     content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
     content += "<h4>+12V BAT level: " +
@@ -117,12 +130,10 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
                "</h4>";
     content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
 
-    //Lifetime usage histograms. They arrive in the same group 0x62 reply as the charge counts, so
-    //they are drawn once those are known. The page carries only the 48 counts; the browser draws
-    //the six charts from them in the cell monitor's bar style. ZE1 carries one more counter ahead
-    //of the tables, which moves them along by one count.
+    //Lifetime usage histograms, the first six of those tables. They are drawn once the charge
+    //counts are known; the page carries only the 48 counts, and the browser draws the six charts
+    //from them in the cell monitor's bar style.
     if (nissan_dl->ChargeCountL1L2) {
-      const uint8_t* bins = nissan_dl->UsageHistograms + ((nissan_dl->LEAF_gen == 2) ? 2 : 0);
       // The style and script below are MINIFIED to save flash. Edit the readable source here,
       // re-minify, and replace the literal.
       /*
@@ -173,7 +184,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
           "SOC'}</h4><div class=hb>${b}</div><div class=ha>${x}</div><p>n = "
           "${n}</p></div>`});document.currentScript.outerHTML=h+'</div>'})([";
       for (uint8_t i = 0; i < 96; i += 2) {
-        content += (bins[i] << 8) | bins[i + 1];
+        content += (history[i] << 8) | history[i + 1];
         content += ",";
       }
       content += "])</script>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -193,7 +193,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
                             : '&lt;' + f(1)}</span>`;
           });
           h += `<div><h4>${k & 1 ? 'Charge' : 'Drive'}` +
-               `${k < 4 ? ` temperature (${k < 2 ? 'peak' : 'start'})` : ' start SOC'}</h4>` +
+               `${k < 4 ? ` temperature (${k < 2 ? 'peak' : 'start'})` : ' start SOC'}:</h4>` +
                `<div class=hb>${b}</div><div class=ha>${x}</div><p>n = ${n}</p></div>`;
         });
         // Replace this script with the charts, so each battery's copy stays in its own section
@@ -208,7 +208,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
           "style=height:${c*100/m}%><b>${c||''}</b></"
           "div>`;x+=`<span>${i?f(i)+(i<7?'-'+f(i+1):'+&nbsp;'+(k<4?'&deg;C':'%')):'&lt;'+f(1)}</"
           "span>`});h+=`<div><h4>${k&1?'Charge':'Drive'}${k<4?` temperature (${k<2?'peak':'start'})`:' start "
-          "SOC'}</h4><div class=hb>${b}</div><div class=ha>${x}</div><p>n = "
+          "SOC'}:</h4><div class=hb>${b}</div><div class=ha>${x}</div><p>n = "
           "${n}</p></div>`});document.currentScript.outerHTML=h+'</div>'})([";
       for (uint8_t i = 0; i < 96; i += 2) {
         content += (history[i] << 8) | history[i + 1];

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -34,13 +34,16 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       .ha span { flex: 1 }                               bin labels under the bars
       .hb, .ha, .hg p { font-size: 12px }
       .hg p { margin: 0; text-align: right }             total under each chart
+      h3 { margin-top: 3px }                             panel titles, the only h3s on the page: as
+                                                         far below the top as content ends above the
+                                                         bottom, not the browser's ~19 px
     </style>
     */
     content +=
         "<style>.hg,.hb,.ha{display:flex}.hg{flex-wrap:wrap}.hg>*{flex:300px;margin:5px}.hb{align-items:flex-end;"
         "height:130px;padding-top:20px;border:1px solid #ccc}.hb div{flex:1;background:blue;border:1px solid "
         "#fff;position:relative}.hb b{position:absolute;bottom:100%;left:0;right:0}.ha span{flex:1}.hb,.ha,.hg "
-        "p{font-size:12px}.hg p{margin:0;text-align:right}</style>";
+        "p{font-size:12px}.hg p{margin:0;text-align:right}h3{margin-top:3px}</style>";
 
     //Identity, in the page's own first panel under the battery heading
     content += "<h4>LEAF generation: ";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -60,9 +60,9 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       default:
         content += String("Unknown</h4>");
     }
-    char readableSerialNumber[16];  // One extra space for null terminator
+    char readableSerialNumber[sizeof(nissan_dl->BatterySerialNumber) + 1];  // One extra space for null terminator
     memcpy(readableSerialNumber, nissan_dl->BatterySerialNumber, sizeof(nissan_dl->BatterySerialNumber));
-    readableSerialNumber[15] = '\0';  // Null terminate the string
+    readableSerialNumber[sizeof(nissan_dl->BatterySerialNumber)] = '\0';  // Null terminate the string
     content += "<h4>Serial number: " + String(readableSerialNumber) + "</h4>";
     char readableFirmware[6];  // One extra space for null terminator
     memcpy(readableFirmware, nissan_dl->BatteryPartNumber, 5);

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -19,6 +19,30 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       return content;
     }
 
+    //Styles shared by the two-column lists and the usage charts: rows that wrap, two 300 px columns
+    //side by side and one on a narrow screen, like the chart grid.
+    // MINIFIED to save flash. Edit the readable source here, re-minify, and replace the literal.
+    /*
+    <style>
+      .hg, .hb, .ha { display: flex }
+      .hg { flex-wrap: wrap }                            two columns, one on a narrow screen
+      .hg>* { flex: 300px; margin: 5px }                 a list entry or a chart, each
+      .hb { align-items: flex-end; height: 130px; padding-top: 20px;
+            border: 1px solid #ccc }                    bar area, as the cell monitor graph
+      .hb div { flex: 1; background: blue; border: 1px solid #fff; position: relative }
+      .hb b { position: absolute; bottom: 100%; left: 0; right: 0 }   count above its bar
+      .ha span { flex: 1 }                               bin labels under the bars
+      .hb, .ha, .hg p { font-size: 12px }
+      .hg p { margin: 0; text-align: right }             total under each chart
+    </style>
+    */
+    content +=
+        "<style>.hg,.hb,.ha{display:flex}.hg{flex-wrap:wrap}.hg>*{flex:300px;margin:5px}.hb{align-items:flex-end;"
+        "height:130px;padding-top:20px;border:1px solid #ccc}.hb div{flex:1;background:blue;border:1px solid "
+        "#fff;position:relative}.hb b{position:absolute;bottom:100%;left:0;right:0}.ha span{flex:1}.hb,.ha,.hg "
+        "p{font-size:12px}.hg p{margin:0;text-align:right}</style>";
+
+    //Identity, in the page's own first panel under the battery heading
     content += "<h4>LEAF generation: ";
     switch (nissan_dl->LEAF_gen) {
       case 0:
@@ -41,11 +65,35 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     memcpy(readableFirmware, nissan_dl->BatteryPartNumber, 5);
     readableFirmware[5] = '\0';  // Null terminate the string
     content += "<h4>Firmware: " + String(readableFirmware) + "</h4>";
+
+    new_panel(content, "Status");
+    content += "<div class=hg>";
+    content += "<h4>+12V BAT level: " +
+               (nissan_dl->VBAT_mV ? String(nissan_dl->VBAT_mV / 1000.0f, 2) + " V" : String("Unknown")) + "</h4>";
+    content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
+    content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
     content += "<h4>GIDS: " + String(nissan_dl->GIDS) + "</h4>";
-    content +=
-        "<h4>Hx: " +
-        (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
-        "</h4>";
+    content += "<h4>Temperature 1: " + String(nissan_dl->temperature1 / 10.0) + " &deg;C</h4>";
+    content += "<h4>Temperature 2: " + String(nissan_dl->temperature2 / 10.0) + " &deg;C</h4>";
+    if (nissan_dl->LEAF_gen == 0) {
+      content += "<h4>Temperature 3: " + String(nissan_dl->temperature3 / 10.0) + " &deg;C</h4>";
+    }
+    content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
+    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
+    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
+    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
+    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
+    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
+    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
+    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
+    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
+    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
+    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
+    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
+    content += "</div>";
+
+    new_panel(content, "Health and lifetime usage");
+    content += "<div class=hg>";
     //What the pack held when new, from the GID count the LBC reports at full charge. Constant per
     //pack size rather than something that tracks wear, which is what makes it the reference the
     //measured capacity below is judged against.
@@ -77,6 +125,10 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     } else {
       content += String("<h4>SOH raw: Unknown</h4>");
     }
+    content +=
+        "<h4>Hx: " +
+        (nissan_dl->battery_HX_pptt ? String(nissan_dl->battery_HX_pptt / 100.0f, 2) + " %" : String("Unknown")) +
+        "</h4>";
     //A used pack always has AC charges on it, so a zero L1/L2 count means the group was not read yet.
     content +=
         "<h4>QC charge count: " + (nissan_dl->ChargeCountL1L2 ? String(nissan_dl->ChargeCountQC) : String("Unknown")) +
@@ -96,59 +148,15 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       content += (history[108] << 8) | history[109];
       content += "</h4>";
     }
-    content += "<h4>Regen kW: " + String(nissan_dl->ChargePowerLimit) + "</h4>";
-    content += "<h4>Charge kW: " + String(nissan_dl->MaxPowerForCharger) + "</h4>";
-    content += "<h4>+12V BAT level: " +
-               (nissan_dl->VBAT_mV ? String(nissan_dl->VBAT_mV / 1000.0f, 2) + " V" : String("Unknown")) + "</h4>";
-    content += "<h4>Temperature 1: " + String(nissan_dl->temperature1 / 10.0) + " &deg;C</h4>";
-    content += "<h4>Temperature 2: " + String(nissan_dl->temperature2 / 10.0) + " &deg;C</h4>";
-    if (nissan_dl->LEAF_gen == 0) {
-      content += "<h4>Temperature 3: " + String(nissan_dl->temperature3 / 10.0) + " &deg;C</h4>";
-    }
-    content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
-    content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
-    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
-    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
-    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
-    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
-    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
-    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
-    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
-    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
-    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
-    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
-    //Both challenge values only ever get filled by the Reset degradation data sequence. Until that
-    //has run, incomingChallenge still holds its 0xFFFFFFFF default and the solved halves are zero,
-    //so say so rather than printing placeholder numbers that look like readings.
-    content += "<h4>CryptoChallenge: " +
-               (nissan_dl->CryptoChallenge != 0xFFFFFFFF ? String(nissan_dl->CryptoChallenge) : String("Not run")) +
-               "</h4>";
-    content += "<h4>SolvedChallenge: " +
-               ((nissan_dl->SolvedChallengeMSB || nissan_dl->SolvedChallengeLSB)
-                    ? String(nissan_dl->SolvedChallengeMSB) + "-" + String(nissan_dl->SolvedChallengeLSB)
-                    : String("Not run")) +
-               "</h4>";
-    content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
+    content += "</div>";
 
     //Lifetime usage histograms, the first six of those tables. They are drawn once the charge
     //counts are known; the page carries only the 48 counts, and the browser draws the six charts
     //from them in the cell monitor's bar style.
     if (nissan_dl->ChargeCountL1L2) {
-      // The style and script below are MINIFIED to save flash. Edit the readable source here,
+      // The script below is MINIFIED to save flash. Edit the readable source here,
       // re-minify, and replace the literal.
       /*
-      <style>
-        .hg, .hb, .ha { display: flex }
-        .hg { flex-wrap: wrap }                            two columns, one on a narrow screen
-        .hg>div { flex: 300px; margin: 5px }
-        .hb { align-items: flex-end; height: 130px; padding-top: 20px;
-              border: 1px solid #ccc }                    bar area, as the cell monitor graph
-        .hb div { flex: 1; background: blue; border: 1px solid #fff; position: relative }
-        .hb b { position: absolute; bottom: 100%; left: 0; right: 0 }   count above its bar
-        .ha span { flex: 1 }                               bin labels under the bars
-        .hb, .ha, .hg p { font-size: 12px }
-        .hg p { margin: 0; text-align: right }             total under each chart
-      </style>
       <script>
       (d => {  // 48 counts, 8 per table, in the LBC's table order (see UsageHistograms)
         let h = '<div class=hg>';
@@ -172,11 +180,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       </script>
       */
       content +=
-          "<style>.hg,.hb,.ha{display:flex}.hg{flex-wrap:wrap}.hg>div{flex:300px;margin:5px}.hb{align-items:flex-end;"
-          "height:130px;padding-top:20px;border:1px solid #ccc}.hb div{flex:1;background:blue;border:1px solid "
-          "#fff;position:relative}.hb b{position:absolute;bottom:100%;left:0;right:0}.ha span{flex:1}.hb,.ha,.hg "
-          "p{font-size:12px}.hg p{margin:0;text-align:right}</style><script>(d=>{let h='<div "
-          "class=hg>';[2,3,0,1,4,5].map((t,k)=>{let "
+          "<script>(d=>{let h='<div class=hg>';[2,3,0,1,4,5].map((t,k)=>{let "
           "f=j=>k<4?30+5*j:j<7?10*j+10:85,v=d.slice(t*8,t*8+8),m=Math.max(...v)||1,n=0,b='',x='';v.map((c,i)=>{n+=c;b+="
           "`<div "
           "style=height:${c*100/m}%><b>${c||''}</b></div>`;x+=`<span>${i?f(i)+(i<7?'-'+f(i+1):'+'):'&lt;'+f(1)}</"
@@ -190,14 +194,45 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
       content += "])</script>";
     }
 
-    if (battery_dl) {
-      content += render_dtc_section(battery_dl->dtc);
-    }
+    return content;
+  }
 
+  //The trouble codes, in a panel of their own after the status ones. The Read and Erase DTC
+  //buttons the page adds next land in the same panel.
+  String get_dtc_html() { return battery_dl ? render_dtc_section(battery_dl->dtc) : String(); }
+
+  //The degradation reset gets a panel of its own: the challenge values its sequence fills in, above
+  //the button that starts it.
+  String get_command_prefix_html(const char* identifier) {
+    String content;
+    if (nissan_dl && strcmp(identifier, "resetSOH") == 0) {
+      new_panel(content, "Reset degradation data");
+      //Both challenge values only ever get filled by the Reset degradation data sequence. Until that
+      //has run, incomingChallenge still holds its 0xFFFFFFFF default and the solved halves are zero,
+      //so say so rather than printing placeholder numbers that look like readings.
+      content += "<h4>CryptoChallenge: " +
+                 (nissan_dl->CryptoChallenge != 0xFFFFFFFF ? String(nissan_dl->CryptoChallenge) : String("Not run")) +
+                 "</h4>";
+      content += "<h4>SolvedChallenge: " +
+                 ((nissan_dl->SolvedChallengeMSB || nissan_dl->SolvedChallengeLSB)
+                      ? String(nissan_dl->SolvedChallengeMSB) + "-" + String(nissan_dl->SolvedChallengeLSB)
+                      : String("Not run")) +
+                 "</h4>";
+      content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
+    }
     return content;
   }
 
  private:
+  //The page streams all of this inside a battery-panel div of its own and closes the last one after
+  //the command buttons. Closing the current panel and opening the next is all it takes to split the
+  //Leaf's information into several, each under a title of its own.
+  static void new_panel(String& content, const char* title) {
+    content += "</div><div class='battery-panel'><h3>";
+    content += title;
+    content += "</h3>";
+  }
+
   // The LBC reports standard 3-byte DTCs, but Nissan service data, LeafSpy and nissan_leaf_dtc.json
   // all use the 5-character short form (P33D7, U1000) built from the first two bytes only. That is
   // therefore what goes into data-dtc-code for the JSON loader to match on. The third byte is the
@@ -207,9 +242,7 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     String content;
     content.reserve(3300 + dtc.dtc_count * 200);
 
-    content +=
-        "<h4 style='margin-top:20px;color:#27b06c;border-bottom:2px solid #27b06c;padding-bottom:5px;'>&#128295; "
-        "Diagnostic Trouble Codes</h4>";
+    new_panel(content, "Diagnostic Trouble Codes");
 
     if (dtc.dtc_last_read_millis == 0) {
       content += "<p style='color:#bbb;'>Not read yet &mdash; use the Read DTC button below to scan.</p>";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -171,7 +171,9 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
           v.map((c, i) => {
             n += c;
             b += `<div style=height:${c * 100 / m}%><b>${c || ''}</b></div>`;
-            x += `<span>${i ? f(i) + (i < 7 ? '-' + f(i + 1) : '+') : '&lt;' + f(1)}</span>`;
+            // The top bin carries the unit: 65+ degC or 85+ %, kept on one line by the no-break space
+            x += `<span>${i ? f(i) + (i < 7 ? '-' + f(i + 1) : '+&nbsp;' + (k < 4 ? '&deg;C' : '%'))
+                            : '&lt;' + f(1)}</span>`;
           });
           h += `<div><h4>${k & 1 ? 'Charge' : 'Drive'}` +
                `${k < 4 ? ` temperature (${k < 2 ? 'peak' : 'start'})` : ' start SOC'}</h4>` +
@@ -186,7 +188,8 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
           "<script>(d=>{let h='<div class=hg>';[2,3,0,1,4,5].map((t,k)=>{let "
           "f=j=>k<4?30+5*j:j<7?10*j+10:85,v=d.slice(t*8,t*8+8),m=Math.max(...v)||1,n=0,b='',x='';v.map((c,i)=>{n+=c;b+="
           "`<div "
-          "style=height:${c*100/m}%><b>${c||''}</b></div>`;x+=`<span>${i?f(i)+(i<7?'-'+f(i+1):'+'):'&lt;'+f(1)}</"
+          "style=height:${c*100/m}%><b>${c||''}</b></"
+          "div>`;x+=`<span>${i?f(i)+(i<7?'-'+f(i+1):'+&nbsp;'+(k<4?'&deg;C':'%')):'&lt;'+f(1)}</"
           "span>`});h+=`<div><h4>${k&1?'Charge':'Drive'}${k<4?` temperature (${k<2?'peak':'start'})`:' start "
           "SOC'}</h4><div class=hb>${b}</div><div class=ha>${x}</div><p>n = "
           "${n}</p></div>`});document.currentScript.outerHTML=h+'</div>'})([";

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -83,16 +83,19 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     }
     content += "<h4>Temperature 4: " + String(nissan_dl->temperature4 / 10.0) + " &deg;C</h4>";
     content += "<h4>Insulation: " + String(nissan_dl->Insulation) + " kΩ</h4>";
-    content += "<h4>Fully charged: " + String(nissan_dl->Full) + "</h4>";
-    content += "<h4>Battery empty: " + String(nissan_dl->Empty) + "</h4>";
-    content += "<h4>Failsafe status: " + String(nissan_dl->FailsafeStatus) + "</h4>";
-    content += "<h4>Interlock: " + String(nissan_dl->Interlock) + "</h4>";
-    content += "<h4>Main relay ON: " + String(nissan_dl->MainRelayOn) + "</h4>";
-    content += "<h4>Relay cut request: " + String(nissan_dl->RelayCutRequest) + "</h4>";
-    content += "<h4>Heater present: " + String(nissan_dl->HeatExist) + "</h4>";
-    content += "<h4>Heating requested: " + String(nissan_dl->HeaterSendRequest) + "</h4>";
-    content += "<h4>Heating started: " + String(nissan_dl->HeatingStart) + "</h4>";
-    content += "<h4>Heating stopped: " + String(nissan_dl->HeatingStop) + "</h4>";
+    //The flags from the LBC's status broadcasts, each unknown until the broadcast carrying it has
+    //arrived since boot (bit 0 0x1DB, bit 1 0x55B, bit 2 0x5C0, see StatusSeen)
+    const uint8_t seen = nissan_dl->StatusSeen;
+    status_row(content, "Fully charged", nissan_dl->Full, seen & 0x01);
+    status_row(content, "Battery empty", nissan_dl->Empty, seen & 0x02);
+    status_row(content, "Failsafe status", nissan_dl->FailsafeStatus, seen & 0x01, true);  //0-7
+    status_row(content, "Interlock", nissan_dl->Interlock, seen & 0x01);
+    status_row(content, "Main relay ON", nissan_dl->MainRelayOn, seen & 0x01);
+    status_row(content, "Relay cut request", nissan_dl->RelayCutRequest, seen & 0x01, true);  //0-3
+    status_row(content, "Heater present", nissan_dl->HeatExist, seen & 0x04);
+    status_row(content, "Heating requested", nissan_dl->HeaterSendRequest, seen & 0x04);
+    status_row(content, "Heating started", nissan_dl->HeatingStart, seen & 0x04);
+    status_row(content, "Heating stopped", nissan_dl->HeatingStop, seen & 0x04);
     content += "</div>";
 
     new_panel(content, "Health and lifetime usage");
@@ -230,6 +233,23 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
   }
 
  private:
+  //One status row, Unknown until the broadcast carrying it has arrived. A true/false flag shows as
+  //a tick or a cross; a wider field, like failsafe status (3 bits) or relay cut request (2 bits),
+  //shows as the number itself.
+  static void status_row(String& content, const char* label, uint8_t value, bool known, bool as_number = false) {
+    content += "<h4>";
+    content += label;
+    content += ": ";
+    if (!known) {
+      content += "Unknown";
+    } else if (as_number) {
+      content += (int)value;
+    } else {
+      content += value ? "&#10003;" : "&#10007;";
+    }
+    content += "</h4>";
+  }
+
   //The page streams all of this inside a battery-panel div of its own and closes the last one after
   //the command buttons. Closing the current panel and opening the next is all it takes to split the
   //Leaf's information into several, each under a title of its own.

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -110,6 +110,68 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
                "</h4>";
     content += "<h4>Challenge failed: " + String(nissan_dl->challengeFailed) + "</h4>";
 
+    //Lifetime usage histograms. They arrive in the same group 0x62 reply as the charge counts, so
+    //they are drawn once those are known. The page carries only the 48 counts; the browser draws
+    //the six charts from them in the cell monitor's bar style. ZE1 carries one more counter ahead
+    //of the tables, which moves them along by one count.
+    if (nissan_dl->ChargeCountL1L2) {
+      const uint8_t* bins = nissan_dl->UsageHistograms + ((nissan_dl->LEAF_gen == 2) ? 2 : 0);
+      // The style and script below are MINIFIED to save flash. Edit the readable source here,
+      // re-minify, and replace the literal.
+      /*
+      <style>
+        .hg, .hb, .ha { display: flex }
+        .hg { flex-wrap: wrap }                            two columns, one on a narrow screen
+        .hg>div { flex: 300px; margin: 5px }
+        .hb { align-items: flex-end; height: 130px; padding-top: 20px;
+              border: 1px solid #ccc }                    bar area, as the cell monitor graph
+        .hb div { flex: 1; background: blue; border: 1px solid #fff; position: relative }
+        .hb b { position: absolute; bottom: 100%; left: 0; right: 0 }   count above its bar
+        .ha span { flex: 1 }                               bin labels under the bars
+        .hb, .ha, .hg p { font-size: 12px }
+        .hg p { margin: 0; text-align: right }             total under each chart
+      </style>
+      <script>
+      (d => {  // 48 counts, 8 per table, in the LBC's table order (see UsageHistograms)
+        let h = '<div class=hg>';
+        // Peak temperatures first, then start temperatures, then SOC
+        [2, 3, 0, 1, 4, 5].map((t, k) => {
+          // Upper edge of bin j = 1..7: 35..65 degC in steps of 5, or SOC 20..70 % in steps of 10, then 85 %
+          let f = j => k < 4 ? 30 + 5 * j : j < 7 ? 10 * j + 10 : 85,
+              v = d.slice(t * 8, t * 8 + 8), m = Math.max(...v) || 1, n = 0, b = '', x = '';
+          v.map((c, i) => {
+            n += c;
+            b += `<div style=height:${c * 100 / m}%><b>${c || ''}</b></div>`;
+            x += `<span>${i ? f(i) + (i < 7 ? '-' + f(i + 1) : '+') : '&lt;' + f(1)}</span>`;
+          });
+          h += `<div><h4>${k & 1 ? 'Charge' : 'Drive'}` +
+               `${k < 4 ? ` temperature (${k < 2 ? 'peak' : 'start'})` : ' start SOC'}</h4>` +
+               `<div class=hb>${b}</div><div class=ha>${x}</div><p>n = ${n}</p></div>`;
+        });
+        // Replace this script with the charts, so each battery's copy stays in its own section
+        document.currentScript.outerHTML = h + '</div>';
+      })([...48 counts...]);
+      </script>
+      */
+      content +=
+          "<style>.hg,.hb,.ha{display:flex}.hg{flex-wrap:wrap}.hg>div{flex:300px;margin:5px}.hb{align-items:flex-end;"
+          "height:130px;padding-top:20px;border:1px solid #ccc}.hb div{flex:1;background:blue;border:1px solid "
+          "#fff;position:relative}.hb b{position:absolute;bottom:100%;left:0;right:0}.ha span{flex:1}.hb,.ha,.hg "
+          "p{font-size:12px}.hg p{margin:0;text-align:right}</style><script>(d=>{let h='<div "
+          "class=hg>';[2,3,0,1,4,5].map((t,k)=>{let "
+          "f=j=>k<4?30+5*j:j<7?10*j+10:85,v=d.slice(t*8,t*8+8),m=Math.max(...v)||1,n=0,b='',x='';v.map((c,i)=>{n+=c;b+="
+          "`<div "
+          "style=height:${c*100/m}%><b>${c||''}</b></div>`;x+=`<span>${i?f(i)+(i<7?'-'+f(i+1):'+'):'&lt;'+f(1)}</"
+          "span>`});h+=`<div><h4>${k&1?'Charge':'Drive'}${k<4?` temperature (${k<2?'peak':'start'})`:' start "
+          "SOC'}</h4><div class=hb>${b}</div><div class=ha>${x}</div><p>n = "
+          "${n}</p></div>`});document.currentScript.outerHTML=h+'</div>'})([";
+      for (uint8_t i = 0; i < 96; i += 2) {
+        content += (bins[i] << 8) | bins[i + 1];
+        content += ",";
+      }
+      content += "])</script>";
+    }
+
     if (battery_dl) {
       content += render_dtc_section(battery_dl->dtc);
     }

--- a/Software/src/battery/NISSAN-LEAF-HTML.h
+++ b/Software/src/battery/NISSAN-LEAF-HTML.h
@@ -88,14 +88,28 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
     const uint8_t seen = nissan_dl->StatusSeen;
     status_row(content, "Fully charged", nissan_dl->Full, seen & 0x01);
     status_row(content, "Battery empty", nissan_dl->Empty, seen & 0x02);
-    status_row(content, "Failsafe status", nissan_dl->FailsafeStatus, seen & 0x01, true);  //0-7
     status_row(content, "Interlock", nissan_dl->Interlock, seen & 0x01);
     status_row(content, "Main relay ON", nissan_dl->MainRelayOn, seen & 0x01);
-    status_row(content, "Relay cut request", nissan_dl->RelayCutRequest, seen & 0x01, true);  //0-3
     status_row(content, "Heater present", nissan_dl->HeatExist, seen & 0x04);
     status_row(content, "Heating requested", nissan_dl->HeaterSendRequest, seen & 0x04);
     status_row(content, "Heating started", nissan_dl->HeatingStart, seen & 0x04);
     status_row(content, "Heating stopped", nissan_dl->HeatingStop, seen & 0x04);
+    //The two wider fields of 0x1DB, named as in the Leaf CAN database (dalathegreat/leaf_can_bus_messages:
+    //LB_Failsafe_Status, LB_Relay_Cut_Request). Failsafe status is three request bits: bit 0 normal
+    //stop, which the driver reads as a discharge stop, bit 1 charging mode stop, bit 2 caution lamp.
+    //Every non-zero relay cut request is a main relay off request.
+    static const char* const failsafe_names[8] = {"Normal",
+                                                  "Discharge stop",
+                                                  "Charge stop",
+                                                  "Discharge + charge stop",
+                                                  "Caution lamp",
+                                                  "Caution lamp, discharge stop",
+                                                  "Caution lamp, charge stop",
+                                                  "Caution lamp, discharge + charge stop"};
+    status_row(content, "Failsafe status", nissan_dl->FailsafeStatus, seen & 0x01,
+               failsafe_names[nissan_dl->FailsafeStatus & 7]);
+    status_row(content, "Relay cut request", nissan_dl->RelayCutRequest, seen & 0x01,
+               nissan_dl->RelayCutRequest ? "Main relay off" : "None");
     content += "</div>";
 
     new_panel(content, "Health and lifetime usage");
@@ -234,18 +248,23 @@ class NissanLeafHtmlRenderer : public BatteryHtmlRenderer {
 
  private:
   //One status row, Unknown until the broadcast carrying it has arrived. A true/false flag shows as
-  //a tick or a cross; a wider field, like failsafe status (3 bits) or relay cut request (2 bits),
-  //shows as the number itself.
-  static void status_row(String& content, const char* label, uint8_t value, bool known, bool as_number = false) {
+  //a tick or a cross. A wider field is given the name of its state instead, shown with the raw
+  //value in brackets unless that is 0, so a reading can still be matched against a CAN log.
+  static void status_row(String& content, const char* label, uint8_t value, bool known, const char* name = nullptr) {
     content += "<h4>";
     content += label;
     content += ": ";
     if (!known) {
       content += "Unknown";
-    } else if (as_number) {
-      content += (int)value;
-    } else {
+    } else if (!name) {
       content += value ? "&#10003;" : "&#10007;";
+    } else {
+      content += name;
+      if (value) {
+        content += " (";
+        content += (int)value;
+        content += ")";
+      }
     }
     content += "</h4>";
   }

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -828,6 +828,10 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   bool HeatingStart;
   /** Heat request sent*/
   bool HeaterSendRequest;
+  /** Which of the LBC's status broadcasts have arrived since boot, as the flags above mean nothing
+   * until then: bit 0 0x1DB (relay cut request, failsafe status, main relay, full, interlock),
+   * bit 1 0x55B (empty), bit 2 0x5C0 (the four heater flags). */
+  uint8_t StatusSeen;
   /** True if the crypto challenge response from BMS is signalling a failed attempt*/
   bool challengeFailed;
 

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -834,12 +834,13 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** Battery info, stores raw HEX values for ASCII chars */
   uint8_t BatterySerialNumber[15];
   uint8_t BatteryPartNumber[7];
-  /** Lifetime usage histograms from group 0x62, stored as the raw reply bytes payload[6..103]:
-   * six tables of eight big-endian u16 counts. They start at [0] on ZE0/AZE0 and at [2] on ZE1,
-   * which carries one more counter ahead of them. Table order: temperature at drive start, at
-   * charge start, peak while driving, peak while charging, then SOC at drive start, at charge start.
+  /** Lifetime usage tables from group 0x62, stored as the raw reply bytes payload[6..124]: seven
+   * tables of eight big-endian u16 counts. They start at [0] on ZE0/AZE0 and at [2] on ZE1, which
+   * carries one more counter ahead of them. Table order: temperature at drive start, at charge
+   * start, peak while driving, peak while charging, then SOC at drive start, at charge start, and
+   * last the charge-to-full table, whose bin 7 counts charges to 100 % and bin 6 turtle events.
    */
-  uint8_t UsageHistograms[98];
+  uint8_t UsageHistograms[119];
 };
 
 struct DATALAYER_INFO_MEB {

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -835,8 +835,9 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** True if the crypto challenge response from BMS is signalling a failed attempt*/
   bool challengeFailed;
 
-  /** Battery info, stores raw HEX values for ASCII chars */
-  uint8_t BatterySerialNumber[15];
+  /** Battery info, stores raw HEX values for ASCII chars. The serial number is 16 characters, not
+   * null-terminated. */
+  uint8_t BatterySerialNumber[16];
   uint8_t BatteryPartNumber[7];
   /** Lifetime usage tables from group 0x62, stored as the raw reply bytes payload[6..124]: seven
    * tables of eight big-endian u16 counts. They start at [0] on ZE0/AZE0 and at [2] on ZE1, which

--- a/Software/src/datalayer/datalayer_extended.h
+++ b/Software/src/datalayer/datalayer_extended.h
@@ -829,6 +829,12 @@ struct DATALAYER_INFO_NISSAN_LEAF {
   /** Battery info, stores raw HEX values for ASCII chars */
   uint8_t BatterySerialNumber[15];
   uint8_t BatteryPartNumber[7];
+  /** Lifetime usage histograms from group 0x62, stored as the raw reply bytes payload[6..103]:
+   * six tables of eight big-endian u16 counts. They start at [0] on ZE0/AZE0 and at [2] on ZE1,
+   * which carries one more counter ahead of them. Table order: temperature at drive start, at
+   * charge start, peak while driving, peak while charging, then SOC at drive start, at charge start.
+   */
+  uint8_t UsageHistograms[98];
 };
 
 struct DATALAYER_INFO_MEB {

--- a/Software/src/devboard/webserver/BatteryHtmlRenderer.h
+++ b/Software/src/devboard/webserver/BatteryHtmlRenderer.h
@@ -16,6 +16,11 @@ class BatteryHtmlRenderer {
   // Optional diagnostics, rendered after the status buffer is released.
   // Empty means none unless html_render_failed() reports a failure.
   virtual String get_dtc_html() { return String(); }
+  // Optional HTML streamed just before the button of the given battery command (the identifier
+  // from battery_commands), for example to start a section of the page around that button. The
+  // page keeps the status, diagnostics and buttons inside one battery-panel div, so closing it and
+  // opening another is how a renderer splits its information into panels. Empty means nothing.
+  virtual String get_command_prefix_html(const char* identifier) { return String(); }
   // Reports failure of the most recent status or diagnostics render.
   virtual bool html_render_failed() const { return false; }
 

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -58,7 +58,7 @@ std::vector<BatteryCommand> battery_commands = {
      [](Battery* b) { return b && b->supports_contactor_close(); }, [](Battery* b) { b->request_close_contactors(); }},
     {"contactorOpen", "Open Contactors", "a contactor open request?",
      [](Battery* b) { return b && b->supports_contactor_close(); }, [](Battery* b) { b->request_open_contactors(); }},
-    {"resetSOH", "Reset degradation data", "reset degradation data?",
+    {"resetSOH", "Perform degradation reset", "reset degradation data?",
      [](Battery* b) { return b && b->supports_reset_SOH(); }, [](Battery* b) { b->reset_SOH(); }},
     {"setFactoryMode", "Set Factory Mode", "set factory mode and disable isolation measurement?",
      [](Battery* b) { return b && b->supports_factory_mode_method(); }, [](Battery* b) { b->set_factory_mode(); }},
@@ -223,7 +223,7 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
           while (!failed && command < battery_commands.size()) {
             const auto& cmd = battery_commands[command++];
             if (cmd.condition(batt)) {
-              section = command_html(cmd);
+              section = command_html(cmd, batt->get_status_renderer().get_command_prefix_html(cmd.identifier));
               if (section.isEmpty()) {
                 failed = true;
                 fragment = render_error;
@@ -245,9 +245,12 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
     }
   }
 
-  String command_html(const BatteryCommand& cmd) const {
+  // The renderer's prefix goes ahead of the button, in the same checked buffer, so a prefix that
+  // failed to build fails the page rather than silently leaving the button out of its section.
+  String command_html(const BatteryCommand& cmd, const String& prefix) const {
     CheckedHtml html;
-    html.reserve(1024);
+    html.reserve(1024 + prefix.length());
+    html += prefix;
     html += "<button onclick='ask" + String(cmd.identifier) + "(" + String(selected) + ")'>" + cmd.title +
             "</button><script>function ask" + cmd.identifier + "(batteryNum){";
     if (cmd.prompt) {

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -1129,3 +1129,19 @@ TEST(NissanLeafStatusFlagTests, ShouldShowTicksAndCrossesPerBroadcast) {
   EXPECT_NE(html.find("<h4>Heating started: &#10007;</h4>"), std::string::npos);
   EXPECT_NE(html.find("<h4>Heating stopped: &#10007;</h4>"), std::string::npos);
 }
+
+// The serial number is the 16 characters straight after the 61 84 header, starting in the first
+// frame. This is the capture the decoder's comment quotes.
+TEST(NissanLeafIdentityTests, ShouldReadWholeSerialNumber) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  auto battery = battery_polling();
+
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, 0x16, 0x61, 0x84, 0x32, 0x33, 0x30, 0x55}));
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x21, 0x4B, 0x31, 0x31, 0x39, 0x32, 0x45, 0x30}));
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x22, 0x30, 0x31, 0x34, 0x38, 0x32, 0x20, 0xA0}));
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+  battery->update_values();
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  EXPECT_NE(renderer.get_status_html().str().find("<h4>Serial number: 230UK1192E001482</h4>"), std::string::npos);
+}

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -1005,6 +1005,8 @@ TEST(NissanLeafPageLayoutTests, ShouldSplitStatusIntoPanels) {
                             "Temperature 4",
                             "Insulation",
                             "Heating stopped",
+                            "Failsafe status",
+                            "Relay cut request",
                             "</div><div class='battery-panel'><h3>Health and lifetime usage</h3>",
                             "Capacity as new",
                             "Actual capacity",
@@ -1081,7 +1083,7 @@ TEST(NissanLeafPageLayoutTests, ShouldBalanceItsPanels) {
 
 // The ten values from the status broadcasts are Unknown until the broadcast carrying them has
 // arrived since boot. After that the true/false flags show as a tick or a cross, and the two wider
-// fields, failsafe status and relay cut request, as their numbers.
+// fields, failsafe status and relay cut request, by the names of their states.
 TEST(NissanLeafStatusFlagTests, ShouldShowUnknownUntilBroadcastsArrive) {
   auto battery = battery_polling();
   battery->update_values();
@@ -1109,9 +1111,9 @@ TEST(NissanLeafStatusFlagTests, ShouldShowTicksAndCrossesPerBroadcast) {
   EXPECT_NE(html.find("<h4>Main relay ON: &#10003;</h4>"), std::string::npos);
   EXPECT_NE(html.find("<h4>Interlock: &#10003;</h4>"), std::string::npos);
   EXPECT_NE(html.find("<h4>Fully charged: &#10007;</h4>"), std::string::npos);
-  // The wider fields stay numbers, even at 0 or 1
-  EXPECT_NE(html.find("<h4>Relay cut request: 0</h4>"), std::string::npos);
-  EXPECT_NE(html.find("<h4>Failsafe status: 2</h4>"), std::string::npos);
+  // The wider fields by name, with the raw value unless it is 0
+  EXPECT_NE(html.find("<h4>Relay cut request: None</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Failsafe status: Charge stop (2)</h4>"), std::string::npos);
   // The other two broadcasts have not come yet
   EXPECT_NE(html.find("<h4>Battery empty: Unknown</h4>"), std::string::npos);
   EXPECT_NE(html.find("<h4>Heater present: Unknown</h4>"), std::string::npos);
@@ -1144,4 +1146,38 @@ TEST(NissanLeafIdentityTests, ShouldReadWholeSerialNumber) {
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
   EXPECT_NE(renderer.get_status_html().str().find("<h4>Serial number: 230UK1192E001482</h4>"), std::string::npos);
+}
+
+// Failsafe status is three request bits and relay cut request two, named as in the Leaf CAN
+// database. They come last in the status list, failsafe status first.
+TEST(NissanLeafStatusFlagTests, ShouldNameFailsafeAndRelayCutStates) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  auto& leaf = datalayer_extended.nissanleaf;
+  leaf.StatusSeen = 0x01;  //0x1DB has arrived
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &leaf);
+
+  const char* failsafe[] = {"Normal",
+                            "Discharge stop (1)",
+                            "Charge stop (2)",
+                            "Discharge + charge stop (3)",
+                            "Caution lamp (4)",
+                            "Caution lamp, discharge stop (5)",
+                            "Caution lamp, charge stop (6)",
+                            "Caution lamp, discharge + charge stop (7)"};
+  for (uint8_t value = 0; value < 8; value++) {
+    leaf.FailsafeStatus = value;
+    std::string row = std::string("<h4>Failsafe status: ") + failsafe[value] + "</h4>";
+    EXPECT_NE(renderer.get_status_html().str().find(row), std::string::npos) << (int)value;
+  }
+  const char* relay_cut[] = {"None", "Main relay off (1)", "Main relay off (2)", "Main relay off (3)"};
+  for (uint8_t value = 0; value < 4; value++) {
+    leaf.RelayCutRequest = value;
+    std::string row = std::string("<h4>Relay cut request: ") + relay_cut[value] + "</h4>";
+    EXPECT_NE(renderer.get_status_html().str().find(row), std::string::npos) << (int)value;
+  }
+
+  // Last in the status list, straight before it closes
+  std::string html = renderer.get_status_html().str();
+  EXPECT_NE(html.find("<h4>Heating stopped: Unknown</h4><h4>Failsafe status: "), std::string::npos);
+  EXPECT_NE(html.find("<h4>Relay cut request: Main relay off (3)</h4></div>"), std::string::npos);
 }

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -1078,3 +1078,54 @@ TEST(NissanLeafPageLayoutTests, ShouldBalanceItsPanels) {
   EXPECT_EQ(count("<div"), count("</div>"));
   EXPECT_LT(status.find("</div>"), status.find("<div"));
 }
+
+// The ten values from the status broadcasts are Unknown until the broadcast carrying them has
+// arrived since boot. After that the true/false flags show as a tick or a cross, and the two wider
+// fields, failsafe status and relay cut request, as their numbers.
+TEST(NissanLeafStatusFlagTests, ShouldShowUnknownUntilBroadcastsArrive) {
+  auto battery = battery_polling();
+  battery->update_values();
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string html = renderer.get_status_html().str();
+  for (const char* label :
+       {"Fully charged", "Battery empty", "Failsafe status", "Interlock", "Main relay ON", "Relay cut request",
+        "Heater present", "Heating requested", "Heating started", "Heating stopped"}) {
+    EXPECT_NE(html.find(std::string("<h4>") + label + ": Unknown</h4>"), std::string::npos) << label;
+  }
+}
+
+TEST(NissanLeafStatusFlagTests, ShouldShowTicksAndCrossesPerBroadcast) {
+  auto battery = battery_polling();
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+
+  // 0x1DB at 360 V: failsafe status 2 (charging mode stop request), no relay cut request, main
+  // relay permitted, not fully charged, interlock closed
+  CAN_frame status = leaf_frame(0x1DB, {0x00, 0x02, 0xB4, 0x28, 0x00, 0x00, 0x00, 0x00});
+  status.data.u8[7] = battery->calculate_crc(status);
+  battery->handle_incoming_can_frame(status);
+  battery->update_values();
+  std::string html = renderer.get_status_html().str();
+  EXPECT_NE(html.find("<h4>Main relay ON: &#10003;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Interlock: &#10003;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Fully charged: &#10007;</h4>"), std::string::npos);
+  // The wider fields stay numbers, even at 0 or 1
+  EXPECT_NE(html.find("<h4>Relay cut request: 0</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Failsafe status: 2</h4>"), std::string::npos);
+  // The other two broadcasts have not come yet
+  EXPECT_NE(html.find("<h4>Battery empty: Unknown</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Heater present: Unknown</h4>"), std::string::npos);
+
+  // 0x55B, not empty, and 0x5C0 with a heater present and idle
+  CAN_frame soc = leaf_frame(0x55B, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+  soc.data.u8[7] = battery->calculate_crc(soc);
+  battery->handle_incoming_can_frame(soc);
+  battery->handle_incoming_can_frame(leaf_frame(0x5C0, {0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}));
+  battery->update_values();
+  html = renderer.get_status_html().str();
+  EXPECT_NE(html.find("<h4>Battery empty: &#10007;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Heater present: &#10003;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Heating requested: &#10007;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Heating started: &#10007;</h4>"), std::string::npos);
+  EXPECT_NE(html.find("<h4>Heating stopped: &#10007;</h4>"), std::string::npos);
+}

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -172,12 +172,29 @@ uint8_t next_polled_group(NissanLeafBattery* battery, unsigned long& t) {
   return 0;
 }
 
+// A polling battery that has seen a ZE1-only broadcast, so it decodes as a ZE1.
+NissanLeafBattery* ze1_battery_polling() {
+  auto battery = battery_polling();
+  battery->handle_incoming_can_frame(leaf_frame(0x5EB, {0, 0, 0, 0, 0, 0, 0, 0}));
+  return battery;
+}
+
+// Feeds a group 0x01 reply of the given layout up to its fifth frame, which carries payload[27..33].
+void feed_group01_to_fifth_frame(NissanLeafBattery* battery, uint8_t layout_length,
+                                 std::initializer_list<uint8_t> fifth_frame) {
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x10, layout_length, 0x61, 0x01, 0x00, 0x00, 0x00, 0x00}));
+  for (uint8_t frame = 0x21; frame <= 0x23; frame++) {
+    battery->handle_incoming_can_frame(leaf_7bb_frame({frame, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+  }
+  battery->handle_incoming_can_frame(leaf_7bb_frame(fifth_frame));
+}
+
 }  // namespace
 
 // The health block is the only group reply longer than 255 bytes, so its first frame announces
 // itself as 1L LL. An equality test against 0x10 would never latch the group at all.
 TEST(NissanLeafHealthTests, ShouldDecodeHealthBlockFromLongFirstFrame) {
-  auto battery = battery_polling();
+  auto battery = ze1_battery_polling();  //The block's Hx is read on ZE1
 
   // 11 4B 61 61 | Hx 0x2AF8 = 110.00 % | SOH 0x2710 = 100.00 %
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
@@ -193,7 +210,7 @@ TEST(NissanLeafHealthTests, ShouldDecodeHealthBlockFromLongFirstFrame) {
 // The LBC's PID 0x61 handler writes BarCount_SOH, SOH_raw, SOH_Internal and two status bits
 // straight after Hx and SOH, so they land in the second frame of the reply.
 TEST(NissanLeafHealthTests, ShouldDecodeTrailingHealthBlockFields) {
-  auto battery = battery_polling();
+  auto battery = ze1_battery_polling();  //The block's Hx is read on ZE1
 
   // 11 4B 61 61 | Hx 0x2AF8 | SOH 0x2710
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
@@ -222,13 +239,41 @@ TEST(NissanLeafHealthTests, ShouldDecodeResetPackHealthBlock) {
 
 // Hx above 100 % is a normal reading on a healthy pack and must survive intact.
 TEST(NissanLeafHealthTests, ShouldNotClampHxAboveOneHundredPercent) {
-  auto battery = battery_polling();
+  auto battery = ze1_battery_polling();  //The block's Hx is read on ZE1
 
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x30, 0xD4, 0x25, 0x8A}));
   battery->update_values();
 
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 12500u);     // 0x30D4
   EXPECT_EQ(datalayer_extended.nissanleaf.battery_SOHavg_pptt, 9610u);  // 0x258A
+}
+
+// Hx comes from one place per generation, as the LBC history guide lays out: group 0x01 on ZE0/AZE0,
+// the health block on ZE1, both in hundredths of a percent. Neither takes the other's.
+TEST(NissanLeafHealthTests, ShouldReadZe0HxFromGroup01Only) {
+  auto battery = battery_polling();
+
+  // AZE0 layout; the fifth frame carries payload[27..33], with Hx 0x2328 at payload[28..29]
+  feed_group01_to_fifth_frame(battery, 0x2B, {0x24, 0x00, 0x23, 0x28, 0x00, 0x00, 0x00, 0x00});
+  // A health block with an Hx of its own, which ZE0/AZE0 leave alone
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 9000u);  // 90.00 %
+}
+
+TEST(NissanLeafHealthTests, ShouldReadZe1HxFromHealthBlockOnly) {
+  auto battery = ze1_battery_polling();
+
+  // ZE1 layout: nothing in its group 0x01 reply is read as Hx
+  feed_group01_to_fifth_frame(battery, 0x35, {0x24, 0x00, 0x23, 0x28, 0x2A, 0xF8, 0x00, 0x00});
+  battery->update_values();
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 0u);
+
+  // The guide's ZE1 capture, 61 61 2A F8: 11000, i.e. 110.00 %, with no divide by 1024
+  battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
+  battery->update_values();
+  EXPECT_EQ(datalayer_extended.nissanleaf.battery_HX_pptt, 11000u);
 }
 
 // Feeds a group 0x01 reply far enough to deliver the pack capacity, which sits in the sixth frame
@@ -367,7 +412,7 @@ TEST(NissanLeafHealthTests, ShouldPreferPolledStateOfHealthOverBroadcast) {
 // previously latched group decoding it, which for cell voltages means writing garbage into
 // the array.
 TEST(NissanLeafHealthTests, ShouldIgnoreNegativeResponse) {
-  auto battery = battery_polling();
+  auto battery = ze1_battery_polling();  //The block's Hx is read on ZE1
 
   battery->handle_incoming_can_frame(leaf_7bb_frame({0x11, 0x4B, 0x61, 0x61, 0x2A, 0xF8, 0x27, 0x10}));
   battery->update_values();
@@ -874,6 +919,9 @@ TEST(NissanLeafUsageHistogramTests, ShouldPublishHistogramsFromAze0Reply) {
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
   std::string html = renderer.get_status_html().str();
   EXPECT_NE(html.find(charted_histogram_counts()), std::string::npos);
+  // The last table's bins 7 and 6, straight under the AC charge count
+  EXPECT_NE(html.find("AC charge count: 2048</h4><h4>Charge to full count: 707</h4><h4>Turtle count: 706</h4>"),
+            std::string::npos);
   // The charts go above the DTC section
   ASSERT_NE(html.find("<style>.hg"), std::string::npos);
   EXPECT_LT(html.find("<style>.hg"), html.find("Diagnostic Trouble Codes"));
@@ -896,7 +944,11 @@ TEST(NissanLeafUsageHistogramTests, ShouldApplyZe1TableOffset) {
   EXPECT_EQ(datalayer_extended.nissanleaf.ChargeCountL1L2, 366u);
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
-  EXPECT_NE(renderer.get_status_html().str().find(charted_histogram_counts()), std::string::npos);
+  std::string html = renderer.get_status_html().str();
+  EXPECT_NE(html.find(charted_histogram_counts()), std::string::npos);
+  // ZE1's last table sits in the reply's seventeenth frame, past where the ZE0/AZE0 reply ends
+  EXPECT_NE(html.find("AC charge count: 366</h4><h4>Charge to full count: 707</h4><h4>Turtle count: 706</h4>"),
+            std::string::npos);
 }
 
 // Until group 0x62 has answered there is nothing to draw, so the charts are left out altogether.
@@ -904,15 +956,19 @@ TEST(NissanLeafUsageHistogramTests, ShouldNotDrawChartsBeforeGroupIsRead) {
   datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
-  EXPECT_EQ(renderer.get_status_html().str().find("<style>.hg"), std::string::npos);
+  std::string html = renderer.get_status_html().str();
+  EXPECT_EQ(html.find("<style>.hg"), std::string::npos);
+  EXPECT_EQ(html.find("Charge to full count"), std::string::npos);
 }
 
-// The counters are all in the first frame, so they do not show that the histograms arrived. A reply
-// cut short keeps the group in the rotation, while a complete one takes it out as before. Nothing
-// here depends on where 0x62 sits in PIDgroups.
+// The counters are all in the first frame, so they do not show that the rest arrived. A reply cut
+// short, in the histograms or in the charge-to-full table after them, keeps the group in the
+// rotation; a complete one takes it out as before. Nothing here depends on where 0x62 sits in
+// PIDgroups.
 TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
   const size_t rotation = 8;  //Entries in PIDgroups, so the most one pass can take
-  for (bool complete : {false, true}) {
+  for (size_t frames : {(size_t)5, (size_t)15, SIZE_MAX}) {
+    const bool complete = (frames == SIZE_MAX);
     datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
     auto battery = battery_polling();
     unsigned long t = 50000;
@@ -921,7 +977,7 @@ TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
     while (next_polled_group(battery, t) != 0x62) {
       ASSERT_LT(++polls, rotation) << "group 0x62 never asked for";
     }
-    feed_group_reply(battery, usage_history_reply({0x0800, 0x015A}), complete ? SIZE_MAX : 5);
+    feed_group_reply(battery, usage_history_reply({0x0800, 0x015A}), frames);
 
     // No other group gets an answer, so none of them drop out: a full pass follows, and it
     // includes 0x62 only if its reply is still owed
@@ -929,6 +985,6 @@ TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
     for (size_t i = 0; i < rotation; i++) {
       asked_again |= (next_polled_group(battery, t) == 0x62);
     }
-    EXPECT_EQ(asked_again, !complete) << (complete ? "complete" : "cut short");
+    EXPECT_EQ(asked_again, !complete) << "consecutive frames fed: " << (complete ? 16 : frames);
   }
 }

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -844,7 +844,7 @@ TEST(NissanLeafDtcTests, ShouldDrainReplyLargerThanStorage) {
   EXPECT_EQ(datalayer.battery.dtc.dtc_reported_count, 149);
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
-  EXPECT_NE(renderer.get_status_html().str().find("32 codes shown of 149 reported"), std::string::npos);
+  EXPECT_NE(renderer.get_dtc_html().str().find("32 codes shown of 149 reported"), std::string::npos);
 }
 
 // When everything fits, the page must not clutter the line with a redundant "of N reported".
@@ -857,7 +857,7 @@ TEST(NissanLeafDtcTests, ShouldNotClaimTruncationWhenEverythingFits) {
   EXPECT_EQ(datalayer.battery.dtc.dtc_reported_count, 1);
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
-  EXPECT_EQ(renderer.get_status_html().str().find("reported"), std::string::npos);
+  EXPECT_EQ(renderer.get_dtc_html().str().find("reported"), std::string::npos);
 }
 
 // nissan_leaf_dtc.json is keyed by the 5-character short form, so that is what has to end up in the
@@ -874,7 +874,7 @@ TEST(NissanLeafDtcTests, ShouldRenderShortNissanCodeAsLookupKey) {
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
-  std::string html = renderer.get_status_html().str();
+  std::string html = renderer.get_dtc_html().str();
 
   EXPECT_NE(html.find("data-dtc-code='P33D7'"), std::string::npos);
   EXPECT_NE(html.find("data-dtc-code='U1000'"), std::string::npos);
@@ -889,16 +889,16 @@ TEST(NissanLeafDtcTests, ShouldRenderReadStateWhenNoTableIsShown) {
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
 
   reset_dtc_state();  // Never read
-  EXPECT_NE(renderer.get_status_html().str().find("Not read yet"), std::string::npos);
+  EXPECT_NE(renderer.get_dtc_html().str().find("Not read yet"), std::string::npos);
 
   reset_dtc_state();
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
   datalayer.battery.dtc.dtc_read_failed = true;
-  EXPECT_NE(renderer.get_status_html().str().find("failed or timed out"), std::string::npos);
+  EXPECT_NE(renderer.get_dtc_html().str().find("failed or timed out"), std::string::npos);
 
   reset_dtc_state();
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
-  EXPECT_NE(renderer.get_status_html().str().find("No DTCs present"), std::string::npos);
+  EXPECT_NE(renderer.get_dtc_html().str().find("No DTCs present"), std::string::npos);
 }
 
 // Group 0x62 carries the lifetime usage histograms after its charge counters. On ZE0/AZE0 the tables
@@ -922,9 +922,9 @@ TEST(NissanLeafUsageHistogramTests, ShouldPublishHistogramsFromAze0Reply) {
   // The last table's bins 7 and 6, straight under the AC charge count
   EXPECT_NE(html.find("AC charge count: 2048</h4><h4>Charge to full count: 707</h4><h4>Turtle count: 706</h4>"),
             std::string::npos);
-  // The charts go above the DTC section
-  ASSERT_NE(html.find("<style>.hg"), std::string::npos);
-  EXPECT_LT(html.find("<style>.hg"), html.find("Diagnostic Trouble Codes"));
+  // The charts go in the health and lifetime usage panel, after its list
+  ASSERT_NE(html.find("<script>(d=>"), std::string::npos);
+  EXPECT_LT(html.find("<h3>Health and lifetime usage</h3>"), html.find("<script>(d=>"));
 }
 
 // ZE1 has a third counter ahead of the tables, which moves them along by one count. The generation
@@ -957,7 +957,7 @@ TEST(NissanLeafUsageHistogramTests, ShouldNotDrawChartsBeforeGroupIsRead) {
 
   NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
   std::string html = renderer.get_status_html().str();
-  EXPECT_EQ(html.find("<style>.hg"), std::string::npos);
+  EXPECT_EQ(html.find("<script>(d=>"), std::string::npos);
   EXPECT_EQ(html.find("Charge to full count"), std::string::npos);
 }
 
@@ -987,4 +987,94 @@ TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
     }
     EXPECT_EQ(asked_again, !complete) << "consecutive frames fed: " << (complete ? 16 : frames);
   }
+}
+
+// The page streams the status, diagnostics and buttons inside one panel of its own. The Leaf closes
+// it and opens the next to split its information into panels: identity under the page's battery
+// heading, then Status, Health and lifetime usage, the trouble codes and the degradation reset.
+TEST(NissanLeafPageLayoutTests, ShouldSplitStatusIntoPanels) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string html = renderer.get_status_html().str();
+
+  const char* in_order[] = {"LEAF generation",
+                            "Firmware",
+                            "</div><div class='battery-panel'><h3>Status</h3>",
+                            "+12V BAT level",
+                            "GIDS",
+                            "Temperature 4",
+                            "Insulation",
+                            "Heating stopped",
+                            "</div><div class='battery-panel'><h3>Health and lifetime usage</h3>",
+                            "Capacity as new",
+                            "Actual capacity",
+                            "SOH raw",
+                            "Hx:",
+                            "QC charge count",
+                            "AC charge count"};
+  size_t last = 0;
+  for (const char* part : in_order) {
+    size_t at = html.find(part);
+    ASSERT_NE(at, std::string::npos) << part;
+    EXPECT_GE(at, last) << part;
+    last = at;
+  }
+  // Those go in panels of their own, from the other hooks
+  EXPECT_EQ(html.find("Diagnostic Trouble Codes"), std::string::npos);
+  EXPECT_EQ(html.find("CryptoChallenge"), std::string::npos);
+}
+
+// The two lists are rows that wrap, like the chart grid: two columns, one on a narrow screen.
+TEST(NissanLeafPageLayoutTests, ShouldListStatusAndHealthInWrappingColumns) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string html = renderer.get_status_html().str();
+
+  EXPECT_NE(html.find(".hg>*{flex:300px;margin:5px}"), std::string::npos);
+  EXPECT_NE(html.find("<h3>Status</h3><div class=hg><h4>+12V BAT level"), std::string::npos);
+  EXPECT_NE(html.find("<h3>Health and lifetime usage</h3><div class=hg><h4>Capacity as new"), std::string::npos);
+}
+
+// The trouble codes open their own panel, under the page's title style rather than their own.
+TEST(NissanLeafPageLayoutTests, ShouldPutTroubleCodesInTheirOwnPanel) {
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string html = renderer.get_dtc_html().str();
+
+  EXPECT_EQ(html.find("</div><div class='battery-panel'><h3>Diagnostic Trouble Codes</h3>"), 0u);
+  EXPECT_EQ(html.find("&#128295;"), std::string::npos);
+}
+
+// The degradation reset opens the last panel just before its button, with the challenge values
+// above it. No other command gets anything in front of its button.
+TEST(NissanLeafPageLayoutTests, ShouldOpenDegradationResetPanelBeforeItsButton) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  datalayer_extended.nissanleaf.CryptoChallenge = 0xFFFFFFFF;
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+
+  std::string html = renderer.get_command_prefix_html("resetSOH").str();
+  EXPECT_EQ(html.find("</div><div class='battery-panel'><h3>Reset degradation data</h3>"), 0u);
+  EXPECT_LT(html.find("CryptoChallenge: Not run"), html.find("SolvedChallenge: Not run"));
+  EXPECT_LT(html.find("SolvedChallenge: Not run"), html.find("Challenge failed: 0"));
+
+  EXPECT_TRUE(renderer.get_command_prefix_html("readDTC").str().empty());
+  EXPECT_TRUE(renderer.get_command_prefix_html("resetDTC").str().empty());
+}
+
+// Every panel the Leaf opens is closed again: the first close is the page's own panel, and the page
+// closes the last one after the buttons.
+TEST(NissanLeafPageLayoutTests, ShouldBalanceItsPanels) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string status = renderer.get_status_html().str();
+  std::string all = status + renderer.get_dtc_html().str() + renderer.get_command_prefix_html("resetSOH").str();
+
+  auto count = [&all](const std::string& tag) {
+    size_t n = 0;
+    for (size_t at = all.find(tag); at != std::string::npos; at = all.find(tag, at + 1)) {
+      n++;
+    }
+    return n;
+  };
+  EXPECT_EQ(count("<div"), count("</div>"));
+  EXPECT_LT(status.find("</div>"), status.find("<div"));
 }

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -9,6 +9,10 @@
 #include "../../Software/src/devboard/utils/events.h"
 #include "Arduino.h"
 
+// Recorder for everything the emulated CAN interface transmits (test/emul/can.cpp).
+void clear_transmitted_frames();
+const std::vector<CAN_frame>& get_transmitted_frames();
+
 namespace {
 
 // Builds a frame on the given ID from up to 8 raw bytes.
@@ -93,6 +97,79 @@ void feed_cell_voltage_reply(NissanLeafBattery* battery, const uint16_t (&cells)
     offset += 7;
     sequence++;
   }
+}
+
+// Feeds a group reply framed the way the LBC sends it: the first frame carries payload[0..5], the
+// 0x61 service byte first, then each consecutive frame seven more bytes, padded with 0xFF. A reply
+// cut short is modelled by stopping after the given number of consecutive frames.
+void feed_group_reply(NissanLeafBattery* battery, const std::vector<uint8_t>& payload,
+                      size_t consecutive_frames = SIZE_MAX) {
+  CAN_frame first = leaf_7bb_frame({});
+  first.data.u8[0] = (uint8_t)(0x10 | ((payload.size() >> 8) & 0x0F));
+  first.data.u8[1] = (uint8_t)(payload.size() & 0xFF);
+  for (size_t i = 0; i < 6; i++) {
+    first.data.u8[2 + i] = payload[i];
+  }
+  battery->handle_incoming_can_frame(first);
+
+  size_t offset = 6;
+  for (size_t frame = 1; offset < payload.size() && frame <= consecutive_frames; frame++) {
+    CAN_frame consecutive = leaf_7bb_frame({});
+    consecutive.data.u8[0] = (uint8_t)(0x20 | (frame & 0x0F));
+    for (size_t i = 0; i < 7; i++) {
+      consecutive.data.u8[1 + i] = (offset + i < payload.size()) ? payload[offset + i] : 0xFF;
+    }
+    battery->handle_incoming_can_frame(consecutive);
+    offset += 7;
+  }
+}
+
+// Value of bin b in table t of the replies below. Distinct everywhere, and most need both bytes.
+uint16_t histogram_count(uint8_t table, uint8_t bin) {
+  return (uint16_t)((table + 1) * 100 + bin);
+}
+
+// A group 0x62 reply: the counters that head it, then seven tables of eight big-endian counts.
+std::vector<uint8_t> usage_history_reply(std::initializer_list<uint16_t> counters) {
+  std::vector<uint8_t> payload = {0x61, 0x62};
+  for (uint16_t counter : counters) {
+    payload.push_back((uint8_t)(counter >> 8));
+    payload.push_back((uint8_t)(counter & 0xFF));
+  }
+  for (uint8_t table = 0; table < 7; table++) {
+    for (uint8_t bin = 0; bin < 8; bin++) {
+      payload.push_back((uint8_t)(histogram_count(table, bin) >> 8));
+      payload.push_back((uint8_t)(histogram_count(table, bin) & 0xFF));
+    }
+  }
+  return payload;
+}
+
+// The counts of the six charted tables as the page hands them to its script, in LBC table order.
+std::string charted_histogram_counts() {
+  std::string counts = "([";
+  for (uint8_t table = 0; table < 6; table++) {
+    for (uint8_t bin = 0; bin < 8; bin++) {
+      counts += std::to_string(histogram_count(table, bin)) + ",";
+    }
+  }
+  return counts + "])";
+}
+
+// Ticks the scheduler until the next group request goes out, and returns the group it asks for.
+uint8_t next_polled_group(NissanLeafBattery* battery, unsigned long& t) {
+  for (int i = 0; i < 30; i++) {
+    t += 1000;
+    set_millis64(t);
+    clear_transmitted_frames();
+    battery->transmit_can(t);
+    for (const CAN_frame& frame : get_transmitted_frames()) {
+      if (frame.ID == 0x79B && frame.data.u8[0] == 0x02 && frame.data.u8[1] == 0x21) {
+        return frame.data.u8[2];
+      }
+    }
+  }
+  return 0;
 }
 
 }  // namespace
@@ -680,4 +757,74 @@ TEST(NissanLeafDtcTests, ShouldRenderReadStateWhenNoTableIsShown) {
   reset_dtc_state();
   datalayer.battery.dtc.dtc_last_read_millis = 50000;
   EXPECT_NE(renderer.get_status_html().str().find("No DTCs present"), std::string::npos);
+}
+
+// Group 0x62 carries the lifetime usage histograms after its charge counters. On ZE0/AZE0 the tables
+// follow the two counters directly, and the page hands their counts to its script in table order.
+TEST(NissanLeafUsageHistogramTests, ShouldPublishHistogramsFromAze0Reply) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  auto battery = battery_polling();
+
+  // 10 76 61 62 | AC 0x0800 | QC 0x015A, the counters of the capture this group was decoded from
+  std::vector<uint8_t> reply = usage_history_reply({0x0800, 0x015A});
+  ASSERT_EQ(reply.size(), 0x76u);
+  feed_group_reply(battery, reply);
+  battery->update_values();
+
+  EXPECT_EQ(datalayer_extended.nissanleaf.ChargeCountL1L2, 0x0800u);
+  EXPECT_EQ(datalayer_extended.nissanleaf.ChargeCountQC, 0x015Au);
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  std::string html = renderer.get_status_html().str();
+  EXPECT_NE(html.find(charted_histogram_counts()), std::string::npos);
+  // The charts go above the DTC section
+  ASSERT_NE(html.find("<style>.hg"), std::string::npos);
+  EXPECT_LT(html.find("<style>.hg"), html.find("Diagnostic Trouble Codes"));
+}
+
+// ZE1 has a third counter ahead of the tables, which moves them along by one count. The generation
+// is applied when the page is drawn, so it does not matter whether it was known when the reply came.
+TEST(NissanLeafUsageHistogramTests, ShouldApplyZe1TableOffset) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+  auto battery = battery_polling();
+
+  // Counts A, B and C of a ZE1 capture: 61 62 01 6E 00 01 00 01
+  std::vector<uint8_t> reply = usage_history_reply({0x016E, 0x0001, 0x0001});
+  ASSERT_EQ(reply.size(), 0x78u);
+  feed_group_reply(battery, reply);
+  battery->handle_incoming_can_frame(leaf_frame(0x5EB, {0, 0, 0, 0, 0, 0, 0, 0}));  //ZE1-only broadcast
+  battery->update_values();
+
+  ASSERT_EQ(datalayer_extended.nissanleaf.LEAF_gen, 2);
+  EXPECT_EQ(datalayer_extended.nissanleaf.ChargeCountL1L2, 366u);
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  EXPECT_NE(renderer.get_status_html().str().find(charted_histogram_counts()), std::string::npos);
+}
+
+// Until group 0x62 has answered there is nothing to draw, so the charts are left out altogether.
+TEST(NissanLeafUsageHistogramTests, ShouldNotDrawChartsBeforeGroupIsRead) {
+  datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+
+  NissanLeafHtmlRenderer renderer(&datalayer.battery, &datalayer_extended.nissanleaf);
+  EXPECT_EQ(renderer.get_status_html().str().find("<style>.hg"), std::string::npos);
+}
+
+// The counters are all in the first frame, so they do not show that the histograms arrived. A reply
+// cut short keeps the group in the rotation, while a complete one takes it out as before.
+TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
+  for (bool complete : {false, true}) {
+    datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
+    auto battery = battery_polling();
+    unsigned long t = 50000;
+
+    ASSERT_EQ(next_polled_group(battery, t), 0x62);
+    feed_group_reply(battery, usage_history_reply({0x0800, 0x015A}), complete ? SIZE_MAX : 5);
+
+    // The rest of the first pass. None of these get an answer, so none drop out.
+    for (uint8_t group : {0x84, 0x04, 0x01, 0x02, 0x06, 0x61, 0x83}) {
+      ASSERT_EQ(next_polled_group(battery, t), group);
+    }
+    EXPECT_EQ(next_polled_group(battery, t), complete ? 0x84 : 0x62) << (complete ? "complete" : "cut short");
+  }
 }

--- a/test/battery/NissanLeafTest.cpp
+++ b/test/battery/NissanLeafTest.cpp
@@ -908,20 +908,27 @@ TEST(NissanLeafUsageHistogramTests, ShouldNotDrawChartsBeforeGroupIsRead) {
 }
 
 // The counters are all in the first frame, so they do not show that the histograms arrived. A reply
-// cut short keeps the group in the rotation, while a complete one takes it out as before.
+// cut short keeps the group in the rotation, while a complete one takes it out as before. Nothing
+// here depends on where 0x62 sits in PIDgroups.
 TEST(NissanLeafUsageHistogramTests, ShouldPollGroupAgainAfterTruncatedReply) {
+  const size_t rotation = 8;  //Entries in PIDgroups, so the most one pass can take
   for (bool complete : {false, true}) {
     datalayer_extended.nissanleaf = DATALAYER_INFO_NISSAN_LEAF{};
     auto battery = battery_polling();
     unsigned long t = 50000;
 
-    ASSERT_EQ(next_polled_group(battery, t), 0x62);
+    size_t polls = 0;
+    while (next_polled_group(battery, t) != 0x62) {
+      ASSERT_LT(++polls, rotation) << "group 0x62 never asked for";
+    }
     feed_group_reply(battery, usage_history_reply({0x0800, 0x015A}), complete ? SIZE_MAX : 5);
 
-    // The rest of the first pass. None of these get an answer, so none drop out.
-    for (uint8_t group : {0x84, 0x04, 0x01, 0x02, 0x06, 0x61, 0x83}) {
-      ASSERT_EQ(next_polled_group(battery, t), group);
+    // No other group gets an answer, so none of them drop out: a full pass follows, and it
+    // includes 0x62 only if its reply is still owed
+    bool asked_again = false;
+    for (size_t i = 0; i < rotation; i++) {
+      asked_again |= (next_polled_group(battery, t) == 0x62);
     }
-    EXPECT_EQ(next_polled_group(battery, t), complete ? 0x84 : 0x62) << (complete ? "complete" : "cut short");
+    EXPECT_EQ(asked_again, !complete) << (complete ? "complete" : "cut short");
   }
 }


### PR DESCRIPTION
### What
This PR implements six lifetime usage histograms on the Nissan LEAF More Battery Info page, above the DTC section.
They show drive and charge temperature (at start and peak) and SOC at drive and charge start, for ZE0/AZE0 and ZE1 packs.

### Why
They show how a pack has been treated over its life (heat exposure, typical SOC levels), which helps when judging a used pack. The data comes from the same LBC group 0x62 reply as the AC/QC charge counts, so no extra polling is needed.

### How
The histogram part of the reply is stored raw in the datalayer, and the browser draws the charts in the Cell Monitor style.

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR https://github.com/dalathegreat/Battery-Emulator-Wiki/pull/56

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
