### PR TITLE
OTA: report a rolled-back update after the settings have switched logging on

### DIFF
--- a/Software/Software.cpp
+++ b/Software/Software.cpp
@@ -745,12 +745,17 @@ void setup() {
 
   init_events();
 
-  /* Before anything that can itself fail: if the previous update never got
-     through setup(), this boot is the bootloader's doing and the user should be
-     told so even if this boot also goes badly. */
-  report_ota_rollback();
-
   init_stored_settings();
+
+  /* AFTER init_stored_settings(), because that is what turns the log sinks on.
+     Reported earlier, the warning line went nowhere: web, USB, syslog and SD
+     logging are all switched on from stored settings, so a rollback report made
+     before that call reached no sink a user can read - and the OTA_ROLLBACK
+     event, which DOES survive, sends them looking for exactly the line that was
+     dropped (v12.5.0 field report). Still before anything that can itself fail,
+     which is what the placement was for: reading settings is the one step that
+     has to come first. */
+  report_ota_rollback();
 
   // AP-button recovery must always run
   xTaskCreatePinnedToCore((TaskFunction_t)&connectivity_loop, "connectivity_loop", 4096, NULL, TASK_CONNECTIVITY_PRIO,

--- a/Software/src/devboard/utils/ota_rollback.h
+++ b/Software/src/devboard/utils/ota_rollback.h
@@ -23,9 +23,15 @@
  * still inside the window.
  */
 
-// Report at boot whether the previous update failed to run. Call it early -
-// after init_events(), before anything that might itself fail - so the reason
-// is visible even if this boot goes badly too.
+// Report at boot whether the previous update failed to run.
+//
+// Call it after init_stored_settings() and before anything that can itself
+// fail. Both halves matter, and the first was learned the hard way: the log
+// sinks - web, USB, syslog, SD - are switched on from stored settings, so a
+// report made before that call writes to nothing and the user is left with an
+// OTA_ROLLBACK event whose text points at a line that was never emitted.
+// Reading settings is therefore the one step that comes first; everything else
+// still comes after, so the reason survives a boot that also goes badly.
 void report_ota_rollback(void);
 
 // The WRITE side of the gate, for ordinary main-task context: performs the

--- a/test/ota_confirm_tests.cpp
+++ b/test/ota_confirm_tests.cpp
@@ -235,6 +235,42 @@ TEST(OtaConfirmPlacement, SetupDoesNotConfirmTheImage) {
       << "setup() performs the confirmation write - it belongs in runtime cadence";
 }
 
+/* THE ROLLBACK REPORT NEEDS A LOG SINK, and setup() is where it gets one.
+ *
+ * `report_ota_rollback()` used to run before `init_stored_settings()`. That call
+ * is what switches web, USB, syslog and SD logging on from stored settings, so
+ * the warning line went to no sink a user can read - while the OTA_ROLLBACK
+ * event, which does survive, tells them to go and read it. A rolled-back update
+ * therefore left the reason nowhere, which is the v12.5.0 field report.
+ *
+ * Held by ORDER rather than by presence, because presence was never the
+ * problem: both calls were there, in the wrong sequence. Read off the source,
+ * like its two neighbours, because Software.cpp's setup() is not in this
+ * binary.
+ */
+TEST(OtaConfirmPlacement, TheRollbackReportRunsOnceLoggingIsConfigured) {
+  const std::string setup = function_body(read_source("../Software/Software.cpp"), "void setup() {");
+  ASSERT_FALSE(setup.empty());
+
+  const size_t settings = setup.find("init_stored_settings(");
+  const size_t report = setup.find("report_ota_rollback(");
+  ASSERT_NE(settings, std::string::npos) << "setup() no longer reads stored settings";
+  ASSERT_NE(report, std::string::npos)
+      << "setup() no longer reports a rollback at all - a rolled-back update would say nothing";
+
+  EXPECT_LT(settings, report)
+      << "report_ota_rollback() runs before init_stored_settings(), so the log sinks are off and its "
+         "warning line reaches nobody - while the OTA_ROLLBACK event survives and points the user at it";
+
+  /* ...and it still comes before the things that can fail, which is what the
+     original early placement was for. `init_events()` is the one call it must
+     follow (it needs the event machinery) and the driver/CAN setup below is
+     what it must precede. */
+  const size_t events = setup.find("init_events(");
+  ASSERT_NE(events, std::string::npos);
+  EXPECT_LT(events, report) << "the report runs before init_events(), so its event has nowhere to go";
+}
+
 /* The check has to be unconditional inside the core tick. Inside the 10 ms or
  * 1 s sub-task it would still fire, but it would then be witnessing that ONE
  * sub-task ran, which is a weaker statement than the tick itself coming round.


### PR DESCRIPTION
When an update is rolled back, v12.5.0 reports it at boot from `setup()`:

```cpp
  init_events();

  report_ota_rollback();   // <- every log sink is still off here

  init_stored_settings();  // <- this is what turns them on
```

`init_stored_settings()` is what sets `web`/`usb`/`syslog`/`SD_logging_active` from stored settings, and `Logging::write()` returns 0 while they are all false. The report's warning line - the one that names the firmware that failed and the one now running - is therefore dropped, as is the log echo of its event. The `OTA_ROLLBACK` event itself survives, because events do not go through the logger, and its text reads "the log line names which version failed". So the one channel that works points the user at the one that does not, and a rolled-back update leaves the reason nowhere.

This is a property of the source, not an observation from one board: `WEBENABLED` is read into `datalayer.system.info.web_logging_active` in `comm_nvm.cpp:242`, inside `init_stored_settings()`, and every web-sink write in `logging.cpp` is gated on that flag (`:262`, `:280`, `:326`, `:364`). A report made before that call therefore runs with the flag at its default `false` - and the same holds for the USB, syslog and SD flags beside it - so the line is dropped whatever the board's stored settings say.

The call moves below `init_stored_settings()`. Both halves of the original placement still hold, which is why this is a move and not a split: it must follow `init_events()`, because it raises an event, and it must precede anything that can itself fail, so the reason survives a boot that also goes badly. Reading stored settings is the one step that has to come first, and nothing is lost by waiting - the event is RAM-only, so a boot that dies inside the settings load takes it with it either way, and the otadata state the report reads is re-read on every boot. The comment on `report_ota_rollback()` now states both constraints instead of only the early one.

A host case pins the order rather than the presence of the two calls (both were always there, in the wrong sequence) and also pins that the report still follows `init_events()`; it reads the source, as its neighbours do, because `Software.cpp`'s `setup()` is not in the host binary. Swapping the calls back fails that case by name and nothing else.

On hardware, a LilyGo T-CAN485 with web logging enabled and an update rolled back for real (push to the passive slot, reset at the chip inside the 42 s window): before, the events page shows `OTA_ROLLBACK` and the log shows nothing; after, the log carries the warning line and the event echo at 0.154 s of uptime. An ordinary OTA still confirms past the gate.

Scope: this affects rollbacks whose fallback image is v12.5.0 or later. A fallback to v12.4.0 or earlier reports nothing regardless, since the report did not exist yet - so the recent reports of a 12.4 to 12.5 update silently reverting are not fixed by this, they are the case where the image that comes back has no report in it at all.
