### PR TITLE
Main page small inprovements for better readability

### DIFF
--- a/Software/src/devboard/utils/events.cpp
+++ b/Software/src/devboard/utils/events.cpp
@@ -442,15 +442,15 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
     case EVENT_CAN_BATTERY_DETECTED:
       return "Successfully communicating with battery. Battery detected!";
     case EVENT_CAN_BATTERY2_DETECTED:
-      return "Successfully communicating with secondary battery. Secondary battery detected!";
+      return "Successfully communicating with 2ⁿᵈ battery. 2ⁿᵈ battery detected!";
     case EVENT_CAN_BATTERY3_DETECTED:
-      return "Successfully communicating with third battery. Third battery detected!";
+      return "Successfully communicating with 3ʳᵈ battery. 3ʳᵈ battery detected!";
     case EVENT_CAN_BATTERY_MISSING:
       return "Battery not sending messages via CAN for the last 60 seconds. Check wiring!";
     case EVENT_CAN_BATTERY2_MISSING:
-      return "Secondary battery not sending messages via CAN for the last 60 seconds. Check wiring!";
+      return "2ⁿᵈ battery not sending messages via CAN for the last 60 seconds. Check wiring!";
     case EVENT_CAN_BATTERY3_MISSING:
-      return "Third battery not sending messages via CAN for the last 60 seconds. Check wiring!";
+      return "3ʳᵈ battery not sending messages via CAN for the last 60 seconds. Check wiring!";
     case EVENT_CAN_CHARGER_DETECTED:
       return "Successfully communicating with charger. Charger detected!";
     case EVENT_CAN_CHARGER_MISSING:
@@ -578,9 +578,9 @@ static String get_event_base_message(EVENTS_ENUM_TYPE event) {
     case EVENT_BATTERY3_SOC_RESET_FAIL:
       return "SOC reset routine failed - check SOC is < 15 or > 90, and contactors are open.";
     case EVENT_VOLTAGE_DIFFERENCE_BAT2:
-      return "Too large voltage diff between the batteries. Second battery cannot join the DC-link";
+      return "Too large voltage diff between the batteries. 2ⁿᵈ battery cannot join the DC-link";
     case EVENT_VOLTAGE_DIFFERENCE_BAT3:
-      return "Too large voltage diff between the batteries. Third battery cannot join the DC-link";
+      return "Too large voltage diff between the batteries. 3ʳᵈ battery cannot join the DC-link";
     case EVENT_SOH_DIFFERENCE:
       return "Large deviation in State of health between packs. Inspect battery.";
     case EVENT_SOH_LOW:

--- a/Software/src/devboard/webserver/advanced_battery_html.cpp
+++ b/Software/src/devboard/webserver/advanced_battery_html.cpp
@@ -150,7 +150,7 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
   }
 
  private:
-  enum class Stage { Start, Tabs, Heading, Status, Dtc, Commands, End, Done };
+  enum class Stage { Start, Tabs, Panel, Status, Dtc, Commands, End, Done };
   Stage stage = Stage::Start;
   unsigned selected;
   unsigned tab = 0;
@@ -176,7 +176,7 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
       switch (stage) {
         case Stage::Start:
           fragment = page_start;
-          stage = (battery2 || battery3) ? Stage::Tabs : Stage::Heading;
+          stage = (battery2 || battery3) ? Stage::Tabs : Stage::Panel;
           return true;
         case Stage::Tabs:
           while (tab < 3) {
@@ -188,11 +188,10 @@ class AdvancedBatteryResponse : public AsyncAbstractResponse {
               return true;
             }
           }
-          stage = Stage::Heading;
+          stage = Stage::Panel;
           break;
-        case Stage::Heading:
-          snprintf(small, sizeof(small), "</nav><div class='battery-panel'><h3>Battery %u</h3>", selected + 1);
-          fragment = small;
+        case Stage::Panel:
+          fragment = "</nav><div class='battery-panel'>";
           stage = Stage::Status;
           return true;
         case Stage::Status: {

--- a/Software/src/devboard/webserver/settings_html.cpp
+++ b/Software/src/devboard/webserver/settings_html.cpp
@@ -1934,7 +1934,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         title="Enable this option if you intend to run two batteries in parallel" />
 
         <div class="if-dblbtr">
-            <label>Battery 2 interface: </label>
+            <label>2ⁿᵈ interface: </label>
             <select name='BATT2COMM'>
                 %BATT2COMM%
             </select>
@@ -1945,7 +1945,7 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         title="Enable this option if you intend to run three batteries in parallel" />
 
         <div class="if-tribtr">
-        <label>Battery 3 interface: </label>
+        <label>3ʳᵈ interface: </label>
         <select name='BATT3COMM'>
             %BATT3COMM%
         </select>
@@ -2163,15 +2163,6 @@ const char* getCANInterfaceName(CAN_Interface interface) {
         %EQSTOP%  
         </select>
 
-        <div class="if-dblbtr">
-            <label>Double-Battery Contactor control via GPIO: </label>
-            <input type='checkbox' name='CNTCTRLDBL' value='on' %CNTCTRLDBL% />
-            <div class="if-tribtr">
-                <label>Triple-Battery Contactor control via GPIO: </label>
-                <input type='checkbox' name='CNTCTRLTRI' value='on' %CNTCTRLTRI% />
-            </div>
-        </div>
-
         <label>Contactor control via GPIO: </label>
         <input type='checkbox' name='CNTCTRL' value='on' %CNTCTRL% />
 
@@ -2199,7 +2190,15 @@ const char* getCANInterfaceName(CAN_Interface interface) {
             min="1" max="1023" step="1"
             title="1-1023 , lower value = lower power consumption" />
               </div>
+        </div>
 
+        <div class="if-dblbtr">
+            <label>2ⁿᵈ battery contactor control via GPIO: </label>
+            <input type='checkbox' name='CNTCTRLDBL' value='on' %CNTCTRLDBL% />
+            <div class="if-tribtr">
+                <label>3ʳᵈ battery contactor control via GPIO: </label>
+                <input type='checkbox' name='CNTCTRLTRI' value='on' %CNTCTRLTRI% />
+            </div>
         </div>
 
         <label>Periodic BMS reset: </label>

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1199,12 +1199,12 @@ String processor(const String& var) {
         content += "<h4 style='color: white;'>Battery protocol: ";
         content += datalayer.system.info.battery_protocol;
         if (battery3) {
-          content += " (&#10005; 3)";
+          content += " | ✕3";
         } else if (battery2) {
-          content += " (&#10005; 2)";
+          content += " | ✕2";
         }
         if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
-          content += " (LFP)";
+          content += " | LFP";
         }
         content += "</h4>";
       }
@@ -1587,31 +1587,31 @@ String processor(const String& var) {
 
     content += "<h4>Emulator allows contactor closing: ";
     if (datalayer.system.status.system_status == FAULT) {
-      content += "<span style='color: red;'>&#10008;</span>";
+      content += "<span style='color: red;'>✗</span>";
     } else {
-      content += "<span>&#10004;</span>";
+      content += "<span>✓</span>";
     }
     content += "<br>Inverter allows contactor closing: ";
     if (datalayer.system.status.inverter_allows_contactor_closing == true) {
-      content += "<span>&#10004;</span></h4>";
+      content += "<span>✓</span></h4>";
     } else {
-      content += "<span style='color: red;'>&#10008;</span></h4>";
+      content += "<span style='color: red;'>✗</span></h4>";
     }
     if (battery2) {
       content += "<h4>2ⁿᵈ battery allowed to join: ";
       if (datalayer.system.status.battery2_allowed_contactor_closing == true) {
-        content += "<span>&#10004;</span>";
+        content += "<span>✓</span>";
       } else {
-        content += "<span style='color: red;'>&#10008;<br>(voltage mismatch)</span>";
+        content += "<span style='color: red;'>✗<br>(voltage mismatch)</span>";
       }
       content += "</h4>";
     }
     if (battery3) {
       content += "<h4>3ʳᵈ battery allowed to join: ";
       if (datalayer.system.status.battery3_allowed_contactor_closing == true) {
-        content += "<span>&#10004;</span>";
+        content += "<span>✓</span>";
       } else {
-        content += "<span style='color: red;'>&#10008;<br>(voltage mismatch)</span>";
+        content += "<span style='color: red;'>✗<br>(voltage mismatch)</span>";
       }
       content += "</h4>";
     }
@@ -1692,17 +1692,17 @@ String processor(const String& var) {
 
       content += "<h4>Charger HV Enabled: ";
       if (datalayer.charger.charger_HV_enabled) {
-        content += "<span>&#10004;</span>";
+        content += "<span>✓</span>";
       } else {
-        content += "<span style='color: red;'>&#10008;</span>";
+        content += "<span style='color: red;'>✗</span>";
       }
       content += "</h4>";
 
       content += "<h4>Charger Aux12v Enabled: ";
       if (datalayer.charger.charger_aux12V_enabled) {
-        content += "<span>&#10004;</span>";
+        content += "<span>✓</span>";
       } else {
-        content += "<span style='color: red;'>&#10008;</span>";
+        content += "<span style='color: red;'>✗</span>";
       }
       content += "</h4>";
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1644,7 +1644,7 @@ String processor(const String& var) {
       }
       content += "</h4></div>";
       if (contactor_control_enabled_double_battery && battery2) {
-        content += "<h4>Contactor 2ⁿᵈ - state: ";
+        content += "<h4>Contactor for 2ⁿᵈ - state: ";
         if (pwm_contactor_control) {
           if (datalayer.system.status.contactors_battery2_engaged) {
             content += "<span style='color: green;'>Economized</span>";
@@ -1663,7 +1663,7 @@ String processor(const String& var) {
         content += "</h4>";
       }
       if (contactor_control_enabled_triple_battery && battery3) {
-        content += "<h4>Contactor 3ʳᵈ - state: ";
+        content += "<h4>Contactor for 3ʳᵈ - state: ";
         if (pwm_contactor_control) {
           if (datalayer.system.status.contactors_battery3_engaged) {
             content += "<span style='color: green;'>Economized</span>";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1199,9 +1199,9 @@ String processor(const String& var) {
         content += "<h4 style='color: white;'>Battery protocol: ";
         content += datalayer.system.info.battery_protocol;
         if (battery3) {
-          content += " | ✕3";
+          content += " | ③";
         } else if (battery2) {
-          content += " | ✕2";
+          content += " | ②";
         }
         if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
           content += " | LFP";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1199,9 +1199,9 @@ String processor(const String& var) {
         content += "<h4 style='color: white;'>Battery protocol: ";
         content += datalayer.system.info.battery_protocol;
         if (battery3) {
-          content += " (&#10006;3)";
+          content += " (&#10005; 3)";
         } else if (battery2) {
-          content += " (&#10006;2)";
+          content += " (&#10005; 2)";
         }
         if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
           content += " (LFP)";

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1199,9 +1199,9 @@ String processor(const String& var) {
         content += "<h4 style='color: white;'>Battery protocol: ";
         content += datalayer.system.info.battery_protocol;
         if (battery3) {
-          content += " (Triple battery)";
+          content += " (&#10006;3)";
         } else if (battery2) {
-          content += " (Double battery)";
+          content += " (&#10006;2)";
         }
         if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
           content += " (LFP)";
@@ -1587,31 +1587,31 @@ String processor(const String& var) {
 
     content += "<h4>Emulator allows contactor closing: ";
     if (datalayer.system.status.system_status == FAULT) {
-      content += "<span style='color: red;'>&#10005;</span>";
+      content += "<span style='color: red;'>&#10008;</span>";
     } else {
-      content += "<span>&#10003;</span>";
+      content += "<span>&#10004;</span>";
     }
     content += "<br>Inverter allows contactor closing: ";
     if (datalayer.system.status.inverter_allows_contactor_closing == true) {
-      content += "<span>&#10003;</span></h4>";
+      content += "<span>&#10004;</span></h4>";
     } else {
-      content += "<span style='color: red;'>&#10005;</span></h4>";
+      content += "<span style='color: red;'>&#10008;</span></h4>";
     }
     if (battery2) {
       content += "<h4>2ⁿᵈ battery allowed to join: ";
       if (datalayer.system.status.battery2_allowed_contactor_closing == true) {
-        content += "<span>&#10003;</span>";
+        content += "<span>&#10004;</span>";
       } else {
-        content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
+        content += "<span style='color: red;'>&#10008;<br>(voltage mismatch)</span>";
       }
       content += "</h4>";
     }
     if (battery3) {
       content += "<h4>3ʳᵈ battery allowed to join: ";
       if (datalayer.system.status.battery3_allowed_contactor_closing == true) {
-        content += "<span>&#10003;</span>";
+        content += "<span>&#10004;</span>";
       } else {
-        content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
+        content += "<span style='color: red;'>&#10008;<br>(voltage mismatch)</span>";
       }
       content += "</h4>";
     }
@@ -1692,17 +1692,17 @@ String processor(const String& var) {
 
       content += "<h4>Charger HV Enabled: ";
       if (datalayer.charger.charger_HV_enabled) {
-        content += "<span>&#10003;</span>";
+        content += "<span>&#10004;</span>";
       } else {
-        content += "<span style='color: red;'>&#10005;</span>";
+        content += "<span style='color: red;'>&#10008;</span>";
       }
       content += "</h4>";
 
       content += "<h4>Charger Aux12v Enabled: ";
       if (datalayer.charger.charger_aux12V_enabled) {
-        content += "<span>&#10003;</span>";
+        content += "<span>&#10004;</span>";
       } else {
-        content += "<span style='color: red;'>&#10005;</span>";
+        content += "<span style='color: red;'>&#10008;</span>";
       }
       content += "</h4>";
 

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1199,12 +1199,12 @@ String processor(const String& var) {
         content += "<h4 style='color: white;'>Battery protocol: ";
         content += datalayer.system.info.battery_protocol;
         if (battery3) {
-          content += " | ③";
+          content += " ③";
         } else if (battery2) {
-          content += " | ②";
+          content += " ②";
         }
         if (datalayer.battery.info.chemistry == battery_chemistry_enum::LFP) {
-          content += " | LFP";
+          content += " (LFP)";
         }
         content += "</h4>";
       }

--- a/Software/src/devboard/webserver/webserver.cpp
+++ b/Software/src/devboard/webserver/webserver.cpp
@@ -1591,27 +1591,29 @@ String processor(const String& var) {
     } else {
       content += "<span>&#10003;</span>";
     }
-    content += " Inverter allows contactor closing: ";
+    content += "<br>Inverter allows contactor closing: ";
     if (datalayer.system.status.inverter_allows_contactor_closing == true) {
       content += "<span>&#10003;</span></h4>";
     } else {
       content += "<span style='color: red;'>&#10005;</span></h4>";
     }
     if (battery2) {
-      content += "<h4>Secondary battery allowed to join ";
+      content += "<h4>2ⁿᵈ battery allowed to join: ";
       if (datalayer.system.status.battery2_allowed_contactor_closing == true) {
         content += "<span>&#10003;</span>";
       } else {
         content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
       }
+      content += "</h4>";
     }
     if (battery3) {
-      content += "<h4>Third battery allowed to join ";
+      content += "<h4>3ʳᵈ battery allowed to join: ";
       if (datalayer.system.status.battery3_allowed_contactor_closing == true) {
         content += "<span>&#10003;</span>";
       } else {
         content += "<span style='color: red;'>&#10005; (voltage mismatch)</span>";
       }
+      content += "</h4>";
     }
 
     if (!contactor_control_enabled) {
@@ -1622,11 +1624,15 @@ String processor(const String& var) {
           "powering the contactors. Battery-Emulator will have limited amount of control over the contactors!</span>";
       content += "</div>";
     } else {  //contactor_control_enabled TRUE
-      content += "<div class=\"tooltip\"><h4>Contactors controlled by emulator, state: ";
+      content += "<div class=\"tooltip\"><h4>Contactors control - state: ";
       if (datalayer.system.status.contactors_engaged == 0) {
         content += "<span style='color: red;'>OFF (DISCONNECTED)</span>";
       } else if (datalayer.system.status.contactors_engaged == 1) {
-        content += "<span style='color: green;'>ON</span>";
+        if (pwm_contactor_control) {
+          content += "<span style='color: green;'>Economized</span>";
+        } else {
+          content += "<span style='color: green;'>ON</span>";
+        }
       } else if (datalayer.system.status.contactors_engaged == 2) {
         content += "<span style='color: red;'>OFF (FAULT)</span>";
         content += "<span class=\"tooltip-icon\"> [!]</span>";
@@ -1638,7 +1644,7 @@ String processor(const String& var) {
       }
       content += "</h4></div>";
       if (contactor_control_enabled_double_battery && battery2) {
-        content += "<h4>Secondary battery contactor, state: ";
+        content += "<h4>Contactor 2ⁿᵈ - state: ";
         if (pwm_contactor_control) {
           if (datalayer.system.status.contactors_battery2_engaged) {
             content += "<span style='color: green;'>Economized</span>";
@@ -1657,7 +1663,7 @@ String processor(const String& var) {
         content += "</h4>";
       }
       if (contactor_control_enabled_triple_battery && battery3) {
-        content += "<h4>Third battery contactor, state: ";
+        content += "<h4>Contactor 3ʳᵈ - state: ";
         if (pwm_contactor_control) {
           if (datalayer.system.status.contactors_battery3_engaged) {
             content += "<span style='color: green;'>Economized</span>";

--- a/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
+++ b/Software/src/lib/pierremolinaro-ACAN2517FD/ACAN2517FD.cpp
@@ -1334,7 +1334,8 @@ ACAN2517FDSettings::Oscillator ACAN2517FD::autodetectCrystalFrequency (void) {
   // Calculate frequency in 0.1MHz units
   const uint32_t freq_times_10 = ((c2 - c1) * 10) / (t2 - t1);
 
-  logging.printf("MCP2518FD autodetected crystal: %ddMHz\n", freq_times_10);
+  // freq_times_10 is in 0.1MHz units, round it to whole MHz for the log line
+  logging.printf("MCP2518FD autodetected crystal: %u MHz\n", (freq_times_10 + 5) / 10);
 
   // Disable TBC again
   writeRegister8 (C1TSCON_REGISTER_16_23, 0x00);


### PR DESCRIPTION
## What
- Reworks the contactor block on the main page: one item per line, shorter and consistent labels, to be more mobile-friendly.
- Main contactors now report `Economized` when PWM contactor control is active.
- Fixes the malformed MCP2518FD crystal autodetect log line. 
- Secondary -> 2ⁿᵈ  and Third -> 3ʳᵈ in the event texts too (save flash + smaller text on UI)

Before:
<img width="1125" height="644" alt="kép" src="https://github.com/user-attachments/assets/fb5b78fb-4e41-45e9-a37b-8f448bc47547" />

```
0.244 MCP2518FD autodetected crystal: 200dMHz
```

After:
<img width="1125" height="589" alt="kép" src="https://github.com/user-attachments/assets/41285135-b310-4028-b5c0-13d084a23ab4" />

```
0.244 MCP2518FD autodetected crystal: 20 MHz
```

<img width="500" height="212" alt="kép" src="https://github.com/user-attachments/assets/bb95b045-8643-4675-af8b-ea614062f011" />


## Why
- The two "allows contactor closing" items ran together on one line, and battery 1/2/3 used three different naming styles.
- Battery 2 and 3 already showed `Economized`, so the main contactors reading `ON` while PWM-held was misleading.
- The log read `200dMHz` / `0dMHz` instead of a usable frequency, making it useless for diagnosing a wrong crystal.

## How
- Split the two items with `<br>`, renamed labels to the 2ⁿᵈ / 3ʳᵈ form, and closed two dangling `<h4>` tags.
- Reused the existing `pwm_contactor_control` check from the double/triple battery paths for `contactors_engaged == 1`.
- Corrected the format string and rounded the 0.1 MHz measurement to whole MHz.


### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [x] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
