### PR TITLE
Bugfix: Economize battery 2/3 contactors too, when PWM contactor control is enabled

### DIFF
--- a/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
+++ b/Software/src/communication/contactorcontrol/comm_contactorcontrol.cpp
@@ -44,6 +44,10 @@ uint16_t pwm_hold_duty = 250;
 #define PWM_OFF_DUTY 0  //No need to have this userconfigurable
 #define PWM_Positive_Channel 0
 #define PWM_Negative_Channel 1
+#define PWM_Battery2_Channel 2
+#define PWM_Battery3_Channel 3
+#define EXTRA_CONTACTOR_PULL_IN_TIME_MS \
+  PRECHARGE_COMPLETED_TIME_MS  // Battery 2/3 coils are held at full duty for this long before being economized
 static uint32_t prechargeStartTime = 0;
 uint32_t negativeStartTime = 0;
 uint32_t prechargeCompletedTime = 0;
@@ -135,8 +139,13 @@ bool init_contactors() {
       return false;
     }
 
-    pinMode(second_contactors, OUTPUT);
-    set(second_contactors, OFF);
+    if (pwm_contactor_control) {
+      ledcAttachChannel(second_contactors, pwm_frequency, PWM_RESOLUTION, PWM_Battery2_Channel);
+      ledcWrite(second_contactors, PWM_OFF_DUTY);
+    } else {
+      pinMode(second_contactors, OUTPUT);
+      set(second_contactors, OFF);
+    }
   }
 
   if (contactor_control_enabled_triple_battery) {
@@ -146,8 +155,13 @@ bool init_contactors() {
       return false;
     }
 
-    pinMode(triple_contactors, OUTPUT);
-    set(triple_contactors, OFF);
+    if (pwm_contactor_control) {
+      ledcAttachChannel(triple_contactors, pwm_frequency, PWM_RESOLUTION, PWM_Battery3_Channel);
+      ledcWrite(triple_contactors, PWM_OFF_DUTY);
+    } else {
+      pinMode(triple_contactors, OUTPUT);
+      set(triple_contactors, OFF);
+    }
   }
 
   // Init BMS contactor
@@ -331,28 +345,44 @@ void handle_contactors() {
   }
 }
 
-void handle_contactors_battery2() {
-  auto second_contactors = esp32hal->SECOND_BATTERY_CONTACTORS_PIN();
-
-  if ((contactorStatus == COMPLETED) && datalayer.system.status.battery2_allowed_contactor_closing) {
-    set(second_contactors, ON);
-    datalayer.system.status.contactors_battery2_engaged = true;
-  } else {  // Closing contactors on secondary battery not allowed
-    set(second_contactors, OFF);
-    datalayer.system.status.contactors_battery2_engaged = false;
+/* Battery 2 and 3 each have a single contactor and no precharge stage of their own, they simply
+   close once the main ladder reaches COMPLETED. Every set() here passes an explicit duty so the
+   PWM path is taken when the user enabled economizing: full duty to pull the coil in, hold duty
+   once it has closed, and 0% to release it. Without PWM the duty argument is ignored and set()
+   falls back to digitalWrite exactly as before, so one call site serves both modes.
+   Note that millis() is read here rather than reusing the file-scope currentTime: these handlers
+   run before handle_contactors() refreshes it, and it is not refreshed at all on the COMPLETED
+   pass, which is precisely when these contactors are closed. */
+static void handle_extra_contactor(gpio_num_t pin, bool close_allowed, bool& engaged, uint32_t& pull_in_start) {
+  if (close_allowed) {
+    if (!engaged) {  // Rising edge, start the pull-in window
+      pull_in_start = millis();
+      engaged = true;
+    }
+    // Economize only after the coil has had the same pull-in time the main pair gets between
+    // closing and PRECHARGE_OFF. Dropping to hold duty any earlier risks the contactor not seating.
+    bool economize = pwm_contactor_control && ((millis() - pull_in_start) >= EXTRA_CONTACTOR_PULL_IN_TIME_MS);
+    set(pin, ON, economize ? pwm_hold_duty : PWM_ON_DUTY);
+  } else {  // Closing contactors on this battery not allowed
+    set(pin, OFF, PWM_OFF_DUTY);
+    engaged = false;
   }
 }
 
-void handle_contactors_battery3() {
-  auto third_contactors = esp32hal->TRIPLE_BATTERY_CONTACTORS_PIN();
+void handle_contactors_battery2() {
+  static uint32_t pull_in_start = 0;
 
-  if ((contactorStatus == COMPLETED) && datalayer.system.status.battery3_allowed_contactor_closing) {
-    set(third_contactors, ON);
-    datalayer.system.status.contactors_battery3_engaged = true;
-  } else {  // Closing contactors on secondary battery not allowed
-    set(third_contactors, OFF);
-    datalayer.system.status.contactors_battery3_engaged = false;
-  }
+  handle_extra_contactor(esp32hal->SECOND_BATTERY_CONTACTORS_PIN(),
+                         (contactorStatus == COMPLETED) && datalayer.system.status.battery2_allowed_contactor_closing,
+                         datalayer.system.status.contactors_battery2_engaged, pull_in_start);
+}
+
+void handle_contactors_battery3() {
+  static uint32_t pull_in_start = 0;
+
+  handle_extra_contactor(esp32hal->TRIPLE_BATTERY_CONTACTORS_PIN(),
+                         (contactorStatus == COMPLETED) && datalayer.system.status.battery3_allowed_contactor_closing,
+                         datalayer.system.status.contactors_battery3_engaged, pull_in_start);
 }
 
 /* PERIODIC_BMS_RESET - Once every configured interval (24h or 48h) we remove power from the BMS_power pin for 30 seconds.

--- a/test/contactor_economize_battery2_tests.cpp
+++ b/test/contactor_economize_battery2_tests.cpp
@@ -49,6 +49,11 @@ class ContactorEconomizeBattery2Test : public ::testing::Test {
     contactor_control_inverted_logic = false;
     pwm_contactor_control = true;
     pwm_hold_duty = 250;
+    // init_contactors() also drives BMS_POWER when either reset feature is on, and both
+    // are globals that another suite may have left set. CI runs the binary shuffled, so
+    // state this fixture depends on has to be stated here rather than inherited.
+    periodic_bms_reset = false;
+    remote_bms_reset = false;
     datalayer.system.status.battery2_allowed_contactor_closing = true;
     second_contactors = esp32hal->SECOND_BATTERY_CONTACTORS_PIN();
     clear_duty_writes();
@@ -68,7 +73,7 @@ class ContactorEconomizeBattery2Test : public ::testing::Test {
     handle_contactors_battery2();
   }
 
-  // The duty last written to the contactor pin, or nothing if it was never driven.
+  // The duty last written to the given pin, or nothing if PWM never drove it.
   static std::optional<uint32_t> last_duty(uint8_t pin) {
     std::optional<uint32_t> duty;
     for (const auto& write : get_duty_writes()) {
@@ -77,6 +82,19 @@ class ContactorEconomizeBattery2Test : public ::testing::Test {
       }
     }
     return duty;
+  }
+
+  // The level last written to the given pin, or nothing if digitalWrite never drove it.
+  // Scoped to one pin on purpose: other pins (BMS power, indicator LEDs) are driven by
+  // code this suite is not testing, and the assertions must not depend on them.
+  static std::optional<uint8_t> last_level(uint8_t pin) {
+    std::optional<uint8_t> level;
+    for (const auto& write : get_pin_writes()) {
+      if (write.pin == pin) {
+        level = write.value;
+      }
+    }
+    return level;
   }
 
   uint8_t second_contactors = 0;
@@ -88,7 +106,7 @@ TEST_F(ContactorEconomizeBattery2Test, InitDrivesThePinThroughPwmWhenEconomizing
   ASSERT_TRUE(init_contactors());
 
   EXPECT_EQ(last_duty(second_contactors), kOffDuty);
-  EXPECT_TRUE(get_pin_writes().empty());  // Nothing driven by digitalWrite
+  EXPECT_FALSE(last_level(second_contactors).has_value());  // Never driven by digitalWrite
 }
 
 // Closing at the hold duty would risk the coil never seating, so the contactor
@@ -148,9 +166,7 @@ TEST_F(ContactorEconomizeBattery2Test, PlainGpioWhenEconomizingIsDisabled) {
   tick_at(kBootMs);
   tick_at(kBootMs + kPullInMs);
 
-  EXPECT_TRUE(get_duty_writes().empty());
-  ASSERT_FALSE(get_pin_writes().empty());
-  EXPECT_EQ(get_pin_writes().back().pin, second_contactors);
-  EXPECT_EQ(get_pin_writes().back().value, HIGH);
+  EXPECT_FALSE(last_duty(second_contactors).has_value());  // Never touched by the LEDC peripheral
+  EXPECT_EQ(last_level(second_contactors), static_cast<uint8_t>(HIGH));
   EXPECT_TRUE(datalayer.system.status.contactors_battery2_engaged);
 }

--- a/test/contactor_economize_battery2_tests.cpp
+++ b/test/contactor_economize_battery2_tests.cpp
@@ -1,0 +1,156 @@
+#include <gtest/gtest.h>
+#include <optional>
+
+#include <Arduino.h>  // Emul: set_millis64(), get_duty_writes(), get_pin_writes()
+
+#include "../Software/src/communication/contactorcontrol/comm_contactorcontrol.h"
+#include "../Software/src/datalayer/datalayer.h"
+#include "../Software/src/devboard/hal/hal.h"
+
+// Covers the secondary battery contactor in handle_contactors_battery2(): that it
+// is driven through the PWM path when the user enabled economizing, that it is
+// pulled in at full duty before being dropped to the hold duty, and that with the
+// setting off it still falls back to a plain digitalWrite.
+//
+// The third battery takes the identical code path with its own pin, but the
+// LilyGo HAL the host build uses has no TRIPLE_BATTERY_CONTACTORS_PIN, so there is
+// nothing meaningful to drive here.
+//
+// Assertions are on the duty actually written to the pin: the whole point of the
+// setting is the current the coil ends up holding at, which no state variable
+// records.
+
+namespace {
+
+// Mirrors the file-scope FSM in comm_contactorcontrol.cpp. Must match it.
+enum SeqState { DISCONNECTED, START_PRECHARGE, PRECHARGE, POSITIVE, PRECHARGE_OFF, COMPLETED, SHUTDOWN_REQUESTED };
+
+// Duties and timings from comm_contactorcontrol.cpp, where they are #defines and
+// so not reachable from here. Kept in step with it deliberately: if the ladder is
+// retimed or the resolution changes these tests must be revisited, not silently pass.
+constexpr uint32_t kFullDuty = 1023;
+constexpr uint32_t kOffDuty = 0;
+constexpr unsigned long kPullInMs = 1000;
+constexpr unsigned long kBootMs = 100000;
+
+}  // namespace
+
+extern SeqState contactorStatus;
+
+class ContactorEconomizeBattery2Test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    datalayer = DataLayer();
+    init_hal();
+    set_millis64(kBootMs);
+    contactorStatus = COMPLETED;        // Battery 2 only joins once the main ladder is done
+    contactor_control_enabled = false;  // Isolate: only the secondary contactor is under test
+    contactor_control_enabled_double_battery = true;
+    contactor_control_inverted_logic = false;
+    pwm_contactor_control = true;
+    pwm_hold_duty = 250;
+    datalayer.system.status.battery2_allowed_contactor_closing = true;
+    second_contactors = esp32hal->SECOND_BATTERY_CONTACTORS_PIN();
+    clear_duty_writes();
+    clear_pin_writes();
+  }
+
+  void TearDown() override {
+    contactorStatus = DISCONNECTED;
+    contactor_control_enabled_double_battery = false;
+    pwm_contactor_control = false;
+    set_millis64(0);
+  }
+
+  // Advances the clock and runs one pass of the secondary contactor handler.
+  static void tick_at(unsigned long ms) {
+    set_millis64(ms);
+    handle_contactors_battery2();
+  }
+
+  // The duty last written to the contactor pin, or nothing if it was never driven.
+  static std::optional<uint32_t> last_duty(uint8_t pin) {
+    std::optional<uint32_t> duty;
+    for (const auto& write : get_duty_writes()) {
+      if (write.pin == pin) {
+        duty = write.duty;
+      }
+    }
+    return duty;
+  }
+
+  uint8_t second_contactors = 0;
+};
+
+// The pin has to be handed to the LEDC peripheral at init, or every later
+// ledcWrite() lands on an unattached pin and the contactor stays at full current.
+TEST_F(ContactorEconomizeBattery2Test, InitDrivesThePinThroughPwmWhenEconomizingIsEnabled) {
+  ASSERT_TRUE(init_contactors());
+
+  EXPECT_EQ(last_duty(second_contactors), kOffDuty);
+  EXPECT_TRUE(get_pin_writes().empty());  // Nothing driven by digitalWrite
+}
+
+// Closing at the hold duty would risk the coil never seating, so the contactor
+// gets the same pull-in window the main pair has between closing and PRECHARGE_OFF.
+TEST_F(ContactorEconomizeBattery2Test, PullsInAtFullDutyThenEconomizes) {
+  tick_at(kBootMs);
+  EXPECT_EQ(last_duty(second_contactors), kFullDuty);
+  EXPECT_TRUE(datalayer.system.status.contactors_battery2_engaged);
+
+  tick_at(kBootMs + kPullInMs - 1);
+  EXPECT_EQ(last_duty(second_contactors), kFullDuty);
+
+  tick_at(kBootMs + kPullInMs);
+  EXPECT_EQ(last_duty(second_contactors), pwm_hold_duty);
+}
+
+// Opening has to go through the PWM path too: a digitalWrite(LOW) on a pin owned
+// by the LEDC peripheral would not necessarily release the coil.
+TEST_F(ContactorEconomizeBattery2Test, ReleasesAtZeroDuty) {
+  tick_at(kBootMs);
+  tick_at(kBootMs + kPullInMs);
+  ASSERT_EQ(last_duty(second_contactors), pwm_hold_duty);
+
+  datalayer.system.status.battery2_allowed_contactor_closing = false;
+  tick_at(kBootMs + kPullInMs + 10);
+
+  EXPECT_EQ(last_duty(second_contactors), kOffDuty);
+  EXPECT_FALSE(datalayer.system.status.contactors_battery2_engaged);
+}
+
+// A contactor that dropped out and closed again is a fresh mechanical pull-in,
+// so the window must restart rather than economize immediately.
+TEST_F(ContactorEconomizeBattery2Test, ReclosingRestartsThePullInWindow) {
+  tick_at(kBootMs);
+  tick_at(kBootMs + kPullInMs);
+  ASSERT_EQ(last_duty(second_contactors), pwm_hold_duty);
+
+  datalayer.system.status.battery2_allowed_contactor_closing = false;
+  tick_at(kBootMs + kPullInMs + 10);
+  datalayer.system.status.battery2_allowed_contactor_closing = true;
+
+  tick_at(kBootMs + kPullInMs + 20);
+  EXPECT_EQ(last_duty(second_contactors), kFullDuty);
+
+  tick_at(kBootMs + kPullInMs + 20 + kPullInMs);
+  EXPECT_EQ(last_duty(second_contactors), pwm_hold_duty);
+}
+
+// With the setting off the contactor must keep behaving exactly as before: a
+// plain GPIO output, never touched by the LEDC peripheral.
+TEST_F(ContactorEconomizeBattery2Test, PlainGpioWhenEconomizingIsDisabled) {
+  pwm_contactor_control = false;
+  ASSERT_TRUE(init_contactors());
+  clear_duty_writes();
+  clear_pin_writes();
+
+  tick_at(kBootMs);
+  tick_at(kBootMs + kPullInMs);
+
+  EXPECT_TRUE(get_duty_writes().empty());
+  ASSERT_FALSE(get_pin_writes().empty());
+  EXPECT_EQ(get_pin_writes().back().pin, second_contactors);
+  EXPECT_EQ(get_pin_writes().back().value, HIGH);
+  EXPECT_TRUE(datalayer.system.status.contactors_battery2_engaged);
+}

--- a/test/emul/Arduino.cpp
+++ b/test/emul/Arduino.cpp
@@ -42,7 +42,20 @@ int max(int a, int b) {
 bool ledcAttachChannel(uint8_t pin, uint32_t freq, uint8_t resolution, int8_t channel) {
   return true;
 }
+// Records every duty the firmware drove, so tests can assert on contactor
+// pull-in vs economized hold without reaching into internal state.
+std::vector<DutyWrite> g_emul_duty_writes;
+
+void clear_duty_writes() {
+  g_emul_duty_writes.clear();
+}
+
+const std::vector<DutyWrite>& get_duty_writes() {
+  return g_emul_duty_writes;
+}
+
 bool ledcWrite(uint8_t pin, uint32_t duty) {
+  g_emul_duty_writes.push_back({pin, duty});
   return true;
 }
 // Records the precharge PWM frequency the firmware asks for, so the regulation

--- a/test/emul/Arduino.h
+++ b/test/emul/Arduino.h
@@ -153,6 +153,15 @@ struct ToneWrite {
 void clear_tone_writes();
 const std::vector<ToneWrite>& get_tone_writes();
 
+// A PWM duty write recorded by the emulated ledcWrite, so tests can tell a
+// contactor pulled in at full duty from one held at the economized duty.
+struct DutyWrite {
+  uint8_t pin;
+  uint32_t duty;
+};
+void clear_duty_writes();
+const std::vector<DutyWrite>& get_duty_writes();
+
 // A pin write recorded by the emulated digitalWrite, for tests that need to
 // assert on what was driven rather than only on state variables.
 struct PinWrite {


### PR DESCRIPTION
## What
The secondary and third battery contactors now follow the "PWM contactor control" setting, the same way the main negative and positive pair already does.

## Why
Their coils sat at full holding current whenever the setting was on, wasting power and heating the coil, while the web UI reported them as "Economized".

## How
LEDC channels 2 and 3 are attached at init, every write passes an explicit duty, and the coil gets a 1 s pull-in at full duty before dropping to the hold duty.
Economizing applies to every contactor the emulator drives, not just the main pair, so the PWM settings stay visible in the web settings  whenever any of the three is enabled.


### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before) 
- [ ] Code quality improvements to existing code or addition of tests

### Related issue or feature (if applicable):

- fixes <link to issue>

### Pull request in [Battery Emulator Wiki](https://github.com/dalathegreat/Battery-Emulator-Wiki) updating documentation (if applicable):

- wiki PR <link to PR>

### Checklist:

  - [x] The code change is tested and works locally.

> [!TIP]
> Don't worry if you haven't submitted the Wiki docs PR yet! You can still submit this PR, but please don't forget to also document your changes in the [docs](https://github.com/dalathegreat/Battery-Emulator-Wiki) as the next step. Then, come back here and edit this description with the link of the PR you just created there.
> 
> [You can help test this PR using these steps](https://dalathegreat.github.io/Battery-Emulator-Wiki/setup/contributing/contributing/#downloading-a-pull-request-build-to-test-locally)
